### PR TITLE
fix(ci): set last-release-sha to reset release version to 0.1.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,6 +7,7 @@
   "include-component-in-tag": false,
   "bump-minor-pre-major": true,
   "bootstrap-sha": "88d7a3dc5b87eff887760e1a374f2b97ce180265",
+  "last-release-sha": "27af03db358aa0712c0256679c42dc334be87cc0",
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
Sets last-release-sha in release-please config to v0.0.1 tag.