### PR TITLE
feat(containers): show git branch in statusline

### DIFF
--- a/_tests/entrypoint/statusline.bats
+++ b/_tests/entrypoint/statusline.bats
@@ -316,18 +316,20 @@ FULL_RATE_LIMITED_JSON='{"model":{"display_name":"Opus 4.6 (1M context)","name":
     [[ "$output" == *"Test"* ]]
 }
 
-@test "branch appears between model and CTX" {
+@test "branch appears between model and CTX in correct order" {
     local repo="$(mktemp -d)"
     git -C "$repo" init -q
     git -C "$repo" commit --allow-empty -m "init" -q
+    local branch
+    branch="$(git -C "$repo" rev-parse --abbrev-ref HEAD)"
     local input='{"model":{"display_name":"Test"},"used_percentage":10,"context_window_size":1000000}'
     export STATUSLINE_WORKSPACE_DIR="$repo"
     run bash -c "echo '$input' | bash $STATUSLINE"
     unset STATUSLINE_WORKSPACE_DIR
     rm -rf "$repo"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Test"* ]]
-    [[ "$output" == *"CTX"* ]]
+    # Branch name must appear between model and CTX
+    [[ "$output" =~ Test.*"$branch".*CTX ]]
 }
 
 # ---------------------------------------------------------------------------

--- a/_tests/entrypoint/statusline.bats
+++ b/_tests/entrypoint/statusline.bats
@@ -272,6 +272,65 @@ FULL_RATE_LIMITED_JSON='{"model":{"display_name":"Opus 4.6 (1M context)","name":
 }
 
 # ---------------------------------------------------------------------------
+# Git branch tests
+# ---------------------------------------------------------------------------
+
+@test "shows git branch when workspace is a git repo" {
+    local repo="$(mktemp -d)"
+    git -C "$repo" init -q
+    git -C "$repo" commit --allow-empty -m "init" -q
+    git -C "$repo" checkout -b feat/my-feature -q
+    local input='{"model":{"display_name":"Test"},"used_percentage":10,"context_window_size":1000000}'
+    export STATUSLINE_WORKSPACE_DIR="$repo"
+    run bash -c "echo '$input' | bash $STATUSLINE"
+    unset STATUSLINE_WORKSPACE_DIR
+    rm -rf "$repo"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"feat/my-feature"* ]]
+}
+
+@test "shows short SHA on detached HEAD" {
+    local repo="$(mktemp -d)"
+    git -C "$repo" init -q
+    git -C "$repo" commit --allow-empty -m "init" -q
+    local sha
+    sha="$(git -C "$repo" rev-parse --short HEAD)"
+    git -C "$repo" checkout --detach -q
+    local input='{"model":{"display_name":"Test"},"used_percentage":10,"context_window_size":1000000}'
+    export STATUSLINE_WORKSPACE_DIR="$repo"
+    run bash -c "echo '$input' | bash $STATUSLINE"
+    unset STATUSLINE_WORKSPACE_DIR
+    rm -rf "$repo"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"$sha"* ]]
+}
+
+@test "no branch shown when workspace is not a git repo" {
+    local repo="$(mktemp -d)"
+    local input='{"model":{"display_name":"Test"},"used_percentage":10,"context_window_size":1000000}'
+    export STATUSLINE_WORKSPACE_DIR="$repo"
+    run bash -c "echo '$input' | bash $STATUSLINE"
+    unset STATUSLINE_WORKSPACE_DIR
+    rm -rf "$repo"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Test"* ]]
+}
+
+@test "branch appears between model and CTX" {
+    local repo="$(mktemp -d)"
+    git -C "$repo" init -q
+    git -C "$repo" commit --allow-empty -m "init" -q
+    local input='{"model":{"display_name":"Test"},"used_percentage":10,"context_window_size":1000000}'
+    export STATUSLINE_WORKSPACE_DIR="$repo"
+    run bash -c "echo '$input' | bash $STATUSLINE"
+    unset STATUSLINE_WORKSPACE_DIR
+    rm -rf "$repo"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Test"* ]]
+    [[ "$output" == *"CTX"* ]]
+}
+
+# ---------------------------------------------------------------------------
 # Float handling tests
 # ---------------------------------------------------------------------------
 

