### PR TITLE
fix(runtime): mitigate CLI TUI hang on long streams via NO_FLICKER

### DIFF
--- a/crates/speedwave-runtime/src/compose.rs
+++ b/crates/speedwave-runtime/src/compose.rs
@@ -3702,6 +3702,73 @@ services:
     }
 
     #[test]
+    fn test_claude_env_has_no_flicker() {
+        let config = ResolvedClaudeConfig {
+            env: crate::defaults::base_env(),
+            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            llm: LlmConfig::default(),
+        };
+        let yaml = render_compose(
+            "test-project",
+            "/home/user/projects/test",
+            &config,
+            &ResolvedIntegrationsConfig::default(),
+            None,
+        )
+        .unwrap();
+        let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(&yaml).unwrap();
+
+        let claude_env = doc
+            .get("services")
+            .and_then(|s| s.get("claude"))
+            .and_then(|c| c.get("environment"))
+            .and_then(|e| e.as_sequence())
+            .expect("claude service must have environment");
+
+        let has_no_flicker = claude_env
+            .iter()
+            .any(|v| v.as_str() == Some("CLAUDE_CODE_NO_FLICKER=1"));
+        assert!(
+            has_no_flicker,
+            "CLAUDE_CODE_NO_FLICKER=1 must be in claude service environment \
+             (mitigates PTY backpressure by reducing ANSI frame size — see issue #451)"
+        );
+    }
+
+    #[test]
+    fn test_claude_env_has_effort_level() {
+        let config = ResolvedClaudeConfig {
+            env: crate::defaults::base_env(),
+            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            llm: LlmConfig::default(),
+        };
+        let yaml = render_compose(
+            "test-project",
+            "/home/user/projects/test",
+            &config,
+            &ResolvedIntegrationsConfig::default(),
+            None,
+        )
+        .unwrap();
+        let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(&yaml).unwrap();
+
+        let claude_env = doc
+            .get("services")
+            .and_then(|s| s.get("claude"))
+            .and_then(|c| c.get("environment"))
+            .and_then(|e| e.as_sequence())
+            .expect("claude service must have environment");
+
+        let has_effort_level = claude_env
+            .iter()
+            .any(|v| v.as_str() == Some("CLAUDE_CODE_EFFORT_LEVEL=max"));
+        assert!(
+            has_effort_level,
+            "CLAUDE_CODE_EFFORT_LEVEL=max must be in claude service environment"
+        );
+    }
+
+    #[test]
     fn test_security_no_ports_on_each_worker() {
         for name in [
             "claude",

--- a/crates/speedwave-runtime/src/defaults.rs
+++ b/crates/speedwave-runtime/src/defaults.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-pub const CLAUDE_VERSION: &str = "2.1.92";
+pub const CLAUDE_VERSION: &str = "2.1.104";
 /// Path inside the container where entrypoint.sh generates the MCP config.
 pub const MCP_CONFIG_PATH: &str = "/home/speedwave/.claude/mcp-config.json";
 
@@ -32,6 +32,13 @@ pub fn base_env() -> HashMap<String, String> {
     // containers run as UID 0 and Claude Code refuses --dangerously-skip-permissions
     // as root. IS_SANDBOX=1 bypasses this check. On macOS/Windows (UID 1000) it's a no-op.
     env.insert("IS_SANDBOX".into(), "1".into());
+    // Claude Code focus-view mode: alt-screen + differential rendering emits smaller
+    // ANSI updates instead of full-frame redraws on every stream chunk. Mitigates PTY
+    // write-side backpressure in the CLI (ssh → nerdctl exec → claude) that caused
+    // long streaming sessions to freeze. Introduced upstream in Claude Code 2.1.97.
+    // See issue #451. Users can override via claude.env.CLAUDE_CODE_NO_FLICKER in
+    // .speedwave.json if they prefer the legacy renderer.
+    env.insert("CLAUDE_CODE_NO_FLICKER".into(), "1".into());
     env
 }
 
@@ -81,6 +88,17 @@ mod tests {
         assert_eq!(
             env.get("CLAUDE_CODE_ENABLE_TELEMETRY").map(|s| s.as_str()),
             Some("0")
+        );
+    }
+
+    #[test]
+    fn base_env_enables_no_flicker() {
+        let env = base_env();
+        assert_eq!(
+            env.get("CLAUDE_CODE_NO_FLICKER").map(|s| s.as_str()),
+            Some("1"),
+            "CLAUDE_CODE_NO_FLICKER=1 mitigates PTY backpressure by emitting smaller \
+             ANSI updates via Claude Code's alt-screen renderer. See issue #451."
         );
     }
 

--- a/docs/adr/ADR-017-claude-code-in-container-via-entrypoint.md
+++ b/docs/adr/ADR-017-claude-code-in-container-via-entrypoint.md
@@ -24,6 +24,19 @@ Claude Code is installed via `install-claude.sh` — a reusable script (SSOT) us
 
 **Accepted residual risk (CWE-494 of bootstrap.sh):** The bootstrap script is fetched via TLS (`--proto '=https' --tlsv1.2`) without hash verification — identical to rustup, nvm, and homebrew. Hash-pinning the bootstrap script is operationally fragile (it changes independently of Claude Code versions). Mitigating factors: (1) official Anthropic installer, (2) TLS protection, (3) installer verifies binary SHA256, (4) container isolation (cap_drop ALL, no tokens, read-only FS).
 
+## Runtime Behavior Flags
+
+Claude Code behavior inside the container is tuned via environment variables injected by `render_compose()`. Defaults live in `defaults::base_env()` so they are user-overridable via `claude.env.<VAR>` in `.speedwave.json` or `~/.speedwave/config.json`.
+
+| Variable                       | Default | Purpose                                                                                                                                                           |
+| ------------------------------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CLAUDE_CODE_ENABLE_TELEMETRY` | `0`     | Disables upstream telemetry.                                                                                                                                      |
+| `DISABLE_AUTOUPDATER`          | `1`     | Prevents in-container auto-update after pinned installation.                                                                                                      |
+| `IS_SANDBOX`                   | `1`     | Signals a sandboxed environment so Claude Code accepts `--dangerously-skip-permissions` under Linux rootless UID 0 (ADR-026).[^39]                                |
+| `CLAUDE_CODE_NO_FLICKER`       | `1`     | Enables the alt-screen / differential renderer (focus view). Mitigates PTY write-side backpressure that previously froze long streaming sessions in the CLI.[^40] |
+
+A separate template-sourced flag (`CLAUDE_CODE_EFFORT_LEVEL=max` in `compose.template.yml`) is considered non-user-overridable — it is a Speedwave policy, not a tuning knob.
+
 ## Persistent Volume
 
 Claude Code binary and user data persist across container rebuilds via a named volume:
@@ -55,3 +68,7 @@ Speedwave v1 used `npm install -g @anthropic-ai/claude-code`. The npm package ha
 [^37]: [Claude Code Output Styles — Custom Styles](https://code.claude.com/docs/en/output-styles)
 
 [^38]: [Claude Code installation — native installer replaces npm](https://code.claude.com/docs/en/setup)
+
+[^39]: [ADR-026: Linux rootless container user](./ADR-026-linux-rootless-container-user.md)
+
+[^40]: [Claude Code CHANGELOG — 2.1.97 introduces `CLAUDE_CODE_NO_FLICKER` / Ctrl+O focus view toggle](https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md)


### PR DESCRIPTION
Release PR — promote `dev` to `main`.

## Contents

**#452** — fix(runtime): mitigate CLI TUI hang on long streams via NO_FLICKER

- Enable \`CLAUDE_CODE_NO_FLICKER=1\` in \`base_env()\` to reduce PTY backpressure from large ANSI frames in the Ink renderer (user-overridable via \`.speedwave.json\`)
- Bump pinned Claude Code to 2.1.104 (NO_FLICKER introduced in 2.1.97)
- New unit test \`base_env_enables_no_flicker\` + integration tests \`test_claude_env_has_no_flicker\` / \`test_claude_env_has_effort_level\`
- ADR-017 updated with runtime-flags table

Closes #451.

## Verification

- All CI green on #452 before merge to \`dev\`
- Empirically verified: long streaming prompt (5× WebSearch + 200-line markdown report) completed in 5m 32s without hang; previously reproducibly froze

## Merge strategy

Squash merge. Title uses \`fix(...)\` conventional commit so release-please emits a patch version bump.