### PR TITLE
docs(docs): enforce edge case test coverage in Claude Code rules

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -16,6 +16,17 @@ Git hooks exist to catch problems early. If a hook fails, **fix the underlying i
 
 **Every piece of code must be covered by tests.** All functions, methods, branches, and error paths must have corresponding test cases. When writing or modifying code, always write or update tests in the same commit. Never leave code untested — if it's worth writing, it's worth testing.
 
+### Required test coverage categories
+
+Every new or modified function must have tests covering **all four categories** where applicable:
+
+1. **Happy path** — expected inputs produce expected outputs. The basic "it works" case.
+2. **Edge cases** — boundary values, empty inputs, `null`/`undefined`/`None`, zero-length collections, maximum values, single-element collections, off-by-one boundaries, Unicode/special characters in strings.
+3. **Error paths** — invalid inputs, malformed data, network failures, permission errors, timeouts, missing files, disk full, concurrent access violations. Verify that errors are reported correctly (right error type, message, status code) — not just that "it doesn't crash."
+4. **State transitions** — when the function mutates state, test the before/after invariants. For concurrent code, test race conditions and ordering guarantees where applicable.
+
+If a category does not apply (e.g., a pure function has no state transitions), skip it — but document **why** in a brief test comment if it's not obvious.
+
 **NEVER skip tests to work around failures.**
 
 - Do not use `.skip`, `xit`, `xdescribe`, or rename files to `.skip`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,7 @@ All plugins are toggled per-project via `integrations.plugins.<key>.enabled`, wh
 - **NEVER leave @deprecated comments** — rewrite the code
 - **NEVER use `#[allow(dead_code)]`** — dead code must be removed, not silenced. If a field/method is only used in tests, gate it behind `#[cfg(test)]`. If a struct field is required by serde but not read, prefix it with `_` and add `#[serde(rename = "original_name")]`.
 - **NEVER use `#[allow(...)]` to suppress lint warnings** — fix the underlying issue instead. No `#[allow(missing_docs)]`, no `#[allow(clippy::unwrap_used)]`, no blanket `#![allow(...)]` at crate level. The only exception is `#[allow(clippy::unwrap_used, clippy::expect_used)]` on `#[cfg(test)] mod tests` blocks, where panicking on test failure is intentional.
-- **Every code change must include tests** in the same commit
+- **Every code change must include tests** in the same commit — covering happy paths, edge cases, error paths, and state transitions (see `.claude/rules/git-workflow.md` for details)
 - **SharePoint `:rw` token mount** — only exception to the `:ro` token mount rule (OAuth refresh, ADR-009). All MCP workers also mount `/workspace:rw` for file access
 - **Linux rootless:** container runs as UID 0 in user namespace (ADR-026)
 - **Documentation is a delivery requirement** — same as tests. New feature -> update guide. Decision -> write ADR.


### PR DESCRIPTION
## Summary
- Expand test rules in `.claude/rules/git-workflow.md` with four required coverage categories: happy path, edge cases, error paths, and state transitions
- Reinforce the test requirement in `CLAUDE.md` "Key Gotchas" section with a cross-reference to the detailed rules

Closes #283

## Test plan
- [x] Documentation-only change — no code tests required
- [ ] Verify rules render correctly in GitHub markdown