### PR TITLE
fix(release): address review findings on macOS keychain import

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -221,6 +221,7 @@ jobs:
       # starts. See: https://v2.tauri.app/distribute/sign/macos/
       - name: Import Apple signing certificate to keychain
         if: matrix.platform == 'macos-latest' && env.APPLE_CERTIFICATE != ''
+        shell: bash
         env:
           CERT: ${{ env.APPLE_CERTIFICATE }}
           CERT_PASSWORD: ${{ env.APPLE_CERTIFICATE_PASSWORD }}
@@ -241,8 +242,11 @@ jobs:
           # Prepend the build keychain to the search list so codesign can find
           # the identity without overriding the login keychain globally. Read
           # the existing list into an array so quoted paths survive word
-          # splitting if a keychain path ever contains spaces.
-          mapfile -t _existing_keychains < <(security list-keychains -d user | tr -d '"' | awk '{$1=$1};1')
+          # splitting if a keychain path ever contains spaces. Trim leading
+          # and trailing whitespace with sed, not `awk '{$1=$1};1'` — the
+          # latter re-splits on internal whitespace and would mangle any path
+          # that contains spaces, defeating the point of mapfile.
+          mapfile -t _existing_keychains < <(security list-keychains -d user | tr -d '"' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | sed '/^$/d')
           security list-keychains -d user -s "$KEYCHAIN_PATH" "${_existing_keychains[@]}"
 
           security import "$CERT_FILE" \

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -239,8 +239,11 @@ jobs:
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
           # Prepend the build keychain to the search list so codesign can find
-          # the identity without overriding the login keychain globally.
-          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
+          # the identity without overriding the login keychain globally. Read
+          # the existing list into an array so quoted paths survive word
+          # splitting if a keychain path ever contains spaces.
+          mapfile -t _existing_keychains < <(security list-keychains -d user | tr -d '"' | awk '{$1=$1};1')
+          security list-keychains -d user -s "$KEYCHAIN_PATH" "${_existing_keychains[@]}"
 
           security import "$CERT_FILE" \
             -k "$KEYCHAIN_PATH" \
@@ -253,9 +256,18 @@ jobs:
 
           rm -f "$CERT_FILE"
 
+          # Guard against an empty APPLE_SIGNING_IDENTITY — `grep -q ""` would
+          # match every line and the verification below would silently pass
+          # even without a usable identity in the keychain.
+          if [ -z "${APPLE_SIGNING_IDENTITY:-}" ]; then
+            echo "::error::APPLE_SIGNING_IDENTITY is empty — check the repository secret"
+            exit 1
+          fi
           # Verify the identity is now resolvable — fail fast if not.
+          # -qF: fixed-string match, since the identity contains `()` which
+          # grep would otherwise treat as regex metacharacters in ERE.
           if ! security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
-               | grep -q "$APPLE_SIGNING_IDENTITY"; then
+               | grep -qF "$APPLE_SIGNING_IDENTITY"; then
             echo "::error::APPLE_SIGNING_IDENTITY not found in imported keychain"
             security find-identity -v -p codesigning "$KEYCHAIN_PATH" || true
             exit 1

--- a/_tests/desktop/release-workflow-signing.bats
+++ b/_tests/desktop/release-workflow-signing.bats
@@ -62,13 +62,37 @@ WORKFLOW="$BATS_TEST_DIRNAME/../../.github/workflows/desktop-release.yml"
     grep -q "security find-identity" "$WORKFLOW"
 }
 
