### PR TITLE
fix(ci): update release-please-action to get force-tag-creation fix

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,7 +18,7 @@ jobs:
       tag_name: ${{ steps.release.outputs.tag_name }}
       version: ${{ steps.release.outputs.version }}
     steps:
-      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38  # v4.4.0
+      - uses: googleapis/release-please-action@8bb7a2ed0f90c9802c83129a9488d235a1f31a7c  # v4 main (release-please 17.3.0 — fixes force-tag-creation with draft releases)
         id: release
         with:
           token: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
## Summary

Root cause of phantom release PRs (v0.4.0): release-please-action v4.4.0 bundles release-please **17.1.3** which does NOT create git tags for draft releases even with `force-tag-creation: true`.

The fix landed in release-please **17.2.0** (PR googleapis/release-please#2627, 2026-01-20). Updated pin to action main HEAD which has release-please **17.3.0**.

## Test plan

- [ ] CI passes
- [ ] After merge to main: release-please run does NOT create phantom PR
- [ ] Next release: tag created automatically before draft release