### PR TITLE
feat(mcp): add spec-compliant annotations to all worker tools

### DIFF
--- a/mcp-servers/gitlab/src/tools/artifact-tools.ts
+++ b/mcp-servers/gitlab/src/tools/artifact-tools.ts
@@ -16,6 +16,7 @@ const listArtifactsTool: Tool = {
   name: 'listArtifacts',
   description: 'List artifacts from a pipeline',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'artifacts', 'pipeline', 'ci', 'build'],
   example:
     'const artifacts = await gitlab.listArtifacts({ project_id: "speedwave/core", pipeline_id: 12345 })',
@@ -59,6 +60,7 @@ const downloadArtifactTool: Tool = {
   name: 'downloadArtifact',
   description: 'Download job artifacts',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'artifact', 'download', 'ci', 'build'],
   example:
     'const artifact = await gitlab.downloadArtifact({ project_id: "speedwave/core", job_id: 54321 })',
@@ -97,6 +99,7 @@ const deleteArtifactsTool: Tool = {
   name: 'deleteArtifacts',
   description: 'Delete job artifacts',
   category: 'delete',
+  annotations: { readOnlyHint: false, destructiveHint: true, openWorldHint: true },
   keywords: ['gitlab', 'artifacts', 'delete', 'remove', 'ci'],
   example: 'await gitlab.deleteArtifacts({ project_id: "speedwave/core", job_id: 54321 })',
   inputSchema: {

--- a/mcp-servers/gitlab/src/tools/branch-tools.ts
+++ b/mcp-servers/gitlab/src/tools/branch-tools.ts
@@ -16,6 +16,7 @@ const listBranchesTool: Tool = {
   name: 'listBranches',
   description: 'List branches in a project',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'branches', 'list', 'git', 'refs'],
   example: 'const branches = await gitlab.listBranches({ project_id: "speedwave/core" })',
   inputSchema: {
@@ -64,6 +65,7 @@ const getBranchTool: Tool = {
   name: 'getBranch',
   description: 'Get details of a specific branch',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'branch', 'get', 'show', 'git'],
   example:
     'const branch = await gitlab.getBranch({ project_id: "speedwave/core", branch: "main" })',
@@ -105,6 +107,7 @@ const createBranchTool: Tool = {
   name: 'createBranch',
   description: 'Create a new branch',
   category: 'write',
+  annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'branch', 'create', 'new', 'git'],
   example:
     'const branch = await gitlab.createBranch({ project_id: "speedwave/core", branch: "feature/new", ref: "main" })',
@@ -145,6 +148,7 @@ const deleteBranchTool: Tool = {
   name: 'deleteBranch',
   description: 'Delete a branch',
   category: 'delete',
+  annotations: { readOnlyHint: false, destructiveHint: true, openWorldHint: true },
   keywords: ['gitlab', 'branch', 'delete', 'remove', 'git'],
   example: 'await gitlab.deleteBranch({ project_id: "speedwave/core", branch: "feature/old" })',
   inputSchema: {
@@ -175,6 +179,7 @@ const compareBranchesTool: Tool = {
   name: 'compareBranches',
   description: 'Compare two branches',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'compare', 'diff', 'branches', 'git'],
   example:
     'const diff = await gitlab.compareBranches({ project_id: "speedwave/core", from: "main", to: "develop" })',

--- a/mcp-servers/gitlab/src/tools/commit-tools.ts
+++ b/mcp-servers/gitlab/src/tools/commit-tools.ts
@@ -16,6 +16,7 @@ const listBranchCommitsTool: Tool = {
   name: 'listBranchCommits',
   description: 'List commits on a specific branch',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'commits', 'branch', 'history', 'log', 'git'],
   example:
     'const commits = await gitlab.listBranchCommits({ project_id: "speedwave/core", branch: "main" })',
@@ -72,6 +73,7 @@ const listCommitsTool: Tool = {
   name: 'listCommits',
   description: 'List commits with filters',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'commits', 'history', 'log', 'git'],
   example:
     'const commits = await gitlab.listCommits({ project_id: "speedwave/core", ref: "main", limit: 10 })',
@@ -128,6 +130,7 @@ const searchCommitsTool: Tool = {
   name: 'searchCommits',
   description: 'Search commits by message',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'commits', 'search', 'find', 'git'],
   example:
     'const commits = await gitlab.searchCommits({ project_id: "speedwave/core", query: "fix bug" })',
@@ -173,6 +176,7 @@ const getCommitDiffTool: Tool = {
   name: 'getCommitDiff',
   description: 'Get diff of a specific commit',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'commit', 'diff', 'changes', 'files', 'git'],
   example:
     'const diff = await gitlab.getCommitDiff({ project_id: "speedwave/core", commit_sha: "abc123" })',

--- a/mcp-servers/gitlab/src/tools/discussion-tools.ts
+++ b/mcp-servers/gitlab/src/tools/discussion-tools.ts
@@ -16,6 +16,7 @@ const listMrDiscussionsTool: Tool = {
   name: 'listMrDiscussions',
   description: 'List discussion threads on a merge request',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'merge', 'request', 'discussions', 'threads'],
   example:
     'const discussions = await gitlab.listMrDiscussions({ project_id: "speedwave/core", mr_iid: 42 })',
@@ -58,6 +59,7 @@ const createMrDiscussionTool: Tool = {
   name: 'createMrDiscussion',
   description: 'Create a discussion thread on a merge request',
   category: 'write',
+  annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'merge', 'request', 'discussion', 'thread'],
   example:
     'await gitlab.createMrDiscussion({ project_id: "speedwave/core", mr_iid: 42, body: "What about error handling?" })',

--- a/mcp-servers/gitlab/src/tools/issue-tools.ts
+++ b/mcp-servers/gitlab/src/tools/issue-tools.ts
@@ -16,6 +16,7 @@ const listIssuesTool: Tool = {
   name: 'listIssues',
   description: 'List project issues',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'issues', 'list', 'bugs', 'tasks'],
   example:
     'const issues = await gitlab.listIssues({ project_id: "speedwave/core", state: "opened" })',
@@ -68,6 +69,7 @@ const getIssueTool: Tool = {
   name: 'getIssue',
   description: 'Get issue details',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'issue', 'get', 'show', 'details'],
   example: 'const issue = await gitlab.getIssue({ project_id: "speedwave/core", issue_iid: 42 })',
   inputSchema: {
@@ -111,6 +113,7 @@ const createIssueTool: Tool = {
   name: 'createIssue',
   description: 'Create a new issue',
   category: 'write',
+  annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'issue', 'create', 'new', 'bug'],
   example:
     'const issue = await gitlab.createIssue({ project_id: "speedwave/core", title: "Fix login bug", labels: "bug,urgent" })',
@@ -167,6 +170,7 @@ const updateIssueTool: Tool = {
   name: 'updateIssue',
   description: 'Update an issue',
   category: 'write',
+  annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'issue', 'update', 'edit', 'modify'],
   example:
     'await gitlab.updateIssue({ project_id: "speedwave/core", issue_iid: 42, title: "Updated title", state_event: "close" })',
@@ -223,6 +227,7 @@ const closeIssueTool: Tool = {
   name: 'closeIssue',
   description: 'Close an issue',
   category: 'write',
+  annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'issue', 'close', 'resolve', 'done'],
   example: 'await gitlab.closeIssue({ project_id: "speedwave/core", issue_iid: 42 })',
   inputSchema: {

--- a/mcp-servers/gitlab/src/tools/label-tools.ts
+++ b/mcp-servers/gitlab/src/tools/label-tools.ts
@@ -16,6 +16,7 @@ const listLabelsTool: Tool = {
   name: 'listLabels',
   description: 'List project labels',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'labels', 'list', 'tags'],
   example: 'const labels = await gitlab.listLabels({ project_id: "speedwave/core" })',
   inputSchema: {
@@ -59,6 +60,7 @@ const createLabelTool: Tool = {
   name: 'createLabel',
   description: 'Create a project label',
   category: 'write',
+  annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'label', 'create', 'new', 'tag'],
   example:
     'const label = await gitlab.createLabel({ project_id: "speedwave/core", name: "urgent", color: "#FF0000" })',

--- a/mcp-servers/gitlab/src/tools/metadata.test.ts
+++ b/mcp-servers/gitlab/src/tools/metadata.test.ts
@@ -27,6 +27,12 @@ describe('GitLab tool metadata', () => {
       expect(['read', 'write', 'delete']).toContain(tool.category);
     });
 
+    it('has annotations with readOnlyHint and destructiveHint', () => {
+      expect(tool.annotations).toBeDefined();
+      expect(typeof tool.annotations!.readOnlyHint).toBe('boolean');
+      expect(typeof tool.annotations!.destructiveHint).toBe('boolean');
+    });
+
     it('has non-empty keywords array', () => {
       expect(tool.keywords).toBeDefined();
       expect(Array.isArray(tool.keywords)).toBe(true);

--- a/mcp-servers/gitlab/src/tools/mr-notes-tools.ts
+++ b/mcp-servers/gitlab/src/tools/mr-notes-tools.ts
@@ -16,6 +16,7 @@ const listMrCommitsTool: Tool = {
   name: 'listMrCommits',
   description: 'List commits in a merge request',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'merge', 'request', 'commits', 'history'],
   example:
     'const commits = await gitlab.listMrCommits({ project_id: "speedwave/core", mr_iid: 42 })',
@@ -60,6 +61,7 @@ const listMrPipelinesTool: Tool = {
   name: 'listMrPipelines',
   description: 'List pipelines associated with a merge request',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'merge', 'request', 'pipelines', 'ci'],
   example:
     'const pipelines = await gitlab.listMrPipelines({ project_id: "speedwave/core", mr_iid: 42 })',
@@ -104,6 +106,7 @@ const listMrNotesTool: Tool = {
   name: 'listMrNotes',
   description: 'List notes/comments on a merge request',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'merge', 'request', 'notes', 'comments'],
   example: 'const notes = await gitlab.listMrNotes({ project_id: "speedwave/core", mr_iid: 42 })',
   inputSchema: {
@@ -147,6 +150,7 @@ const createMrNoteTool: Tool = {
   name: 'createMrNote',
   description: 'Add a comment/note to a merge request',
   category: 'write',
+  annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'merge', 'request', 'comment', 'note'],
   example: 'await gitlab.createMrNote({ project_id: "speedwave/core", mr_iid: 42, body: "LGTM!" })',
   inputSchema: {

--- a/mcp-servers/gitlab/src/tools/mr-tools.ts
+++ b/mcp-servers/gitlab/src/tools/mr-tools.ts
@@ -16,6 +16,7 @@ const listMrIdsTool: Tool = {
   name: 'listMrIds',
   description: 'List merge request IIDs. Use get_mr_full for details.',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'merge', 'request', 'mr', 'list', 'pull', 'ids'],
   example:
     'const { mrs, count } = await gitlab.listMrIds({ project_id: "speedwave/core", state: "opened" })',
@@ -82,6 +83,7 @@ const getMrFullTool: Tool = {
   name: 'getMrFull',
   description: 'Get complete merge request data. No truncation.',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'merge', 'request', 'mr', 'show', 'detail', 'full'],
   example: 'const mr = await gitlab.getMrFull({ project_id: "speedwave/core", mr_iid: 123 })',
   inputSchema: {
@@ -146,6 +148,7 @@ const createMergeRequestTool: Tool = {
   name: 'createMergeRequest',
   description: 'Create a new merge request',
   category: 'write',
+  annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'merge', 'request', 'mr', 'create', 'new', 'pull'],
   example:
     'const mr = await gitlab.createMergeRequest({ project_id: "speedwave/core", source_branch: "feature/x", target_branch: "main", title: "Add feature X" })',
@@ -209,6 +212,7 @@ const approveMergeRequestTool: Tool = {
   name: 'approveMergeRequest',
   description: 'Approve a merge request',
   category: 'write',
+  annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'merge', 'request', 'approve', 'review', 'accept'],
   example: 'await gitlab.approveMergeRequest({ project_id: "speedwave/core", mr_iid: 42 })',
   inputSchema: {
@@ -249,6 +253,7 @@ const mergeMergeRequestTool: Tool = {
   name: 'mergeMergeRequest',
   description: 'Merge a merge request',
   category: 'write',
+  annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'merge', 'request', 'accept', 'complete', 'finish'],
   example:
     'await gitlab.mergeMergeRequest({ project_id: "speedwave/core", mr_iid: 42, auto_merge: true })',
@@ -311,6 +316,7 @@ const updateMergeRequestTool: Tool = {
   name: 'updateMergeRequest',
   description: 'Update an existing merge request',
   category: 'write',
+  annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'merge', 'request', 'update', 'edit', 'modify'],
   example:
     'await gitlab.updateMergeRequest({ project_id: "speedwave/core", mr_iid: 42, title: "Updated: Add authentication flow", state_event: "close" })',
@@ -376,6 +382,7 @@ const getMrChangesTool: Tool = {
   name: 'getMrChanges',
   description: 'Get diff/changes of a merge request',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'merge', 'request', 'diff', 'changes', 'files'],
   example:
     'const changes = await gitlab.getMrChanges({ project_id: "speedwave/core", mr_iid: 42 })',

--- a/mcp-servers/gitlab/src/tools/pipeline-tools.ts
+++ b/mcp-servers/gitlab/src/tools/pipeline-tools.ts
@@ -17,6 +17,7 @@ const listPipelineIdsTool: Tool = {
   name: 'listPipelineIds',
   description: 'List pipeline IDs. Use get_pipeline_full for details.',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'pipeline', 'ci', 'cd', 'list', 'build', 'ids'],
   example:
     'const { pipelines, count } = await gitlab.listPipelineIds({ project_id: "speedwave/core", status: "failed" })',
@@ -75,6 +76,7 @@ const getPipelineFullTool: Tool = {
   name: 'getPipelineFull',
   description: 'Get complete pipeline data. No truncation.',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'pipeline', 'ci', 'details', 'jobs', 'status', 'full'],
   example:
     'const pipeline = await gitlab.getPipelineFull({ project_id: "speedwave/core", pipeline_id: 123456 })',
@@ -139,6 +141,7 @@ const getJobLogTool: Tool = {
   name: 'getJobLog',
   description: 'Get log output of a pipeline job',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'job', 'log', 'ci', 'build', 'debug'],
   example:
     'const log = await gitlab.getJobLog({ project_id: "speedwave/core", job_id: 12345, tail_lines: 50 })',
@@ -184,6 +187,7 @@ const retryPipelineTool: Tool = {
   name: 'retryPipeline',
   description: 'Retry a failed pipeline',
   category: 'write',
+  annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'pipeline', 'retry', 'rerun', 'ci', 'build'],
   example: 'await gitlab.retryPipeline({ project_id: "speedwave/core", pipeline_id: 123456 })',
   inputSchema: {
@@ -230,6 +234,7 @@ const triggerPipelineTool: Tool = {
   name: 'triggerPipeline',
   description: 'Trigger a new pipeline with optional variables',
   category: 'write',
+  annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'pipeline', 'trigger', 'create', 'run', 'ci', 'release', 'variables'],
   example: `// Trigger pipeline with CI variable
 await gitlab.triggerPipeline({

--- a/mcp-servers/gitlab/src/tools/project-tools.ts
+++ b/mcp-servers/gitlab/src/tools/project-tools.ts
@@ -16,6 +16,7 @@ const listProjectIdsTool: Tool = {
   name: 'listProjectIds',
   description: 'List project IDs and paths. Use get_project_full for details.',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'projects', 'list', 'repositories', 'repos', 'ids'],
   example: 'const { projects, count } = await gitlab.listProjectIds({ search: "speedwave" })',
   inputSchema: {
@@ -68,6 +69,7 @@ const getProjectFullTool: Tool = {
   name: 'getProjectFull',
   description: 'Get complete project data. No truncation.',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'project', 'show', 'get', 'detail', 'full'],
   example: 'const project = await gitlab.getProjectFull({ project_id: "speedwave/core" })',
   inputSchema: {
@@ -119,6 +121,7 @@ const searchCodeTool: Tool = {
   name: 'searchCode',
   description: 'Search for code in GitLab projects',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'search', 'code', 'find', 'grep', 'regex'],
   example:
     'const results = await gitlab.searchCode({ query: "function authenticate", project_id: "speedwave/core" })',

--- a/mcp-servers/gitlab/src/tools/release-tools.ts
+++ b/mcp-servers/gitlab/src/tools/release-tools.ts
@@ -16,6 +16,7 @@ const createTagTool: Tool = {
   name: 'createTag',
   description: 'Create a new Git tag',
   category: 'write',
+  annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'tag', 'create', 'release', 'version', 'git'],
   example:
     'const tag = await gitlab.createTag({ project_id: "speedwave/core", tag_name: "v1.0.0", ref: "main", message: "Release v1.0.0 - Initial stable release" })',
@@ -70,6 +71,7 @@ const deleteTagTool: Tool = {
   name: 'deleteTag',
   description: 'Delete a Git tag from the repository',
   category: 'delete',
+  annotations: { readOnlyHint: false, destructiveHint: true, openWorldHint: true },
   keywords: ['gitlab', 'tag', 'delete', 'remove', 'git', 'version', 'release'],
   example: 'await gitlab.deleteTag({ project_id: "speedwave/core", tag_name: "v1.0.0" })',
   inputSchema: {
@@ -105,6 +107,7 @@ const createReleaseTool: Tool = {
   name: 'createRelease',
   description: 'Create a new release from a tag',
   category: 'write',
+  annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'release', 'create', 'changelog', 'version', 'publish'],
   example:
     'const release = await gitlab.createRelease({ project_id: "speedwave/core", tag_name: "v1.0.0", name: "Initial Release", description: "## Changelog\\n- Feature: Authentication\\n- Feature: MCP integration" })',

--- a/mcp-servers/gitlab/src/tools/repository-tools.ts
+++ b/mcp-servers/gitlab/src/tools/repository-tools.ts
@@ -16,6 +16,7 @@ const getTreeTool: Tool = {
   name: 'getTree',
   description: 'Get repository file tree',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'tree', 'files', 'repository', 'ls'],
   example: 'const tree = await gitlab.getTree({ project_id: "speedwave/core", path: "src" })',
   inputSchema: {
@@ -66,6 +67,7 @@ const getFileTool: Tool = {
   name: 'getFile',
   description: 'Get file content from repository',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'file', 'content', 'read', 'cat'],
   example:
     'const file = await gitlab.getFile({ project_id: "speedwave/core", file_path: "README.md" })',
@@ -117,6 +119,7 @@ const getBlameTool: Tool = {
   name: 'getBlame',
   description: 'Get git blame for a file',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['gitlab', 'blame', 'annotate', 'history', 'git'],
   example:
     'const blame = await gitlab.getBlame({ project_id: "speedwave/core", file_path: "src/index.ts" })',

--- a/mcp-servers/os/src/tools/calendar-tools.ts
+++ b/mcp-servers/os/src/tools/calendar-tools.ts
@@ -79,6 +79,7 @@ const listCalendarsTool: Tool = {
   name: 'listCalendars',
   description: 'List all calendars available on this device',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['os', 'calendar', 'calendars', 'list', 'schedule'],
   example: 'const { calendars } = await os.listCalendars()',
   inputSchema: {
@@ -115,6 +116,7 @@ const listEventsTool: Tool = {
   name: 'listEvents',
   description: 'List calendar events within a date range',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['os', 'calendar', 'events', 'list', 'schedule', 'meetings', 'appointments'],
   example:
     'const { events } = await os.listEvents({ start: "2025-01-13T00:00:00Z", end: "2025-01-17T23:59:59Z" })',
@@ -170,6 +172,7 @@ const getEventTool: Tool = {
   name: 'getEvent',
   description: 'Get a specific calendar event by ID',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['os', 'calendar', 'event', 'get', 'detail', 'show', 'meeting'],
   example: 'const event = await os.getEvent({ id: "evt-123" })',
   inputSchema: {
@@ -207,6 +210,7 @@ const createEventTool: Tool = {
   name: 'createEvent',
   description: 'Create a new calendar event',
   category: 'write',
+  annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
   keywords: ['os', 'calendar', 'event', 'create', 'new', 'add', 'meeting', 'schedule'],
   example:
     'const { id } = await os.createEvent({ summary: "Team standup", start: "2025-01-15T09:00:00Z", end: "2025-01-15T09:30:00Z" })',
@@ -258,6 +262,7 @@ const updateEventTool: Tool = {
   name: 'updateEvent',
   description: 'Update an existing calendar event',
   category: 'write',
+  annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
   keywords: ['os', 'calendar', 'event', 'update', 'edit', 'modify', 'reschedule'],
   example:
     'await os.updateEvent({ id: "evt-123", summary: "Updated meeting title", start: "2025-01-15T10:00:00Z", end: "2025-01-15T11:00:00Z" })',
@@ -302,6 +307,7 @@ const deleteEventTool: Tool = {
   name: 'deleteEvent',
   description: 'Delete a calendar event',
   category: 'delete',
+  annotations: { readOnlyHint: false, destructiveHint: true, openWorldHint: true },
   keywords: ['os', 'calendar', 'event', 'delete', 'remove', 'cancel'],
   example: 'await os.deleteEvent({ id: "evt-123" })',
   inputSchema: {

--- a/mcp-servers/os/src/tools/mail-tools.ts
+++ b/mcp-servers/os/src/tools/mail-tools.ts
@@ -83,6 +83,7 @@ const detectMailClientsTool: Tool = {
   name: 'detectMailClients',
   description: 'Detect available mail clients on this device (Apple Mail, Outlook, etc.)',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['os', 'mail', 'email', 'detect', 'clients', 'outlook', 'thunderbird'],
   example: 'const { clients } = await os.detectMailClients()',
   inputSchema: {
@@ -116,6 +117,7 @@ const listMailboxesTool: Tool = {
   name: 'listMailboxes',
   description: 'List mail accounts and mailboxes/folders',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['os', 'mail', 'email', 'mailboxes', 'accounts', 'inbox', 'folders'],
   example: 'const { mailboxes } = await os.listMailboxes()',
   inputSchema: {
@@ -157,6 +159,7 @@ const listEmailsTool: Tool = {
   name: 'listEmails',
   description: 'List emails in a mailbox',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['os', 'mail', 'email', 'list', 'inbox', 'messages'],
   example: 'const { emails } = await os.listEmails({ limit: 10 })',
   inputSchema: {
@@ -203,6 +206,7 @@ const getEmailTool: Tool = {
   name: 'getEmail',
   description: 'Get a specific email by ID with full body',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['os', 'mail', 'email', 'get', 'read', 'detail', 'body', 'content'],
   example: 'const email = await os.getEmail({ id: "msg-456" })',
   inputSchema: {
@@ -247,6 +251,7 @@ const searchEmailsTool: Tool = {
   name: 'searchEmails',
   description: 'Search emails by query string',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['os', 'mail', 'email', 'search', 'find', 'query'],
   example: 'const { emails } = await os.searchEmails({ query: "quarterly report" })',
   inputSchema: {
@@ -293,6 +298,7 @@ const sendEmailTool: Tool = {
   name: 'sendEmail',
   description: 'Send a new email. Requires confirm_send=true as safety check.',
   category: 'write',
+  annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
   keywords: ['os', 'mail', 'email', 'send', 'compose', 'write', 'new'],
   example:
     'await os.sendEmail({ to: ["alice@example.com"], subject: "Meeting notes", body: "See attached.", confirm_send: true })',
@@ -345,6 +351,7 @@ const replyToEmailTool: Tool = {
   name: 'replyToEmail',
   description: 'Reply to an existing email. Requires confirm_send=true as safety check.',
   category: 'write',
+  annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
   keywords: ['os', 'mail', 'email', 'reply', 'respond', 'answer'],
   example:
     'await os.replyToEmail({ id: "msg-456", body: "Sounds good, let\'s proceed.", confirm_send: true })',

--- a/mcp-servers/os/src/tools/metadata.test.ts
+++ b/mcp-servers/os/src/tools/metadata.test.ts
@@ -36,6 +36,12 @@ describe('OS tool metadata', () => {
       expect(VALID_CATEGORIES).toContain(td.tool.category);
     });
 
+    it('has annotations with readOnlyHint and destructiveHint', () => {
+      expect(td.tool.annotations).toBeDefined();
+      expect(typeof td.tool.annotations!.readOnlyHint).toBe('boolean');
+      expect(typeof td.tool.annotations!.destructiveHint).toBe('boolean');
+    });
+
     it('has a non-empty keywords array', () => {
       expect(td.tool.keywords).toBeDefined();
       expect(Array.isArray(td.tool.keywords)).toBe(true);

--- a/mcp-servers/os/src/tools/notes-tools.ts
+++ b/mcp-servers/os/src/tools/notes-tools.ts
@@ -71,6 +71,7 @@ const listNoteFoldersTool: Tool = {
   name: 'listNoteFolders',
   description: 'List all note folders/notebooks available on this device',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['os', 'notes', 'folders', 'notebooks', 'list', 'categories'],
   example: 'const { folders } = await os.listNoteFolders()',
   inputSchema: {
@@ -106,6 +107,7 @@ const listNotesTool: Tool = {
   name: 'listNotes',
   description: 'List notes, optionally filtered by folder',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['os', 'notes', 'list', 'documents', 'memos'],
   example: 'const { notes } = await os.listNotes({ limit: 20 })',
   inputSchema: {
@@ -149,6 +151,7 @@ const getNoteTool: Tool = {
   name: 'getNote',
   description: 'Get a specific note by ID with full body content',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['os', 'note', 'get', 'read', 'detail', 'content', 'body'],
   example: 'const note = await os.getNote({ id: "note-789" })',
   inputSchema: {
@@ -183,6 +186,7 @@ const searchNotesTool: Tool = {
   name: 'searchNotes',
   description: 'Search notes by query string',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['os', 'notes', 'search', 'find', 'query'],
   example: 'const { notes } = await os.searchNotes({ query: "meeting notes" })',
   inputSchema: {
@@ -229,6 +233,7 @@ const createNoteTool: Tool = {
   name: 'createNote',
   description: 'Create a new note',
   category: 'write',
+  annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
   keywords: ['os', 'note', 'create', 'new', 'add', 'write'],
   example:
     'const { id } = await os.createNote({ title: "Sprint Retro Notes", body: "## What went well\\n- Deployment was smooth" })',
@@ -268,6 +273,7 @@ const updateNoteTool: Tool = {
   name: 'updateNote',
   description: 'Update an existing note',
   category: 'write',
+  annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
   keywords: ['os', 'note', 'update', 'edit', 'modify'],
   example: 'await os.updateNote({ id: "note-789", body: "Updated content here" })',
   inputSchema: {
@@ -301,6 +307,7 @@ const deleteNoteTool: Tool = {
   name: 'deleteNote',
   description: 'Delete a note',
   category: 'delete',
+  annotations: { readOnlyHint: false, destructiveHint: true, openWorldHint: true },
   keywords: ['os', 'note', 'delete', 'remove'],
   example: 'await os.deleteNote({ id: "note-789" })',
   inputSchema: {

--- a/mcp-servers/os/src/tools/reminder-tools.ts
+++ b/mcp-servers/os/src/tools/reminder-tools.ts
@@ -59,6 +59,7 @@ const listReminderListsTool: Tool = {
   name: 'listReminderLists',
   description: 'List all reminder lists/groups available on this device',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['os', 'reminders', 'lists', 'calendars', 'groups', 'categories'],
   example: 'const lists = await os.listReminderLists()',
   inputSchema: {
@@ -93,6 +94,7 @@ const listRemindersTool: Tool = {
   name: 'listReminders',
   description: 'List reminders, optionally filtered by list',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['os', 'reminders', 'list', 'tasks', 'todo', 'due'],
   example: 'const { reminders } = await os.listReminders({ show_completed: false, limit: 20 })',
   inputSchema: {
@@ -149,6 +151,7 @@ const getReminderTool: Tool = {
   name: 'getReminder',
   description: 'Get a specific reminder by ID',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['os', 'reminder', 'get', 'detail', 'show'],
   example: 'const reminder = await os.getReminder({ id: "abc-123" })',
   inputSchema: {
@@ -189,6 +192,7 @@ const createReminderTool: Tool = {
   name: 'createReminder',
   description: 'Create a new reminder',
   category: 'write',
+  annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
   keywords: ['os', 'reminder', 'create', 'new', 'add', 'task', 'todo'],
   example:
     'const { id } = await os.createReminder({ name: "Review PR #42", due_date: "2025-01-15T10:00:00Z", priority: 1 })',
@@ -241,6 +245,7 @@ const completeReminderTool: Tool = {
   name: 'completeReminder',
   description: 'Mark a reminder as completed',
   category: 'write',
+  annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
   keywords: ['os', 'reminder', 'complete', 'done', 'finish', 'check'],
   example: 'await os.completeReminder({ id: "abc-123" })',
   inputSchema: {

--- a/mcp-servers/redmine/src/tools/config-tools.ts
+++ b/mcp-servers/redmine/src/tools/config-tools.ts
@@ -15,6 +15,7 @@ const getMappingsTool: Tool = {
   name: 'getMappings',
   description: 'Get project-specific Redmine ID mappings (status, priority, tracker, activity)',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['redmine', 'mappings', 'config', 'status', 'priority', 'tracker', 'activity'],
   example: `const mappings = await redmine.getMappings()`,
   inputSchema: {
@@ -70,6 +71,7 @@ const getConfigTool: Tool = {
   description:
     'Get project configuration (default project_id, project_name, Redmine URL). project_name is auto-fetched from the Redmine API at startup when absent from config.',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['redmine', 'config', 'configuration', 'project', 'url', 'settings'],
   example: `const config = await redmine.getConfig()`,
   inputSchema: {

--- a/mcp-servers/redmine/src/tools/issue-tools.ts
+++ b/mcp-servers/redmine/src/tools/issue-tools.ts
@@ -17,6 +17,7 @@ const listIssueIdsTool: Tool = {
   name: 'listIssueIds',
   description: 'List issue IDs with optional filters. Returns only IDs for efficiency.',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['redmine', 'issues', 'list', 'filter', 'tasks', 'bugs', 'ids'],
   example: `const { ids, total_count } = await redmine.listIssueIds({ status: "open", assigned_to: "me" })`,
   inputSchema: {
@@ -90,6 +91,7 @@ const getIssueFullTool: Tool = {
   name: 'getIssueFull',
   description: 'Get complete issue data including custom_fields, relations. No truncation.',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['redmine', 'issue', 'show', 'get', 'detail', 'single', 'full'],
   example: `const issue = await redmine.getIssueFull({ issue_id: 12345, include: ["journals", "attachments"] })`,
   inputSchema: {
@@ -173,6 +175,7 @@ const searchIssueIdsTool: Tool = {
   name: 'searchIssueIds',
   description: 'Search issues by text query. Returns matching IDs only.',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['redmine', 'issue', 'search', 'find', 'query', 'ids'],
   example: `const { ids, total_count } = await redmine.searchIssueIds({ query: "authentication error", project_id: "my-project" })`,
   inputSchema: {
@@ -225,6 +228,7 @@ const createIssueTool: Tool = {
   name: 'createIssue',
   description: 'Create a new Redmine issue',
   category: 'write',
+  annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
   keywords: ['redmine', 'issue', 'create', 'new', 'task', 'bug', 'add'],
   example: `const issue = await redmine.createIssue({ subject: "Fix bug", project_id: "my-project", tracker: "bug" })`,
   inputSchema: {
@@ -300,6 +304,7 @@ const updateIssueTool: Tool = {
   name: 'updateIssue',
   description: 'Update an existing Redmine issue',
   category: 'write',
+  annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
   keywords: ['redmine', 'issue', 'update', 'modify', 'change', 'edit', 'move', 'project'],
   example: `const updated = await redmine.updateIssue({ issue_id: 12345, assigned_to_id: userId });
 // IMPORTANT: Verify change was applied - Redmine silently ignores some changes for closed issues
@@ -372,6 +377,7 @@ const commentIssueTool: Tool = {
   name: 'commentIssue',
   description: 'Add a comment to an issue',
   category: 'write',
+  annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
   keywords: ['redmine', 'issue', 'comment', 'note', 'add'],
   example: `await redmine.commentIssue({ issue_id: 12345, notes: "Work in progress" })`,
   inputSchema: {

--- a/mcp-servers/redmine/src/tools/journal-tools.ts
+++ b/mcp-servers/redmine/src/tools/journal-tools.ts
@@ -15,6 +15,7 @@ const listJournalsTool: Tool = {
   name: 'listJournals',
   description: 'List all journals (comments/updates) for an issue',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['redmine', 'journals', 'history', 'comments', 'audit', 'changelog'],
   example: `const journals = await redmine.listJournals({ issue_id: 12345 })`,
   inputSchema: {
@@ -75,6 +76,7 @@ const updateJournalTool: Tool = {
   name: 'updateJournal',
   description: 'Update an existing journal entry',
   category: 'write',
+  annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
   keywords: ['redmine', 'journal', 'update', 'comment', 'edit', 'modify'],
   example: `await redmine.updateJournal({ issue_id: 12345, journal_id: 67890, notes: "Updated comment with more details" })`,
   inputSchema: {
@@ -121,6 +123,7 @@ const deleteJournalTool: Tool = {
   name: 'deleteJournal',
   description: 'Delete a journal entry',
   category: 'delete',
+  annotations: { readOnlyHint: false, destructiveHint: true, openWorldHint: true },
   keywords: ['redmine', 'journal', 'delete', 'remove', 'comment'],
   example: `await redmine.deleteJournal({ issue_id: 12345, journal_id: 67890 })`,
   inputSchema: {

--- a/mcp-servers/redmine/src/tools/metadata.test.ts
+++ b/mcp-servers/redmine/src/tools/metadata.test.ts
@@ -52,6 +52,12 @@ describe('Redmine tool metadata', () => {
       expect(['read', 'write', 'delete']).toContain(tool.category);
     });
 
+    it('has annotations with readOnlyHint and destructiveHint', () => {
+      expect(tool.annotations).toBeDefined();
+      expect(typeof tool.annotations!.readOnlyHint).toBe('boolean');
+      expect(typeof tool.annotations!.destructiveHint).toBe('boolean');
+    });
+
     it('has keywords with at least 1 entry', () => {
       expect(tool.keywords).toBeDefined();
       expect(Array.isArray(tool.keywords)).toBe(true);

--- a/mcp-servers/redmine/src/tools/project-tools.ts
+++ b/mcp-servers/redmine/src/tools/project-tools.ts
@@ -15,6 +15,7 @@ const listProjectIdsTool: Tool = {
   name: 'listProjectIds',
   description: 'List project IDs with optional filters. Returns only IDs for efficiency.',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['redmine', 'projects', 'list', 'ids', 'filter', 'active', 'closed'],
   example: `const { ids } = await redmine.listProjectIds({ status: 'active' })`,
   inputSchema: {
@@ -35,6 +36,7 @@ const getProjectFullTool: Tool = {
   name: 'getProjectFull',
   description: 'Get complete project data including trackers, categories, modules. No truncation.',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['redmine', 'project', 'details', 'full', 'trackers', 'categories', 'modules'],
   example: `const project = await redmine.getProjectFull({ project_id: 'my-project' })`,
   inputSchema: {
@@ -55,6 +57,7 @@ const searchProjectIdsTool: Tool = {
   name: 'searchProjectIds',
   description: 'Search projects by name, identifier or description. Returns matching IDs only.',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['redmine', 'projects', 'search', 'find', 'query', 'name'],
   example: `const { ids } = await redmine.searchProjectIds({ query: 'mobile' })`,
   inputSchema: {

--- a/mcp-servers/redmine/src/tools/relation-tools.ts
+++ b/mcp-servers/redmine/src/tools/relation-tools.ts
@@ -15,6 +15,7 @@ const listRelationsTool: Tool = {
   name: 'listRelations',
   description: 'List all relations for an issue (blocks, precedes, duplicates, etc.)',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['redmine', 'relation', 'link', 'dependency', 'blocks', 'precedes', 'follows', 'list'],
   example: `const { relations } = await redmine.listRelations({ issue_id: 12345 })`,
   inputSchema: {
@@ -72,6 +73,7 @@ const createRelationTool: Tool = {
   name: 'createRelation',
   description: 'Create a relation between two issues',
   category: 'write',
+  annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
   keywords: ['redmine', 'relation', 'create', 'link', 'dependency', 'blocks', 'precedes'],
   example: `await redmine.createRelation({ issue_id: 100, issue_to_id: 101, relation_type: 'blocks' })`,
   inputSchema: {
@@ -151,6 +153,7 @@ const deleteRelationTool: Tool = {
   name: 'deleteRelation',
   description: 'Delete a relation between issues',
   category: 'delete',
+  annotations: { readOnlyHint: false, destructiveHint: true, openWorldHint: true },
   keywords: ['redmine', 'relation', 'delete', 'remove', 'unlink'],
   example: `await redmine.deleteRelation({ relation_id: 456 })`,
   inputSchema: {

--- a/mcp-servers/redmine/src/tools/time-entry-tools.ts
+++ b/mcp-servers/redmine/src/tools/time-entry-tools.ts
@@ -16,6 +16,7 @@ const listTimeEntriesTool: Tool = {
   name: 'listTimeEntries',
   description: 'List time entries with optional filters.',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['redmine', 'time', 'entries', 'list', 'hours', 'log'],
   example: `const entries = await redmine.listTimeEntries({ issue_id: 12345 })`,
   inputSchema: {
@@ -79,6 +80,7 @@ const createTimeEntryTool: Tool = {
   name: 'createTimeEntry',
   description: 'Log time on an issue or project',
   category: 'write',
+  annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
   keywords: ['redmine', 'time', 'entry', 'create', 'log', 'hours'],
   example: `await redmine.createTimeEntry({ hours: 2.5, issue_id: 12345, activity: "development", comments: "Code review" })`,
   inputSchema: {
@@ -145,6 +147,7 @@ const updateTimeEntryTool: Tool = {
   name: 'updateTimeEntry',
   description: 'Update an existing time entry',
   category: 'write',
+  annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
   keywords: ['redmine', 'time', 'update', 'modify', 'hours', 'edit'],
   example: `await redmine.updateTimeEntry({ time_entry_id: 789, hours: 3.5 })`,
   inputSchema: {

--- a/mcp-servers/redmine/src/tools/user-tools.ts
+++ b/mcp-servers/redmine/src/tools/user-tools.ts
@@ -15,6 +15,7 @@ const listUsersTool: Tool = {
   name: 'listUsers',
   description: 'List users (optionally filtered by project membership)',
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['redmine', 'users', 'list', 'members', 'team', 'assignable'],
   example: `const users = await redmine.listUsers({ project_id: "my-project" })`,
   inputSchema: {
@@ -65,6 +66,7 @@ const resolveUserTool: Tool = {
   name: 'resolveUser',
   description: "Resolve user identifier to user ID (supports 'me', user ID, or username)",
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['redmine', 'user', 'resolve', 'lookup', 'identity', 'id'],
   example: `const user = await redmine.resolveUser({ identifier: "john@example.com" })`,
   inputSchema: {
@@ -112,6 +114,7 @@ const getCurrentUserTool: Tool = {
   name: 'getCurrentUser',
   description: "Get current authenticated user's profile (id, login, email, name)",
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['redmine', 'user', 'profile', 'current', 'me', 'authenticated'],
   example: `const user = await redmine.getCurrentUser()`,
   inputSchema: {

--- a/mcp-servers/shared/src/index.ts
+++ b/mcp-servers/shared/src/index.ts
@@ -40,6 +40,7 @@ export type {
   ClientCapabilities,
   ServerCapabilities,
   Tool,
+  ToolAnnotations,
   ToolsListRequest,
   ToolsListResult,
   ToolsCallRequest,

--- a/mcp-servers/shared/src/types.ts
+++ b/mcp-servers/shared/src/types.ts
@@ -198,6 +198,23 @@ export interface ServerCapabilities {
 //═══════════════════════════════════════════════════════════════════════════════
 
 /**
+ * Hints describing a tool's behavior per MCP spec 2025-03-26.
+ * Used by clients to make UI/policy decisions without executing the tool.
+ * @interface ToolAnnotations
+ * @see https://modelcontextprotocol.io/docs/specification/tools#annotations
+ */
+export interface ToolAnnotations {
+  /** If true, the tool does not modify any state (default: assumed false). */
+  readOnlyHint?: boolean;
+  /** If true, the tool may perform destructive operations such as deleting data (default: assumed true). */
+  destructiveHint?: boolean;
+  /** If true, the tool may interact with entities outside the user's organization (default: assumed true). */
+  openWorldHint?: boolean;
+  /** If true, repeated calls with the same arguments produce the same result (default: assumed false). */
+  idempotentHint?: boolean;
+}
+
+/**
  * MCP tool definition describing a callable function/operation.
  * Tools are exposed by servers and can be invoked by clients.
  * @interface Tool
@@ -226,6 +243,8 @@ export interface Tool {
   }>;
   /** Tool category for audit logging: read, write, or delete */
   category?: 'read' | 'write' | 'delete';
+  /** MCP spec annotations describing tool behavior hints */
+  annotations?: ToolAnnotations;
   /** Search keywords for tool discovery */
   keywords?: string[];
   /** Usage example showing how to call the tool */

--- a/mcp-servers/sharepoint/src/tools/file-tools.ts
+++ b/mcp-servers/sharepoint/src/tools/file-tools.ts
@@ -59,6 +59,7 @@ const listFileIdsTool: Tool = {
     },
   },
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['sharepoint', 'files', 'list', 'directory', 'folder'],
   example: 'const files = await sharepoint.listFileIds({ path: "documents" })',
   outputSchema: {
@@ -104,6 +105,7 @@ const getFileFullTool: Tool = {
     required: ['file_id'],
   },
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['sharepoint', 'file', 'get', 'detail', 'download', 'metadata'],
   example: 'const file = await sharepoint.getFileFull({ file_id: "abc123", include: ["content"] })',
   outputSchema: {
@@ -152,6 +154,7 @@ const downloadFileTool: Tool = {
     },
   },
   category: 'write',
+  annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
   keywords: ['sharepoint', 'download', 'file', 'get', 'fetch'],
   example:
     'await sharepoint.downloadFile({ sharepoint_path: "docs/report.pdf", local_path: "/workspace/report.pdf" })',
@@ -196,6 +199,7 @@ const uploadFileTool: Tool = {
     },
   },
   category: 'write',
+  annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
   keywords: ['sharepoint', 'upload', 'file', 'put', 'write', 'sync'],
   example:
     'await sharepoint.uploadFile({ local_path: "/workspace/report.pdf", sharepoint_path: "docs/report.pdf" })',

--- a/mcp-servers/sharepoint/src/tools/metadata.test.ts
+++ b/mcp-servers/sharepoint/src/tools/metadata.test.ts
@@ -20,6 +20,12 @@ describe('SharePoint tool metadata', () => {
         expect(['read', 'write', 'delete']).toContain(tool.category);
       });
 
+      it('should have annotations with readOnlyHint and destructiveHint', () => {
+        expect(tool.annotations).toBeDefined();
+        expect(typeof tool.annotations!.readOnlyHint).toBe('boolean');
+        expect(typeof tool.annotations!.destructiveHint).toBe('boolean');
+      });
+
       it('should have keywords with at least 1 entry', () => {
         expect(tool.keywords).toBeDefined();
         expect(Array.isArray(tool.keywords)).toBe(true);

--- a/mcp-servers/sharepoint/src/tools/user-tools.ts
+++ b/mcp-servers/sharepoint/src/tools/user-tools.ts
@@ -14,6 +14,7 @@ const getCurrentUserTool: Tool = {
     properties: {},
   },
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['sharepoint', 'user', 'current', 'me', 'auth'],
   example: 'const user = await sharepoint.getCurrentUser()',
   outputSchema: {

--- a/mcp-servers/slack/src/tools/channel-tools.ts
+++ b/mcp-servers/slack/src/tools/channel-tools.ts
@@ -47,6 +47,7 @@ const sendChannelTool: Tool = {
     required: ['channel', 'message'],
   },
   category: 'write',
+  annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
   keywords: ['slack', 'send', 'message', 'channel', 'post', 'write'],
   example: 'await slack.sendChannel({ channel: "#general", message: "Hello!" })',
   outputSchema: {
@@ -85,6 +86,7 @@ const getChannelMessagesTool: Tool = {
     required: ['channel'],
   },
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['slack', 'read', 'message', 'history', 'channel', 'get'],
   example: 'const messages = await slack.getChannelMessages({ channel: "#general", limit: 10 })',
   outputSchema: {
@@ -136,6 +138,7 @@ const listChannelIdsTool: Tool = {
     },
   },
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['slack', 'channels', 'list', 'get', 'member'],
   example: 'const channels = await slack.listChannelIds()',
   outputSchema: {

--- a/mcp-servers/slack/src/tools/metadata.test.ts
+++ b/mcp-servers/slack/src/tools/metadata.test.ts
@@ -21,6 +21,12 @@ describe('tool metadata', () => {
         expect(['read', 'write', 'delete']).toContain(tool.category);
       });
 
+      it('should have annotations with readOnlyHint and destructiveHint', () => {
+        expect(tool.annotations).toBeDefined();
+        expect(typeof tool.annotations!.readOnlyHint).toBe('boolean');
+        expect(typeof tool.annotations!.destructiveHint).toBe('boolean');
+      });
+
       it('should have keywords with at least 1 entry', () => {
         expect(tool.keywords).toBeDefined();
         expect(Array.isArray(tool.keywords)).toBe(true);

--- a/mcp-servers/slack/src/tools/user-tools.ts
+++ b/mcp-servers/slack/src/tools/user-tools.ts
@@ -21,6 +21,7 @@ const getUsersTool: Tool = {
     required: ['email'],
   },
   category: 'read',
+  annotations: { readOnlyHint: true, destructiveHint: false, openWorldHint: true },
   keywords: ['slack', 'user', 'email', 'lookup', 'find'],
   example: 'const user = await slack.getUsers({ email: "alice@example.com" })',
   outputSchema: {


### PR DESCRIPTION
## Summary

- Add MCP spec 2025-03-26 `annotations` field to all 103 tool definitions across all 5 workers (gitlab: 46, redmine: 23, os: 25, sharepoint: 5, slack: 4)
- Add `ToolAnnotations` interface to `mcp-servers/shared/src/types.ts` and export it from the shared package
- Add annotations validation tests to all 5 worker metadata test suites

## Details

Each tool's `annotations` is derived from its existing `category`:

| `category` | `annotations` |
|---|---|
| `read` | `{ readOnlyHint: true, destructiveHint: false, openWorldHint: true }` |
| `write` | `{ readOnlyHint: false, destructiveHint: false, openWorldHint: true }` |
| `delete` | `{ readOnlyHint: false, destructiveHint: true, openWorldHint: true }` |

The existing `category` field is retained for backward compatibility (will be removed in a separate unit of the MCP compliance plan).

## Test plan

- [x] All 5 metadata test suites pass with new annotations assertions (gitlab: 278 tests, redmine: 94, os: 153, sharepoint: 21, slack: 17)
- [x] Shared library tests pass (356 tests)
- [x] Hub tests pass (469 tests)