### PR TITLE
fix(desktop): format Settings timestamps as DD-MM-YYYY HH:MM:SS

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -4679,6 +4679,7 @@ name = "speedwave-desktop"
 version = "0.6.1"
 dependencies = [
  "anyhow",
+ "chrono",
  "dirs",
  "futures-util",
  "http",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -32,6 +32,7 @@ http = "1"
 zip = { version = "8", default-features = false, features = ["deflate"] }
 tempfile = "3"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 
 [target.'cfg(windows)'.dependencies]

--- a/desktop/src-tauri/src/container_logs_cmd.rs
+++ b/desktop/src-tauri/src/container_logs_cmd.rs
@@ -317,7 +317,7 @@ mod tests {
     fn read_tail_sanitized_reads_and_sanitizes() {
         let tmp = tempfile::tempdir().unwrap();
         let log_content =
-            "[100] SESSION: started\n[101] STDERR: Bearer sk-ant-secret-key-abc\n[102] SESSION: stopped\n";
+            "[07-04-2026 14:30:00] SESSION: started\n[07-04-2026 14:30:01] STDERR: Bearer sk-ant-secret-key-abc\n[07-04-2026 14:30:02] SESSION: stopped\n";
         let log_path = tmp.path().join("claude-session.log");
         std::fs::write(&log_path, log_content).unwrap();
 

--- a/desktop/src-tauri/src/log_file.rs
+++ b/desktop/src-tauri/src/log_file.rs
@@ -15,7 +15,6 @@ pub fn open_log_file(path: &Path) -> Option<std::fs::File> {
 }
 
 /// Format a DateTime as DD-MM-YYYY HH:MM:SS for log lines.
-/// Format must match Angular date pipe in system-health.component.ts template.
 fn format_timestamp<Tz: chrono::TimeZone>(dt: &chrono::DateTime<Tz>) -> String
 where
     Tz::Offset: std::fmt::Display,

--- a/desktop/src-tauri/src/log_file.rs
+++ b/desktop/src-tauri/src/log_file.rs
@@ -14,19 +14,25 @@ pub fn open_log_file(path: &Path) -> Option<std::fs::File> {
     opts.open(path).ok()
 }
 
+/// Format a DateTime as DD-MM-YYYY HH:MM:SS for log lines.
+/// Format must match Angular date pipe in system-health.component.ts template.
+fn format_timestamp<Tz: chrono::TimeZone>(dt: &chrono::DateTime<Tz>) -> String
+where
+    Tz::Offset: std::fmt::Display,
+{
+    dt.format("%d-%m-%Y %H:%M:%S").to_string()
+}
+
 /// Write a timestamped line to the log file. Errors are silently ignored.
 /// When `prefix` is empty, writes `[ts] line`; otherwise `[ts] prefix: line`.
 pub fn write_log_line(file: &mut Option<std::fs::File>, prefix: &str, line: &str) {
     use std::io::Write;
     if let Some(ref mut f) = file {
-        let secs = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
+        let ts = format_timestamp(&chrono::Local::now());
         if prefix.is_empty() {
-            let _ = writeln!(f, "[{secs}] {line}");
+            let _ = writeln!(f, "[{ts}] {line}");
         } else {
-            let _ = writeln!(f, "[{secs}] {prefix}: {line}");
+            let _ = writeln!(f, "[{ts}] {prefix}: {line}");
         }
     }
 }
@@ -73,6 +79,26 @@ mod tests {
     }
 
     #[test]
+    fn format_timestamp_day_greater_than_12() {
+        use chrono::TimeZone;
+        let dt = chrono::FixedOffset::east_opt(3600)
+            .unwrap()
+            .with_ymd_and_hms(2026, 12, 25, 9, 5, 3)
+            .unwrap();
+        assert_eq!(format_timestamp(&dt), "25-12-2026 09:05:03");
+    }
+
+    #[test]
+    fn format_timestamp_day_less_than_12() {
+        use chrono::TimeZone;
+        let dt = chrono::FixedOffset::east_opt(0)
+            .unwrap()
+            .with_ymd_and_hms(2026, 3, 7, 0, 0, 0)
+            .unwrap();
+        assert_eq!(format_timestamp(&dt), "07-03-2026 00:00:00");
+    }
+
+    #[test]
     fn write_log_line_with_prefix() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("prefixed.log");
@@ -87,8 +113,17 @@ mod tests {
         );
         assert!(
             content.starts_with('['),
-            "should start with timestamp bracket"
+            "should start with bracket: {content}"
         );
+        let close = content.find(']').expect("should have closing bracket");
+        let ts_inner = &content[1..close];
+        assert_eq!(
+            ts_inner.len(),
+            19,
+            "timestamp should be 19 chars (DD-MM-YYYY HH:MM:SS): {content}"
+        );
+        let year: u32 = ts_inner[6..10].parse().expect("year should be numeric");
+        assert!(year >= 2025, "year should be plausible: {year}");
     }
 
     #[test]
@@ -105,6 +140,19 @@ mod tests {
             !content.contains(": bare line"),
             "no colon separator when prefix is empty: {content}"
         );
+        assert!(
+            content.starts_with('['),
+            "should start with bracket: {content}"
+        );
+        let close = content.find(']').expect("should have closing bracket");
+        let ts_inner = &content[1..close];
+        assert_eq!(
+            ts_inner.len(),
+            19,
+            "timestamp should be 19 chars (DD-MM-YYYY HH:MM:SS): {content}"
+        );
+        let year: u32 = ts_inner[6..10].parse().expect("year should be numeric");
+        assert!(year >= 2025, "year should be plausible: {year}");
     }
 
     #[test]

--- a/desktop/src/src/app/settings/system-health.component.spec.ts
+++ b/desktop/src/src/app/settings/system-health.component.spec.ts
@@ -166,7 +166,10 @@ describe('SystemHealthComponent', () => {
       fixture.detectChanges();
 
       const el = fixture.nativeElement.querySelector('[data-testid="last-updated"]');
-      expect(el.textContent).toMatch(/\d{2}-\d{2}-\d{4} \d{2}:\d{2}:\d{2}/);
+      const match = el.textContent?.match(/(\d{2})-(\d{2})-(\d{4}) (\d{2}):(\d{2}):(\d{2})/);
+      expect(match).toBeTruthy();
+      const year = parseInt(match![3], 10);
+      expect(year).toBeGreaterThanOrEqual(2025);
     });
 
     it('sets error and nulls report on failure', async () => {

--- a/desktop/src/src/app/settings/system-health.component.spec.ts
+++ b/desktop/src/src/app/settings/system-health.component.spec.ts
@@ -156,6 +156,19 @@ describe('SystemHealthComponent', () => {
       expect(component.lastUpdated).toBeInstanceOf(Date);
     });
 
+    it('renders last-updated with full date and time', async () => {
+      mockTauri.invokeHandler = async (cmd: string) => {
+        if (cmd === 'get_health') return makeHealthReport();
+        if (cmd === 'get_bridge_status') return null;
+        return undefined;
+      };
+      await component.refresh();
+      fixture.detectChanges();
+
+      const el = fixture.nativeElement.querySelector('[data-testid="last-updated"]');
+      expect(el.textContent).toMatch(/\d{2}-\d{2}-\d{4} \d{2}:\d{2}:\d{2}/);
+    });
+
     it('sets error and nulls report on failure', async () => {
       mockTauri.invokeHandler = async (cmd: string) => {
         if (cmd === 'get_health') throw new Error('connection refused');
@@ -396,7 +409,7 @@ describe('SystemHealthComponent', () => {
       component.tailLines = 200;
       mockTauri.invokeHandler = async (cmd: string) => {
         if (cmd === 'get_container_logs') return 'container output';
-        if (cmd === 'get_claude_session_logs') return '[123] SESSION: started';
+        if (cmd === 'get_claude_session_logs') return '[07-04-2026 14:30:00] SESSION: started';
         return '';
       };
 
@@ -404,7 +417,7 @@ describe('SystemHealthComponent', () => {
 
       expect(component.logContent).toContain('container output');
       expect(component.logContent).toContain('--- Claude Session Logs ---');
-      expect(component.logContent).toContain('[123] SESSION: started');
+      expect(component.logContent).toContain('[07-04-2026 14:30:00] SESSION: started');
       expect(component.logLoading).toBe(false);
     });
 

--- a/desktop/src/src/app/settings/system-health.component.ts
+++ b/desktop/src/src/app/settings/system-health.component.ts
@@ -356,7 +356,7 @@ import type { BridgeStatus, ContainerHealth, HealthReport } from '../models/heal
 
       <div class="text-center text-sw-slider text-xs" data-testid="last-updated">
         @if (lastUpdated) {
-          Last updated: {{ lastUpdated | date: 'HH:mm:ss' }}
+          Last updated: {{ lastUpdated | date: 'dd-MM-yyyy HH:mm:ss' }}
         } @else {
           Waiting for first health check...
         }
@@ -370,6 +370,7 @@ export class SystemHealthComponent implements OnInit, OnDestroy {
   report: HealthReport | null = null;
   loading = false;
   error: string | null = null;
+  // Format 'dd-MM-yyyy HH:mm:ss' in template must match chrono format in log_file.rs:write_log_line()
   lastUpdated: Date | null = null;
 
   bridgeStatus: BridgeStatus | null = null;

--- a/desktop/src/src/app/settings/system-health.component.ts
+++ b/desktop/src/src/app/settings/system-health.component.ts
@@ -370,7 +370,6 @@ export class SystemHealthComponent implements OnInit, OnDestroy {
   report: HealthReport | null = null;
   loading = false;
   error: string | null = null;
-  // Format 'dd-MM-yyyy HH:mm:ss' in template must match chrono format in log_file.rs:write_log_line()
   lastUpdated: Date | null = null;
 
   bridgeStatus: BridgeStatus | null = null;


### PR DESCRIPTION
## Summary
- Replace raw Unix epoch seconds (`[1775566001]`) in Claude session logs with formatted `[DD-MM-YYYY HH:MM:SS]` timestamps using `chrono::Local::now()`
- Change Angular date pipe from `'HH:mm:ss'` (time-only) to `'dd-MM-yyyy HH:mm:ss'` (full date+time) in system-health "Last updated" display
- Add `chrono` as direct dependency (already in lockfile as transitive dep via `serde_with`)

## Test plan
- [x] 2 new Rust tests: `format_timestamp_day_greater_than_12` and `format_timestamp_day_less_than_12` verify DD-MM ordering with known dates
- [x] 2 updated Rust tests: `write_log_line_with_prefix` and `write_log_line_without_prefix` validate timestamp length=19 and year>=2025
- [x] Updated synthetic test data in `container_logs_cmd.rs` to match production format
- [x] New Angular template render test verifies `[data-testid="last-updated"]` contains full date+time pattern
- [x] Updated Angular mock session log data to production format
- [x] `cargo test` — 759 passed
- [x] `vitest run` — 784 passed
- [x] Angular ESLint — passed
- [x] Clippy (changed files) — 0 warnings