### PR TITLE
fix(release): replace mapfile with while-read loop for bash 3.2

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -240,13 +240,12 @@ jobs:
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
           # Prepend the build keychain to the search list so codesign can find
-          # the identity without overriding the login keychain globally. Read
-          # the existing list into an array so quoted paths survive word
-          # splitting if a keychain path ever contains spaces. Trim leading
-          # and trailing whitespace with sed, not `awk '{$1=$1};1'` — the
-          # latter re-splits on internal whitespace and would mangle any path
-          # that contains spaces, defeating the point of mapfile.
-          mapfile -t _existing_keychains < <(security list-keychains -d user | tr -d '"' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | sed '/^$/d')
+          # the identity without overriding the login keychain globally.
+          # macOS ships bash 3.2 which lacks mapfile — use a while-read loop.
+          _existing_keychains=()
+          while IFS= read -r _kc; do
+            [ -n "$_kc" ] && _existing_keychains+=("$_kc")
+          done < <(security list-keychains -d user | tr -d '"' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
           security list-keychains -d user -s "$KEYCHAIN_PATH" "${_existing_keychains[@]}"
 
           security import "$CERT_FILE" \

--- a/_tests/desktop/release-workflow-signing.bats
+++ b/_tests/desktop/release-workflow-signing.bats
@@ -78,11 +78,11 @@ WORKFLOW="$BATS_TEST_DIRNAME/../../.github/workflows/desktop-release.yml"
     grep -qF 'APPLE_SIGNING_IDENTITY is empty' "$WORKFLOW"
 }
 
-@test "keychain import uses mapfile for safe keychain list expansion" {
-    # `security list-keychains -d user` output was previously consumed via
-    # an unquoted $(...) subshell, which is subject to word splitting and
-    # glob expansion. `mapfile` + quoted array expansion is the robust form.
-    grep -qF 'mapfile -t' "$WORKFLOW"
+@test "keychain import uses while-read loop for safe keychain list expansion" {
+    # `security list-keychains -d user` output must be read into an array
+    # without word splitting. macOS ships bash 3.2 which lacks mapfile, so
+    # a while-read loop is the bash 3.2-compatible equivalent.
+    grep -qF 'while IFS= read -r' "$WORKFLOW"
 }
 
 @test "keychain import step gates on matrix.platform == 'macos-latest'" {


### PR DESCRIPTION
Cherry-pick of #470 from main. Required because `workflow_dispatch` on `desktop-release.yml` reads workflow YAML from the **default branch** (`dev`), not from `main`. Without this fix on dev, manually-triggered release builds fail with `mapfile: command not found` on macOS runners (bash 3.2).

After merge, re-trigger `desktop-release.yml` workflow_dispatch with `version: 0.7.2`.