--- a/_tests/entrypoint/statusline.bats
+++ b/_tests/entrypoint/statusline.bats
@@ -278,6 +278,8 @@ FULL_RATE_LIMITED_JSON='{"model":{"display_name":"Opus 4.6 (1M context)","name":
 @test "shows git branch when workspace is a git repo" {
     local repo="$(mktemp -d)"
     git -C "$repo" init -q
+    git -C "$repo" config user.email "test@test.com"
+    git -C "$repo" config user.name "Test"
     git -C "$repo" commit --allow-empty -m "init" -q
     git -C "$repo" checkout -b feat/my-feature -q
     local input='{"model":{"display_name":"Test"},"used_percentage":10,"context_window_size":1000000}'
@@ -292,6 +294,8 @@ FULL_RATE_LIMITED_JSON='{"model":{"display_name":"Opus 4.6 (1M context)","name":
 @test "shows short SHA on detached HEAD" {
     local repo="$(mktemp -d)"
     git -C "$repo" init -q
+    git -C "$repo" config user.email "test@test.com"
+    git -C "$repo" config user.name "Test"
     git -C "$repo" commit --allow-empty -m "init" -q
     local sha
     sha="$(git -C "$repo" rev-parse --short HEAD)"
@@ -319,6 +323,8 @@ FULL_RATE_LIMITED_JSON='{"model":{"display_name":"Opus 4.6 (1M context)","name":
 @test "branch appears between model and CTX in correct order" {
     local repo="$(mktemp -d)"
     git -C "$repo" init -q
+    git -C "$repo" config user.email "test@test.com"
+    git -C "$repo" config user.name "Test"
     git -C "$repo" commit --allow-empty -m "init" -q
     local branch
     branch="$(git -C "$repo" rev-parse --abbrev-ref HEAD)"

--- a/containers/claude-resources/statusline.sh
+++ b/containers/claude-resources/statusline.sh
@@ -3,8 +3,9 @@
 # rate limits, and cost. Reads JSON from stdin (Claude Code pipes
 # conversation state). Outputs a single line for the status bar.
 #
-# Security: no network calls, no token access, no file reads — safe for the
-# Speedwave container (cap_drop: ALL, no-new-privileges, no credentials).
+# Security: no network calls, no token access, no credentials — safe for the
+# Speedwave container (cap_drop: ALL, no-new-privileges). Reads .git for
+# branch name only (no secrets in .git/HEAD).
 #
 # JSON parsing: regex-based, no jq dependency. Handles flat and 2-level
 # nested keys. Input is collapsed to a single line before extraction
@@ -185,6 +186,21 @@ if [[ -z "$total_cost" ]]; then
     total_cost="$(extract_json_float "$INPUT" "total_cost_usd")"
 fi
 
+# ── Git branch ───────────────────────────────────────────────────────────────
+# Read current branch from workspace if it's a git repo. Graceful fallback:
+# no git, no repo, detached HEAD — all handled silently.
+# STATUSLINE_WORKSPACE_DIR allows tests to override the workspace path.
+
+WORKSPACE="${STATUSLINE_WORKSPACE_DIR:-/workspace}"
+git_branch=""
+if command -v git >/dev/null 2>&1 && [ -d "$WORKSPACE/.git" ]; then
+    git_branch="$(git -C "$WORKSPACE" rev-parse --abbrev-ref HEAD 2>/dev/null)"
+    # Detached HEAD returns "HEAD" — show short SHA instead
+    if [[ "$git_branch" == "HEAD" ]]; then
+        git_branch="$(git -C "$WORKSPACE" rev-parse --short HEAD 2>/dev/null)"
+    fi
+fi
+
 # ── Build output ─────────────────────────────────────────────────────────────
 
 parts=()
@@ -192,7 +208,12 @@ parts=()
 # Part 1: Model — bold cyan (display_name already includes context info)
 parts+=("$(printf '%b%b%s%b' "$BOLD" "$CYAN" "$model_name" "$RESET")")
 
-# Part 2: CTX — context usage bar and percentage (same color as bar)
+# Part 2: Git branch — dim white (omitted if not in a git repo)
+if [[ -n "$git_branch" ]]; then
+    parts+=("$(printf '%b%s%b' "$DIM" "$git_branch" "$RESET")")
+fi
+
+# Part 3: CTX — context usage bar and percentage (same color as bar)
 if (( used_pct > 0 || context_window_size > 0 )); then
     ctx_bar="$(build_bar "$used_pct")"
     parts+=("$(printf '%bCTX%b %s %b%s%%%b' "$DIM" "$RESET" "$ctx_bar" "$BAR_COLOR" "$used_pct" "$RESET")")
@@ -201,7 +222,7 @@ fi
 # Determine mode — use has_rl_key so seven_day-only input is still rate-limit mode
 has_rate_limits="$has_rl_key"
 
-# Part 3: 5h rate limit — only when data available
+# Part 4: 5h rate limit — only when data available
 if [[ "$has_rate_limits" == true ]] && [[ -n "$five_hour_pct" ]]; then
     five_bar="$(build_bar "$five_hour_pct")"
     reset_str=""
@@ -214,7 +235,7 @@ if [[ "$has_rate_limits" == true ]] && [[ -n "$five_hour_pct" ]]; then
     parts+=("$(printf '%b5h%b %s %b%s%%%b%s' "$DIM" "$RESET" "$five_bar" "$BAR_COLOR" "$five_hour_pct" "$RESET" "$reset_str")")
 fi
 
-# Part 4: 7d rate limit — only when data available
+# Part 5: 7d rate limit — only when data available
 if [[ "$has_rate_limits" == true ]] && [[ -n "$seven_day_pct" ]]; then
     seven_bar="$(build_bar "$seven_day_pct")"
     reset_str=""
@@ -227,7 +248,7 @@ if [[ "$has_rate_limits" == true ]] && [[ -n "$seven_day_pct" ]]; then
     parts+=("$(printf '%b7d%b %s %b%s%%%b%s' "$DIM" "$RESET" "$seven_bar" "$BAR_COLOR" "$seven_day_pct" "$RESET" "$reset_str")")
 fi
 
-# Part 5: Cost — only in API key mode (no rate limits), only when > 0
+# Part 6: Cost — only in API key mode (no rate limits), only when > 0
 # Cost is zero if it matches 0, 0.0, 0.00, etc.
 cost_is_zero=true
 if [[ -n "$total_cost" ]]; then

--- a/containers/claude-resources/statusline.sh
+++ b/containers/claude-resources/statusline.sh
@@ -188,12 +188,13 @@ fi
 
 # ── Git branch ───────────────────────────────────────────────────────────────
 # Read current branch from workspace if it's a git repo. Graceful fallback:
-# no git, no repo, detached HEAD — all handled silently.
+# no git, no repo, worktree, detached HEAD — all handled silently.
+# Skips the [ -d .git ] check: in git worktrees .git is a file, not a dir.
 # STATUSLINE_WORKSPACE_DIR allows tests to override the workspace path.
 
 WORKSPACE="${STATUSLINE_WORKSPACE_DIR:-/workspace}"
 git_branch=""
-if command -v git >/dev/null 2>&1 && [ -d "$WORKSPACE/.git" ]; then
+if command -v git >/dev/null 2>&1; then
     git_branch="$(git -C "$WORKSPACE" rev-parse --abbrev-ref HEAD 2>/dev/null)"
     # Detached HEAD returns "HEAD" — show short SHA instead
     if [[ "$git_branch" == "HEAD" ]]; then


### PR DESCRIPTION
## Summary
- Display current git branch between model name and context bar in statusline
- Detached HEAD shows short SHA instead of branch name
- Gracefully omitted when `/workspace` is not a git repo
- Uses `STATUSLINE_WORKSPACE_DIR` env var for test overrides

## Test plan
- [x] 53 bats tests pass (4 new git branch tests)
- [x] Tests run 2x stable (no shared state between tests)
- [ ] Manual: verify branch display in container with git project
- [ ] Manual: verify no branch when workspace has no `.git`