### PR TITLE
fix(ci): fix release-please label step — parse PR number from JSON output

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,11 +29,17 @@ jobs:
       # release-please can fail transiently (PR node ID not propagated yet).
       - name: Ensure release PR has autorelease label
         if: steps.release.outputs.pr
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-          PR_NUMBER: ${{ steps.release.outputs.pr }}
+          PR_JSON: ${{ steps.release.outputs.pr }}
           REPO: ${{ github.repository }}
         run: |
+          PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number // empty' 2>/dev/null || echo "$PR_JSON")
+          if [ -z "$PR_NUMBER" ] || ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "::warning::Could not parse PR number from release-please output"
+            exit 0
+          fi
           LABELS=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels --jq '.labels[].name')
           if echo "$LABELS" | grep -q "autorelease: pending"; then
             echo "Label already present"


### PR DESCRIPTION
## Summary

- `release-please-action` `outputs.pr` is a JSON object, not a plain PR number
- The label-ensure step was passing the full JSON as `PR_NUMBER`, causing `gh pr view` to fail
- Now parses `.number` from JSON with jq, falls back to raw value
- Adds `continue-on-error: true` so label step cannot block `build-and-publish`

This caused both release-please runs after v0.3.1 merge to fail, preventing automated build trigger.

## Test plan

- [ ] CI passes