### PR TITLE
fix(ci): add release-please.yml to VERSION_EXCLUDES in backmerge

### DIFF
--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -64,6 +64,7 @@ jobs:
           VERSION_EXCLUDES=(
             ':!.release-please-manifest.json'
             ':!release-please-config.json'
+            ':!.github/workflows/release-please.yml'
             ':!CHANGELOG.md'
             ':!package.json' ':!package-lock.json'
             ':!desktop/src/package.json' ':!desktop/src/package-lock.json'


### PR DESCRIPTION
## Summary

Aligns `VERSION_EXCLUDES` with `AUTO_RESOLVE_FILES` in `backmerge.yml`. Without this, changes to `release-please.yml` during a release would trigger the fallback merge path instead of the force-push path.

Follow-up to #307 — this one-line fix was identified by code review but didn't make it before merge.

## Test plan

- [ ] CI passes