### PR TITLE
fix(security): add missing entitlements for limactl, mail-cli, notes-cli

### DIFF
--- a/.claude/skills/speedwave-review-plan/SKILL.md
+++ b/.claude/skills/speedwave-review-plan/SKILL.md
@@ -233,6 +233,8 @@ Check:
 
 - Does it touch OS prerequisite checks (`os_prereqs.rs`)? Verify violations still block container start.
 
+- If the plan adds a new bundled binary: does it include entitlements analysis? Is `SIGN_TARGETS` in `sign-bundled-binaries.sh` updated? Is the entitlements plist created in `desktop/src-tauri/entitlements/` if needed? Is ADR-037 updated? Does the plan account for Hardened Runtime restrictions (Virtualization.framework, Apple Events/osascript, JIT, other restricted APIs)?
+
 **Severity: Any security relaxation without an ADR justification = BLOCKER.**
 
 ### 2. ARCHITECTURAL INTEGRITY & SSOT
@@ -292,6 +294,8 @@ Check:
 - **Build context:** `prepare_build_context()` handles path translation for VMs. Does the plan respect this?
 
 - **Resource limits:** Adaptive on macOS/Linux (formulas in `resources.rs`), fixed on Windows. Does the plan change memory/CPU assumptions?
+
+- **macOS code signing:** If the plan adds a new bundled binary: is it added to `SIGN_TARGETS` in `sign-bundled-binaries.sh`? Does it need entitlements under Hardened Runtime (Virtualization.framework, Apple Events/osascript, JIT, other restricted APIs)? Is the entitlements plist in `desktop/src-tauri/entitlements/` created? Is ADR-037 entitlements inventory table updated?
 
 **Severity: Platform blindness = HIGH. Silent failures on platforms the developer didn't test on.**
 

--- a/.claude/skills/speedwave-write-plan/SKILL.md
+++ b/.claude/skills/speedwave-write-plan/SKILL.md
@@ -100,6 +100,8 @@ For EVERY change, answer:
 
 - Does it affect installer artifacts? (.dmg, .deb, .exe)
 
+- Does this change add or modify a bundled macOS binary? If yes: (1) add to `SIGN_TARGETS` in `sign-bundled-binaries.sh`, (2) determine if it needs entitlements under Hardened Runtime (check: does it use Virtualization.framework, Apple Events/osascript, JIT, or other restricted APIs?), (3) create entitlements plist in `desktop/src-tauri/entitlements/` if needed, (4) update ADR-037 entitlements inventory table
+
 - Filesystem case sensitivity? (macOS VirtioFS insensitive, Linux ext4 sensitive)
 
 If the change is platform-independent, state WHY it's platform-independent — don't just skip this section.
@@ -193,6 +195,8 @@ Answer EVERY question. "N/A" is acceptable only with justification.
 - [ ] Authentication gates preserved? (backend + frontend)
 
 - [ ] `path-validator.ts` denylist intact? (`.git/`, `.env`, `.speedwave/`)
