### PR TITLE
feat(desktop): auth UX improvements and v0.4.2 release

### DIFF
--- a/desktop/src/src/app/app.routes.ts
+++ b/desktop/src/src/app/app.routes.ts
@@ -1,6 +1,7 @@
 import { Routes } from '@angular/router';
 import { setupCompleteGuard } from './guards/setup-complete.guard';
 import { setupNotCompleteGuard } from './guards/setup-not-complete.guard';
+import { authRequiredGuard } from './guards/auth-required.guard';
 
 export const routes: Routes = [
   {
@@ -17,6 +18,7 @@ export const routes: Routes = [
       { path: '', redirectTo: 'chat', pathMatch: 'full' },
       {
         path: 'chat',
+        canActivate: [authRequiredGuard],
         loadComponent: () => import('./chat/chat.component').then((m) => m.ChatComponent),
       },
       {

--- a/desktop/src/src/app/chat/chat.component.spec.ts
+++ b/desktop/src/src/app/chat/chat.component.spec.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { RouterModule } from '@angular/router';
 import { ChatComponent } from './chat.component';
 import { TauriService } from '../services/tauri.service';
 import { ChatStateService } from '../services/chat-state.service';
@@ -42,7 +44,7 @@ describe('ChatComponent', () => {
     };
 
     await TestBed.configureTestingModule({
-      imports: [ChatComponent],
+      imports: [ChatComponent, RouterModule.forRoot([])],
       providers: [{ provide: TauriService, useValue: mockTauri }],
     }).compileComponents();
 
@@ -449,7 +451,8 @@ describe('ChatComponent', () => {
       );
     });
 
-    it('routes auth error in resumeConversation to auth_required', async () => {
+    it('routes auth error in resumeConversation to retryAuth', async () => {
+      const retrySpy = vi.spyOn(projectState, 'retryAuth').mockResolvedValue();
       const mockTranscript = {
         session_id: 's1',
         messages: [{ role: 'user', content: 'Hi', timestamp: '2026-03-06T10:00:00Z' }],
@@ -464,7 +467,8 @@ describe('ChatComponent', () => {
       };
 
       await component.resumeConversation('s1');
-      expect(projectState.status).toBe('auth_required');
+      expect(retrySpy).toHaveBeenCalled();
+      retrySpy.mockRestore();
     });
 
     it('clears transcript and history state after resuming', async () => {
@@ -812,6 +816,26 @@ describe('ChatComponent', () => {
       expect(component2.chat.messages).toHaveLength(1);
       expect(component2.chat.messages[0].blocks[0]).toEqual({ type: 'text', content: 'persisted' });
       fixture2.destroy();
+    });
+  });
+
+  // ── Auth-expired redirect ───────────────────────────────────────────────
+
+  describe('auth-expired redirect', () => {
+    it('navigates to /settings when projectState becomes auth_required', async () => {
+      const router = TestBed.inject(Router);
+      const navigateSpy = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+
+      projectState.status = 'ready';
+      await component.ngOnInit();
+      fixture.detectChanges();
+
+      // Simulate auth expiry via notifyChange
+      projectState.status = 'auth_required';
+      projectState['notifyChange']();
+
+      expect(navigateSpy).toHaveBeenCalledWith(['/settings']);
+      navigateSpy.mockRestore();
     });
   });
 });

--- a/desktop/src/src/app/chat/chat.component.ts
+++ b/desktop/src/src/app/chat/chat.component.ts
@@ -11,6 +11,7 @@ import {
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
 import { marked } from 'marked';
 import { TauriService } from '../services/tauri.service';
 import { ChatStateService } from '../services/chat-state.service';
@@ -45,8 +46,10 @@ export class ChatComponent implements OnInit, OnDestroy {
   readonly projectState = inject(ProjectStateService);
   private cdr = inject(ChangeDetectorRef);
   private tauri = inject(TauriService);
+  private router = inject(Router);
   private unsubChange: (() => void) | null = null;
   private unsubProjectReady: (() => void) | null = null;
+  private unsubAuthWatch: (() => void) | null = null;
 
   /** Subscribes to state changes from the service. */
   constructor() {
@@ -61,6 +64,12 @@ export class ChatComponent implements OnInit, OnDestroy {
     await this.chat.init();
     this.cdr.markForCheck();
     this.scrollToBottom();
+
+    this.unsubAuthWatch = this.projectState.onChange(() => {
+      if (this.projectState.status === 'auth_required') {
+        this.router.navigate(['/settings']);
+      }
+    });
 
     this.unsubProjectReady = this.projectState.onProjectReady(async () => {
       this.viewingTranscript = null;
@@ -193,7 +202,7 @@ export class ChatComponent implements OnInit, OnDestroy {
     } catch (err) {
       const msg = String(err);
       if (msg.includes('not authenticated')) {
-        this.projectState.status = 'auth_required';
+        await this.projectState.retryAuth();
       } else {
         this.chat.loadMessages([
           ...messages,
@@ -293,6 +302,10 @@ export class ChatComponent implements OnInit, OnDestroy {
     if (this.unsubProjectReady) {
       this.unsubProjectReady();
       this.unsubProjectReady = null;
+    }
+    if (this.unsubAuthWatch) {
+      this.unsubAuthWatch();
+      this.unsubAuthWatch = null;
     }
   }
 }

--- a/desktop/src/src/app/guards/auth-required.guard.spec.ts
+++ b/desktop/src/src/app/guards/auth-required.guard.spec.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { Router, UrlTree } from '@angular/router';
+import { RouterModule } from '@angular/router';
+import { authRequiredGuard } from './auth-required.guard';
+import { ProjectStateService } from '../services/project-state.service';
+import { TauriService } from '../services/tauri.service';
+import { MockTauriService } from '../testing/mock-tauri.service';
+
+describe('authRequiredGuard', () => {
+  let router: Router;
+  let projectState: ProjectStateService;
+
+  beforeEach(async () => {
+    const mockTauri = new MockTauriService();
+
+    await TestBed.configureTestingModule({
+      imports: [RouterModule.forRoot([])],
+      providers: [{ provide: TauriService, useValue: mockTauri }],
+    }).compileComponents();
+
+    router = TestBed.inject(Router);
+    projectState = TestBed.inject(ProjectStateService);
+  });
+
+  it('should allow access when status is ready', () => {
+    projectState.status = 'ready';
+    const result = TestBed.runInInjectionContext(() => authRequiredGuard({} as never, {} as never));
+    expect(result).toBe(true);
+  });
+
+  it('should redirect to /settings when status is auth_required', () => {
+    projectState.status = 'auth_required';
+    const result = TestBed.runInInjectionContext(() => authRequiredGuard({} as never, {} as never));
+    expect(result).toBeInstanceOf(UrlTree);
+    expect(router.serializeUrl(result as UrlTree)).toBe('/settings');
+  });
+
+  it('should allow access (fail-open) during transient states', () => {
+    projectState.status = 'loading';
+    const result = TestBed.runInInjectionContext(() => authRequiredGuard({} as never, {} as never));
+    expect(result).toBe(true);
+  });
+});

--- a/desktop/src/src/app/guards/auth-required.guard.ts
+++ b/desktop/src/src/app/guards/auth-required.guard.ts
@@ -1,0 +1,11 @@
+import { CanActivateFn } from '@angular/router';
+import { inject } from '@angular/core';
+import { Router } from '@angular/router';
+import { ProjectStateService } from '../services/project-state.service';
+
+/** Redirects to /settings if Claude authentication has not been completed. */
+export const authRequiredGuard: CanActivateFn = () => {
+  const router = inject(Router);
+  const projectState = inject(ProjectStateService);
+  return projectState.status === 'auth_required' ? router.createUrlTree(['/settings']) : true;
+};

--- a/desktop/src/src/app/services/project-state.service.spec.ts
+++ b/desktop/src/src/app/services/project-state.service.spec.ts
@@ -644,6 +644,43 @@ describe('ProjectStateService', () => {
       expect(service.status).toBe('auth_required');
     });
 
+    it('retryAuth sets auth_required when no auth configured', async () => {
+      mockTauri.invokeHandler = async (cmd: string) => {
+        switch (cmd) {
+          case 'get_auth_status':
+            return { api_key_configured: false, oauth_authenticated: false };
+          default:
+            return undefined;
+        }
+      };
+      service.activeProject = 'test';
+      service.status = 'ready';
+
+      await service.retryAuth();
+      expect(service.status).toBe('auth_required');
+    });
+
+    it('applyAuthStatus sets ready when auth is valid', () => {
+      service.status = 'auth_required';
+      service.applyAuthStatus({ api_key_configured: true, oauth_authenticated: false });
+      expect(service.status).toBe('ready');
+    });
+
+    it('applyAuthStatus sets auth_required when no auth', () => {
+      service.status = 'ready';
+      service.applyAuthStatus({ api_key_configured: false, oauth_authenticated: false });
+      expect(service.status).toBe('auth_required');
+    });
+
+    it('applyAuthStatus does not downgrade ready to ready', () => {
+      service.status = 'ready';
+      const cb = vi.fn();
+      service.onChange(cb);
+      service.applyAuthStatus({ api_key_configured: true, oauth_authenticated: false });
+      expect(service.status).toBe('ready');
+      expect(cb).not.toHaveBeenCalled();
+    });
+
     it('does not fire onProjectReady for auth_required', async () => {
       mockTauri.invokeHandler = async (cmd: string) => {
         switch (cmd) {

--- a/desktop/src/src/app/services/project-state.service.ts
+++ b/desktop/src/src/app/services/project-state.service.ts
@@ -15,7 +15,8 @@ export type ProjectStatus =
   | 'switching'
   | 'error';
 
-interface AuthStatusResponse {
+/** Backend response from the `get_auth_status` Tauri command. */
+export interface AuthStatusResponse {
   api_key_configured: boolean;
   oauth_authenticated: boolean;
 }
@@ -195,9 +196,31 @@ export class ProjectStateService {
         this.notifyChange();
         this.notifyReady();
         this.notifySettled();
+      } else {
+        this.status = 'auth_required';
+        this.notifyChange();
       }
     } catch {
-      // Auth check failed — stay in auth_required
+      this.status = 'auth_required';
+      this.notifyChange();
+    }
+  }
+
+  /**
+   * Applies a pre-fetched auth status without an extra Tauri round-trip.
+   * @param auth - The auth status response from the backend.
+   */
+  applyAuthStatus(auth: AuthStatusResponse): void {
+    if (auth.api_key_configured || auth.oauth_authenticated) {
+      if (this.status === 'auth_required') {
+        this.status = 'ready';
+        this.notifyChange();
+        this.notifyReady();
+        this.notifySettled();
+      }
+    } else {
+      this.status = 'auth_required';
+      this.notifyChange();
     }
   }
 
@@ -219,7 +242,6 @@ export class ProjectStateService {
     }
     this.notifyChange();
   }
-
   /**
    * The ONLY way to switch projects from the frontend.
    * @param name - The project name to switch to.

--- a/desktop/src/src/app/settings/auth-section/auth-section.component.spec.ts
+++ b/desktop/src/src/app/settings/auth-section/auth-section.component.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AuthSectionComponent } from './auth-section.component';
 import { TauriService } from '../../services/tauri.service';
+import { ProjectStateService } from '../../services/project-state.service';
 import { MockTauriService } from '../../testing/mock-tauri.service';
 
 function setupMockTauri(mockTauri: MockTauriService): void {
@@ -106,6 +107,43 @@ describe('AuthSectionComponent', () => {
     component.activeProject = 'test-project';
     await component.loadAuthStatus();
     expect(component.oauthAuthenticated).toBe(true);
+  });
+
+  it('calls applyAuthStatus when loadAuthStatus detects no auth', async () => {
+    const projectState = TestBed.inject(ProjectStateService);
+    const applySpy = vi.spyOn(projectState, 'applyAuthStatus');
+
+    mockTauri.invokeHandler = async (cmd: string) => {
+      if (cmd === 'get_auth_status')
+        return { api_key_configured: false, oauth_authenticated: false };
+      return undefined;
+    };
+
+    component.activeProject = 'test';
+    await component.loadAuthStatus();
+
+    expect(applySpy).toHaveBeenCalledWith({
+      api_key_configured: false,
+      oauth_authenticated: false,
+    });
+    applySpy.mockRestore();
+  });
+
+  it('calls applyAuthStatus when loadAuthStatus finds valid auth', async () => {
+    const projectState = TestBed.inject(ProjectStateService);
+    const applySpy = vi.spyOn(projectState, 'applyAuthStatus');
+
+    mockTauri.invokeHandler = async (cmd: string) => {
+      if (cmd === 'get_auth_status')
+        return { api_key_configured: true, oauth_authenticated: false };
+      return undefined;
+    };
+
+    component.activeProject = 'test';
+    await component.loadAuthStatus();
+
+    expect(applySpy).toHaveBeenCalledWith({ api_key_configured: true, oauth_authenticated: false });
+    applySpy.mockRestore();
   });
 
   it('does not load auth status when activeProject is null', async () => {
@@ -266,5 +304,62 @@ describe('AuthSectionComponent', () => {
     fixture.detectChanges();
     const valueEl = fixture.nativeElement.querySelector('[data-testid="auth-status-value"]');
     expect(valueEl?.textContent?.trim()).toContain('Not authenticated');
+  });
+
+  it('calls applyAuthStatus after saving API key', async () => {
+    const projectState = TestBed.inject(ProjectStateService);
+    const applySpy = vi.spyOn(projectState, 'applyAuthStatus');
+
+    mockTauri.invokeHandler = async (cmd: string) => {
+      if (cmd === 'save_api_key') return undefined;
+      if (cmd === 'get_auth_status')
+        return { api_key_configured: true, oauth_authenticated: false };
+      return undefined;
+    };
+
+    component.activeProject = 'test';
+    component.apiKeyInput = 'sk-ant-test';
+    await component.saveApiKey();
+
+    expect(applySpy).toHaveBeenCalledWith({ api_key_configured: true, oauth_authenticated: false });
+    applySpy.mockRestore();
+  });
+
+  it('calls applyAuthStatus after deleting API key', async () => {
+    const projectState = TestBed.inject(ProjectStateService);
+    const applySpy = vi.spyOn(projectState, 'applyAuthStatus');
+
+    mockTauri.invokeHandler = async (cmd: string) => {
+      if (cmd === 'delete_api_key') return undefined;
+      if (cmd === 'get_auth_status')
+        return { api_key_configured: false, oauth_authenticated: false };
+      return undefined;
+    };
+
+    component.activeProject = 'test';
+    await component.deleteApiKey();
+
+    expect(applySpy).toHaveBeenCalledWith({
+      api_key_configured: false,
+      oauth_authenticated: false,
+    });
+    applySpy.mockRestore();
+  });
+
+  it('calls applyAuthStatus after OAuth done', async () => {
+    const projectState = TestBed.inject(ProjectStateService);
+    const applySpy = vi.spyOn(projectState, 'applyAuthStatus');
+
+    mockTauri.invokeHandler = async (cmd: string) => {
+      if (cmd === 'get_auth_status')
+        return { api_key_configured: false, oauth_authenticated: true };
+      return undefined;
+    };
+
+    component.activeProject = 'test';
+    await component.onOAuthDone(true);
+
+    expect(applySpy).toHaveBeenCalledWith({ api_key_configured: false, oauth_authenticated: true });
+    applySpy.mockRestore();
   });
 });

--- a/desktop/src/src/app/settings/auth-section/auth-section.component.ts
+++ b/desktop/src/src/app/settings/auth-section/auth-section.component.ts
@@ -12,12 +12,8 @@ import {
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { TauriService } from '../../services/tauri.service';
+import { ProjectStateService, AuthStatusResponse } from '../../services/project-state.service';
 import { AuthTerminalComponent } from '../auth-terminal.component';
-
-interface AuthStatusResponse {
-  api_key_configured: boolean;
-  oauth_authenticated: boolean;
-}
 
 /** Displays authentication status and controls for API key / OAuth login. */
 @Component({
@@ -142,6 +138,7 @@ export class AuthSectionComponent implements OnChanges {
 
   private cdr = inject(ChangeDetectorRef);
   private tauri = inject(TauriService);
+  private projectState = inject(ProjectStateService);
 
   /**
    * Reloads auth status when the active project changes.
@@ -162,6 +159,7 @@ export class AuthSectionComponent implements OnChanges {
       });
       this.apiKeyConfigured = status.api_key_configured;
       this.oauthAuthenticated = status.oauth_authenticated;
+      this.projectState.applyAuthStatus(status);
     } catch {
       // Auth status check failed -- container may not be running
     }

--- a/desktop/src/src/app/shell/shell.component.spec.ts
+++ b/desktop/src/src/app/shell/shell.component.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Router, RouterModule } from '@angular/router';
+import { RouterModule } from '@angular/router';
 import { ShellComponent } from './shell.component';
 import { TauriService } from '../services/tauri.service';
 import { ProjectStateService } from '../services/project-state.service';
@@ -47,20 +47,6 @@ describe('ShellComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should render nav with Chat, Integrations, Plugins, Settings', () => {
-    const nav = fixture.nativeElement.querySelector('[data-testid="app-nav"]');
-    const links = Array.from(nav.querySelectorAll('a')) as HTMLAnchorElement[];
-    const labels = links.map((a) => a.textContent?.trim());
-    expect(labels).toEqual(['Chat', 'Integrations', 'Plugins', 'Settings']);
-  });
-
-  it('should NOT render a Setup link', () => {
-    const nav = fixture.nativeElement.querySelector('[data-testid="app-nav"]');
-    const links = Array.from(nav.querySelectorAll('a')) as HTMLAnchorElement[];
-    const labels = links.map((a) => a.textContent?.trim());
-    expect(labels).not.toContain('Setup');
-  });
-
   it('should render update-notification', () => {
     const el = fixture.nativeElement.querySelector('app-update-notification');
     expect(el).toBeTruthy();
@@ -96,7 +82,6 @@ describe('ShellComponent', () => {
   it('shows rebuilding overlay when reconcile in progress', async () => {
     await component.ngOnInit();
     await fixture.whenStable();
-    // Force rebuilding status
     projectState.status = 'rebuilding';
     component['cdr'].markForCheck();
     fixture.detectChanges();
@@ -225,39 +210,52 @@ describe('ShellComponent', () => {
     expect(overlay.textContent).toContain('Running system checks...');
   });
 
-  it('shows auth-required overlay only on /chat', async () => {
-    const router = TestBed.inject(Router);
-    await router.navigateByUrl('/chat');
+  it('does not show blocking overlay when auth_required', async () => {
+    await component.ngOnInit();
     projectState.status = 'auth_required';
     component['cdr'].markForCheck();
     fixture.detectChanges();
 
-    const overlay = fixture.nativeElement.querySelector('[data-testid="blocking-auth-required"]');
-    expect(overlay).not.toBeNull();
-    expect(overlay.textContent).toContain('Authentication Required');
-  });
-
-  it('auth-required overlay has only Go to Settings link', async () => {
-    const router = TestBed.inject(Router);
-    await router.navigateByUrl('/chat');
-    projectState.status = 'auth_required';
-    component['cdr'].markForCheck();
-    fixture.detectChanges();
-
-    expect(fixture.nativeElement.querySelector('[data-testid="auth-settings-btn"]')).not.toBeNull();
-    expect(fixture.nativeElement.querySelector('[data-testid="auth-authenticate-btn"]')).toBeNull();
-    expect(fixture.nativeElement.querySelector('[data-testid="auth-check-btn"]')).toBeNull();
-  });
-
-  it('does not show auth-required overlay on /settings', async () => {
-    const router = TestBed.inject(Router);
-    await router.navigateByUrl('/settings');
-    projectState.status = 'auth_required';
-    component['cdr'].markForCheck();
-    fixture.detectChanges();
-
+    expect(fixture.nativeElement.querySelector('[data-testid="blocking-overlay"]')).toBeNull();
     expect(
       fixture.nativeElement.querySelector('[data-testid="blocking-auth-required"]')
     ).toBeNull();
+  });
+
+  it('hides Chat nav link when status is auth_required', async () => {
+    await component.ngOnInit();
+    projectState.status = 'auth_required';
+    component['cdr'].markForCheck();
+    fixture.detectChanges();
+
+    const nav = fixture.nativeElement.querySelector('[data-testid="app-nav"]');
+    const links = Array.from(nav.querySelectorAll('a')) as HTMLAnchorElement[];
+    const labels = links.map((a) => a.textContent?.trim());
+    expect(labels).toEqual(['Integrations', 'Plugins', 'Settings']);
+    expect(labels).not.toContain('Chat');
+  });
+
+  it('shows Chat nav link when status is ready', async () => {
+    await component.ngOnInit();
+    await fixture.whenStable();
+    projectState.status = 'ready';
+    component['cdr'].markForCheck();
+    fixture.detectChanges();
+
+    const nav = fixture.nativeElement.querySelector('[data-testid="app-nav"]');
+    const links = Array.from(nav.querySelectorAll('a')) as HTMLAnchorElement[];
+    const labels = links.map((a) => a.textContent?.trim());
+    expect(labels).toEqual(['Chat', 'Integrations', 'Plugins', 'Settings']);
+  });
+
+  it('shows Chat nav link when status is error', async () => {
+    await component.ngOnInit();
+    await fixture.whenStable();
+    projectState.status = 'error';
+    projectState.error = 'something failed';
+    component['cdr'].markForCheck();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[data-testid="nav-chat"]')).not.toBeNull();
   });
 });

--- a/desktop/src/src/app/shell/shell.component.ts
+++ b/desktop/src/src/app/shell/shell.component.ts
@@ -6,7 +6,7 @@ import {
   OnDestroy,
   OnInit,
 } from '@angular/core';
-import { Router, RouterOutlet, RouterLink, RouterLinkActive } from '@angular/router';
+import { RouterOutlet, RouterLink, RouterLinkActive } from '@angular/router';
 import { ProjectSwitcherComponent } from '../project-switcher/project-switcher.component';
 import { UpdateNotificationComponent } from '../update-notification/update-notification.component';
 import { ProjectStateService } from '../services/project-state.service';
@@ -25,7 +25,7 @@ import { ProjectStateService } from '../services/project-state.service';
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="flex flex-col h-screen bg-sw-bg-darkest text-sw-text">
-      @if (projectState.status !== 'ready') {
+      @if (projectState.status !== 'ready' && projectState.status !== 'auth_required') {
         @if (projectState.status === 'check_failed') {
           <div
             class="fixed inset-0 z-[9999] flex flex-col items-center justify-center bg-sw-bg-darkest"
@@ -44,24 +44,6 @@ import { ProjectStateService } from '../services/project-state.service';
             >
               Retry
             </button>
-          </div>
-        } @else if (projectState.status === 'auth_required' && isChatRoute) {
-          <div
-            class="fixed inset-0 z-[9999] flex flex-col items-center justify-center bg-sw-bg-darkest"
-            data-testid="blocking-auth-required"
-          >
-            <span class="text-sw-accent text-lg font-mono font-bold">Authentication Required</span>
-            <p class="mt-4 max-w-lg text-center font-mono text-sm text-sw-text-muted">
-              Claude Code needs to be authenticated before you can start a conversation. Go to
-              Settings to configure your API key or log in via OAuth.
-            </p>
-            <a
-              routerLink="/settings"
-              class="mt-6 px-6 py-2.5 rounded text-sm font-semibold font-mono border-none cursor-pointer transition-colors bg-sw-accent text-white hover:bg-sw-accent-hover no-underline"
-              data-testid="auth-settings-btn"
-            >
-              Go to Settings
-            </a>
           </div>
         } @else if (projectState.status === 'error') {
           <div
@@ -104,13 +86,15 @@ import { ProjectStateService } from '../services/project-state.service';
           >Speedwave</span
         >
         <nav class="flex gap-4" data-testid="app-nav">
-          <a
-            routerLink="/chat"
-            routerLinkActive="!text-sw-accent font-bold"
-            class="text-sw-text-muted no-underline text-[13px] font-mono px-2 py-1 rounded transition-colors duration-200 hover:text-sw-text"
-            data-testid="nav-chat"
-            >Chat</a
-          >
+          @if (projectState.status === 'ready' || projectState.status === 'error') {
+            <a
+              routerLink="/chat"
+              routerLinkActive="!text-sw-accent font-bold"
+              class="text-sw-text-muted no-underline text-[13px] font-mono px-2 py-1 rounded transition-colors duration-200 hover:text-sw-text"
+              data-testid="nav-chat"
+              >Chat</a
+            >
+          }
           <a
             routerLink="/integrations"
             routerLinkActive="!text-sw-accent font-bold"
@@ -144,13 +128,7 @@ import { ProjectStateService } from '../services/project-state.service';
 export class ShellComponent implements OnInit, OnDestroy {
   readonly projectState = inject(ProjectStateService);
   private cdr = inject(ChangeDetectorRef);
-  private router = inject(Router);
   private unsubscribe: (() => void) | null = null;
-
-  /** Whether the current route is /chat (auth overlay only blocks chat). */
-  get isChatRoute(): boolean {
-    return this.router.url === '/chat' || this.router.url.startsWith('/chat?');
-  }
 
   /** Human-readable status message for the blocking overlay. */
   get statusMessage(): string {


### PR DESCRIPTION
## Summary

- Replace fullscreen auth overlay with conditional Chat nav link and route guard
- Fix auth state propagation when API key is removed or auth expires outside UI
- Add `applyAuthStatus()` for efficient pre-fetched auth state updates
- Export `AuthStatusResponse` as shared type (DRY)

## Test plan

- [x] `make test` — 667 Angular + 672 Rust tests pass
- [x] `make check` — clippy + lint + format pass
- [ ] E2E tests on Linux, Windows, macOS (in progress)