### PR TITLE
fix(ci): allow org members to trigger Claude Code Review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,7 +15,7 @@ jobs:
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.user.login != 'dependabot[bot]' &&
-      github.actor == github.repository_owner
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
## Summary

- Replace `github.actor == github.repository_owner` with `author_association` check (OWNER, MEMBER, COLLABORATOR)
- The old condition always evaluated to false for org repos because actor (individual user) never equals repository_owner (org name)
- This caused Claude Code Review to be permanently skipped on all PRs

## Test plan

- [x] Verify workflow syntax is valid
- [ ] After merge, open a PR and confirm Claude Code Review triggers