+
+- [ ] New or modified bundled macOS binary? → (1) added to `SIGN_TARGETS` in `sign-bundled-binaries.sh`, (2) entitlements analysis done (Virtualization.framework, Apple Events/osascript, JIT, other restricted APIs), (3) entitlements plist created in `desktop/src-tauri/entitlements/` if needed, (4) ADR-037 entitlements inventory table updated
 
 ### 7. Documentation Plan
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ Security-first AI platform connecting Claude Code with external services (Slack,
 - **SSOT: `mcp-servers/shared/`** — MCP protocol utilities shared by all servers
 - **SSOT: `containers/compose.template.yml`** — container definitions. `render_compose()` generates per-project files
 - **SSOT alignment:** `scripts/bundle-build-context.sh` IMAGES list must stay aligned with `crates/speedwave-runtime/src/build.rs` IMAGES constant
+- **SSOT alignment:** `scripts/sign-bundled-binaries.sh` SIGN_TARGETS must stay aligned with `desktop/src-tauri/tauri.macos.conf.json` bundle.resources — every bundled Mach-O must be signed, and binaries using restricted platform APIs need entitlements plists in `desktop/src-tauri/entitlements/`
 - **Per-project isolation:** `~/.speedwave/tokens/<project>/<service>/` (read-only mount), `speedwave_<project>_network` (isolated network)
 - **ContainerRuntime trait:** `Box<dyn ContainerRuntime>` — implementations: `LimaRuntime`, `NerdctlRuntime`, `WslRuntime`
 - **MCP Hub:** port 4000, the ONLY MCP server Claude sees. Hub has zero tokens.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -33,6 +33,7 @@ Store the private key as `TAURI_SIGNING_PRIVATE_KEY`. The public key is already 
 - `RELEASE_TOKEN` missing — release-please cannot create PRs or push to `main`. The workflow fails with a permissions error.
 - `TAURI_SIGNING_PRIVATE_KEY` missing — tauri-action produces unsigned bundles. The Tauri updater will **refuse to install** them (signature verification fails). Users cannot auto-update.
 - Apple/Windows signing secrets missing — builds succeed but produce unsigned binaries. macOS Gatekeeper blocks the app (users must right-click > Open). Windows SmartScreen shows a warning.
+- Entitlements plists missing — builds and notarization succeed, but binaries crash at runtime when they attempt to use restricted platform APIs (Virtualization.framework, Apple Events). This is NOT caught by CI — only by manual testing.
 
 **Operational setup for Apple signing** (certificate generation, Keychain import, notary configuration, rotation) is documented in [Release Signing Guide](docs/contributing/release-signing.md). The architectural rationale — including why every Mach-O binary in `Contents/Resources/` is signed individually — is in [ADR-037](docs/adr/ADR-037-code-signing-and-bundled-binary-signing.md).
 

--- a/_tests/desktop/sign-bundled-binaries.bats
+++ b/_tests/desktop/sign-bundled-binaries.bats
@@ -62,6 +62,7 @@ populate_targets() {
     local ent_src="$BATS_TEST_DIRNAME/../../desktop/src-tauri/entitlements"
     cp "$ent_src/node.plist" "$SRC_TAURI/entitlements/node.plist"
     cp "$ent_src/limactl.plist" "$SRC_TAURI/entitlements/limactl.plist"
+    cp "$ent_src/calendars.plist" "$SRC_TAURI/entitlements/calendars.plist"
     cp "$ent_src/apple-events.plist" "$SRC_TAURI/entitlements/apple-events.plist"
 }
 
@@ -175,12 +176,20 @@ for key in conf.get('bundle', {}).get('resources', {}):
     grep -qF 'node:$SRC_TAURI/entitlements/node.plist' "$SCRIPT"
 }
 
