### PR TITLE
fix(security): align Makefile audit with CI, add audit as required check (#5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Granular targets:
 - **Build:** `build-runtime`, `build-cli`, `build-desktop`, `build-native-macos`, `build-os-cli`, `build-mcp`, `build-angular`, `build-tauri`
 - **Check:** `check-clippy`, `check-desktop-clippy`, `check-fmt`, `check-mcp`, `check-mcp-lint`, `check-angular`, `check-angular-lint`
 - **Coverage:** `coverage-rust`, `coverage-mcp`, `coverage-angular`
-- **Audit:** `audit-rust`, `audit-mcp`
+- **Audit:** `audit-rust`, `audit-mcp`, `audit-desktop`
 - **Download:** `download-lima`, `download-nodejs`, `download-nerdctl-full`, `download-wsl-resources` (+ `clean-*` variants)
 - **Other:** `lint`, `install-deps`, `install-hooks`, `clean`
 

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ LIMA_VERSION := $(shell cat .lima-version 2>/dev/null || echo 2.0.2)
         check-clippy check-desktop-clippy check-angular check-mcp check-fmt \
         check-mcp-lint check-angular-lint check-all \
         coverage coverage-rust coverage-mcp coverage-html \
-        audit audit-rust audit-mcp \
+        audit audit-rust audit-mcp audit-desktop \
         fmt lint status \
         download-lima clean-lima \
         download-nodejs clean-nodejs \
@@ -473,17 +473,22 @@ check-angular-lint:
 
 # ── Security audit ────────────────────────────────────────────────────────────
 
-audit: audit-rust audit-mcp
+audit: audit-rust audit-mcp audit-desktop
 	@echo "\n✅ No known vulnerabilities"
 
 audit-rust:
 	@command -v cargo-audit >/dev/null 2>&1 || { echo "❌ cargo-audit not found. Install: cargo install cargo-audit"; exit 1; }
 	cargo audit
+	cargo audit --file desktop/src-tauri/Cargo.lock
 	@echo "✅ Rust dependencies: no vulnerabilities"
 
 audit-mcp:
-	cd mcp-servers && npm audit --omit=dev
+	cd mcp-servers && npm audit --audit-level=high --omit=dev
 	@echo "✅ MCP dependencies: no vulnerabilities"
+
+audit-desktop:
+	cd desktop/src && npm audit --audit-level=high --omit=dev
+	@echo "✅ Desktop dependencies: no vulnerabilities"
 
 # ── Full quality gate (run before push) ──────────────────────────────────────
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -35,6 +35,7 @@ export default {
         'lint',
         'config',
         'native',
+        'security',
       ],
     ],
     'scope-empty': [1, 'never'],


### PR DESCRIPTION
## Summary
- Add `audit` job as **required status check** on `dev` branch protection (via GitHub API)
- Add `--audit-level=high` to `audit-mcp` Makefile target (matches CI)
- Add `audit-desktop` Makefile target for `desktop/src` npm audit (matches CI)
- Add `desktop/src-tauri/Cargo.lock` audit to `audit-rust` target (matches CI)
- Add `security` scope to commitlint config

Closes #5

## Test plan
- [x] `make audit` passes locally (all 3 sub-targets: `audit-rust`, `audit-mcp`, `audit-desktop`)
- [x] `make test` passes (pre-push hook)
- [ ] CI `audit` job runs and blocks merge if it fails