### PR TITLE
chore(ci): sync CHANGELOG.md with main to resolve merge conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@
 ### Features
 
 * release — docs sync, Lima memory fix, plugin system, Swift CI alignment ([#215](https://github.com/speednet-software/speedwave/issues/215)) ([b7b045d](https://github.com/speednet-software/speedwave/commit/b7b045d576547476d5542c5cd23bc57c7d8e5020))
+* release — plugin system, Tailwind migration, chat UI, security hardening ([#203](https://github.com/speednet-software/speedwave/issues/203)) ([4155156](https://github.com/speednet-software/speedwave/commit/415515630b159bf7da6eddbcf3bab3b377e8e0c9))
+* **runtime:** plugin system, transactional project switching, streaming chat UI, security hardening ([#134](https://github.com/speednet-software/speedwave/issues/134)) ([8dc90cb](https://github.com/speednet-software/speedwave/commit/8dc90cb9c3d307eddb1fc9193d058f83845a971d))
+
+
+### Bug Fixes
+
+* **ci:** reset release-please manifest to 0.0.1 for clean 0.1.0 release ([#162](https://github.com/speednet-software/speedwave/issues/162)) ([0802a35](https://github.com/speednet-software/speedwave/commit/0802a350bd28370802874cb300f5abcd67f92ce8))
+* **ci:** set last-release-sha to v0.0.1 tag to reset version to 0.1.0 ([#160](https://github.com/speednet-software/speedwave/issues/160)) ([6e1a6a7](https://github.com/speednet-software/speedwave/commit/6e1a6a7bb7f2ce91e327fda57e502c56719bef86))
+* **ci:** sync claude.yml with dev — allowlist guard, remove redundant permissions ([#129](https://github.com/speednet-software/speedwave/issues/129)) ([24e879a](https://github.com/speednet-software/speedwave/commit/24e879a5ba7698a379805f8e28527307371def2a))
+* **ci:** use login allowlist for Claude Code Review trigger ([#89](https://github.com/speednet-software/speedwave/issues/89)) ([8cce77e](https://github.com/speednet-software/speedwave/commit/8cce77e1b27e71f8c6ff80d6987ab502bafa193c))
+* **deps:** sync desktop dependencies from dev — Angular 21.2.4, Express 5, audit fixes ([#132](https://github.com/speednet-software/speedwave/issues/132)) ([8bfd1b5](https://github.com/speednet-software/speedwave/commit/8bfd1b53517723d6051eb254948f953114ded0ea))
 
 ## [0.2.0](https://github.com/speednet-software/speedwave/compare/v0.1.0...v0.2.0) (2026-03-18)
 


### PR DESCRIPTION
## Summary

- Syncs CHANGELOG.md on dev with main's version (full v0.3.0 section from release-please)
- Resolves conflict blocking PR #221 (dev → main)

## Test plan

- [ ] CI passes