### PR TITLE
feat(containers): rewrite statusline with real data from Claude Code API

### DIFF
--- a/_tests/entrypoint/statusline.bats
+++ b/_tests/entrypoint/statusline.bats
@@ -235,6 +235,20 @@ FULL_RATE_LIMITED_JSON='{"model":{"display_name":"Opus 4.6 (1M context)","name":
     [[ "$output" != *'$'* ]]
 }
 
+@test "cost hidden when total_cost_usd is 0.0" {
+    local input='{"model":{"display_name":"Test"},"used_percentage":10,"context_window_size":1000000,"cost":{"total_cost_usd":0.0}}'
+    run bash -c "echo '$input' | bash $STATUSLINE"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *'$'* ]]
+}
+
+@test "cost hidden when total_cost_usd is 0.00" {
+    local input='{"model":{"display_name":"Test"},"used_percentage":10,"context_window_size":1000000,"cost":{"total_cost_usd":0.00}}'
+    run bash -c "echo '$input' | bash $STATUSLINE"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *'$'* ]]
+}
+
 @test "cost hidden when rate limits present" {
     local input='{"model":{"display_name":"Test"},"used_percentage":10,"context_window_size":1000000,"rate_limits":{"five_hour":{"used_percentage":12,"resets_at":1775580120}},"cost":{"total_cost_usd":0.42}}'
     run bash -c "echo '$input' | bash $STATUSLINE"
@@ -309,11 +323,13 @@ FULL_RATE_LIMITED_JSON='{"model":{"display_name":"Opus 4.6 (1M context)","name":
     [ "$status" -eq 0 ]
 }
 