+@test "calendar-cli has calendars entitlement in SIGN_TARGETS" {
+    grep -qF 'calendar-cli:$CALENDARS_ENTITLEMENTS' "$SCRIPT" || \
+    grep -qF 'calendar-cli:$SRC_TAURI/entitlements/calendars.plist' "$SCRIPT"
+}
+
+@test "reminders-cli has calendars entitlement in SIGN_TARGETS" {
+    grep -qF 'reminders-cli:$CALENDARS_ENTITLEMENTS' "$SCRIPT" || \
+    grep -qF 'reminders-cli:$SRC_TAURI/entitlements/calendars.plist' "$SCRIPT"
+}
+
 @test "speedwave CLI has no entitlements in SIGN_TARGETS" {
     # speedwave is pure Rust — no restricted APIs, no entitlements needed.
     # The entry must end with ":" (empty entitlements).
-    grep -qF 'cli/speedwave:' "$SCRIPT"
-    # Must NOT have an entitlement path after the colon
-    ! grep -qP 'cli/speedwave:\$' "$SCRIPT"
+    grep -qF 'cli/speedwave:"' "$SCRIPT"
 }
 
 @test "post-sign verification calls codesign -v --strict" {
@@ -195,7 +204,13 @@ for key in conf.get('bundle', {}).get('resources', {}):
     local ent_dir="$BATS_TEST_DIRNAME/../../desktop/src-tauri/entitlements"
     [ -f "$ent_dir/node.plist" ]
     [ -f "$ent_dir/limactl.plist" ]
+    [ -f "$ent_dir/calendars.plist" ]
     [ -f "$ent_dir/apple-events.plist" ]
+}
+
+@test "calendars.plist contains calendars entitlement" {
+    local plist="$BATS_TEST_DIRNAME/../../desktop/src-tauri/entitlements/calendars.plist"
+    grep -qF 'com.apple.security.personal-information.calendars' "$plist"
 }
 
 @test "limactl.plist contains virtualization entitlement" {

--- a/_tests/desktop/sign-bundled-binaries.bats
+++ b/_tests/desktop/sign-bundled-binaries.bats
@@ -59,8 +59,10 @@ populate_targets() {
     write_mach_o "$SRC_TAURI/lima/bin/limactl"
     write_mach_o "$SRC_TAURI/nodejs/bin/node"
     mkdir -p "$SRC_TAURI/entitlements"
-    cp "$BATS_TEST_DIRNAME/../../desktop/src-tauri/entitlements/node.plist" \
-       "$SRC_TAURI/entitlements/node.plist"
+    local ent_src="$BATS_TEST_DIRNAME/../../desktop/src-tauri/entitlements"
+    cp "$ent_src/node.plist" "$SRC_TAURI/entitlements/node.plist"
+    cp "$ent_src/limactl.plist" "$SRC_TAURI/entitlements/limactl.plist"
+    cp "$ent_src/apple-events.plist" "$SRC_TAURI/entitlements/apple-events.plist"
 }
 
 @test "sign-bundled-binaries script exists and is executable" {
@@ -112,6 +114,98 @@ populate_targets() {
 
     [ "$status" -eq 1 ]
     [[ "$output" == *"is not a Mach-O binary"* ]]
+}
+
+@test "SIGN_TARGETS covers every executable resource in tauri.macos.conf.json" {
+    # Prevents the "added binary to tauri.macos.conf.json but forgot
+    # SIGN_TARGETS" regression. Extracts executable resource keys (those
+    # that don't end with /) and verifies each has a SIGN_TARGETS entry.
+    local macos_conf="$BATS_TEST_DIRNAME/../../desktop/src-tauri/tauri.macos.conf.json"
+    [ -f "$macos_conf" ]
+
+    # Extract resource keys that are individual files (not directories ending in /)
+    local resources
+    resources=$(python3 -c "
+import json, sys
+with open('$macos_conf') as f:
+    conf = json.load(f)
+for key in conf.get('bundle', {}).get('resources', {}):
+    if not key.endswith('/'):
+        print(key)
+" | sort)
+
+    # Extract paths from SIGN_TARGETS (relative to SRC_TAURI)
+    local targets
+    targets=$(sed -n 's/.*"\$SRC_TAURI\/\([^":]*\).*/\1/p' "$SCRIPT" | sort)
+
+    [ -n "$resources" ]
+    [ -n "$targets" ]
+
+    # Every executable resource must have a SIGN_TARGETS entry
+    local missing=""
+    while IFS= read -r res; do
+        if ! echo "$targets" | grep -qF "$res"; then
+            missing="$missing  $res"
+        fi
+    done <<< "$resources"
+
+    if [ -n "$missing" ]; then
+        echo "Resources in tauri.macos.conf.json missing from SIGN_TARGETS:$missing" >&2
+        return 1
+    fi
+}
+
+@test "limactl has virtualization entitlement in SIGN_TARGETS" {
+    grep -qF 'limactl:$LIMACTL_ENTITLEMENTS' "$SCRIPT" || \
+    grep -qF 'limactl:$SRC_TAURI/entitlements/limactl.plist' "$SCRIPT"
+}
+
+@test "mail-cli has apple-events entitlement in SIGN_TARGETS" {
+    grep -qF 'mail-cli:$APPLE_EVENTS_ENTITLEMENTS' "$SCRIPT" || \
+    grep -qF 'mail-cli:$SRC_TAURI/entitlements/apple-events.plist' "$SCRIPT"
+}
+
+@test "notes-cli has apple-events entitlement in SIGN_TARGETS" {
+    grep -qF 'notes-cli:$APPLE_EVENTS_ENTITLEMENTS' "$SCRIPT" || \
+    grep -qF 'notes-cli:$SRC_TAURI/entitlements/apple-events.plist' "$SCRIPT"
+}
+
+@test "node has JIT entitlement in SIGN_TARGETS" {
+    grep -qF 'node:$NODE_ENTITLEMENTS' "$SCRIPT" || \
+    grep -qF 'node:$SRC_TAURI/entitlements/node.plist' "$SCRIPT"
+}
+
+@test "speedwave CLI has no entitlements in SIGN_TARGETS" {
+    # speedwave is pure Rust — no restricted APIs, no entitlements needed.
+    # The entry must end with ":" (empty entitlements).
+    grep -qF 'cli/speedwave:' "$SCRIPT"
+    # Must NOT have an entitlement path after the colon
+    ! grep -qP 'cli/speedwave:\$' "$SCRIPT"
+}
+
+@test "post-sign verification calls codesign -v --strict" {
+    grep -qF 'codesign -v --strict' "$SCRIPT"
+}
+
+@test "post-sign verification checks entitlements via codesign -d --entitlements" {
+    grep -qF 'codesign -d --entitlements' "$SCRIPT"
+}
+
+@test "all entitlements plists exist" {
+    local ent_dir="$BATS_TEST_DIRNAME/../../desktop/src-tauri/entitlements"
+    [ -f "$ent_dir/node.plist" ]
+    [ -f "$ent_dir/limactl.plist" ]
+    [ -f "$ent_dir/apple-events.plist" ]
+}
+
+@test "limactl.plist contains virtualization entitlement" {
+    local plist="$BATS_TEST_DIRNAME/../../desktop/src-tauri/entitlements/limactl.plist"
+    grep -qF 'com.apple.security.virtualization' "$plist"
+}
+
+@test "apple-events.plist contains automation entitlement" {
+    local plist="$BATS_TEST_DIRNAME/../../desktop/src-tauri/entitlements/apple-events.plist"
+    grep -qF 'com.apple.security.automation.apple-events' "$plist"
 }
 
 @test "error message names the missing file and gives actionable hint" {

--- a/desktop/src-tauri/entitlements/apple-events.plist
+++ b/desktop/src-tauri/entitlements/apple-events.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.automation.apple-events</key>
+	<true/>
+</dict>
+</plist>

--- a/desktop/src-tauri/entitlements/calendars.plist
+++ b/desktop/src-tauri/entitlements/calendars.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.personal-information.calendars</key>
+	<true/>
+</dict>
+</plist>

--- a/desktop/src-tauri/entitlements/limactl.plist
+++ b/desktop/src-tauri/entitlements/limactl.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.virtualization</key>
+	<true/>
+</dict>
+</plist>

--- a/docs/adr/ADR-020-legal-compliance-and-license-analysis.md
+++ b/docs/adr/ADR-020-legal-compliance-and-license-analysis.md
@@ -165,7 +165,7 @@ Permitted for building and shipping Speedwave.[^19] The prohibition applies only
 - [ ] **Add `cargo-deny` to GitHub Actions CI** for dependency license auditing
 - [x] **Publish LICENSE** (Apache-2.0 chosen for Speedwave) at repo root
 - [ ] **Obtain Apple Developer Program membership** for notarization + VZ entitlement
-- [ ] **Apply for `com.apple.security.virtualization` entitlement** in Apple Developer portal
+- [ ] **Embed `com.apple.security.virtualization` entitlement** via codesign during bundle signing (self-serve, no Apple approval needed) — see [ADR-037](ADR-037-code-signing-and-bundled-binary-signing.md)
 
 ### Ongoing
 

--- a/docs/adr/ADR-037-code-signing-and-bundled-binary-signing.md
+++ b/docs/adr/ADR-037-code-signing-and-bundled-binary-signing.md
@@ -100,10 +100,12 @@ Hardened Runtime disables several platform capabilities by default[^11]. Bundled
 | `mail-cli` | `apple-events.plist` | `com.apple.security.automation.apple-events` | Sends Apple Events to Mail.app/Outlook via osascript |
 | `notes-cli` | `apple-events.plist` | `com.apple.security.automation.apple-events` | Sends Apple Events to Notes.app via osascript |
 | `speedwave` | none | — | AOT Rust, no restricted APIs |
-| `calendar-cli` | none | — | EventKit (TCC-gated, no entitlement needed) |
-| `reminders-cli` | none | — | EventKit (TCC-gated, no entitlement needed) |
+| `calendar-cli` | `calendars.plist` | `com.apple.security.personal-information.calendars` | EventKit read-write access (Hardened Runtime Resource Access)[^17] |
+| `reminders-cli` | `calendars.plist` | `com.apple.security.personal-information.calendars` | EventKit read-write access (Hardened Runtime Resource Access)[^17] |
 
-If a future bundled binary requires JIT (e.g. a Python runtime with PyPy), virtualization APIs, or Apple Events automation, add its entitlements plist under `desktop/src-tauri/entitlements/` and reference it from the `SIGN_TARGETS` table in the script.
+If a future bundled binary requires JIT (e.g. a Python runtime with PyPy), virtualization APIs, Apple Events automation, or access to personal information (calendars, contacts, photos), add its entitlements plist under `desktop/src-tauri/entitlements/` and reference it from the `SIGN_TARGETS` table in the script.
+
+[^17]: Apple's Hardened Runtime documentation lists Calendars under Resource Access — `com.apple.security.personal-information.calendars` is required for EventKit read-write access. There is no separate Reminders entitlement; the calendars entitlement covers both Calendar and Reminders since both use EventKit. See https://developer.apple.com/documentation/security/hardened_runtime
 
 [^16]: Lima uses Apple's Virtualization.framework (`vmType: vz`) for VM management. The upstream Lima project carries a similar entitlements file at [`vz.entitlements`](https://github.com/lima-vm/lima/blob/master/vz.entitlements).
 

--- a/docs/adr/ADR-037-code-signing-and-bundled-binary-signing.md
+++ b/docs/adr/ADR-037-code-signing-and-bundled-binary-signing.md
@@ -89,9 +89,23 @@ Three reasons:
 
 tauri-action's macOS signing logic was designed assuming the Tauri app has no bundled external binaries. It signs `Contents/MacOS/<main>` and the `.app` bundle root, but does not recursively sign `Contents/Resources/**/*` Mach-O files[^10]. This is a known limitation — PRs to extend it upstream have stalled. Implementing it ourselves via `beforeBundleCommand` is more maintainable than carrying a fork.
 
-#### Why Node.js needs entitlements and other binaries do not
+#### Entitlements inventory
 
-Hardened Runtime disables several legacy behaviors by default (JIT, DYLD env vars, library validation). `limactl` is a Go binary with no JIT; our Swift and Rust CLIs are AOT-compiled. Only Node.js (V8 engine) needs `allow-jit` + `allow-unsigned-executable-memory` entitlements[^11]. If a future bundled binary requires JIT (e.g. a Python runtime with PyPy) or DYLD injection, add its entitlements plist under `desktop/src-tauri/entitlements/` and reference it from the `SIGN_TARGETS` table in the script.
+Hardened Runtime disables several platform capabilities by default[^11]. Bundled binaries that use restricted APIs must carry entitlements plists to opt back in. The complete inventory:
+
+| Binary | Entitlements plist | Keys | Reason |
+|---|---|---|---|
+| `nodejs/bin/node` | `node.plist` | `allow-jit`, `allow-unsigned-executable-memory` | V8 JIT engine |
+| `lima/bin/limactl` | `limactl.plist` | `com.apple.security.virtualization` | Apple Virtualization Framework[^16] |
+| `mail-cli` | `apple-events.plist` | `com.apple.security.automation.apple-events` | Sends Apple Events to Mail.app/Outlook via osascript |
+| `notes-cli` | `apple-events.plist` | `com.apple.security.automation.apple-events` | Sends Apple Events to Notes.app via osascript |
+| `speedwave` | none | — | AOT Rust, no restricted APIs |
+| `calendar-cli` | none | — | EventKit (TCC-gated, no entitlement needed) |
+| `reminders-cli` | none | — | EventKit (TCC-gated, no entitlement needed) |
+
+If a future bundled binary requires JIT (e.g. a Python runtime with PyPy), virtualization APIs, or Apple Events automation, add its entitlements plist under `desktop/src-tauri/entitlements/` and reference it from the `SIGN_TARGETS` table in the script.
+
+[^16]: Lima uses Apple's Virtualization.framework (`vmType: vz`) for VM management. The upstream Lima project carries a similar entitlements file at [`vz.entitlements`](https://github.com/lima-vm/lima/blob/master/vz.entitlements).
 
 ## Consequences
 

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -260,6 +260,8 @@ Speedwave desktop artifacts are cryptographically signed at two layers that prot
 
 Every Mach-O binary shipped inside `Speedwave.app` (bundled Lima, Node.js, Swift helpers, Rust CLI) is signed with the Speednet Developer ID Application certificate, uses Hardened Runtime, and carries an RFC 3161 timestamp from Apple. The full bundle is submitted to Apple Notary Service, and the resulting ticket is stapled so Gatekeeper validates offline.
 
+Hardened Runtime restricts platform APIs by default; specific binaries carry entitlements to opt back in (virtualization for limactl, Apple Events for mail/notes CLIs, JIT for Node.js). See [ADR-037](../adr/ADR-037-code-signing-and-bundled-binary-signing.md#entitlements-inventory) for the full inventory.
+
 This layer gates **first-time installs** (user downloads the DMG) and all launches thereafter. It protects against:
 
 - **Tampering in transit** — a modified binary fails Gatekeeper signature verification on launch

--- a/docs/contributing/release-signing.md
+++ b/docs/contributing/release-signing.md
@@ -1,6 +1,6 @@
 # Release Code Signing
 
-Operational guide for setting up and maintaining macOS and Windows code signing for Speedwave releases. For the architectural rationale (why every Mach-O in `Contents/Resources/` is signed individually, entitlements required for Node.js, choice of flags), see [ADR-037](../adr/ADR-037-code-signing-and-bundled-binary-signing.md).
+Operational guide for setting up and maintaining macOS and Windows code signing for Speedwave releases. For the architectural rationale (why every Mach-O in `Contents/Resources/` is signed individually, entitlements required for bundled binaries, choice of flags), see [ADR-037](../adr/ADR-037-code-signing-and-bundled-binary-signing.md).
 
 ## When this matters
 
@@ -198,7 +198,12 @@ Common failure modes:
 When a PR introduces a new executable resource in `tauri.macos.conf.json → bundle.resources`:
 
 1. Add its source path to the `SIGN_TARGETS` array in `scripts/sign-bundled-binaries.sh` with an entitlements suffix: `"$SRC_TAURI/<path>:"` for no entitlements, or `"$SRC_TAURI/<path>:$SOME_PLIST"` for a plist
-2. If the binary is a language runtime with JIT (Python with PyPy, Ruby YARV, another Node variant), create a plist in `desktop/src-tauri/entitlements/` with `com.apple.security.cs.allow-jit` and reference it in step 1
+2. If the binary uses restricted platform APIs, create or reuse an entitlements plist in `desktop/src-tauri/entitlements/` and reference it in step 1. Three categories require entitlements:
+   - **(a) JIT runtimes** (V8, PyPy, YARV): `com.apple.security.cs.allow-jit` + `com.apple.security.cs.allow-unsigned-executable-memory` — see `node.plist`
+   - **(b) Virtualization API users** (Apple Virtualization.framework): `com.apple.security.virtualization` — see `limactl.plist`
+   - **(c) Apple Events senders** (osascript / NSAppleScript): `com.apple.security.automation.apple-events` — see `apple-events.plist`
+
+   See the [ADR-037 entitlements inventory](../adr/ADR-037-code-signing-and-bundled-binary-signing.md#entitlements-inventory) for the full table of bundled binaries and their entitlements.
 3. Verify locally with `make build-tauri` + the notarization test above — if Apple rejects, the log says which binary is missing
 4. Update [ADR-037](../adr/ADR-037-code-signing-and-bundled-binary-signing.md) inventory if the binary is architecturally significant
 

--- a/scripts/sign-bundled-binaries.sh
+++ b/scripts/sign-bundled-binaries.sh
@@ -33,6 +33,7 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SRC_TAURI="${SRC_TAURI:-$REPO_ROOT/desktop/src-tauri}"
 NODE_ENTITLEMENTS="$SRC_TAURI/entitlements/node.plist"
 LIMACTL_ENTITLEMENTS="$SRC_TAURI/entitlements/limactl.plist"
+CALENDARS_ENTITLEMENTS="$SRC_TAURI/entitlements/calendars.plist"
 APPLE_EVENTS_ENTITLEMENTS="$SRC_TAURI/entitlements/apple-events.plist"
 
 # Paths that tauri.macos.conf.json copies into .app/Contents/Resources/.
@@ -46,8 +47,8 @@ APPLE_EVENTS_ENTITLEMENTS="$SRC_TAURI/entitlements/apple-events.plist"
 # Runtime blocks by default. Without the entitlement, node crashes at startup.
 SIGN_TARGETS=(
   "$SRC_TAURI/cli/speedwave:"
-  "$SRC_TAURI/reminders-cli:"
-  "$SRC_TAURI/calendar-cli:"
+  "$SRC_TAURI/reminders-cli:$CALENDARS_ENTITLEMENTS"
+  "$SRC_TAURI/calendar-cli:$CALENDARS_ENTITLEMENTS"
   "$SRC_TAURI/mail-cli:$APPLE_EVENTS_ENTITLEMENTS"
   "$SRC_TAURI/notes-cli:$APPLE_EVENTS_ENTITLEMENTS"
   "$SRC_TAURI/lima/bin/limactl:$LIMACTL_ENTITLEMENTS"

--- a/scripts/sign-bundled-binaries.sh
+++ b/scripts/sign-bundled-binaries.sh
@@ -92,17 +92,25 @@ sign_macho() {
     exit 1
   fi
 
-  # Verify entitlements were applied correctly
+  # Verify entitlements were applied correctly — check every <key> in the
+  # plist, not just the first, so multi-key plists (e.g. node.plist with
+  # allow-jit + allow-unsigned-executable-memory) are fully verified.
   if [[ -n "$entitlements" ]]; then
-    local expected_key
-    expected_key="$(grep '<key>' "$entitlements" | head -1 | sed 's/.*<key>\(.*\)<\/key>.*/\1/')"
-    if [[ -n "$expected_key" ]]; then
-      if ! codesign -d --entitlements - "$path" 2>/dev/null | grep -q "$expected_key"; then
+    local ent_output
+    ent_output="$(codesign -d --entitlements - "$path" 2>/dev/null)"
+    local all_verified=true
+    while IFS= read -r expected_key; do
+      if ! echo "$ent_output" | grep -qF "$expected_key"; then
         echo "ERROR: entitlement '$expected_key' not found in signed binary $path" >&2
-        exit 1
+        all_verified=false
       fi
-      echo "  verified: signature valid, entitlement '$expected_key' present"
+    done < <(grep '<key>' "$entitlements" | sed 's/.*<key>\(.*\)<\/key>.*/\1/')
+    if [[ "$all_verified" != "true" ]]; then
+      exit 1
     fi
+    local key_count
+    key_count="$(grep -c '<key>' "$entitlements")"
+    echo "  verified: signature valid, $key_count entitlement(s) present"
   else
     echo "  verified: signature valid"
   fi

--- a/scripts/sign-bundled-binaries.sh
+++ b/scripts/sign-bundled-binaries.sh
@@ -32,6 +32,8 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 # In production, this resolves to desktop/src-tauri/ within the repo.
 SRC_TAURI="${SRC_TAURI:-$REPO_ROOT/desktop/src-tauri}"
 NODE_ENTITLEMENTS="$SRC_TAURI/entitlements/node.plist"
+LIMACTL_ENTITLEMENTS="$SRC_TAURI/entitlements/limactl.plist"
+APPLE_EVENTS_ENTITLEMENTS="$SRC_TAURI/entitlements/apple-events.plist"
 
 # Paths that tauri.macos.conf.json copies into .app/Contents/Resources/.
 # Source: desktop/src-tauri/tauri.macos.conf.json → bundle.resources.
@@ -46,9 +48,9 @@ SIGN_TARGETS=(
   "$SRC_TAURI/cli/speedwave:"
   "$SRC_TAURI/reminders-cli:"
   "$SRC_TAURI/calendar-cli:"
-  "$SRC_TAURI/mail-cli:"
-  "$SRC_TAURI/notes-cli:"
-  "$SRC_TAURI/lima/bin/limactl:"
+  "$SRC_TAURI/mail-cli:$APPLE_EVENTS_ENTITLEMENTS"
+  "$SRC_TAURI/notes-cli:$APPLE_EVENTS_ENTITLEMENTS"
+  "$SRC_TAURI/lima/bin/limactl:$LIMACTL_ENTITLEMENTS"
   "$SRC_TAURI/nodejs/bin/node:$NODE_ENTITLEMENTS"
 )
 
@@ -81,6 +83,27 @@ sign_macho() {
       --timestamp \
       --sign "$APPLE_SIGNING_IDENTITY" \
       "$path"
+  fi
+
+  # Verify signature is valid
+  if ! codesign -v --strict "$path"; then
+    echo "ERROR: signature verification failed for $path" >&2
+    exit 1
+  fi
+
+  # Verify entitlements were applied correctly
+  if [[ -n "$entitlements" ]]; then
+    local expected_key
+    expected_key="$(grep '<key>' "$entitlements" | head -1 | sed 's/.*<key>\(.*\)<\/key>.*/\1/')"
+    if [[ -n "$expected_key" ]]; then
+      if ! codesign -d --entitlements - "$path" 2>/dev/null | grep -q "$expected_key"; then
+        echo "ERROR: entitlement '$expected_key' not found in signed binary $path" >&2
+        exit 1
+      fi
+      echo "  verified: signature valid, entitlement '$expected_key' present"
+    fi
+  else
+    echo "  verified: signature valid"
   fi
 }
 


### PR DESCRIPTION
## Summary

Fixes the v0.7.2 crash: `VZErrorDomain Code=2 "The process doesn't have the com.apple.security.virtualization entitlement"`. Also fixes silent Apple Events failures for mail-cli and notes-cli.

### Root cause

Hardened Runtime (`codesign --options runtime`) blocks restricted platform APIs. Three bundled binaries were signed without entitlements:

| Binary | Missing entitlement | Failure mode |
|---|---|---|
| `limactl` | `com.apple.security.virtualization` | **Hard crash** — VM creation fails |
| `mail-cli` | `com.apple.security.automation.apple-events` | **Silent failure** — osascript blocked |
| `notes-cli` | `com.apple.security.automation.apple-events` | **Silent failure** — osascript blocked |

### Changes

**Code (P0):**
- New `desktop/src-tauri/entitlements/limactl.plist` (virtualization)
- New `desktop/src-tauri/entitlements/apple-events.plist` (automation)
- `scripts/sign-bundled-binaries.sh` — updated SIGN_TARGETS + post-sign verification (`codesign -v --strict` + entitlement check)

**Tests:**
- 11 new bats tests: SIGN_TARGETS ↔ tauri.macos.conf.json sync, per-binary entitlement assertions, plist content checks, verification assertions

**Documentation:**
- ADR-037 — replaced "Only Node.js needs entitlements" with full inventory table
- release-signing.md — expanded "Adding new binary" checklist (3 entitlement categories)
- security.md — added entitlements trade-off paragraph
- CLAUDE.md — added SIGN_TARGETS SSOT alignment note
- ADR-020 — fixed checklist wording
- RELEASING.md — added runtime failure warning

**Skills:**
- speedwave-write-plan — added signing/entitlements check
- speedwave-review-plan — added entitlements verification axis

### Investigation: lima-driver-krunkit / limactl-mcp

These Lima binaries exist in the download but are NOT bundled. Confirmed not needed — Speedwave uses `vmType: vz` with embedded driver, never invokes krunkit or limactl-mcp.

## Test plan

- [x] `bats _tests/desktop/sign-bundled-binaries.bats` — 17/17
- [x] `bats _tests/desktop/release-workflow-signing.bats` — 10/10
- [ ] CI green
- [ ] After release 0.7.3: limactl starts VM on signed .app (ultimate proof)

Refs #376