### PR TITLE
fix: silence cross-target unused warnings surfaced by e2e

### DIFF
--- a/crates/speedwave-runtime/src/resources.rs
+++ b/crates/speedwave-runtime/src/resources.rs
@@ -19,6 +19,7 @@ pub const HOST_OVERHEAD_GIB: u32 = 6;
 /// Floor is intentionally safer than rounding: a 16 GB MacBook with ~15.7 GiB
 /// usable RAM returns 15, which the adaptive formula (`host/2`) then maps to
 /// 7 GiB VM — avoiding an unexpected jump to 8 GiB.
+#[cfg(any(target_os = "macos", target_os = "linux", test))]
 fn bytes_to_gib(bytes: u64) -> u32 {
     (bytes / (1024 * 1024 * 1024)) as u32
 }

--- a/desktop/src-tauri/src/mcp_os_process.rs
+++ b/desktop/src-tauri/src/mcp_os_process.rs
@@ -1,6 +1,8 @@
 use std::io::BufRead;
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command};
+use std::process::Child;
+#[cfg(any(unix, test))]
+use std::process::Command;
 use std::thread::JoinHandle;
 
 use speedwave_runtime::consts;

--- a/desktop/src-tauri/src/setup_wizard.rs
+++ b/desktop/src-tauri/src/setup_wizard.rs
@@ -1812,6 +1812,7 @@ fn link_cli_from(cli_source: &std::path::Path, home: &std::path::Path) -> anyhow
 
     #[cfg(target_os = "windows")]
     {
+        let _ = home;
         let cli_dir = consts::data_dir().join("bin");
 
         let cli_dir_str = cli_dir.to_string_lossy().to_string();


### PR DESCRIPTION
## Summary

Pierwszy pełny `make test-e2e-all` na wszystkich 3 VM (Linux, macOS, Windows × 2 instalacje) przeszedł 100% PASSED, ale odsłonił 3 cross-target `unused_*` warningi, których macOS dev host nie widzi. Fix: minimalne `#[cfg]` gating, zero zmiany runtime behavior.

## Changes

- `crates/speedwave-runtime/src/resources.rs` — gate `bytes_to_gib` do `#[cfg(any(target_os = "macos", target_os = "linux", test))]`. Funkcja jest prywatna, używana tylko w macOS/Linux impl; Windows impl to stub zwracający `None`.
- `desktop/src-tauri/src/mcp_os_process.rs` — gate `Command` import do `#[cfg(any(unix, test))]`. Windows production używa `speedwave_runtime::binary::system_command`; test module wywołuje `Command::new` bezwarunkowo → `test` w cfg zachowuje widoczność dla `use super::*`.
- `desktop/src-tauri/src/setup_wizard.rs` — konsumacja nieużywanego parametru `home` w Windows branch `link_cli_from` przez `let _ = home;`. Windows ustawia PATH przez HKCU\\Environment z `consts::data_dir()`, nie dotyka `home`.

## Test plan

- [x] `make check` na macOS host: 0 warnings
- [x] `make test`: 756+ desktop testów + pozostałe suites PASS
- [x] `cargo clippy --target x86_64-pc-windows-msvc -p speedwave-runtime`: 0 warnings (bytes_to_gib warning GONE)
- [x] `make test-e2e-all` na wszystkich 3 VM × 2 instalacje: **7/7 spec PASSED na każdej platformie**, zero wystąpień wszystkich 3 warningów w pełnym logu
- [x] Upgrade-safety audit: zero blockerów dla 10 obszarów (wire contract, auto-update, containers, CLI, tokens, MCP, platforms, tests, rollback, backmerge)

## Follow-up issues

Za każde z out-of-scope observations z e2e otworzony osobny issue:

- #422 Linux .deb updater logs misleading ERROR on every check
- #423 ADR-025 does not reflect actual code behavior
- #424 Document containerd overlayfs snapshotter race as known upstream
- #425 CI: cross-target clippy matrix (Windows, Linux) as regression guard
- #426 Tauri v1 updater plugin deprecated — plan v2 migration
- #427 Boy Scout: remove \`#[cfg_attr(..., allow(unused_*))]\` from main.rs

## Note

Branch wcześniej istniał jako \`worktree-fix+e2e-warnings\` (PR #428, automatycznie zamknięty). Rename do \`fix/cross-target-warnings\` bo \`+\` w nazwie odrzucał \`claude-review\` GitHub action.