### PR TITLE
fix(ci): allow release-please PRs to pass claude-review required check

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,9 +12,7 @@ on:
 
 jobs:
   claude-review:
-    if: >-
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      contains(fromJSON('["slawomir-it"]'), github.event.pull_request.user.login)
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -25,12 +23,19 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
 
     steps:
+      - name: Skip non-reviewable PRs
+        if: >-
+          !contains(fromJSON('["slawomir-it"]'), github.event.pull_request.user.login)
+        run: echo "Skipping review — PR author not in allowlist (e.g. release-please bot)"
+
       - name: Checkout repository
+        if: contains(fromJSON('["slawomir-it"]'), github.event.pull_request.user.login)
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
+        if: contains(fromJSON('["slawomir-it"]'), github.event.pull_request.user.login)
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:


### PR DESCRIPTION
## Summary
Moves the author allowlist from job-level `if` to step-level `if`. The job now always **runs** for same-repo PRs (satisfying the required check) but **skips the actual review** for PRs authored by bots (e.g. release-please).

## Problem
Release-please PRs are authored by `github-actions[bot]`, not `slawomir-it`. The job-level `if` caused the entire job to be **skipped**, and GitHub treats a skipped required check as a failure — permanently blocking release PR merges.

## After this change
- Human PRs: full Claude Code Review (unchanged)
- Bot PRs (release-please): job runs, prints "Skipping review", exits successfully