### PR TITLE
fix(release): import Apple cert into keychain before tauri-action on macOS

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -211,6 +211,57 @@ jobs:
             echo "::notice::macOS code signing skipped (no APPLE_CERTIFICATE secret)"
           fi
 
+      # tauri-action does not import the certificate into the macOS keychain —
+      # it only passes APPLE_CERTIFICATE to tauri-bundler for signing the outer
+      # .app. Our beforeBundleCommand (scripts/sign-bundled-binaries.sh) runs
+      # `codesign --sign "$APPLE_SIGNING_IDENTITY"` on bundled Mach-O resources
+      # and requires the identity to already be resolvable in a keychain.
+      # This step performs the prescribed Tauri/Apple pattern of creating a
+      # throwaway build keychain and importing the .p12 before tauri-action
+      # starts. See: https://v2.tauri.app/distribute/sign/macos/
+      - name: Import Apple signing certificate to keychain
+        if: matrix.platform == 'macos-latest' && env.APPLE_CERTIFICATE != ''
+        env:
+          CERT: ${{ env.APPLE_CERTIFICATE }}
+          CERT_PASSWORD: ${{ env.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          set -euo pipefail
+          CERT_FILE="$RUNNER_TEMP/apple-cert.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/build.keychain-db"
+          # Random password — keychain is ephemeral, destroyed with the runner.
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"
+          echo "::add-mask::$KEYCHAIN_PASSWORD"
+
+          echo "$CERT" | base64 --decode > "$CERT_FILE"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Prepend the build keychain to the search list so codesign can find
+          # the identity without overriding the login keychain globally.
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
+
+          security import "$CERT_FILE" \
+            -k "$KEYCHAIN_PATH" \
+            -P "$CERT_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          rm -f "$CERT_FILE"
+
+          # Verify the identity is now resolvable — fail fast if not.
+          if ! security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
+               | grep -q "$APPLE_SIGNING_IDENTITY"; then
+            echo "::error::APPLE_SIGNING_IDENTITY not found in imported keychain"
+            security find-identity -v -p codesigning "$KEYCHAIN_PATH" || true
+            exit 1
+          fi
+          echo "::notice::Apple signing identity imported and verified in build keychain"
+
       - name: Configure Windows code signing
         if: matrix.platform == 'windows-latest'
         env:

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -221,6 +221,7 @@ jobs:
       # starts. See: https://v2.tauri.app/distribute/sign/macos/
       - name: Import Apple signing certificate to keychain
         if: matrix.platform == 'macos-latest' && env.APPLE_CERTIFICATE != ''
+        shell: bash
         env:
           CERT: ${{ env.APPLE_CERTIFICATE }}
           CERT_PASSWORD: ${{ env.APPLE_CERTIFICATE_PASSWORD }}
@@ -239,8 +240,14 @@ jobs:
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
           # Prepend the build keychain to the search list so codesign can find
-          # the identity without overriding the login keychain globally.
-          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
+          # the identity without overriding the login keychain globally. Read
+          # the existing list into an array so quoted paths survive word
+          # splitting if a keychain path ever contains spaces. Trim leading
+          # and trailing whitespace with sed, not `awk '{$1=$1};1'` — the
+          # latter re-splits on internal whitespace and would mangle any path
+          # that contains spaces, defeating the point of mapfile.
+          mapfile -t _existing_keychains < <(security list-keychains -d user | tr -d '"' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | sed '/^$/d')
+          security list-keychains -d user -s "$KEYCHAIN_PATH" "${_existing_keychains[@]}"
 
           security import "$CERT_FILE" \
             -k "$KEYCHAIN_PATH" \
@@ -253,9 +260,18 @@ jobs:
 
           rm -f "$CERT_FILE"
 
+          # Guard against an empty APPLE_SIGNING_IDENTITY — `grep -q ""` would
+          # match every line and the verification below would silently pass
+          # even without a usable identity in the keychain.
+          if [ -z "${APPLE_SIGNING_IDENTITY:-}" ]; then
+            echo "::error::APPLE_SIGNING_IDENTITY is empty — check the repository secret"
+            exit 1
+          fi
           # Verify the identity is now resolvable — fail fast if not.
+          # -qF: fixed-string match, since the identity contains `()` which
+          # grep would otherwise treat as regex metacharacters in ERE.
           if ! security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
-               | grep -q "$APPLE_SIGNING_IDENTITY"; then
+               | grep -qF "$APPLE_SIGNING_IDENTITY"; then
             echo "::error::APPLE_SIGNING_IDENTITY not found in imported keychain"
             security find-identity -v -p codesigning "$KEYCHAIN_PATH" || true
             exit 1

--- a/Makefile
+++ b/Makefile
@@ -362,6 +362,7 @@ test-desktop-build: build-angular build-mcp
 	bats _tests/desktop/bundle-build-context.bats
 	bats _tests/desktop/verify-bundled-assets.bats
 	bats _tests/desktop/sign-bundled-binaries.bats
+	bats _tests/desktop/release-workflow-signing.bats
 	@echo "✅ Desktop build tests passed"
 
 # ── Desktop E2E tests ────────────────────────────────────────────────────────

--- a/_tests/desktop/release-workflow-signing.bats
+++ b/_tests/desktop/release-workflow-signing.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+
+# Static sanity checks on .github/workflows/desktop-release.yml to prevent the
+# macOS signing regression that shipped in PR #458 / v0.7.2-draft: without a
+# keychain-import step before tauri-action, `beforeBundleCommand` runs
+# `codesign --sign "$APPLE_SIGNING_IDENTITY"` against an empty keychain and the
+# entire macOS matrix fails with "item could not be found in the keychain".
+#
+# These tests guard the contract between the workflow and
+# scripts/sign-bundled-binaries.sh: by the time tauri-action starts on macOS,
+# the identity must already be importable and the script's `codesign` call must
+# be able to resolve it.
+
+WORKFLOW="$BATS_TEST_DIRNAME/../../.github/workflows/desktop-release.yml"
+
+@test "desktop-release.yml exists" {
+    [ -f "$WORKFLOW" ]
+}
+
+@test "workflow imports Apple certificate into keychain before tauri-action" {
+    # Grab line numbers of the keychain-import step and the tauri-action step.
+    # `grep -n` prints "LINE:content"; cut to just the line number.
+    import_line=$(grep -n "Import Apple signing certificate to keychain" "$WORKFLOW" | head -1 | cut -d: -f1)
+    tauri_line=$(grep -n "tauri-apps/tauri-action@" "$WORKFLOW" | head -1 | cut -d: -f1)
+
+    [ -n "$import_line" ]
+    [ -n "$tauri_line" ]
+    # Import must come before tauri-action, otherwise beforeBundleCommand sees
+    # an empty keychain on the ephemeral GitHub runner.
+    [ "$import_line" -lt "$tauri_line" ]
+}
+
+@test "keychain import uses the prescribed security commands" {
+    # security create-keychain + import + set-key-partition-list is the
+    # pattern Tauri and Apple require for codesign to find a Developer ID
+    # identity on a headless CI runner. All three must be present.
+    grep -q "security create-keychain" "$WORKFLOW"
+    grep -q "security import" "$WORKFLOW"
+    grep -q "security set-key-partition-list" "$WORKFLOW"
+}
+
+@test "keychain import grants codesign access to the imported key" {
+    # `-T /usr/bin/codesign` is what lets codesign read the private key from
+    # the build keychain without triggering a GUI password prompt. Missing
+    # this flag is a common silent-failure mode.
+    grep -q -- "-T /usr/bin/codesign" "$WORKFLOW"
+}
+
+@test "keychain import prepends build keychain to search list" {
+    # codesign resolves identities via the user's keychain search list; if the
+    # build keychain is created but not added to that list, `find-identity`
+    # returns empty and signing fails. `security list-keychains -s` is the
+    # single command that fixes this.
+    grep -q "security list-keychains" "$WORKFLOW"
+}
+
+@test "keychain import fails fast if identity is not resolvable" {
+    # The step must verify the identity is actually importable, not just
+    # that `security import` exited 0 — a malformed .p12 can import without
+    # producing a usable codesigning identity. `find-identity` after import
+    # is the canonical smoke test.
+    grep -q "security find-identity" "$WORKFLOW"
+}
+
+@test "keychain import step gates on matrix.platform == 'macos-latest'" {
+    # Must not run on Linux/Windows matrix jobs — security commands don't
+    # exist there and the step would error out the entire matrix. The `if:`
+    # guard must appear on the line immediately following the step name
+    # (standard Actions step layout).
+    import_line=$(grep -n "Import Apple signing certificate to keychain" "$WORKFLOW" | head -1 | cut -d: -f1)
+    [ -n "$import_line" ]
+    guard_line=$((import_line + 1))
+    sed -n "${guard_line}p" "$WORKFLOW" | grep -q "matrix.platform == 'macos-latest'"
+}

--- a/_tests/desktop/release-workflow-signing.bats
+++ b/_tests/desktop/release-workflow-signing.bats
@@ -62,13 +62,37 @@ WORKFLOW="$BATS_TEST_DIRNAME/../../.github/workflows/desktop-release.yml"
     grep -q "security find-identity" "$WORKFLOW"
 }
 
+@test "keychain import uses fixed-string grep for identity verification" {
+    # The identity string contains `(TEAM)` — grep without -F treats the
+    # parentheses as regex metacharacters. More importantly, `grep -q ""`
+    # matches every line, so without `-F` and an empty-identity guard the
+    # verification silently passes when APPLE_SIGNING_IDENTITY is unset.
+    grep -qF 'grep -qF' "$WORKFLOW"
+}
+
+@test "keychain import guards against empty APPLE_SIGNING_IDENTITY" {
+    # If APPLE_CERTIFICATE is set but APPLE_SIGNING_IDENTITY isn't, the
+    # downstream grep verification would match every line (empty pattern) and
+    # silently report success — then tauri-action would fail cryptically
+    # inside the bundle step. The step must fail fast before find-identity.
+    grep -qF 'APPLE_SIGNING_IDENTITY is empty' "$WORKFLOW"
+}
+
+@test "keychain import uses mapfile for safe keychain list expansion" {
+    # `security list-keychains -d user` output was previously consumed via
+    # an unquoted $(...) subshell, which is subject to word splitting and
+    # glob expansion. `mapfile` + quoted array expansion is the robust form.
+    grep -qF 'mapfile -t' "$WORKFLOW"
+}
+
 @test "keychain import step gates on matrix.platform == 'macos-latest'" {
     # Must not run on Linux/Windows matrix jobs — security commands don't
-    # exist there and the step would error out the entire matrix. The `if:`
-    # guard must appear on the line immediately following the step name
-    # (standard Actions step layout).
+    # exist there and the step would error out the entire matrix. Search
+    # forward from the step name for the next `if:` line instead of assuming
+    # a fixed offset — tolerates blank lines or comments between them.
     import_line=$(grep -n "Import Apple signing certificate to keychain" "$WORKFLOW" | head -1 | cut -d: -f1)
     [ -n "$import_line" ]
-    guard_line=$((import_line + 1))
+    guard_line=$(awk -v start="$import_line" 'NR>start && /^        if:/ { print NR; exit }' "$WORKFLOW")
+    [ -n "$guard_line" ]
     sed -n "${guard_line}p" "$WORKFLOW" | grep -q "matrix.platform == 'macos-latest'"
 }


### PR DESCRIPTION
## Summary

Cherry-pick of #463 + #464 from dev directly onto main. Previous attempts via dev→main PR (#466, #468) hit merge conflicts caused by SHA divergence after the v0.7.2 revert (#465). Cherry-pick avoids the conflict because the changes (workflow YAML + bats tests + Makefile) don't touch version files.

### What this brings to main

- Import Apple .p12 into throwaway build keychain before tauri-action — fixes the "item could not be found in the keychain" failure that killed the v0.7.2 draft release
- Empty APPLE_SIGNING_IDENTITY guard
- `grep -qF` for identity verification
- `mapfile` + safe trim for keychain list expansion
- `shell: bash` for mapfile compatibility
- 10 bats assertions guarding the contract

### After merge

1. Release-please updates PR #467 (adds changelog entry for this fix)
2. Merge #467 → tag v0.7.2 → desktop-release.yml builds with keychain fix
3. macOS builds should pass this time

## Test plan

- [x] Cherry-pick clean — zero conflicts
- [x] Bats 10/10 on dev
- [ ] CI green on this PR
- [ ] Merge → release-please updates #467
- [ ] Merge #467 → macOS builds pass

Refs #376, #463, #464