### PR TITLE
fix(ci): use login allowlist for Claude Code Review trigger

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -14,8 +14,7 @@ jobs:
   claude-review:
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.user.login != 'dependabot[bot]' &&
-      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+      contains(fromJSON('["slawomir-it"]'), github.event.pull_request.user.login)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
## Summary

- Replace `author_association` check with explicit login allowlist
- `author_association` in webhook payload returns `CONTRIBUTOR` (not `MEMBER`) for org members with prior commits — causing permanent skip
- Allowlist approach is also more secure: only named users can trigger Claude Code Review (which consumes API tokens)

## Test plan

- [ ] After merge to dev+main, PR #86 Claude Code Review should trigger