### PR TITLE
fix(ci): use GitHub-hosted runner for Claude Code action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,7 +19,7 @@ jobs:
         (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
         (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
       )
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Switch `runs-on` from `self-hosted` to `ubuntu-latest` in `claude.yml`
- Self-hosted runner is not configured on the new repository

## Test plan
- [ ] Verify Claude Code action triggers correctly on `ubuntu-latest`
- [ ] Test `@claude` mention in a PR comment