### PR TITLE
fix(ci): add explicit rustup target add to desktop-build for macOS cross-compilation

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -77,6 +77,10 @@ jobs:
         with:
           targets: ${{ matrix.rust-targets }}
 
+      - name: Ensure cross-compile target is installed
+        if: matrix.platform == 'macos-latest'
+        run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
+
       - name: Rust cache
         uses: swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5  # v2.8.2
         with:


### PR DESCRIPTION
## Summary
- `desktop-build.yml` was missing the `rustup target add` step that `desktop-release.yml` already has (#151, #157)
- `dtolnay/rust-toolchain` `targets` parameter alone does not reliably install `rust-std` for `x86_64-apple-darwin` on ARM runners
- Same fix pattern as desktop-release.yml: explicit `rustup target add` after toolchain setup

## Test plan
- [x] Verified `desktop-release.yml` has this fix and passes
- [x] Verified `desktop-build.yml` x86_64-apple-darwin job fails without it (runs #23332955386, #23299185074)
- [ ] CI passes on this PR