### PR TITLE
docs(containers): rewrite container CLAUDE.md with MCP Hub meta-tool guidance

### DIFF
--- a/containers/claude-resources/CLAUDE.md
+++ b/containers/claude-resources/CLAUDE.md
@@ -37,3 +37,4 @@ Service globals are injected automatically based on enabled integrations (no imp
   - Merging or closing merge requests
   - Writing to or deleting SharePoint documents
 - NEVER write to or delete files outside `/workspace` and `$HOME` without explicit user confirmation
+- Always confirm before any other destructive operation on user data


### PR DESCRIPTION
## Summary

- Rewrite `containers/claude-resources/CLAUDE.md` to teach Claude about MCP Hub meta-tools (`search_tools`, `execute_code`) instead of listing hardcoded services
- Replace static service list with dynamic discovery workflow — Claude discovers available integrations and plugins at runtime
- Add Speednet attribution

## Motivation

The previous CLAUDE.md listed specific services (Slack, SharePoint, etc.) without explaining how to actually use them through the Hub's meta-tools. Claude in the container had no guidance on the `search_tools` → `full_schema` → `execute_code` workflow, and didn't know about the plugin system or that services are user-configurable.

## Test plan

- [x] `make test-entrypoint` passes
- [x] Pre-push hooks pass (full test suite)