### PR TITLE
fix(security): sanitize SSE fields to prevent injection (CodeQL)

### DIFF
--- a/mcp-servers/shared/src/sse.test.ts
+++ b/mcp-servers/shared/src/sse.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { SSEStream, createSSEStream, sendJSONResponse } from './sse.js';
+import { SSEStream, createSSEStream, sendJSONResponse, sanitizeSSEField } from './sse.js';
 import type { JSONRPCResponse, JSONRPCError } from './types.js';
 import { JSONRPCErrorCode } from './types.js';
 import type { Response } from 'express';
@@ -665,6 +665,36 @@ describe('sse', () => {
 
       expect(mockRes.setHeader).toHaveBeenCalledTimes(2);
       expect(mockRes.json).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('sanitizeSSEField', () => {
+    it('strips newline', () => {
+      expect(sanitizeSSEField('foo\nbar')).toBe('foobar');
+    });
+
+    it('strips carriage return', () => {
+      expect(sanitizeSSEField('foo\rbar')).toBe('foobar');
+    });
+
+    it('strips CRLF', () => {
+      expect(sanitizeSSEField('foo\r\nbar')).toBe('foobar');
+    });
+
+    it('leaves clean values unchanged', () => {
+      expect(sanitizeSSEField('message')).toBe('message');
+    });
+
+    it('strips injection payload', () => {
+      expect(sanitizeSSEField('0\r\nevent: injected')).toBe('0event: injected');
+    });
+
+    it('strips multiple newlines', () => {
+      expect(sanitizeSSEField('a\nb\nc\r\nd')).toBe('abcd');
+    });
+
+    it('handles empty string', () => {
+      expect(sanitizeSSEField('')).toBe('');
     });
   });
 });

--- a/mcp-servers/shared/src/sse.ts
+++ b/mcp-servers/shared/src/sse.ts
@@ -10,7 +10,7 @@ import type { SSEEvent, JSONRPCResponse, JSONRPCError } from './types.js';
  * Strip newlines and carriage returns — SSE single-value fields must be one line.
  * @param value - raw field value to sanitize
  */
-function sanitizeSSEField(value: string): string {
+export function sanitizeSSEField(value: string): string {
   return value.replace(/[\r\n]/g, '');
 }
 
@@ -87,6 +87,7 @@ export class SSEStream {
 
     if (event.data) {
       for (const line of String(event.data).split('\n')) {
+        // \r stripped inline (not via sanitizeSSEField) to preserve intentional \n-splitting
         message += `data: ${line.replace(/\r/g, '')}\n`;
       }
     }


### PR DESCRIPTION
## Summary
- Adds `sanitizeSSEField()` to strip `\n` and `\r` from SSE `id`, `event`, and `retry` fields
- Strips `\r` from `data` lines
- Defense-in-depth: current callers only pass internally-produced values, but this guards against future callsite changes and satisfies CodeQL

## Test plan
- [x] 4 new sanitization tests in `sse.test.ts`
- [x] All 49 SSE tests pass
- [x] `make test-mcp` passes