### PR TITLE
fix: address PR #257 code review findings

### DIFF
--- a/crates/speedwave-runtime/src/runtime/mod.rs
+++ b/crates/speedwave-runtime/src/runtime/mod.rs
@@ -395,8 +395,8 @@ pub fn ensure_exec_healthy(
         let msg = e.to_string().to_ascii_lowercase();
         if msg.contains("no such image") || msg.contains("image not found") {
             anyhow::anyhow!(
-                "Container images are missing — please restart the app \
-                 to trigger a rebuild. ({e})"
+                "Container images are missing — restarting the app \
+                 will trigger an automatic rebuild. ({e})"
             )
         } else {
             anyhow::anyhow!(
@@ -1094,7 +1094,8 @@ services:
                 Ok(Command::new("true"))
             } else if let Some(ref msg) = self.custom_error {
                 let mut cmd = Command::new("sh");
-                cmd.args(["-c", &format!("echo '{}' >&2; exit 1", msg)]);
+                cmd.env("TEST_MSG", msg)
+                    .args(["-c", "echo \"$TEST_MSG\" >&2; exit 1"]);
                 Ok(cmd)
             } else {
                 let mut cmd = Command::new("sh");

--- a/desktop/src/src/app/services/project-state.service.spec.ts
+++ b/desktop/src/src/app/services/project-state.service.spec.ts
@@ -631,6 +631,33 @@ describe('ProjectStateService', () => {
       expect(service.status).toBe('ready');
     });
 
+    it('retryAuth stays in auth_required when auth check fails', async () => {
+      mockTauri.invokeHandler = async (cmd: string) => {
+        switch (cmd) {
+          case 'list_projects':
+            return { projects: [{ name: 'test', dir: '/tmp/test' }], active_project: 'test' };
+          case 'get_bundle_reconcile_state':
+            return MOCK_BUNDLE_RECONCILE_DONE;
+          case 'run_system_check':
+            return undefined;
+          case 'check_containers_running':
+            return true;
+          case 'get_auth_status':
+            throw new Error('connection refused');
+          default:
+            return undefined;
+        }
+      };
+      service.activeProject = 'test';
+      service.status = 'auth_required';
+
+      const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+      await service.retryAuth();
+      expect(service.status).toBe('auth_required');
+      expect(debugSpy).toHaveBeenCalledWith('retryAuth: auth check failed', expect.any(Error));
+      debugSpy.mockRestore();
+    });
+
     it('does not fire onProjectReady for auth_required', async () => {
       mockTauri.invokeHandler = async (cmd: string) => {
         switch (cmd) {

--- a/desktop/src/src/app/services/project-state.service.ts
+++ b/desktop/src/src/app/services/project-state.service.ts
@@ -215,8 +215,9 @@ export class ProjectStateService {
         this.notifyReady();
         this.notifySettled();
       }
-    } catch {
-      // Auth check failed — stay in auth_required
+    } catch (err) {
+      console.debug('retryAuth: auth check failed', err);
+      // Stay in auth_required
     }
   }
 

--- a/scripts/diagnose-cli.sh
+++ b/scripts/diagnose-cli.sh
@@ -2,7 +2,7 @@
 # Speedwave CLI diagnostic script
 # Run on a machine where `speedwave` command is not working.
 
-set -euo pipefail
+set -uo pipefail
 
 echo "=== Speedwave CLI Diagnostics ==="
 echo "Date: $(date)"


### PR DESCRIPTION
## Summary
Fixes 4 of 5 issues from [PR #257](https://github.com/speednet-software/speedwave/pull/257#issuecomment-4113453053) code review:

- **Shell injection in test mock** — `ProbeTestRuntime::container_exec_piped` used `format!("echo '{}' >&2")` which breaks on single quotes. Now uses env var (`TEST_MSG`) to pass the message safely.
- **Misleading recovery error message** — changed "please restart the app to trigger a rebuild" to "restarting the app will trigger an automatic rebuild" since the rebuild is automatic.
- **`retryAuth()` silently discards errors** — added `console.debug('retryAuth: auth check failed', err)` so failures are visible in devtools.
- **`diagnose-cli.sh` exits too aggressively** — removed `set -e` so the diagnostic script continues collecting info even when individual checks fail.

### Not addressed: Issue #1 (startup performance on Windows)
The reviewer claims `check_os_prereqs()` blocks `--help` and all CLI invocations. This is incorrect — `--help`/`--version` are handled by clap before entering `main()`, and early-exit actions (`SelfUpdate`, `Init`, `Update`, plugins) return before line 509. The prereq check only runs for `speedwave check` and the default container-start path, which is the correct scope. On macOS/Linux it returns instantly (empty Vec). The 10s WSL timeout on Windows is acceptable for detecting a missing prerequisite before container start.

## Test plan
- [x] `make test` — 681 Rust + 650 Angular tests pass
- [x] `make check` — clippy, eslint, prettier all pass
- [x] New test: `retryAuth stays in auth_required when auth check fails`