-@test "empty rate_limits object handled" {
-    run bash -c "echo '{\"rate_limits\":{}}' | bash $STATUSLINE"
+@test "empty rate_limits object handled — no bars but cost suppressed" {
+    run bash -c "echo '{\"rate_limits\":{},\"cost\":{\"total_cost_usd\":1.0}}' | bash $STATUSLINE"
     [ "$status" -eq 0 ]
     [[ "$output" != *"5h"* ]]
     [[ "$output" != *"7d"* ]]
+    # rate_limits key present = subscription mode, so cost is hidden
+    [[ "$output" != *'$'* ]]
 }
 
 @test "JSON with only cost block, no rate_limits key" {

--- a/_tests/entrypoint/statusline.bats
+++ b/_tests/entrypoint/statusline.bats
@@ -378,7 +378,7 @@ JSON
 }
 
 @test "script does not access tokens or credentials" {
-    ! grep -v '^\s*#' "$STATUSLINE" | grep -qE 'security |secret-tool|keychain|oauth|/tokens|api\.anthropic\.com'
+    ! grep -v '^\s*#' "$STATUSLINE" | grep -qE '\bsecurity\b|secret-tool|keychain|oauth|/tokens|api\.anthropic\.com'
 }
 
 @test "script does not write to /tmp cache" {

--- a/_tests/entrypoint/statusline.bats
+++ b/_tests/entrypoint/statusline.bats
@@ -4,18 +4,13 @@
 
 STATUSLINE="$BATS_TEST_DIRNAME/../../containers/claude-resources/statusline.sh"
 
-setup() {
-    TEST_HOME="$(mktemp -d)"
-    export HOME="$TEST_HOME"
-    mkdir -p "$HOME/.claude"
-}
-
-teardown() {
-    rm -rf "$TEST_HOME"
-}
+# Full rate-limited JSON for reuse across multiple tests.
+# resets_at values are Unix epoch seconds (not ISO strings).
+# 1775580120 = some future timestamp, 1776186000 = ~7 days later.
+FULL_RATE_LIMITED_JSON='{"model":{"display_name":"Opus 4.6 (1M context)","name":"claude-opus-4-6"},"used_percentage":38,"context_window_size":1000000,"rate_limits":{"five_hour":{"used_percentage":12,"resets_at":1775580120},"seven_day":{"used_percentage":82,"resets_at":1776186000}}}'
 
 # ---------------------------------------------------------------------------
-# Empty stdin — fallback to defaults
+# Happy path tests
 # ---------------------------------------------------------------------------
 
 @test "empty stdin outputs default model name 'Claude'" {
@@ -24,162 +19,193 @@ teardown() {
     [[ "$output" == *"Claude"* ]]
 }
 
-@test "empty stdin shows thinking status" {
+@test "empty stdin does not crash" {
     run bash "$STATUSLINE" < /dev/null
     [ "$status" -eq 0 ]
-    [[ "$output" == *"thinking"* ]]
 }
 
-# ---------------------------------------------------------------------------
-# Valid JSON input — model name extraction
-# ---------------------------------------------------------------------------
+@test "full rate-limited JSON produces correct format" {
+    run bash -c "echo '$FULL_RATE_LIMITED_JSON' | bash $STATUSLINE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Opus 4.6 (1M context)"* ]]
+    [[ "$output" == *"CTX"* ]]
+    [[ "$output" == *"38%"* ]]
+    [[ "$output" == *"5h"* ]]
+    [[ "$output" == *"12%"* ]]
+    [[ "$output" == *"reset"* ]]
+    [[ "$output" == *"7d"* ]]
+    [[ "$output" == *"82%"* ]]
+}
 
-@test "extracts display_name from JSON" {
-    local input='{"model":{"display_name":"Opus 4"},"tokens_used":1000,"tokens_max":200000}'
+@test "API key mode shows cost instead of rate limits" {
+    local input='{"model":{"display_name":"Opus 4.6 (1M context)"},"used_percentage":38,"context_window_size":1000000,"cost":{"total_cost_usd":0.42}}'
     run bash -c "echo '$input' | bash $STATUSLINE"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Opus 4"* ]]
+    [[ "$output" == *'$0.42'* ]]
+    [[ "$output" != *"5h"* ]]
+    [[ "$output" != *"7d"* ]]
+}
+
+@test "API key mode with top-level total_cost_usd" {
+    local input='{"model":{"display_name":"Opus"},"used_percentage":38,"context_window_size":1000000,"total_cost_usd":1.23}'
+    run bash -c "echo '$input' | bash $STATUSLINE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'$1.23'* ]]
+}
+
+@test "extracts display_name from JSON" {
+    local input='{"model":{"display_name":"Sonnet 4.6 (200K context)"},"used_percentage":10,"context_window_size":200000}'
+    run bash -c "echo '$input' | bash $STATUSLINE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Sonnet 4.6 (200K context)"* ]]
 }
 
 @test "falls back to name when display_name absent" {
-    local input='{"model":{"name":"claude-sonnet-4-6"},"tokens_used":500,"tokens_max":100000}'
+    local input='{"model":{"name":"claude-sonnet-4-6"},"used_percentage":10,"context_window_size":200000}'
     run bash -c "echo '$input' | bash $STATUSLINE"
     [ "$status" -eq 0 ]
     [[ "$output" == *"claude-sonnet-4-6"* ]]
 }
 
-# ---------------------------------------------------------------------------
-# Token usage display
-# ---------------------------------------------------------------------------
-
-@test "shows token usage with progress bar" {
-    local input='{"display_name":"Opus","tokens_used":50000,"tokens_max":200000}'
+@test "CTX label with percentage" {
+    local input='{"model":{"display_name":"Test"},"used_percentage":38,"context_window_size":1000000}'
     run bash -c "echo '$input' | bash $STATUSLINE"
     [ "$status" -eq 0 ]
-    # Should show formatted tokens and percentage
-    [[ "$output" == *"50.0K"* ]] || [[ "$output" == *"50"* ]]
-    [[ "$output" == *"200.0K"* ]] || [[ "$output" == *"200"* ]]
+    [[ "$output" == *"CTX"* ]]
+    [[ "$output" == *"38%"* ]]
 }
 
-@test "shows only used tokens when max is zero" {
-    local input='{"display_name":"Opus","tokens_used":12345,"tokens_max":0}'
+@test "5h reset time formatted from epoch" {
+    local input='{"model":{"display_name":"Test"},"used_percentage":10,"context_window_size":1000000,"rate_limits":{"five_hour":{"used_percentage":12,"resets_at":1775580120}}}'
     run bash -c "echo '$input' | bash $STATUSLINE"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"12,345"* ]]
+    [[ "$output" == *"5h"* ]]
+    [[ "$output" == *"reset"* ]]
+    # Reset time should be HH:MM format
+    [[ "$output" =~ [0-9]{2}:[0-9]{2} ]]
 }
 
-@test "no token section when both used and max are zero" {
-    local input='{"display_name":"Opus","tokens_used":0,"tokens_max":0}'
+@test "7d reset date formatted from epoch" {
+    local input='{"model":{"display_name":"Test"},"used_percentage":10,"context_window_size":1000000,"rate_limits":{"five_hour":{"used_percentage":12,"resets_at":1775580120},"seven_day":{"used_percentage":82,"resets_at":1776186000}}}'
     run bash -c "echo '$input' | bash $STATUSLINE"
     [ "$status" -eq 0 ]
-    # Should NOT contain "tokens" or progress bar characters
-    [[ "$output" != *"tokens:"* ]]
+    [[ "$output" == *"7d"* ]]
+    [[ "$output" == *"reset"* ]]
+    # Reset date should be dd.mm format
+    [[ "$output" =~ [0-9]{2}\.[0-9]{2} ]]
+}
+
+@test "sections separated by dim │" {
+    run bash -c "echo '$FULL_RATE_LIMITED_JSON' | bash $STATUSLINE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"│"* ]]
 }
 
 # ---------------------------------------------------------------------------
-# Thinking status from settings.json
+# Color threshold tests
 # ---------------------------------------------------------------------------
 
-@test "thinking shows 'on' by default" {
-    run bash "$STATUSLINE" < /dev/null
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"thinking"* ]]
-    [[ "$output" != *"thinking off"* ]]
-}
-
-@test "thinking shows 'off' when disabled in user-level settings" {
-    cat > "$HOME/.claude/settings.json" << 'EOF'
-{
-  "thinking": false
-}
-EOF
-    run bash "$STATUSLINE" < /dev/null
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"thinking off"* ]]
-}
-
-@test "thinking shows 'on' when explicitly enabled in user-level settings" {
-    cat > "$HOME/.claude/settings.json" << 'EOF'
-{
-  "thinking": true
-}
-EOF
-    run bash "$STATUSLINE" < /dev/null
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"thinking"* ]]
-    [[ "$output" != *"thinking off"* ]]
-}
-
-@test "thinking shows 'off' when disabled in project-level settings" {
-    local workspace="$TEST_HOME/workspace"
-    mkdir -p "$workspace/.claude"
-    cat > "$workspace/.claude/settings.json" << 'EOF'
-{
-  "thinking": false
-}
-EOF
-    # Patch script to use temp workspace path (cleaned by teardown via $TEST_HOME)
-    local patched
-    patched="$(mktemp "$TEST_HOME/patched.XXXXXX")"
-    sed "s|/workspace/.claude/settings.json|$workspace/.claude/settings.json|" "$STATUSLINE" > "$patched"
-    run bash "$patched" < /dev/null
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"thinking off"* ]]
-}
-
-@test "project-level thinking setting takes precedence over user-level" {
-    # User-level has no thinking key (bundled settings.json)
-    cat > "$HOME/.claude/settings.json" << 'EOF'
-{
-  "statusLine": {"type": "command", "command": "~/.claude/statusline.sh"}
-}
-EOF
-    # Project-level disables thinking
-    local workspace="$TEST_HOME/workspace"
-    mkdir -p "$workspace/.claude"
-    cat > "$workspace/.claude/settings.json" << 'EOF'
-{
-  "thinking": false
-}
-EOF
-    local patched
-    patched="$(mktemp "$TEST_HOME/patched.XXXXXX")"
-    sed "s|/workspace/.claude/settings.json|$workspace/.claude/settings.json|" "$STATUSLINE" > "$patched"
-    run bash "$patched" < /dev/null
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"thinking off"* ]]
-}
-
-@test "thinking defaults to 'on' when bundled settings.json has no thinking key" {
-    # Simulate the real bundled settings.json (statusLine only, no thinking key)
-    cat > "$HOME/.claude/settings.json" << 'EOF'
-{
-  "statusLine": {"type": "command", "command": "~/.claude/statusline.sh"}
-}
-EOF
-    run bash "$STATUSLINE" < /dev/null
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"thinking"* ]]
-    [[ "$output" != *"thinking off"* ]]
-}
-
-# ---------------------------------------------------------------------------
-# Missing / partial JSON fields — graceful fallback
-# ---------------------------------------------------------------------------
-
-@test "missing tokens_max defaults to zero gracefully" {
-    local input='{"display_name":"Opus","tokens_used":500}'
+@test "green below 50%" {
+    local input='{"model":{"display_name":"Test"},"used_percentage":25,"context_window_size":1000000}'
     run bash -c "echo '$input' | bash $STATUSLINE"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Opus"* ]]
+    [[ "$output" == *$'\033[32m'* ]]
 }
 
-@test "missing model name defaults to Claude" {
-    local input='{"tokens_used":1000,"tokens_max":200000}'
+@test "green at 49%" {
+    local input='{"model":{"display_name":"Test"},"used_percentage":49,"context_window_size":1000000}'
     run bash -c "echo '$input' | bash $STATUSLINE"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Claude"* ]]
+    [[ "$output" == *$'\033[32m'* ]]
 }
+
+@test "yellow at 50%" {
+    local input='{"model":{"display_name":"Test"},"used_percentage":50,"context_window_size":1000000}'
+    run bash -c "echo '$input' | bash $STATUSLINE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *$'\033[33m'* ]]
+}
+
+@test "yellow at 75%" {
+    local input='{"model":{"display_name":"Test"},"used_percentage":75,"context_window_size":1000000}'
+    run bash -c "echo '$input' | bash $STATUSLINE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *$'\033[33m'* ]]
+}
+
+@test "red at 76%" {
+    local input='{"model":{"display_name":"Test"},"used_percentage":76,"context_window_size":1000000}'
+    run bash -c "echo '$input' | bash $STATUSLINE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *$'\033[31m'* ]]
+}
+
+@test "red at 89%" {
+    local input='{"model":{"display_name":"Test"},"used_percentage":89,"context_window_size":1000000}'
+    run bash -c "echo '$input' | bash $STATUSLINE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *$'\033[31m'* ]]
+}
+
+@test "bold red at 90%" {
+    local input='{"model":{"display_name":"Test"},"used_percentage":90,"context_window_size":1000000}'
+    run bash -c "echo '$input' | bash $STATUSLINE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *$'\033[1m'* ]]
+    [[ "$output" == *$'\033[31m'* ]]
+}
+
+@test "bold red at 95%" {
+    local input='{"model":{"display_name":"Test"},"used_percentage":95,"context_window_size":1000000}'
+    run bash -c "echo '$input' | bash $STATUSLINE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *$'\033[1m'* ]]
+    [[ "$output" == *$'\033[31m'* ]]
+}
+
+@test "5h rate limit bar uses correct color at 60%" {
+    local input='{"model":{"display_name":"Test"},"used_percentage":10,"context_window_size":1000000,"rate_limits":{"five_hour":{"used_percentage":60,"resets_at":1775580120}}}'
+    run bash -c "echo '$input' | bash $STATUSLINE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *$'\033[33m'* ]]
+}
+
+@test "7d rate limit bar uses correct color at 85%" {
+    local input='{"model":{"display_name":"Test"},"used_percentage":10,"context_window_size":1000000,"rate_limits":{"five_hour":{"used_percentage":10,"resets_at":1775580120},"seven_day":{"used_percentage":85,"resets_at":1776186000}}}'
+    run bash -c "echo '$input' | bash $STATUSLINE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *$'\033[31m'* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Bar width tests
+# ---------------------------------------------------------------------------
+
+@test "CTX bar 40% has 2 filled, 3 empty" {
+    local input='{"model":{"display_name":"Test"},"used_percentage":40,"context_window_size":1000000}'
+    run bash -c "echo '$input' | bash $STATUSLINE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"██░░░"* ]]
+}
+
+@test "CTX bar 100% is fully filled" {
+    local input='{"model":{"display_name":"Test"},"used_percentage":100,"context_window_size":1000000}'
+    run bash -c "echo '$input' | bash $STATUSLINE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"█████"* ]]
+    [[ "$output" == *"100%"* ]]
+}
+
+@test "CTX bar 0% is fully empty" {
+    local input='{"model":{"display_name":"Test"},"used_percentage":0,"context_window_size":1000000}'
+    run bash -c "echo '$input' | bash $STATUSLINE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"░░░░░"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
 
 @test "completely empty JSON object does not crash" {
     run bash -c "echo '{}' | bash $STATUSLINE"
@@ -187,69 +213,148 @@ EOF
     [[ "$output" == *"Claude"* ]]
 }
 
-# ---------------------------------------------------------------------------
-# format_tokens — verified via full script with specific token values
-# ---------------------------------------------------------------------------
-
-@test "format_tokens renders millions correctly" {
-    local input='{"display_name":"Test","tokens_used":1234567,"tokens_max":5000000}'
+@test "missing model name defaults to Claude" {
+    local input='{"used_percentage":50,"context_window_size":1000000}'
     run bash -c "echo '$input' | bash $STATUSLINE"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"1.2M"* ]]
-    [[ "$output" == *"5.0M"* ]]
+    [[ "$output" == *"Claude"* ]]
 }
 
-@test "format_tokens renders thousands correctly" {
-    local input='{"display_name":"Test","tokens_used":45600,"tokens_max":200000}'
+@test "7d section hidden when seven_day data absent" {
+    local input='{"model":{"display_name":"Test"},"used_percentage":10,"context_window_size":1000000,"rate_limits":{"five_hour":{"used_percentage":12,"resets_at":1775580120}}}'
     run bash -c "echo '$input' | bash $STATUSLINE"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"45.6K"* ]]
-    [[ "$output" == *"200.0K"* ]]
+    [[ "$output" == *"5h"* ]]
+    [[ "$output" != *"7d"* ]]
 }
 
-# ---------------------------------------------------------------------------
-# build_bar color thresholds
-# ---------------------------------------------------------------------------
-
-@test "progress bar is yellow at 75% usage" {
-    # 150000/200000 = 75%
-    local input='{"display_name":"Test","tokens_used":150000,"tokens_max":200000}'
+@test "cost hidden when total_cost_usd is 0" {
+    local input='{"model":{"display_name":"Test"},"used_percentage":10,"context_window_size":1000000,"cost":{"total_cost_usd":0}}'
     run bash -c "echo '$input' | bash $STATUSLINE"
     [ "$status" -eq 0 ]
-    # Yellow ANSI escape: \033[33m
-    [[ "$output" == *$'\033[33m'* ]]
-    [[ "$output" == *"25%"* ]]
+    [[ "$output" != *'$'* ]]
 }
 
-@test "progress bar is red at 90% usage" {
-    # 180000/200000 = 90%
-    local input='{"display_name":"Test","tokens_used":180000,"tokens_max":200000}'
+@test "cost hidden when rate limits present" {
+    local input='{"model":{"display_name":"Test"},"used_percentage":10,"context_window_size":1000000,"rate_limits":{"five_hour":{"used_percentage":12,"resets_at":1775580120}},"cost":{"total_cost_usd":0.42}}'
     run bash -c "echo '$input' | bash $STATUSLINE"
     [ "$status" -eq 0 ]
-    # Red ANSI escape: \033[31m
-    [[ "$output" == *$'\033[31m'* ]]
-    [[ "$output" == *"10%"* ]]
+    [[ "$output" != *'$'* ]]
+    [[ "$output" == *"5h"* ]]
 }
 
-@test "progress bar is green below 75% usage" {
-    # 50000/200000 = 25%
-    local input='{"display_name":"Test","tokens_used":50000,"tokens_max":200000}'
+@test "no CTX section when used_percentage absent" {
+    local input='{"model":{"display_name":"Test"}}'
     run bash -c "echo '$input' | bash $STATUSLINE"
     [ "$status" -eq 0 ]
-    # Green ANSI escape: \033[32m — appears in the bar (not just thinking)
-    [[ "$output" == *$'\033[32m'* ]]
-    [[ "$output" == *"75%"* ]]
+    [[ "$output" != *"CTX"* ]]
 }
 
-@test "format_commas used for small token counts without max" {
-    local input='{"display_name":"Test","tokens_used":999,"tokens_max":0}'
+@test "cost with decimal places passed through" {
+    local input='{"model":{"display_name":"Test"},"used_percentage":10,"context_window_size":1000000,"cost":{"total_cost_usd":12.345}}'
     run bash -c "echo '$input' | bash $STATUSLINE"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"999"* ]]
+    [[ "$output" == *'$12.345'* ]]
 }
 
 # ---------------------------------------------------------------------------
-# Security: no network calls, no credential access
+# Float handling tests
+# ---------------------------------------------------------------------------
+
+@test "used_percentage as float truncated to integer" {
+    local input='{"model":{"display_name":"Test"},"used_percentage":38.7,"context_window_size":1000000}'
+    run bash -c "echo '$input' | bash $STATUSLINE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"38%"* ]]
+    [[ "$output" != *"38.7%"* ]]
+}
+
+@test "used_percentage as integer works" {
+    local input='{"model":{"display_name":"Test"},"used_percentage":38,"context_window_size":1000000}'
+    run bash -c "echo '$input' | bash $STATUSLINE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"38%"* ]]
+}
+
+@test "rate limit percentage as float truncated" {
+    local input='{"model":{"display_name":"Test"},"used_percentage":10,"context_window_size":1000000,"rate_limits":{"five_hour":{"used_percentage":12.5,"resets_at":1775580120}}}'
+    run bash -c "echo '$input' | bash $STATUSLINE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"12%"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Malformed / broken JSON error path tests
+# ---------------------------------------------------------------------------
+
+@test "malformed JSON with extra braces does not crash" {
+    run bash -c "echo '{\"rate_limits\":{\"five_hour\":{\"used_percentage\":12}}}}' | bash $STATUSLINE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Claude"* ]]
+}
+
+@test "truncated JSON does not crash" {
+    run bash -c 'echo "{\"rate_limits\":{\"five_hour\":{\"use" | bash '"$STATUSLINE"
+    [ "$status" -eq 0 ]
+}
+
+@test "deeply nested JSON beyond expected depth does not crash" {
+    local input='{"rate_limits":{"five_hour":{"nested":{"deep":1},"used_percentage":12,"resets_at":1775580120}}}'
+    run bash -c "echo '$input' | bash $STATUSLINE"
+    [ "$status" -eq 0 ]
+}
+
+@test "empty nested objects handled gracefully" {
+    run bash -c "echo '{\"rate_limits\":{\"five_hour\":{}}}' | bash $STATUSLINE"
+    [ "$status" -eq 0 ]
+}
+
+@test "empty rate_limits object handled" {
+    run bash -c "echo '{\"rate_limits\":{}}' | bash $STATUSLINE"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"5h"* ]]
+    [[ "$output" != *"7d"* ]]
+}
+
+@test "JSON with only cost block, no rate_limits key" {
+    run bash -c "echo '{\"cost\":{\"total_cost_usd\":1.50}}' | bash $STATUSLINE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'$1.50'* ]]
+}
+
+@test "pretty-printed multi-line JSON parses correctly" {
+    run bash "$STATUSLINE" << 'JSON'
+{
+  "model": {
+    "display_name": "Opus 4.6 (1M context)",
+    "name": "claude-opus-4-6"
+  },
+  "used_percentage": 38,
+  "context_window_size": 1000000,
+  "rate_limits": {
+    "five_hour": {
+      "used_percentage": 12,
+      "resets_at": 1775580120
+    },
+    "seven_day": {
+      "used_percentage": 82,
+      "resets_at": 1776186000
+    }
+  }
+}
+JSON
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Opus 4.6 (1M context)"* ]]
+    [[ "$output" == *"CTX"* ]]
+    [[ "$output" == *"38%"* ]]
+    [[ "$output" == *"5h"* ]]
+    [[ "$output" == *"12%"* ]]
+    [[ "$output" == *"7d"* ]]
+    [[ "$output" == *"82%"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Security tests
 # ---------------------------------------------------------------------------
 
 @test "script does not use curl" {
@@ -257,7 +362,6 @@ EOF
 }
 
 @test "script does not access tokens or credentials" {
-    # Strip comments, then check for credential-accessing commands
     ! grep -v '^\s*#' "$STATUSLINE" | grep -qE 'security |secret-tool|keychain|oauth|/tokens|api\.anthropic\.com'
 }
 
@@ -267,4 +371,12 @@ EOF
 
 @test "script does not use wget or network tools" {
     ! grep -qE 'wget|nc |netcat|fetch ' "$STATUSLINE"
+}
+
+@test "script does not read settings.json" {
+    ! grep -q 'settings.json' "$STATUSLINE"
+}
+
+@test "script does not use jq" {
+    ! grep -v '^\s*#' "$STATUSLINE" | grep -qE '\bjq\b'
 }

--- a/containers/claude-resources/statusline.sh
+++ b/containers/claude-resources/statusline.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
-# Speedwave statusline for Claude Code — displays model, tokens, and thinking status.
-# Reads JSON from stdin (Claude Code pipes conversation state).
-# Outputs a single line for the status bar.
+# Speedwave statusline for Claude Code — displays model, context usage,
+# rate limits, and cost. Reads JSON from stdin (Claude Code pipes
+# conversation state). Outputs a single line for the status bar.
 #
-# Security: no network calls, no token access, no OAuth — safe for the
+# Security: no network calls, no token access, no file reads — safe for the
 # Speedwave container (cap_drop: ALL, no-new-privileges, no credentials).
+#
+# JSON parsing: regex-based, no jq dependency. Handles flat and 2-level
+# nested keys. Input is collapsed to a single line before extraction
+# to handle both minified and pretty-printed JSON from Claude Code.
 
 set -f
 
@@ -21,50 +25,23 @@ WHITE='\033[37m'
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
-# format_commas 1234567 → "1,234,567"
-format_commas() {
-    local n="$1"
-    local result=""
-    local count=0
-    local i
-    for (( i=${#n}-1; i>=0; i-- )); do
-        if (( count > 0 && count % 3 == 0 )); then
-            result=",${result}"
-        fi
-        result="${n:$i:1}${result}"
-        (( count++ ))
-    done
-    printf '%s' "$result"
-}
-
-# format_tokens 1234567 → "1.2M"
-format_tokens() {
-    local n="$1"
-    if (( n >= 1000000 )); then
-        local major=$(( n / 1000000 ))
-        local minor=$(( (n % 1000000) / 100000 ))
-        printf '%s.%sM' "$major" "$minor"
-    elif (( n >= 1000 )); then
-        local major=$(( n / 1000 ))
-        local minor=$(( (n % 1000) / 100 ))
-        printf '%s.%sK' "$major" "$minor"
-    else
-        printf '%s' "$n"
-    fi
-}
-
-# build_bar <percent> → colored bar "████░░░░░░"
+# build_bar <percent> → colored bar "██░░░" (5 chars)
+# Sets global BAR_COLOR for caller to reuse on percentage text.
+# Thresholds: <50% green, 50-75% yellow, 76-90% red, >90% bold red.
+BAR_COLOR=""
 build_bar() {
     local pct="$1"
-    local width=10
+    local width=5
     local filled=$(( pct * width / 100 ))
     local empty=$(( width - filled ))
 
-    local color="$GREEN"
+    BAR_COLOR="$GREEN"
     if (( pct >= 90 )); then
-        color="$RED"
-    elif (( pct >= 75 )); then
-        color="$YELLOW"
+        BAR_COLOR="${BOLD}${RED}"
+    elif (( pct >= 76 )); then
+        BAR_COLOR="$RED"
+    elif (( pct >= 50 )); then
+        BAR_COLOR="$YELLOW"
     fi
 
     local bar=""
@@ -72,20 +49,41 @@ build_bar() {
     for (( i=0; i<filled; i++ )); do bar+="█"; done
     for (( i=0; i<empty; i++ )); do bar+="░"; done
 
-    printf '%b%s%b' "$color" "$bar" "$RESET"
+    printf '%b%s%b' "$BAR_COLOR" "$bar" "$RESET"
 }
 
-# ── Read JSON from stdin ─────────────────────────────────────────────────────
+# format_reset_time <epoch_seconds> → "16:42" (local time)
+format_reset_time() {
+    local epoch="$1"
+    if [[ -n "$epoch" ]] && (( epoch > 0 )); then
+        date -r "$epoch" '+%H:%M' 2>/dev/null || date -d "@$epoch" '+%H:%M' 2>/dev/null
+    fi
+}
+
+# format_reset_date <epoch_seconds> → "14.04" (local time)
+format_reset_date() {
+    local epoch="$1"
+    if [[ -n "$epoch" ]] && (( epoch > 0 )); then
+        date -r "$epoch" '+%d.%m' 2>/dev/null || date -d "@$epoch" '+%d.%m' 2>/dev/null
+    fi
+}
+
+# ── Read JSON from stdin ──────────────────────────────────────────────────────
 
 INPUT=""
 if [ ! -t 0 ]; then
     INPUT="$(cat)"
 fi
 
-# ── Extract fields ───────────────────────────────────────────────────────────
+# Collapse to single line — makes regex extraction safe for both
+# minified and pretty-printed JSON. This is the key simplification:
+# instead of building a multi-line-aware parser, normalize the input.
+INPUT="$(printf '%s' "$INPUT" | tr '\n' ' ')"
 
-# Safe JSON field extraction using parameter expansion — no jq dependency.
-# Handles the flat JSON structure Claude Code pipes to statusline commands.
+# ── JSON extraction helpers ──────────────────────────────────────────────────
+
+# Safe JSON field extraction using regex — no jq dependency.
+# Works on single-line JSON (input is collapsed above).
 extract_json_string() {
     local json="$1" key="$2"
     local pattern="\"${key}\"[[:space:]]*:[[:space:]]*\""
@@ -103,18 +101,31 @@ extract_json_number() {
     fi
 }
 
-extract_json_bool() {
+extract_json_float() {
     local json="$1" key="$2"
-    local pattern="\"${key}\"[[:space:]]*:[[:space:]]*(true|false)"
+    local pattern="\"${key}\"[[:space:]]*:[[:space:]]*([0-9]+\.?[0-9]*)"
     if [[ "$json" =~ $pattern ]]; then
         printf '%s' "${BASH_REMATCH[1]}"
     fi
 }
 
-# Model name — from nested model.display_name or model.name
+# extract_block "json" "key" → returns content between { and } for "key": { ... }
+# Limitation: handles 1 level of nesting only. Sufficient for rate_limits.five_hour
+# and cost objects. If Claude Code ever nests deeper, this needs revisiting.
+extract_block() {
+    local json="$1" key="$2"
+    local pattern="\"${key}\"[[:space:]]*:[[:space:]]*\{"
+    if [[ "$json" =~ $pattern ]]; then
+        local after="${json#*\"${key}\"*\{}"
+        printf '%s' "${after%%\}*}"
+    fi
+}
+
+# ── Extract fields ───────────────────────────────────────────────────────────
+
+# Model name — from display_name or name
 model_name=""
 if [[ -n "$INPUT" ]]; then
-    # Try display_name first, then name
     model_name="$(extract_json_string "$INPUT" "display_name")"
     if [[ -z "$model_name" ]]; then
         model_name="$(extract_json_string "$INPUT" "name")"
@@ -122,62 +133,109 @@ if [[ -n "$INPUT" ]]; then
 fi
 model_name="${model_name:-Claude}"
 
-# Token usage
-tokens_used="$(extract_json_number "$INPUT" "tokens_used")"
-tokens_used="${tokens_used:-0}"
+# Context window size
+context_window_size="$(extract_json_number "$INPUT" "context_window_size")"
+context_window_size="${context_window_size:-0}"
 
-tokens_max="$(extract_json_number "$INPUT" "tokens_max")"
-tokens_max="${tokens_max:-0}"
+# Context usage percentage — truncate to integer for bash arithmetic
+used_pct_raw="$(extract_json_float "$INPUT" "used_percentage")"
+used_pct="${used_pct_raw%%.*}"
+used_pct="${used_pct:-0}"
 
-# ── Thinking status ───────────────────────────────────────────────────────────
-# Check project-level settings first (higher precedence), then user-level.
-# User-level ~/.claude/settings.json is a symlink to the bundled read-only
-# resource (statusLine config only, no thinking key), so project-level
-# /workspace/.claude/settings.json is where teams configure thinking.
+# Rate limits — detect presence of rate_limits key, then extract five_hour/seven_day
+# directly from INPUT. Extracting sub-blocks directly avoids the %%\}* limitation
+# (which would stop at the first } inside a nested object when extracting rl_block).
+has_rl_key=false
+rl_pattern='"rate_limits"[[:space:]]*:[[:space:]]*\{'
+if [[ "$INPUT" =~ $rl_pattern ]]; then
+    has_rl_key=true
+fi
 
-thinking="on"
-PROJECT_SETTINGS="/workspace/.claude/settings.json"
-USER_SETTINGS="${HOME}/.claude/settings.json"
-for settings_file in "$PROJECT_SETTINGS" "$USER_SETTINGS"; do
-    if [ -f "$settings_file" ]; then
-        thinking_enabled="$(extract_json_bool "$(cat "$settings_file")" "thinking")"
-        if [[ "$thinking_enabled" == "false" ]]; then
-            thinking="off"
-            break
-        elif [[ "$thinking_enabled" == "true" ]]; then
-            break
-        fi
+five_hour_pct=""
+five_hour_resets_at=""
+if [[ "$has_rl_key" == true ]]; then
+    fh_block="$(extract_block "$INPUT" "five_hour")"
+    if [[ -n "$fh_block" ]]; then
+        five_hour_pct="$(extract_json_float "$fh_block" "used_percentage")"
+        five_hour_resets_at="$(extract_json_number "$fh_block" "resets_at")"
     fi
-done
+fi
+
+seven_day_pct=""
+seven_day_resets_at=""
+if [[ "$has_rl_key" == true ]]; then
+    sd_block="$(extract_block "$INPUT" "seven_day")"
+    if [[ -n "$sd_block" ]]; then
+        seven_day_pct="$(extract_json_float "$sd_block" "used_percentage")"
+        seven_day_resets_at="$(extract_json_number "$sd_block" "resets_at")"
+    fi
+fi
+
+# Truncate rate limit percentages to integer for bash arithmetic
+five_hour_pct="${five_hour_pct%%.*}"
+seven_day_pct="${seven_day_pct%%.*}"
+
+# Cost — try nested "cost": { "total_cost_usd": ... } first, then top-level
+total_cost=""
+cost_block="$(extract_block "$INPUT" "cost")"
+if [[ -n "$cost_block" ]]; then
+    total_cost="$(extract_json_float "$cost_block" "total_cost_usd")"
+fi
+if [[ -z "$total_cost" ]]; then
+    total_cost="$(extract_json_float "$INPUT" "total_cost_usd")"
+fi
 
 # ── Build output ─────────────────────────────────────────────────────────────
 
 parts=()
 
-# Model
+# Part 1: Model — bold cyan (display_name already includes context info)
 parts+=("$(printf '%b%b%s%b' "$BOLD" "$CYAN" "$model_name" "$RESET")")
 
-# Tokens
-if (( tokens_max > 0 )); then
-    used_fmt="$(format_tokens "$tokens_used")"
-    max_fmt="$(format_tokens "$tokens_max")"
-    pct_used=$(( tokens_used * 100 / tokens_max ))
-    pct_remain=$(( 100 - pct_used ))
-    bar="$(build_bar "$pct_used")"
-    parts+=("$(printf '%b%s/%s%b %s %b%s%%%b' "$DIM" "$used_fmt" "$max_fmt" "$RESET" "$bar" "$WHITE" "$pct_remain" "$RESET")")
-elif (( tokens_used > 0 )); then
-    used_fmt="$(format_commas "$tokens_used")"
-    parts+=("$(printf '%btokens: %s%b' "$DIM" "$used_fmt" "$RESET")")
+# Part 2: CTX — context usage bar and percentage (same color as bar)
+if (( used_pct > 0 || context_window_size > 0 )); then
+    ctx_bar="$(build_bar "$used_pct")"
+    parts+=("$(printf '%bCTX%b %s %b%s%%%b' "$DIM" "$RESET" "$ctx_bar" "$BAR_COLOR" "$used_pct" "$RESET")")
 fi
 
-# Thinking
-if [[ "$thinking" == "on" ]]; then
-    parts+=("$(printf '%b⚡thinking%b' "$GREEN" "$RESET")")
-else
-    parts+=("$(printf '%b⚡thinking off%b' "$DIM" "$RESET")")
+# Determine mode
+has_rate_limits=false
+if [[ -n "$five_hour_pct" ]]; then
+    has_rate_limits=true
 fi
 
-# Join with separator
+# Part 3: 5h rate limit
+if [[ "$has_rate_limits" == true ]]; then
+    five_bar="$(build_bar "$five_hour_pct")"
+    reset_str=""
+    if [[ -n "$five_hour_resets_at" ]]; then
+        reset_time="$(format_reset_time "$five_hour_resets_at")"
+        if [[ -n "$reset_time" ]]; then
+            reset_str="$(printf ' %breset%b %s' "$DIM" "$RESET" "$reset_time")"
+        fi
+    fi
+    parts+=("$(printf '%b5h%b %s %b%s%%%b%s' "$DIM" "$RESET" "$five_bar" "$BAR_COLOR" "$five_hour_pct" "$RESET" "$reset_str")")
+fi
+
+# Part 4: 7d rate limit — only when data available
+if [[ "$has_rate_limits" == true ]] && [[ -n "$seven_day_pct" ]]; then
+    seven_bar="$(build_bar "$seven_day_pct")"
+    reset_str=""
+    if [[ -n "$seven_day_resets_at" ]]; then
+        reset_date="$(format_reset_date "$seven_day_resets_at")"
+        if [[ -n "$reset_date" ]]; then
+            reset_str="$(printf ' %breset%b %s' "$DIM" "$RESET" "$reset_date")"
+        fi
+    fi
+    parts+=("$(printf '%b7d%b %s %b%s%%%b%s' "$DIM" "$RESET" "$seven_bar" "$BAR_COLOR" "$seven_day_pct" "$RESET" "$reset_str")")
+fi
+
+# Part 5: Cost — only in API key mode (no rate limits), only when > 0
+if [[ "$has_rate_limits" == false ]] && [[ -n "$total_cost" ]] && [[ "$total_cost" != "0" ]]; then
+    parts+=("$(printf '%b$%s%b' "$DIM" "$total_cost" "$RESET")")
+fi
+
+# Join with dim │ separator
 OLD_IFS="$IFS"
 IFS=''; output=""
 for (( i=0; i<${#parts[@]}; i++ )); do

--- a/containers/claude-resources/statusline.sh
+++ b/containers/claude-resources/statusline.sh
@@ -198,14 +198,11 @@ if (( used_pct > 0 || context_window_size > 0 )); then
     parts+=("$(printf '%bCTX%b %s %b%s%%%b' "$DIM" "$RESET" "$ctx_bar" "$BAR_COLOR" "$used_pct" "$RESET")")
 fi
 
-# Determine mode
-has_rate_limits=false
-if [[ -n "$five_hour_pct" ]]; then
-    has_rate_limits=true
-fi
+# Determine mode — use has_rl_key so seven_day-only input is still rate-limit mode
+has_rate_limits="$has_rl_key"
 
-# Part 3: 5h rate limit
-if [[ "$has_rate_limits" == true ]]; then
+# Part 3: 5h rate limit — only when data available
+if [[ "$has_rate_limits" == true ]] && [[ -n "$five_hour_pct" ]]; then
     five_bar="$(build_bar "$five_hour_pct")"
     reset_str=""
     if [[ -n "$five_hour_resets_at" ]]; then
@@ -231,19 +228,26 @@ if [[ "$has_rate_limits" == true ]] && [[ -n "$seven_day_pct" ]]; then
 fi
 
 # Part 5: Cost — only in API key mode (no rate limits), only when > 0
-if [[ "$has_rate_limits" == false ]] && [[ -n "$total_cost" ]] && [[ "$total_cost" != "0" ]]; then
+# Cost is zero if it matches 0, 0.0, 0.00, etc.
+cost_is_zero=true
+if [[ -n "$total_cost" ]]; then
+    cost_check="${total_cost//0/}"
+    cost_check="${cost_check/./}"
+    if [[ -n "$cost_check" ]]; then
+        cost_is_zero=false
+    fi
+fi
+if [[ "$has_rate_limits" == false ]] && [[ "$cost_is_zero" == false ]]; then
     parts+=("$(printf '%b$%s%b' "$DIM" "$total_cost" "$RESET")")
 fi
 
 # Join with dim │ separator
-OLD_IFS="$IFS"
-IFS=''; output=""
+output=""
 for (( i=0; i<${#parts[@]}; i++ )); do
     if (( i > 0 )); then
         output+="$(printf ' %b│%b ' "$DIM" "$RESET")"
     fi
     output+="${parts[$i]}"
 done
-IFS="$OLD_IFS"
 
 printf '%s\n' "$output"


### PR DESCRIPTION
## Summary
- Rewrite `statusline.sh` to use real Claude Code JSON fields (`used_percentage`, `rate_limits`, `cost`)
- Remove fake thinking status (was reading settings.json, not actual session state)
- Add 5h/7d rate limit bars with reset time/date for Pro/Max subscribers
- Add cost display ($USD) for API key mode
- Fix model name duplication (display_name already includes context info)
- 5-char progress bars with color thresholds: green <50%, yellow 50-75%, red 76-90%, bold red >90%

Closes #275

## Test plan
- [x] 47 bats tests pass (`make test-entrypoint`)
- [x] `make check` passes
- [ ] Manual: verify statusline in container with subscription (rate limits visible)
- [ ] Manual: verify statusline in container with API key (cost visible)