### PR TITLE
feat(security): add speedwave-review-deps skill for Dependabot PR audit

### DIFF
--- a/.claude/skills/speedwave-review-deps/SKILL.md
+++ b/.claude/skills/speedwave-review-deps/SKILL.md
@@ -94,10 +94,16 @@ Before using CLI tools, check availability with `which npm` / `which cargo`. If 
 2. **SHA-to-tag verification (CRITICAL)** — Dependabot pins actions by SHA (e.g., `actions/checkout@abc1234`). Verify that the new SHA corresponds to a signed, tagged release — a SHA that doesn't match any release tag is a **HIGH-SEVERITY red flag** (could be a malicious commit pushed directly). Use:
 
    ```bash
-   gh api repos/<owner>/<action>/git/matching-refs/tags --jq '.[].object.sha'
+   gh api repos/<owner>/<action>/git/matching-refs/tags --jq '.[].object'
    ```
 
-   Cross-reference the new SHA from the PR diff against the tag SHAs. Also verify the tag points to the expected version via `gh api repos/<owner>/<action>/releases`.
+   For each tag ref: if `object.type` is `"tag"` (annotated tag), dereference to the commit SHA:
+
+   ```bash
+   gh api repos/<owner>/<action>/git/tags/<object.sha> --jq '.object.sha'
+   ```
+
+   If `object.type` is `"commit"` (lightweight tag), use the SHA directly. Cross-reference the dereferenced commit SHAs against the new SHA from the PR diff. Also verify the tag points to the expected version via `gh api repos/<owner>/<action>/releases`.
 
 3. **Release/tag inspection** — fetch the release notes for the new version tag. Check what changed.
 4. **Security advisories** — `WebSearch` for any known security incidents involving the action (e.g., compromised action, credential theft).

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -15,7 +15,8 @@ on:
       - "mcp-servers/package-lock.json"
       - "mcp-servers/shared/**"
       - "mcp-servers/os/**"
-      - "scripts/bundle-build-context*"
+      - "scripts/bundle-build-context.sh"
+      - "scripts/bundle-build-context.ps1"
   push:
     branches: [main, dev]
     paths:
@@ -30,7 +31,8 @@ on:
       - "mcp-servers/package-lock.json"
       - "mcp-servers/shared/**"
       - "mcp-servers/os/**"
-      - "scripts/bundle-build-context*"
+      - "scripts/bundle-build-context.sh"
+      - "scripts/bundle-build-context.ps1"
 
 permissions:
   contents: read

--- a/_tests/desktop/bundle-build-context.bats
+++ b/_tests/desktop/bundle-build-context.bats
@@ -2,6 +2,9 @@
 # Tests for scripts/bundle-build-context.sh
 # Verifies that the script creates the expected directory structure.
 #
+# Note: bundle-build-context.ps1 (Windows equivalent) receives identical
+# changes but is only exercised inside Windows E2E VMs (scripts/e2e-vm.sh).
+#
 # Prerequisite: `make build-mcp` must be run first so that mcp-servers/os/dist/
 # and mcp-servers/shared/dist/ exist for dev-mode copying.
 
