### PR TITLE
chore(runtime): backmerge main into dev — resolve conflicts

### DIFF
--- a/desktop/src/src/app/services/project-state.service.spec.ts
+++ b/desktop/src/src/app/services/project-state.service.spec.ts
@@ -651,11 +651,8 @@ describe('ProjectStateService', () => {
       service.activeProject = 'test';
       service.status = 'auth_required';
 
-      const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
       await service.retryAuth();
       expect(service.status).toBe('auth_required');
-      expect(debugSpy).toHaveBeenCalledWith('retryAuth: auth check failed', expect.any(Error));
-      debugSpy.mockRestore();
     });
 
     it('does not fire onProjectReady for auth_required', async () => {

--- a/desktop/src/src/app/services/project-state.service.ts
+++ b/desktop/src/src/app/services/project-state.service.ts
@@ -215,9 +215,8 @@ export class ProjectStateService {
         this.notifyReady();
         this.notifySettled();
       }
-    } catch (err) {
-      console.debug('retryAuth: auth check failed', err);
-      // Stay in auth_required
+    } catch {
+      // Auth check failed — stay in auth_required
     }
   }
 


### PR DESCRIPTION
## Summary

Regular merge of `main` into `dev` to resolve conflicts blocking the release PR #278.

4 conflicts resolved:
- `runtime/mod.rs`: keep dev's improved error message and env-safe test helper
- `project-state.service.ts`: adopt main's cleaner `catch` without debug log
- `project-state.service.spec.ts`: keep retryAuth failure test, remove debug spy (matches implementation)
- `diagnose-cli.sh`: keep dev's `set -uo` (no `-e` — diagnostic script should not abort on errors)

## Test plan

- [x] `make test` passes (all 672 Rust + 654 Angular tests)