### PR TITLE
fix(ci): add explicit rustup target add for macOS cross-compilation

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -145,6 +145,10 @@ jobs:
         with:
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
+      - name: Ensure cross-compile target is installed
+        if: matrix.platform == 'macos-latest'
+        run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
+
       - name: Rust cache
         uses: swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5  # v2.8.2
         with:


### PR DESCRIPTION
## Summary
Adds explicit `rustup target add` step to fix v0.1.0 release build failure on macOS x86_64.

After merge, re-run failed jobs on the v0.1.0 release build.