### PR TITLE
fix(desktop): auth overlay blocks only chat, setup regressions, OS prereqs

### DIFF
--- a/desktop/src/src/app/services/project-state.service.spec.ts
+++ b/desktop/src/src/app/services/project-state.service.spec.ts
@@ -632,24 +632,13 @@ describe('ProjectStateService', () => {
     });
 
     it('retryAuth stays in auth_required when auth check fails', async () => {
-      mockTauri.invokeHandler = async (cmd: string) => {
-        switch (cmd) {
-          case 'list_projects':
-            return { projects: [{ name: 'test', dir: '/tmp/test' }], active_project: 'test' };
-          case 'get_bundle_reconcile_state':
-            return MOCK_BUNDLE_RECONCILE_DONE;
-          case 'run_system_check':
-            return undefined;
-          case 'check_containers_running':
-            return true;
-          case 'get_auth_status':
-            throw new Error('connection refused');
-          default:
-            return undefined;
-        }
-      };
       service.activeProject = 'test';
       service.status = 'auth_required';
+
+      mockTauri.invokeHandler = async (cmd: string) => {
+        if (cmd === 'get_auth_status') throw new Error('connection refused');
+        return undefined;
+      };
 
       await service.retryAuth();
       expect(service.status).toBe('auth_required');

--- a/desktop/src/src/app/services/project-state.service.ts
+++ b/desktop/src/src/app/services/project-state.service.ts
@@ -183,6 +183,24 @@ export class ProjectStateService {
     }
   }
 
+  /** Re-checks Claude auth status after user completes authentication. */
+  async retryAuth(): Promise<void> {
+    if (!this.activeProject) return;
+    try {
+      const auth = await this.tauri.invoke<AuthStatusResponse>('get_auth_status', {
+        project: this.activeProject,
+      });
+      if (auth.api_key_configured || auth.oauth_authenticated) {
+        this.status = 'ready';
+        this.notifyChange();
+        this.notifyReady();
+        this.notifySettled();
+      }
+    } catch {
+      // Auth check failed — stay in auth_required
+    }
+  }
+
   /** Dismisses the error banner, checking containers first. */
   async dismissError(): Promise<void> {
     try {
@@ -200,24 +218,6 @@ export class ProjectStateService {
       this.error = '';
     }
     this.notifyChange();
-  }
-
-  /** Re-checks Claude auth status after user completes authentication. */
-  async retryAuth(): Promise<void> {
-    if (!this.activeProject) return;
-    try {
-      const auth = await this.tauri.invoke<AuthStatusResponse>('get_auth_status', {
-        project: this.activeProject,
-      });
-      if (auth.api_key_configured || auth.oauth_authenticated) {
-        this.status = 'ready';
-        this.notifyChange();
-        this.notifyReady();
-        this.notifySettled();
-      }
-    } catch {
-      // Auth check failed — stay in auth_required
-    }
   }
 
   /**

--- a/desktop/src/src/app/shell/shell.component.spec.ts
+++ b/desktop/src/src/app/shell/shell.component.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterModule } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
 import { ShellComponent } from './shell.component';
 import { TauriService } from '../services/tauri.service';
 import { ProjectStateService } from '../services/project-state.service';
@@ -27,7 +27,13 @@ describe('ShellComponent', () => {
     };
 
     await TestBed.configureTestingModule({
-      imports: [ShellComponent, RouterModule.forRoot([])],
+      imports: [
+        ShellComponent,
+        RouterModule.forRoot([
+          { path: 'chat', component: ShellComponent },
+          { path: 'settings', component: ShellComponent },
+        ]),
+      ],
       providers: [{ provide: TauriService, useValue: mockTauri }],
     }).compileComponents();
 
@@ -219,8 +225,9 @@ describe('ShellComponent', () => {
     expect(overlay.textContent).toContain('Running system checks...');
   });
 
-  it('shows auth-required overlay when status is auth_required', async () => {
-    await component.ngOnInit();
+  it('shows auth-required overlay only on /chat', async () => {
+    const router = TestBed.inject(Router);
+    await router.navigateByUrl('/chat');
     projectState.status = 'auth_required';
     component['cdr'].markForCheck();
     fixture.detectChanges();
@@ -230,15 +237,27 @@ describe('ShellComponent', () => {
     expect(overlay.textContent).toContain('Authentication Required');
   });
 
-  it('auth-required overlay has authenticate and check-status buttons', async () => {
-    await component.ngOnInit();
+  it('auth-required overlay has only Go to Settings link', async () => {
+    const router = TestBed.inject(Router);
+    await router.navigateByUrl('/chat');
+    projectState.status = 'auth_required';
+    component['cdr'].markForCheck();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[data-testid="auth-settings-btn"]')).not.toBeNull();
+    expect(fixture.nativeElement.querySelector('[data-testid="auth-authenticate-btn"]')).toBeNull();
+    expect(fixture.nativeElement.querySelector('[data-testid="auth-check-btn"]')).toBeNull();
+  });
+
+  it('does not show auth-required overlay on /settings', async () => {
+    const router = TestBed.inject(Router);
+    await router.navigateByUrl('/settings');
     projectState.status = 'auth_required';
     component['cdr'].markForCheck();
     fixture.detectChanges();
 
     expect(
-      fixture.nativeElement.querySelector('[data-testid="auth-authenticate-btn"]')
-    ).not.toBeNull();
-    expect(fixture.nativeElement.querySelector('[data-testid="auth-check-btn"]')).not.toBeNull();
+      fixture.nativeElement.querySelector('[data-testid="blocking-auth-required"]')
+    ).toBeNull();
   });
 });

--- a/desktop/src/src/app/shell/shell.component.ts
+++ b/desktop/src/src/app/shell/shell.component.ts
@@ -6,11 +6,10 @@ import {
   OnDestroy,
   OnInit,
 } from '@angular/core';
-import { RouterOutlet, RouterLink, RouterLinkActive } from '@angular/router';
+import { Router, RouterOutlet, RouterLink, RouterLinkActive } from '@angular/router';
 import { ProjectSwitcherComponent } from '../project-switcher/project-switcher.component';
 import { UpdateNotificationComponent } from '../update-notification/update-notification.component';
 import { ProjectStateService } from '../services/project-state.service';
-import { TauriService } from '../services/tauri.service';
 
 /** Main application shell with header navigation and project switcher. */
 @Component({
@@ -46,32 +45,23 @@ import { TauriService } from '../services/tauri.service';
               Retry
             </button>
           </div>
-        } @else if (projectState.status === 'auth_required') {
+        } @else if (projectState.status === 'auth_required' && isChatRoute) {
           <div
             class="fixed inset-0 z-[9999] flex flex-col items-center justify-center bg-sw-bg-darkest"
             data-testid="blocking-auth-required"
           >
             <span class="text-sw-accent text-lg font-mono font-bold">Authentication Required</span>
             <p class="mt-4 max-w-lg text-center font-mono text-sm text-sw-text-muted">
-              Claude Code needs to be authenticated before you can start a conversation. Click
-              "Authenticate" to open a terminal and complete the login.
+              Claude Code needs to be authenticated before you can start a conversation. Go to
+              Settings to configure your API key or log in via OAuth.
             </p>
-            <div class="mt-6 flex gap-3">
-              <button
-                class="px-6 py-2.5 rounded text-sm font-semibold font-mono border-none cursor-pointer transition-colors bg-sw-accent text-white hover:bg-sw-accent-hover"
-                data-testid="auth-authenticate-btn"
-                (click)="openAuthTerminal()"
-              >
-                Authenticate
-              </button>
-              <button
-                class="px-6 py-2.5 rounded text-sm font-semibold font-mono border border-sw-border bg-transparent text-sw-text cursor-pointer transition-colors hover:bg-sw-bg-dark"
-                data-testid="auth-check-btn"
-                (click)="checkAuth()"
-              >
-                Check Status
-              </button>
-            </div>
+            <a
+              routerLink="/settings"
+              class="mt-6 px-6 py-2.5 rounded text-sm font-semibold font-mono border-none cursor-pointer transition-colors bg-sw-accent text-white hover:bg-sw-accent-hover no-underline"
+              data-testid="auth-settings-btn"
+            >
+              Go to Settings
+            </a>
           </div>
         } @else if (projectState.status === 'error') {
           <div
@@ -154,8 +144,13 @@ import { TauriService } from '../services/tauri.service';
 export class ShellComponent implements OnInit, OnDestroy {
   readonly projectState = inject(ProjectStateService);
   private cdr = inject(ChangeDetectorRef);
-  private tauri = inject(TauriService);
+  private router = inject(Router);
   private unsubscribe: (() => void) | null = null;
+
+  /** Whether the current route is /chat (auth overlay only blocks chat). */
+  get isChatRoute(): boolean {
+    return this.router.url === '/chat' || this.router.url.startsWith('/chat?');
+  }
 
   /** Human-readable status message for the blocking overlay. */
   get statusMessage(): string {
@@ -172,8 +167,6 @@ export class ShellComponent implements OnInit, OnDestroy {
         return 'Switching project...';
       case 'rebuilding':
         return 'Rebuilding container images...';
-      case 'auth_required':
-        return 'Claude authentication required';
       default:
         return '';
     }
@@ -195,25 +188,6 @@ export class ShellComponent implements OnInit, OnDestroy {
   /** Retries system check (prereqs + security). */
   retryCheck(): void {
     this.projectState.ensureContainersRunning();
-  }
-
-  /** Opens a native terminal for Claude OAuth login. */
-  async openAuthTerminal(): Promise<void> {
-    const project = this.projectState.activeProject;
-    if (project) {
-      try {
-        await this.tauri.invoke('open_auth_terminal', { project });
-      } catch (err) {
-        this.projectState.error = `Failed to open terminal: ${err}`;
-        this.cdr.markForCheck();
-      }
-    }
-  }
-
-  /** Re-checks auth status after user completes authentication. */
-  async checkAuth(): Promise<void> {
-    await this.projectState.retryAuth();
-    this.cdr.markForCheck();
   }
 
   /** Dismisses the error banner. */


### PR DESCRIPTION
## Summary

- **Auth gate before chat:** Backend pre-flight `check_claude_auth` in `start_chat`/`resume_conversation` prevents hang when Claude Code is not authenticated. Frontend `auth_required` status in `ProjectStateService` with overlay on `/chat` only — does not block Settings or other routes. Users are directed to Settings to configure API key or OAuth.
- **Setup screen regressions:** Fix setup wizard dead-end after v0.4.0 update, fix setup screen shown incorrectly after app update
- **OS prerequisite checks:** System checks (Lima VM health, disk space, etc.) run before container startup with blocking UI on failure
- **Container recovery:** Auto-recover from stale containers after macOS sleep/resume, adaptive memory with OOM detection
- **Shell detection:** Intelligent shell detection for CLI PATH configuration
- **E2E test fixes:** Repair broken selectors and macOS clean_state after Tailwind migration
- **CI/CD fixes:** Release-please fixes, backmerge automation, Windows CLI build, tag creation

## Test plan

- [x] `make test` — all Rust (672) + Angular (655) + MCP + entrypoint tests pass
- [x] `make check` — clippy + ESLint + type-check + format clean
- [x] All pre-push hooks pass