@@ -161,7 +164,7 @@ teardown() {
 @test "mcp-os/shared standalone lockfile resolves without workspace context" {
     run "$SCRIPT"
     [ "$status" -eq 0 ]
-    # Verify npm install produced a standalone lockfile
+    # Verify the two-step install produced a standalone lockfile
     [ -f "$DEST/mcp-os/shared/package-lock.json" ]
     # Verify the lockfile can be consumed standalone (npm ci in clean dir succeeds)
     local tmpdir
@@ -170,7 +173,8 @@ teardown() {
     cp "$DEST/mcp-os/shared/package.json" "$tmpdir/"
     cp "$DEST/mcp-os/shared/package-lock.json" "$tmpdir/"
     (cd "$tmpdir" && npm ci --omit=dev --ignore-scripts)
-    [ -d "$tmpdir/node_modules/express" ]
+    # At least one production dependency must be installed
+    [ "$(ls "$tmpdir/node_modules" | wc -l)" -gt 0 ]
 }
 
 @test "bundle script --ci works without pre-built dist directories" {

--- a/scripts/bundle-build-context.ps1
+++ b/scripts/bundle-build-context.ps1
@@ -45,12 +45,14 @@ foreach ($svc in $services) {
 New-Item -ItemType Directory -Path "$dest\mcp-os\os","$dest\mcp-os\shared" -Force | Out-Null
 Copy-Item -Recurse mcp-servers\os\dist "$dest\mcp-os\os\dist"
 Copy-Item -Recurse mcp-servers\shared\dist "$dest\mcp-os\shared\dist"
-# Install production deps only. Uses npm install (not npm ci) because the
-# workspace-scoped package-lock.json has workspace-relative entries that
-# don't resolve in this isolated context.
+# Install production deps only. Cannot use the workspace-scoped
+# package-lock.json directly — it contains workspace-relative entries
+# that don't resolve in isolation. Two-step: generate standalone lockfile,
+# then install deterministically with npm ci.
 Copy-Item mcp-servers\shared\package.json "$dest\mcp-os\shared\"
 Push-Location "$dest\mcp-os\shared"
-npm install --omit=dev --ignore-scripts
+npm install --package-lock-only --ignore-scripts
+npm ci --omit=dev --ignore-scripts
 Pop-Location
 
 # Copy @speedwave/mcp-shared so Node.js resolves it from os/dist/index.js.

--- a/scripts/bundle-build-context.sh
+++ b/scripts/bundle-build-context.sh
@@ -54,12 +54,13 @@ mkdir -p "$DEST/mcp-os/os" "$DEST/mcp-os/shared"
 cp -r "$REPO_ROOT/mcp-servers/os/dist" "$DEST/mcp-os/os/"
 cp -r "$REPO_ROOT/mcp-servers/shared/dist" "$DEST/mcp-os/shared/"
 
-# Install production deps only. Uses npm install (not npm ci) because the
-# workspace-scoped package-lock.json has workspace-relative entries that
-# don't resolve in this isolated context. The generated standalone lockfile
-# is ephemeral — the destination is cleaned on every run (line 20).
+# Install production deps only. Cannot use the workspace-scoped
+# package-lock.json directly — it contains workspace-relative entries
+# (e.g. "shared/node_modules/vitest") that don't resolve in isolation.
+# Two-step approach: generate a standalone lockfile, then install from it
+# deterministically with npm ci.
 cp "$REPO_ROOT/mcp-servers/shared/package.json" "$DEST/mcp-os/shared/"
-(cd "$DEST/mcp-os/shared" && npm install --omit=dev --ignore-scripts)
+(cd "$DEST/mcp-os/shared" && npm install --package-lock-only --ignore-scripts && npm ci --omit=dev --ignore-scripts)
 
 # Copy @speedwave/mcp-shared so Node.js resolves it from os/dist/index.js.
 # Uses cp -r instead of ln -s because Tauri's resource bundler does not


### PR DESCRIPTION
## Summary

- Adds `/speedwave-review-deps` skill for critical security review of Dependabot dependency update PRs
- Supports all 4 Speedwave ecosystems: **npm**, **Cargo (Rust)**, **GitHub Actions**, **Docker**
- Launches parallel agents per package to verify supply chain integrity
- Includes explicit **publish method verification** (OIDC vs manual token) inspired by the [axios 1.14.1 supply chain attack](https://niebezpiecznik.pl/post/powazny-atak-programistow-popularna-biblioteka-axios-byla-zainfekowana/) (March 2026)

### What the skill checks per package

| Check | What it catches |
|---|---|
| Registry verification | Fake packages, tampered checksums |
| Publish method (CRITICAL) | Compromised maintainer token bypassing CI/CD (axios-style attack) |
| Maintainer continuity | Account takeover, ownership transfers |
| Security advisories | Known CVEs in old and new versions |
| Dependency delta | Injected malicious dependencies (e.g., `plain-crypto-js`) |
| Breaking changes | API/behavioral changes that could break Speedwave |
| Changelog analysis | Scope and risk of included changes |

### Usage

```
/speedwave-review-deps https://github.com/speednet-software/speedwave/pull/352
```

## Test plan

- [ ] Invoke `/speedwave-review-deps` on an npm PR (e.g., #352) and verify it produces full analysis + recommendation
- [ ] Invoke on a Cargo PR (e.g., #353) and verify Rust-specific checks run
- [ ] Invoke on a GitHub Actions PR (e.g., #350) and verify action-specific checks run