+@test "keychain import uses fixed-string grep for identity verification" {
+    # The identity string contains `(TEAM)` — grep without -F treats the
+    # parentheses as regex metacharacters. More importantly, `grep -q ""`
+    # matches every line, so without `-F` and an empty-identity guard the
+    # verification silently passes when APPLE_SIGNING_IDENTITY is unset.
+    grep -q 'grep -qF' "$WORKFLOW"
+}
+
+@test "keychain import guards against empty APPLE_SIGNING_IDENTITY" {
+    # If APPLE_CERTIFICATE is set but APPLE_SIGNING_IDENTITY isn't, the
+    # downstream grep verification would match every line (empty pattern) and
+    # silently report success — then tauri-action would fail cryptically
+    # inside the bundle step. The step must fail fast before find-identity.
+    grep -qE 'APPLE_SIGNING_IDENTITY is empty' "$WORKFLOW"
+}
+
+@test "keychain import uses mapfile for safe keychain list expansion" {
+    # `security list-keychains -d user` output was previously consumed via
+    # an unquoted $(...) subshell, which is subject to word splitting and
+    # glob expansion. `mapfile` + quoted array expansion is the robust form.
+    grep -q 'mapfile -t' "$WORKFLOW"
+}
+
 @test "keychain import step gates on matrix.platform == 'macos-latest'" {
     # Must not run on Linux/Windows matrix jobs — security commands don't
-    # exist there and the step would error out the entire matrix. The `if:`
-    # guard must appear on the line immediately following the step name
-    # (standard Actions step layout).
+    # exist there and the step would error out the entire matrix. Search
+    # forward from the step name for the next `if:` line instead of assuming
+    # a fixed offset — tolerates blank lines or comments between them.
     import_line=$(grep -n "Import Apple signing certificate to keychain" "$WORKFLOW" | head -1 | cut -d: -f1)
     [ -n "$import_line" ]
-    guard_line=$((import_line + 1))
+    guard_line=$(awk -v start="$import_line" 'NR>start && /^        if:/ { print NR; exit }' "$WORKFLOW")
+    [ -n "$guard_line" ]
     sed -n "${guard_line}p" "$WORKFLOW" | grep -q "matrix.platform == 'macos-latest'"
 }

--- a/_tests/desktop/release-workflow-signing.bats
+++ b/_tests/desktop/release-workflow-signing.bats
@@ -75,7 +75,7 @@ WORKFLOW="$BATS_TEST_DIRNAME/../../.github/workflows/desktop-release.yml"
     # downstream grep verification would match every line (empty pattern) and
     # silently report success — then tauri-action would fail cryptically
     # inside the bundle step. The step must fail fast before find-identity.
-    grep -qE 'APPLE_SIGNING_IDENTITY is empty' "$WORKFLOW"
+    grep -qF 'APPLE_SIGNING_IDENTITY is empty' "$WORKFLOW"
 }
 
 @test "keychain import uses mapfile for safe keychain list expansion" {

--- a/_tests/desktop/release-workflow-signing.bats
+++ b/_tests/desktop/release-workflow-signing.bats
@@ -67,7 +67,7 @@ WORKFLOW="$BATS_TEST_DIRNAME/../../.github/workflows/desktop-release.yml"
     # parentheses as regex metacharacters. More importantly, `grep -q ""`
     # matches every line, so without `-F` and an empty-identity guard the
     # verification silently passes when APPLE_SIGNING_IDENTITY is unset.
-    grep -q 'grep -qF' "$WORKFLOW"
+    grep -qF 'grep -qF' "$WORKFLOW"
 }
 
 @test "keychain import guards against empty APPLE_SIGNING_IDENTITY" {
@@ -82,7 +82,7 @@ WORKFLOW="$BATS_TEST_DIRNAME/../../.github/workflows/desktop-release.yml"
     # `security list-keychains -d user` output was previously consumed via
     # an unquoted $(...) subshell, which is subject to word splitting and
     # glob expansion. `mapfile` + quoted array expansion is the robust form.
-    grep -q 'mapfile -t' "$WORKFLOW"
+    grep -qF 'mapfile -t' "$WORKFLOW"
 }
 
 @test "keychain import step gates on matrix.platform == 'macos-latest'" {


### PR DESCRIPTION
## Summary

Follow-up to #463, addressing the three findings from `claude-review`:

1. **Medium — empty `APPLE_SIGNING_IDENTITY` silently passed verification.** `grep -q ""` matches every line, so the `find-identity` check would report success even without a usable identity. Added an explicit pre-check that fails fast.
2. **Low — `grep -q` instead of `grep -qF`.** Identity contains `()` metacharacters. Fixed-string matching is the correct form, and pairs with #1 to close the silent-failure class.
3. **Low — unquoted `$(security list-keychains …)` subshell expansion.** Word splitting / glob expansion latent bug. Replaced with `mapfile -t` + quoted array expansion.

Plus the observation from the review:

4. **Brittle bats assertion.** The `if:` guard check assumed fixed offset (`name_line + 1`). Replaced with `awk` forward search — tolerates blank lines or comments.

Added three new bats assertions covering the fixes: `-qF` usage, empty-identity guard, mapfile expansion.

## Test plan

- [x] `bats _tests/desktop/release-workflow-signing.bats` — 10/10 pass locally
- [x] `python3 yaml.safe_load` — YAML parses clean
- [ ] CI green on PR
- [ ] Merge → ready for release retry