### PR TITLE
fix(ci): fix Windows CLI build, tag creation, and backmerge conflicts

### DIFF
--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -92,8 +92,11 @@ jobs:
           echo "Merge conflicts detected — attempting auto-resolution of version files"
 
           # Auto-resolve version files (main wins — it has the latest release version)
-          VERSION_FILES=(
+          # Version files + release config (main always wins)
+          AUTO_RESOLVE_FILES=(
             .release-please-manifest.json
+            release-please-config.json
+            .github/workflows/release-please.yml
             package.json
             package-lock.json
             desktop/src/package.json
@@ -115,7 +118,7 @@ jobs:
             CHANGELOG.md
           )
 
-          for f in "${VERSION_FILES[@]}"; do
+          for f in "${AUTO_RESOLVE_FILES[@]}"; do
             if git diff --name-only --diff-filter=U | grep -qx "$f"; then
               echo "Auto-resolving $f (using main's version)"
               git checkout --theirs "$f"
@@ -126,48 +129,10 @@ jobs:
           # Check if any unresolved conflicts remain
           REMAINING=$(git diff --name-only --diff-filter=U || true)
           if [ -n "$REMAINING" ]; then
-            echo "::warning::Unresolved conflicts remain in: $REMAINING"
+            echo "::error::Unresolved conflicts in: $REMAINING"
+            echo "::error::Manual backmerge needed. Run: git checkout -b chore/backmerge origin/dev && git merge origin/main"
             git merge --abort
-
-            # Create PR for manual resolution
-            # Reset branch to dev HEAD for the PR (can't push unresolved conflicts)
-            git checkout -B "$BRANCH" origin/dev
-            git push origin "$BRANCH" --force
-            gh pr create \
-              --repo "$REPO" \
-              --head "$BRANCH" \
-              --base dev \
-              --title "chore: backmerge main into dev after $TAG (conflicts)" \
-              --body "$(cat <<PREOF
-          ## Summary
-
-          Automated backmerge of \`main\` into \`dev\` after release \`$TAG\` has **unresolved conflicts**.
-
-          ### Conflicting files
-
-          \`\`\`
-          $REMAINING
-          \`\`\`
-
-          ### How to resolve
-
-          \`\`\`bash
-          git fetch origin
-          git checkout $BRANCH
-          git merge origin/main
-          # Resolve conflicts manually
-          git add .
-          git commit
-          git push
-          \`\`\`
-
-          ## Test plan
-
-          - [ ] All conflicts resolved
-          - [ ] CI passes on this PR
-          PREOF
-          )"
-            exit 0
+            exit 1
           fi
 
           # All conflicts auto-resolved

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -355,6 +355,7 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Ensure cross-compile target is installed
+        shell: bash
         env:
           TARGET: ${{ matrix.target }}
         run: rustup target add "$TARGET"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -51,6 +51,29 @@ jobs:
           done
           echo "::warning::Failed to apply label after 3 retries"
 
+      # Defense-in-depth: ensure the git tag exists as a ref. GitHub draft
+      # releases may not create a git ref, even with force-tag-creation: true.
+      # Without the tag, checkout in desktop-release.yml fails.
+      - name: Ensure release tag exists
+        if: steps.release.outputs.release_created == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          TAG_NAME: ${{ steps.release.outputs.tag_name }}
+          SHA: ${{ github.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          if gh api "repos/$REPO/git/refs/tags/${TAG_NAME#v}" --jq '.ref' 2>/dev/null || \
+             gh api "repos/$REPO/git/refs/tags/$TAG_NAME" --jq '.ref' 2>/dev/null; then
+            echo "Tag $TAG_NAME already exists"
+            exit 0
+          fi
+          echo "Tag $TAG_NAME missing — creating from $SHA"
+          gh api "repos/$REPO/git/refs" \
+            -f "ref=refs/tags/$TAG_NAME" \
+            -f "sha=$SHA" --jq '.ref'
+          echo "Tag created successfully"
+
   build-and-publish:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'


### PR DESCRIPTION
## Summary

Fixes discovered during v0.3.1 release:

- **Windows CLI build**: add `shell: bash` to cli job cross-compile step (`$TARGET` doesn't expand in PowerShell)
- **Tag creation**: add explicit tag creation step in `release-please.yml` — draft releases may not create git refs even with `force-tag-creation: true`
- **Backmerge conflicts**: add `release-please.yml` and `release-please-config.json` to auto-resolve list; fix fallback path (error + exit instead of creating empty PR)

## Test plan

- [ ] CI passes