### PR TITLE
fix(desktop): fix setup screen shown after app update

### DIFF
--- a/desktop/src/src/app/setup/setup-wizard.component.spec.ts
+++ b/desktop/src/src/app/setup/setup-wizard.component.spec.ts
@@ -236,4 +236,60 @@ describe('SetupWizardComponent', () => {
     expect(component.steps[3].status).toBe('done');
     expect(component.projectName).toBe('active-one');
   });
+
+  it('should fall back to first project when active_project is stale', async () => {
+    mockTauri.invokeHandler = async (cmd: string) => {
+      switch (cmd) {
+        case 'get_platform':
+          return 'macos';
+        case 'check_runtime':
+          return 'Ready';
+        case 'list_projects':
+          return {
+            projects: [{ name: 'only-project', dir: '/tmp/x' }],
+            active_project: 'deleted-project',
+          };
+        case 'build_images':
+        case 'start_containers':
+        case 'link_cli':
+          return undefined;
+        default:
+          return undefined;
+      }
+    };
+
+    await component.startSetup();
+    await fixture.whenStable();
+
+    expect(component.steps[3].status).toBe('done');
+    expect(component.projectName).toBe('only-project');
+  });
+
+  it('should set detail text on skipped project step', async () => {
+    mockTauri.invokeHandler = async (cmd: string) => {
+      switch (cmd) {
+        case 'get_platform':
+          return 'macos';
+        case 'check_runtime':
+          return 'Ready';
+        case 'list_projects':
+          return {
+            projects: [{ name: 'my-project', dir: '/tmp/p' }],
+            active_project: 'my-project',
+          };
+        case 'build_images':
+        case 'start_containers':
+        case 'link_cli':
+          return undefined;
+        default:
+          return undefined;
+      }
+    };
+
+    await component.startSetup();
+    await fixture.whenStable();
+
+    expect(component.steps[3].status).toBe('done');
+    expect(component.steps[3].detail).toBe('Using existing project: my-project');
+  });
 });

--- a/desktop/src/src/app/setup/setup-wizard.component.ts
+++ b/desktop/src/src/app/setup/setup-wizard.component.ts
@@ -95,10 +95,15 @@ interface SetupStep {
                     {{ step.title }}
                   </div>
                   <div class="text-xs text-sw-text-ghost">{{ step.description }}</div>
-                  @if (step.detail && (step.status === 'active' || step.status === 'error')) {
+                  @if (
+                    step.detail &&
+                    (step.status === 'active' || step.status === 'error' || step.status === 'done')
+                  ) {
                     <div
                       class="text-xs mt-0.5 font-mono"
-                      [class.text-sw-text-faint]="step.status === 'active'"
+                      [class.text-sw-text-faint]="
+                        step.status === 'active' || step.status === 'done'
+                      "
                       [class.text-sw-error]="step.status === 'error'"
                     >
                       {{ step.detail }}


### PR DESCRIPTION
## Summary

- **Bug 1 fix** (already on dev via backmerge): Remove `SetupState` reset from `ensure_lima_vm_config()` — VM memory migration was resetting `images_built` and `containers_started` flags that were never restored, causing existing macOS users with ≥32 GB RAM to see the Setup screen after updating to 0.4.0
- **Bug 2 fix** (this PR): Setup wizard now detects existing projects via `list_projects` and auto-skips the "Create Project" step, preferring the `active_project`. Prevents the dead-end where "Start Setup" leads to a project creation form that an existing user cannot meaningfully fill out
- Add explicit `list_projects` handler to all wizard test overrides for test hygiene

## Test plan

- [ ] Verify `make check` passes (clippy, lint, typecheck, format)
- [ ] Verify `make test` passes (all Rust + Angular + MCP tests)
- [ ] Manual: on macOS with ≥32 GB RAM, update from 0.4.0 → confirm Setup screen is not shown
- [ ] Manual: if Setup screen is forced (e.g. via corrupted `setup_state.json`), confirm wizard auto-selects existing project and completes without requiring project creation