### PR TITLE
fix(release): import Apple cert into keychain before tauri-action on macOS

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -211,6 +211,57 @@ jobs:
             echo "::notice::macOS code signing skipped (no APPLE_CERTIFICATE secret)"
           fi
 
+      # tauri-action does not import the certificate into the macOS keychain —
+      # it only passes APPLE_CERTIFICATE to tauri-bundler for signing the outer
+      # .app. Our beforeBundleCommand (scripts/sign-bundled-binaries.sh) runs
+      # `codesign --sign "$APPLE_SIGNING_IDENTITY"` on bundled Mach-O resources
+      # and requires the identity to already be resolvable in a keychain.
+      # This step performs the prescribed Tauri/Apple pattern of creating a
+      # throwaway build keychain and importing the .p12 before tauri-action
+      # starts. See: https://v2.tauri.app/distribute/sign/macos/
+      - name: Import Apple signing certificate to keychain
+        if: matrix.platform == 'macos-latest' && env.APPLE_CERTIFICATE != ''
+        env:
+          CERT: ${{ env.APPLE_CERTIFICATE }}
+          CERT_PASSWORD: ${{ env.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          set -euo pipefail
+          CERT_FILE="$RUNNER_TEMP/apple-cert.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/build.keychain-db"
+          # Random password — keychain is ephemeral, destroyed with the runner.
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"
+          echo "::add-mask::$KEYCHAIN_PASSWORD"
+
+          echo "$CERT" | base64 --decode > "$CERT_FILE"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Prepend the build keychain to the search list so codesign can find
+          # the identity without overriding the login keychain globally.
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
+
+          security import "$CERT_FILE" \
+            -k "$KEYCHAIN_PATH" \
+            -P "$CERT_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          rm -f "$CERT_FILE"
+
+          # Verify the identity is now resolvable — fail fast if not.
+          if ! security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
+               | grep -q "$APPLE_SIGNING_IDENTITY"; then
+            echo "::error::APPLE_SIGNING_IDENTITY not found in imported keychain"
+            security find-identity -v -p codesigning "$KEYCHAIN_PATH" || true
+            exit 1
+          fi
+          echo "::notice::Apple signing identity imported and verified in build keychain"
+
       - name: Configure Windows code signing
         if: matrix.platform == 'windows-latest'
         env:

--- a/Makefile
+++ b/Makefile
@@ -362,6 +362,7 @@ test-desktop-build: build-angular build-mcp
 	bats _tests/desktop/bundle-build-context.bats
 	bats _tests/desktop/verify-bundled-assets.bats
 	bats _tests/desktop/sign-bundled-binaries.bats
+	bats _tests/desktop/release-workflow-signing.bats
 	@echo "✅ Desktop build tests passed"
 
 # ── Desktop E2E tests ────────────────────────────────────────────────────────

--- a/_tests/desktop/release-workflow-signing.bats
+++ b/_tests/desktop/release-workflow-signing.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+
+# Static sanity checks on .github/workflows/desktop-release.yml to prevent the
+# macOS signing regression that shipped in PR #458 / v0.7.2-draft: without a
+# keychain-import step before tauri-action, `beforeBundleCommand` runs
+# `codesign --sign "$APPLE_SIGNING_IDENTITY"` against an empty keychain and the
+# entire macOS matrix fails with "item could not be found in the keychain".
+#
+# These tests guard the contract between the workflow and
+# scripts/sign-bundled-binaries.sh: by the time tauri-action starts on macOS,
+# the identity must already be importable and the script's `codesign` call must
+# be able to resolve it.
+
+WORKFLOW="$BATS_TEST_DIRNAME/../../.github/workflows/desktop-release.yml"
+
+@test "desktop-release.yml exists" {
+    [ -f "$WORKFLOW" ]
+}
+
+@test "workflow imports Apple certificate into keychain before tauri-action" {
+    # Grab line numbers of the keychain-import step and the tauri-action step.
+    # `grep -n` prints "LINE:content"; cut to just the line number.
+    import_line=$(grep -n "Import Apple signing certificate to keychain" "$WORKFLOW" | head -1 | cut -d: -f1)
+    tauri_line=$(grep -n "tauri-apps/tauri-action@" "$WORKFLOW" | head -1 | cut -d: -f1)
+
+    [ -n "$import_line" ]
+    [ -n "$tauri_line" ]
+    # Import must come before tauri-action, otherwise beforeBundleCommand sees
+    # an empty keychain on the ephemeral GitHub runner.
+    [ "$import_line" -lt "$tauri_line" ]
+}
+
+@test "keychain import uses the prescribed security commands" {
+    # security create-keychain + import + set-key-partition-list is the
+    # pattern Tauri and Apple require for codesign to find a Developer ID
+    # identity on a headless CI runner. All three must be present.
+    grep -q "security create-keychain" "$WORKFLOW"
+    grep -q "security import" "$WORKFLOW"
+    grep -q "security set-key-partition-list" "$WORKFLOW"
+}
+
+@test "keychain import grants codesign access to the imported key" {
+    # `-T /usr/bin/codesign` is what lets codesign read the private key from
+    # the build keychain without triggering a GUI password prompt. Missing
+    # this flag is a common silent-failure mode.
+    grep -q -- "-T /usr/bin/codesign" "$WORKFLOW"
+}
+
+@test "keychain import prepends build keychain to search list" {
+    # codesign resolves identities via the user's keychain search list; if the
+    # build keychain is created but not added to that list, `find-identity`
+    # returns empty and signing fails. `security list-keychains -s` is the
+    # single command that fixes this.
+    grep -q "security list-keychains" "$WORKFLOW"
+}
+
+@test "keychain import fails fast if identity is not resolvable" {
+    # The step must verify the identity is actually importable, not just
+    # that `security import` exited 0 — a malformed .p12 can import without
+    # producing a usable codesigning identity. `find-identity` after import
+    # is the canonical smoke test.
+    grep -q "security find-identity" "$WORKFLOW"
+}
+
+@test "keychain import step gates on matrix.platform == 'macos-latest'" {
+    # Must not run on Linux/Windows matrix jobs — security commands don't
+    # exist there and the step would error out the entire matrix. The `if:`
+    # guard must appear on the line immediately following the step name
+    # (standard Actions step layout).
+    import_line=$(grep -n "Import Apple signing certificate to keychain" "$WORKFLOW" | head -1 | cut -d: -f1)
+    [ -n "$import_line" ]
+    guard_line=$((import_line + 1))
+    sed -n "${guard_line}p" "$WORKFLOW" | grep -q "matrix.platform == 'macos-latest'"
+}


### PR DESCRIPTION
## Summary

Fixes the macOS signing regression that killed the v0.7.2 draft release. The `beforeBundleCommand` hook added in #458 runs `codesign --sign "$APPLE_SIGNING_IDENTITY"` on bundled Mach-O resources, but **tauri-action does not import `APPLE_CERTIFICATE` into the macOS keychain** — it only forwards the env var to tauri-bundler. Without a separate keychain-import step, `codesign` fails with `"The specified item could not be found in the keychain"` and the entire macOS matrix collapses.

Add the step prescribed by [Tauri v2's macOS signing guide](https://v2.tauri.app/distribute/sign/macos/): create a throwaway build keychain, import the .p12 with `-T /usr/bin/codesign`, prepend the keychain to the user search list, and verify the identity is resolvable before handing off to tauri-action.

## Why the previous flow looked like it worked locally

PR #458's local verification used `~/Library/Keychains/login.keychain-db` which already had the Developer ID cert imported manually — so `codesign --sign IDENTITY` resolved via the login keychain. GitHub runners are ephemeral with empty keychains; the bug only manifests in CI.

## Changes

- `.github/workflows/desktop-release.yml` — new `Import Apple signing certificate to keychain` step, gated on `matrix.platform == 'macos-latest' && env.APPLE_CERTIFICATE != ''`, placed between the existing `Configure macOS code signing` step and tauri-action.
- `_tests/desktop/release-workflow-signing.bats` — 7 static assertions that guard against regressions (step presence, ordering, `-T /usr/bin/codesign` flag, search-list update, `find-identity` verification, macos-latest guard).
- `Makefile` — wires the new bats file into `test-desktop-build`.

## Test plan

- [x] `bats _tests/desktop/release-workflow-signing.bats` — 7/7 pass locally
- [x] `bats _tests/desktop/sign-bundled-binaries.bats` — 6/6 still pass (no script changes)
- [x] `.github/workflows/desktop-release.yml` parses as valid YAML
- [ ] CI green on PR
- [ ] After merge to dev → merge to main → release-please reopens 0.7.2 release PR → the macOS builds actually succeed end-to-end (the ultimate proof)

Refs #376, #458