### PR TITLE
ci: add dev branch to CI workflow triggers

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -2,7 +2,7 @@ name: Desktop Build
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev]
     paths:
       - "desktop/**"
       - "crates/**"
@@ -11,7 +11,7 @@ on:
       - ".node-version"
       - ".github/actions/download-nodejs/**"
   push:
-    branches: [main]
+    branches: [main, dev]
     paths:
       - "desktop/**"
       - "crates/**"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
     branches: [main, dev]
 


### PR DESCRIPTION
## Summary
- Add `dev` to `push` triggers in `test.yml` and `desktop-build.yml` workflows
- Ensures CI runs on pushes to `dev` now that it is the default branch
- `release-please.yml` and `release-please-lockfile.yml` left on `main` only (release flow)

## Context
Default branch has been changed from `main` to `dev` via GitHub API. This aligns with our workflow where all PRs target `dev` and `main` is only updated via release merges.