### PR TITLE
feat(mcp): add Origin header validation per MCP spec

### DIFF
--- a/mcp-servers/shared/src/index.ts
+++ b/mcp-servers/shared/src/index.ts
@@ -59,6 +59,7 @@ export { JSONRPCErrorCode } from './types.js';
 export {
   loadToken,
   validateJSONRPCMessage,
+  validateOrigin,
   validateParams,
   validateSessionId,
   validateToolName,

--- a/mcp-servers/shared/src/security.test.ts
+++ b/mcp-servers/shared/src/security.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   validateJSONRPCMessage,
+  validateOrigin,
   validateParams,
   validateSessionId,
   validateToolName,
@@ -460,6 +461,51 @@ describe('security', () => {
 
     it('rejects URL with fragment', () => {
       expect(validateWorkerUrl('http://mcp-slack:4001#frag')).toBe(false);
+    });
+  });
+
+  describe('validateOrigin', () => {
+    it('allows missing origin (non-browser client)', () => {
+      expect(validateOrigin(undefined, ['http://localhost:3000'])).toBe(true);
+    });
+
+    it('allows valid origin in allowlist', () => {
+      expect(validateOrigin('http://localhost:3000', ['http://localhost:3000'])).toBe(true);
+    });
+
+    it('rejects origin not in allowlist', () => {
+      expect(validateOrigin('http://evil.com', ['http://localhost:3000'])).toBe(false);
+    });
+
+    it('rejects origin when allowlist is empty', () => {
+      expect(validateOrigin('http://localhost:3000', [])).toBe(false);
+    });
+
+    it('matches second origin in allowlist', () => {
+      expect(
+        validateOrigin('http://localhost:4000', ['http://localhost:3000', 'http://localhost:4000'])
+      ).toBe(true);
+    });
+
+    it('requires exact match (trailing slash matters)', () => {
+      expect(validateOrigin('http://localhost:3000/', ['http://localhost:3000'])).toBe(false);
+      expect(validateOrigin('http://localhost:3000', ['http://localhost:3000/'])).toBe(false);
+    });
+
+    it('allows null origin (treated as falsy, same as missing)', () => {
+      expect(validateOrigin(null as unknown as undefined, ['http://localhost:3000'])).toBe(true);
+    });
+
+    it('rejects empty string origin (present but empty)', () => {
+      expect(validateOrigin('', ['http://localhost:3000'])).toBe(false);
+    });
+
+    it('rejects origin when allowedOrigins is undefined', () => {
+      expect(validateOrigin('http://localhost:3000')).toBe(false);
+    });
+
+    it('allows missing origin when allowedOrigins is undefined', () => {
+      expect(validateOrigin(undefined)).toBe(true);
     });
   });
 });

--- a/mcp-servers/shared/src/security.ts
+++ b/mcp-servers/shared/src/security.ts
@@ -5,9 +5,7 @@
  * Security Principles:
  * 1. Validate ALL inputs
  * 2. Never expose tokens
- *
- * Note: MCP servers run inside an isolated Docker network without host-exposed
- * ports. No Origin/CORS validation is needed at the application layer.
+ * 3. Validate Origin headers per MCP Streamable HTTP spec
  */
 import fs from 'fs/promises';
 
@@ -178,4 +176,18 @@ export function validateWorkerUrl(url: string): boolean {
   if (parsed.username !== '' || parsed.password !== '') return false;
 
   return true;
+}
+
+/**
+ * Validate Origin header per MCP Streamable HTTP spec.
+ * Missing Origin (non-browser clients) is allowed.
+ * Present Origin must be in allowedOrigins list.
+ * @param origin - Origin header value (undefined if absent)
+ * @param allowedOrigins - List of allowed origin strings
+ * @returns true if the origin is acceptable
+ */
+export function validateOrigin(origin: string | undefined, allowedOrigins?: string[]): boolean {
+  if (origin == null) return true;
+  if (allowedOrigins && allowedOrigins.length > 0) return allowedOrigins.includes(origin);
+  return false;
 }


### PR DESCRIPTION
## Summary
- Add `validateOrigin()` function to `mcp-servers/shared/src/security.ts` per MCP Streamable HTTP spec (2025-11-25)
- Missing Origin (non-browser clients) is allowed; present Origin must be in the configured allowlist
- Export from `index.ts` for use by all MCP servers

## Test plan
- [x] No origin (undefined) returns true
- [x] Null origin returns true (same as missing)
- [x] Valid origin in allowlist returns true
- [x] Invalid origin not in allowlist returns false
- [x] Empty allowlist with origin present returns false
- [x] Multiple origins in allowlist, match second returns true
- [x] Trailing slash exact match required
- [x] Empty string origin returns false (not treated as missing)
- [x] Undefined allowedOrigins with present origin returns false
- [x] All 366 shared tests pass