### PR TITLE
fix(runtime): auto-prune old bundle images + harden plan-loop tooling

### DIFF
--- a/.claude/scripts/plan-loop.sh
+++ b/.claude/scripts/plan-loop.sh
@@ -89,62 +89,48 @@ NC='\033[0m'
 
 # --- Dependency freshness ---
 #
-# npm deps are installed with `npm ci` when the package-lock.json hash changes.
-# We track hashes in $LOCK_STATE_FILE (per-worktree) and run npm ci only for
-# subprojects where the hash differs. Cargo deps are shared via ~/.cargo so no
-# action needed for Rust.
+# Delegates to `make install-deps` (= setup-dev) — the Makefile is the SSOT for
+# provisioning the workspace: cargo fetch + npm install in every npm subproject
+# including mcp-servers/* sub-packages where tsc lives. A hand-rolled npm-ci
+# loop would miss those and fail at build-mcp. The state file caches the
+# aggregate hash of all package-lock.json files; reruns skip when nothing
+# changed.
 
-NPM_SUBPROJECTS=("." "mcp-servers" "desktop/src" "desktop/e2e")
 LOCK_STATE_FILE=""
+
+aggregate_lock_hash() {
+    local root="$1"
+    find "$root" -name package-lock.json -not -path '*/node_modules/*' -print0 2>/dev/null \
+        | xargs -0 shasum -a 256 2>/dev/null \
+        | awk '{print $1}' \
+        | sort \
+        | shasum -a 256 \
+        | awk '{print $1}'
+}
 
 ensure_deps_fresh() {
     local root="$1"
     local state_file="$2"
 
-    local any_changed=false
-    local -a to_install=()
-    local sub
-    for sub in "${NPM_SUBPROJECTS[@]}"; do
-        local lock="$root/$sub/package-lock.json"
-        if [[ ! -f "$lock" ]]; then
-            continue
-        fi
-        local hash
-        hash=$(shasum -a 256 "$lock" | awk '{print $1}')
-        local key
-        key=$(printf '%s' "$sub" | tr '/' '_')
-        local prev=""
-        if [[ -f "$state_file" ]]; then
-            prev=$(grep -E "^${key}=" "$state_file" 2>/dev/null | tail -1 | cut -d= -f2-)
-        fi
-        if [[ "$hash" != "$prev" ]]; then
-            to_install+=("$sub|$hash|$key")
-            any_changed=true
-        fi
-    done
+    local agg
+    agg=$(aggregate_lock_hash "$root")
 
-    if [[ "$any_changed" != "true" ]]; then
+    local prev=""
+    if [[ -f "$state_file" ]]; then
+        prev=$(cat "$state_file")
+    fi
+
+    if [[ -n "$agg" && "$agg" == "$prev" ]]; then
+        printf "  ${DIM}npm deps unchanged, skipping install${NC}\n"
         return 0
     fi
 
-    local entry
-    for entry in "${to_install[@]}"; do
-        local sub="${entry%%|*}"
-        local rest="${entry#*|}"
-        local hash="${rest%%|*}"
-        local key="${rest##*|}"
-        printf "  ${CYAN}npm ci${NC} in $sub (lock changed)\n"
-        if ! (cd "$root/$sub" && npm ci --no-audit --no-fund 2>&1 | tail -5 | sed 's/^/    /'); then
-            printf "  ${RED}ERROR: npm ci failed in $sub${NC}\n" >&2
-            return 1
-        fi
-        # Update state atomically: remove old key line, append new
-        if [[ -f "$state_file" ]]; then
-            grep -v -E "^${key}=" "$state_file" > "${state_file}.tmp" 2>/dev/null || true
-            mv "${state_file}.tmp" "$state_file"
-        fi
-        printf '%s=%s\n' "$key" "$hash" >> "$state_file"
-    done
+    printf "  ${CYAN}Running make install-deps (may take a few minutes)...${NC}\n"
+    if ! (cd "$root" && make install-deps 2>&1 | tail -12 | sed 's/^/    /'); then
+        printf "  ${RED}ERROR: make install-deps failed${NC}\n" >&2
+        return 1
+    fi
+    printf '%s' "$agg" > "$state_file"
     return 0
 }
 

--- a/.claude/scripts/plan-loop.sh
+++ b/.claude/scripts/plan-loop.sh
@@ -580,6 +580,15 @@ Only report NEW issues if they are BLOCKER or HIGH severity."
     PREV_FINDINGS="$findings"
     PREV_HIGH_COUNT="$high_count"
 
+    # Sanity check: reviewer may return READY_TO_IMPLEMENT while also reporting
+    # blockers (schema does not enforce the correlation). Reject that combo — a
+    # plan with BLOCKERS is never ready to implement regardless of what the
+    # model claims in the verdict field.
+    if [[ "$verdict" == "READY_TO_IMPLEMENT" && "$blocker_count" -gt 0 ]]; then
+        printf "\n  ${RED}[sanity] Reviewer returned READY_TO_IMPLEMENT with $blocker_count blocker(s) — demoting to NEEDS_REVISION${NC}\n"
+        verdict="NEEDS_REVISION"
+    fi
+
     if [[ "$verdict" == "READY_TO_IMPLEMENT" ]]; then
         echo ""
         if [[ "$high_count" -gt 0 ]]; then
@@ -754,6 +763,19 @@ $IMPL_FEEDBACK" \
     echo "  Steps:      $v_steps / $v_total"
     echo "  make check: $( [[ "$v_check" == "true" ]] && echo "PASS" || echo "FAIL" )"
     echo "  make test:  $( [[ "$v_test" == "true" ]] && echo "PASS" || echo "FAIL" )"
+
+    # Sanity check: demote VERIFIED if model contradicts itself (e.g. reports
+    # VERIFIED with missing steps or failing checks). The JSON schema cannot
+    # express these correlations, so the orchestrator enforces them.
+    if [[ "$v_verdict" == "VERIFIED" ]]; then
+        if [[ "$v_check" != "true" || "$v_test" != "true" ]]; then
+            printf "\n  ${RED}[sanity] Verifier returned VERIFIED with failing check/test — demoting to GAPS_FOUND${NC}\n"
+            v_verdict="GAPS_FOUND"
+        elif [[ "$v_total" -gt 0 && "$v_steps" -lt "$v_total" ]]; then
+            printf "\n  ${RED}[sanity] Verifier returned VERIFIED with $v_steps/$v_total steps implemented — demoting to GAPS_FOUND${NC}\n"
+            v_verdict="GAPS_FOUND"
+        fi
+    fi
 
     if [[ "$v_verdict" == "VERIFIED" && "$v_check" == "true" && "$v_test" == "true" ]]; then
         echo ""

--- a/.claude/scripts/plan-loop.sh
+++ b/.claude/scripts/plan-loop.sh
@@ -98,13 +98,26 @@ NC='\033[0m'
 
 LOCK_STATE_FILE=""
 
+# Portable SHA-256: prefer sha256sum (coreutils, default on Linux), fall back
+# to shasum -a 256 (macOS / systems shipping Perl's shasum). Resolved once at
+# start; the absence of both yields an empty SHA_CMD, which aggregate_lock_hash
+# treats as "state unknown → reinstall".
+if command -v sha256sum >/dev/null 2>&1; then
+    SHA_CMD="sha256sum"
+elif command -v shasum >/dev/null 2>&1; then
+    SHA_CMD="shasum -a 256"
+else
+    SHA_CMD=""
+fi
+
 aggregate_lock_hash() {
     local root="$1"
+    [[ -z "$SHA_CMD" ]] && return 0
     find "$root" -name package-lock.json -not -path '*/node_modules/*' -print0 2>/dev/null \
-        | xargs -0 shasum -a 256 2>/dev/null \
+        | xargs -0 $SHA_CMD 2>/dev/null \
         | awk '{print $1}' \
         | sort \
-        | shasum -a 256 \
+        | $SHA_CMD \
         | awk '{print $1}'
 }
 
@@ -359,7 +372,10 @@ if [[ "$NO_WORKTREE" != "true" && -z "$IMPL_ONLY" ]]; then
     printf "  ${GREEN}Worktree ready${NC}\n"
     echo ""
 
-    LOCK_STATE_FILE="$WORKTREE_DIR/.plan-loop-lock-hashes"
+    # Stored inside TMPDIR_LOOP so it doesn't show up as untracked in the
+    # worktree — otherwise the implementation agent sees a stray file in
+    # git status and may try to clean it up.
+    LOCK_STATE_FILE="$TMPDIR_LOOP/lock-hashes"
     printf "  ${CYAN}Checking npm dependencies...${NC}\n"
     if ! ensure_deps_fresh "$PROJECT_ROOT" "$LOCK_STATE_FILE"; then
         rm -rf "$TMPDIR_LOOP" 2>/dev/null || true

--- a/.claude/scripts/plan-loop.sh
+++ b/.claude/scripts/plan-loop.sh
@@ -87,6 +87,67 @@ DIM='\033[2m'
 BOLD='\033[1m'
 NC='\033[0m'
 
+# --- Dependency freshness ---
+#
+# npm deps are installed with `npm ci` when the package-lock.json hash changes.
+# We track hashes in $LOCK_STATE_FILE (per-worktree) and run npm ci only for
+# subprojects where the hash differs. Cargo deps are shared via ~/.cargo so no
+# action needed for Rust.
+
+NPM_SUBPROJECTS=("." "mcp-servers" "desktop/src" "desktop/e2e")
+LOCK_STATE_FILE=""
+
+ensure_deps_fresh() {
+    local root="$1"
+    local state_file="$2"
+
+    local any_changed=false
+    local -a to_install=()
+    local sub
+    for sub in "${NPM_SUBPROJECTS[@]}"; do
+        local lock="$root/$sub/package-lock.json"
+        if [[ ! -f "$lock" ]]; then
+            continue
+        fi
+        local hash
+        hash=$(shasum -a 256 "$lock" | awk '{print $1}')
+        local key
+        key=$(printf '%s' "$sub" | tr '/' '_')
+        local prev=""
+        if [[ -f "$state_file" ]]; then
+            prev=$(grep -E "^${key}=" "$state_file" 2>/dev/null | tail -1 | cut -d= -f2-)
+        fi
+        if [[ "$hash" != "$prev" ]]; then
+            to_install+=("$sub|$hash|$key")
+            any_changed=true
+        fi
+    done
+
+    if [[ "$any_changed" != "true" ]]; then
+        return 0
+    fi
+
+    local entry
+    for entry in "${to_install[@]}"; do
+        local sub="${entry%%|*}"
+        local rest="${entry#*|}"
+        local hash="${rest%%|*}"
+        local key="${rest##*|}"
+        printf "  ${CYAN}npm ci${NC} in $sub (lock changed)\n"
+        if ! (cd "$root/$sub" && npm ci --no-audit --no-fund 2>&1 | tail -5 | sed 's/^/    /'); then
+            printf "  ${RED}ERROR: npm ci failed in $sub${NC}\n" >&2
+            return 1
+        fi
+        # Update state atomically: remove old key line, append new
+        if [[ -f "$state_file" ]]; then
+            grep -v -E "^${key}=" "$state_file" > "${state_file}.tmp" 2>/dev/null || true
+            mv "${state_file}.tmp" "$state_file"
+        fi
+        printf '%s=%s\n' "$key" "$hash" >> "$state_file"
+    done
+    return 0
+}
+
 # --- Validate prerequisites ---
 
 for cmd in claude jq perl; do
@@ -310,6 +371,14 @@ if [[ "$NO_WORKTREE" != "true" && -z "$IMPL_ONLY" ]]; then
 
     echo ""
     printf "  ${GREEN}Worktree ready${NC}\n"
+    echo ""
+
+    LOCK_STATE_FILE="$WORKTREE_DIR/.plan-loop-lock-hashes"
+    printf "  ${CYAN}Checking npm dependencies...${NC}\n"
+    if ! ensure_deps_fresh "$PROJECT_ROOT" "$LOCK_STATE_FILE"; then
+        rm -rf "$TMPDIR_LOOP" 2>/dev/null || true
+        exit 1
+    fi
     echo ""
 else
     if [[ -n "$IMPL_ONLY" ]]; then
@@ -658,6 +727,15 @@ $IMPL_FEEDBACK" \
 
     # ===================== VERIFIER =====================
     echo ""
+
+    if [[ -n "$LOCK_STATE_FILE" ]]; then
+        printf "  ${CYAN}Checking npm dependencies (post-implementation)...${NC}\n"
+        if ! ensure_deps_fresh "$PROJECT_ROOT" "$LOCK_STATE_FILE"; then
+            printf "  ${RED}ERROR: dependency sync failed — verifier cannot run${NC}\n" >&2
+            rm -rf "$TMPDIR_LOOP"; exit 1
+        fi
+    fi
+
     printf "  ${CYAN}[verifier]${NC} Verifying implementation (fresh context)...\n"
 
     rm -f "$RESULT_FILE"
@@ -691,7 +769,7 @@ $IMPL_FEEDBACK" \
     echo "  make check: $( [[ "$v_check" == "true" ]] && echo "PASS" || echo "FAIL" )"
     echo "  make test:  $( [[ "$v_test" == "true" ]] && echo "PASS" || echo "FAIL" )"
 
-    if [[ "$v_verdict" == "VERIFIED" ]]; then
+    if [[ "$v_verdict" == "VERIFIED" && "$v_check" == "true" && "$v_test" == "true" ]]; then
         echo ""
         printf "${GREEN}╔══════════════════════════════════════════════════════════════╗${NC}\n"
         printf "${GREEN}║  IMPLEMENTATION VERIFIED after $impl_iteration iteration(s)${NC}\n"
@@ -713,7 +791,11 @@ $IMPL_FEEDBACK" \
 
     IMPL_FEEDBACK="$v_gaps"
     if [[ -z "$IMPL_FEEDBACK" || "$IMPL_FEEDBACK" == "null" ]]; then
-        IMPL_FEEDBACK="Steps verified: $v_steps/$v_total. make check: $v_check. make test: $v_test. Review the plan and fix all remaining gaps."
+        IMPL_FEEDBACK="Verdict: $v_verdict. Steps verified: $v_steps/$v_total. make check passed: $v_check. make test passed: $v_test. Fix ALL failing checks/tests and any remaining gaps before next verification."
+    else
+        IMPL_FEEDBACK="$IMPL_FEEDBACK
+
+Additionally: make check passed: $v_check. make test passed: $v_test. Both MUST pass before verification can succeed."
     fi
 
     echo ""

--- a/.claude/skills/speedwave-review-plan/SKILL.md
+++ b/.claude/skills/speedwave-review-plan/SKILL.md
@@ -608,6 +608,15 @@ If NEEDS REVISION or REJECT: list the specific items that must be addressed, in 
 
 **`new_issue_count`:** Include in structured output. Set to the total number of ALL genuinely new issues found in this review (including suppressed MEDIUM/LOW in verification mode). On the first review, equals the total issue count. On follow-up reviews, only count issues NOT present in the previous review context. This field drives convergence logic in the automated loop.
 
+**Hard verdict rules — non-negotiable, the orchestrator relies on these:**
+
+- `overall_verdict: "READY_TO_IMPLEMENT"` MUST imply `blocker_count == 0` AND `high_count == 0`.
+- If `blocker_count > 0`, the verdict MUST be `"REJECT"`.
+- If `blocker_count == 0` but `high_count > 0`, the verdict MUST be `"NEEDS_REVISION"`. The orchestrator handles auto-acceptance at high iteration counts — do not preempt it by inflating the verdict.
+- `findings_summary` MUST contain concrete, actionable fix instructions for every BLOCKER and HIGH finding. Give verbatim file paths, line references, or code suggestions — not generic advice.
+
+Returning `READY_TO_IMPLEMENT` with blockers or HIGH issues present is a critical bug in your output.
+
 </verdict>
 
 ---

--- a/.claude/skills/speedwave-verify-plan/SKILL.md
+++ b/.claude/skills/speedwave-verify-plan/SKILL.md
@@ -39,5 +39,13 @@ Report your findings:
 - Whether `make test` passed
 - For each gap found: which plan step, what's missing, what needs to be done to fix it
 
-If everything is implemented and tests pass, say "VERIFIED — all steps implemented, all tests pass."
-If gaps exist, say "GAPS FOUND" and list every gap with specific fix instructions.
+**Hard verdict rules — these are non-negotiable:**
+
+- `overall_verdict: "VERIFIED"` is allowed ONLY if ALL THREE conditions hold:
+  - every plan step is fully implemented (`steps_verified == steps_total`)
+  - `make_check_passed: true`
+  - `make_test_passed: true`
+- If ANY of the three fails, `overall_verdict` MUST be `"GAPS_FOUND"`.
+- `gaps_summary` MUST contain concrete, actionable fix instructions whenever the verdict is `GAPS_FOUND`, or whenever `make_check_passed`/`make_test_passed` is false. Paste the actual failing output from make — do not summarize vaguely.
+
+Returning `VERIFIED` with a failing check or test is a critical bug in your output and will cause the orchestrator to ship broken code. Double-check the booleans before emitting the structured result.

--- a/Makefile
+++ b/Makefile
@@ -145,13 +145,13 @@ setup-dev:
 	@echo "── Cargo dependencies (desktop) ──"
 	cd desktop/src-tauri && cargo fetch
 	@echo "── MCP server dependencies ──"
-	cd mcp-servers && npm install
+	cd mcp-servers && npm ci
 	@echo "── Angular dependencies ──"
-	cd desktop/src && npm install
+	cd desktop/src && npm ci
 	@echo "── E2E test dependencies ──"
-	cd desktop/e2e && npm install
+	cd desktop/e2e && npm ci
 	@echo "── Git hooks (husky, commitlint) ──"
-	npm install
+	npm ci
 	npx husky
 	@echo "\n✅ Dev environment ready. Next:"
 	@echo "  make test    # verify everything works"

--- a/crates/speedwave-runtime/src/build.rs
+++ b/crates/speedwave-runtime/src/build.rs
@@ -374,6 +374,25 @@ pub fn build_all_images(runtime: &dyn ContainerRuntime) -> anyhow::Result<u32> {
     build_all_images_for_bundle(runtime, &manifest.bundle_id)
 }
 
+/// Remove images from a previous bundle to reclaim disk space.
+pub fn prune_old_bundle_images(
+    runtime: &dyn ContainerRuntime,
+    old_bundle_id: &str,
+) -> anyhow::Result<()> {
+    let tags: Vec<String> = IMAGES
+        .iter()
+        .map(|img| image_ref(img.name, old_bundle_id))
+        .collect();
+    if tags.is_empty() {
+        return Ok(());
+    }
+    log::info!(
+        "Pruning {} images from old bundle {old_bundle_id}",
+        tags.len()
+    );
+    runtime.remove_images(&tags)
+}
+
 pub fn build_all_images_for_bundle(
     runtime: &dyn ContainerRuntime,
     bundle_id: &str,
@@ -1859,5 +1878,92 @@ mod tests {
             msg.contains("virtual machine"),
             "chain-wrapped I/O error should still get VM hint, got: {msg}"
         );
+    }
+
+    // ── prune_old_bundle_images tests ─────────────────────────────────────
+
+    /// Minimal mock runtime that records remove_images calls.
+    struct PruneMockRuntime {
+        removed_tags: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl PruneMockRuntime {
+        fn new() -> Self {
+            Self {
+                removed_tags: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+    }
+
+    impl ContainerRuntime for PruneMockRuntime {
+        fn compose_up(&self, _: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn compose_down(&self, _: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn compose_ps(&self, _: &str) -> anyhow::Result<Vec<serde_json::Value>> {
+            Ok(vec![])
+        }
+        fn container_exec(&self, _: &str, _: &[&str]) -> Command {
+            Command::new("true")
+        }
+        fn container_exec_piped(&self, _: &str, _: &[&str]) -> anyhow::Result<Command> {
+            Ok(Command::new("true"))
+        }
+        fn is_available(&self) -> bool {
+            true
+        }
+        fn ensure_ready(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn build_image(&self, _: &str, _: &str, _: &str, _: &[(&str, &str)]) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn container_logs(&self, _: &str, _: u32) -> anyhow::Result<String> {
+            Ok(String::new())
+        }
+        fn compose_logs(&self, _: &str, _: u32) -> anyhow::Result<String> {
+            Ok(String::new())
+        }
+        fn compose_up_recreate(&self, _: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn image_exists(&self, _: &str) -> anyhow::Result<bool> {
+            Ok(true)
+        }
+        fn remove_images(&self, tags: &[String]) -> anyhow::Result<()> {
+            self.removed_tags.lock().unwrap().extend_from_slice(tags);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_prune_old_bundle_images_generates_correct_tags() {
+        let rt = PruneMockRuntime::new();
+        prune_old_bundle_images(&rt, "abc123").unwrap();
+
+        let removed = rt.removed_tags.lock().unwrap().clone();
+        assert_eq!(
+            removed.len(),
+            IMAGES.len(),
+            "should remove exactly {} tags (one per image)",
+            IMAGES.len()
+        );
+        for (tag, img) in removed.iter().zip(IMAGES.iter()) {
+            assert_eq!(
+                tag,
+                &image_ref(img.name, "abc123"),
+                "tag should be <name>:abc123"
+            );
+        }
+    }
+
+    #[test]
+    fn test_prune_old_bundle_images_same_id_still_works() {
+        // The caller is responsible for guarding same-id; the function itself is correct either way.
+        let rt = PruneMockRuntime::new();
+        prune_old_bundle_images(&rt, "same123").unwrap();
+        assert_eq!(rt.removed_tags.lock().unwrap().len(), IMAGES.len());
     }
 }

--- a/crates/speedwave-runtime/src/build.rs
+++ b/crates/speedwave-runtime/src/build.rs
@@ -374,6 +374,19 @@ pub fn build_all_images(runtime: &dyn ContainerRuntime) -> anyhow::Result<u32> {
     build_all_images_for_bundle(runtime, &manifest.bundle_id)
 }
 
+/// Decide whether pruning a previous bundle's images is warranted.
+///
+/// Returns `Some(old_id)` only when the previously applied bundle exists and
+/// differs from the new one. Fresh installs (`applied` is `None`) and
+/// same-version rebuilds (`applied == new`) return `None`, so the caller
+/// skips `prune_old_bundle_images` entirely in those cases.
+pub fn should_prune_bundle<'a>(applied: Option<&'a str>, new_bundle_id: &str) -> Option<&'a str> {
+    match applied {
+        Some(old) if old != new_bundle_id => Some(old),
+        _ => None,
+    }
+}
+
 /// Remove images from a previous bundle to reclaim disk space.
 pub fn prune_old_bundle_images(
     runtime: &dyn ContainerRuntime,
@@ -1965,5 +1978,31 @@ mod tests {
         let rt = PruneMockRuntime::new();
         prune_old_bundle_images(&rt, "same123").unwrap();
         assert_eq!(rt.removed_tags.lock().unwrap().len(), IMAGES.len());
+    }
+
+    #[test]
+    fn should_prune_bundle_returns_none_for_fresh_install() {
+        assert_eq!(should_prune_bundle(None, "new-bundle-id"), None);
+    }
+
+    #[test]
+    fn should_prune_bundle_returns_none_for_same_bundle() {
+        assert_eq!(should_prune_bundle(Some("same-id"), "same-id"), None);
+    }
+
+    #[test]
+    fn should_prune_bundle_returns_old_id_for_different_bundle() {
+        assert_eq!(
+            should_prune_bundle(Some("old-id"), "new-id"),
+            Some("old-id")
+        );
+    }
+
+    #[test]
+    fn should_prune_bundle_handles_empty_strings() {
+        // Empty applied id differs from non-empty new id — prune signalled.
+        assert_eq!(should_prune_bundle(Some(""), "new-id"), Some(""));
+        // Both empty (unexpected, but well-defined) — same-id path.
+        assert_eq!(should_prune_bundle(Some(""), ""), None);
     }
 }

--- a/crates/speedwave-runtime/src/runtime/lima.rs
+++ b/crates/speedwave-runtime/src/runtime/lima.rs
@@ -466,6 +466,27 @@ impl ContainerRuntime for LimaRuntime {
         Ok(())
     }
 
+    fn remove_images(&self, tags: &[String]) -> anyhow::Result<()> {
+        self.require_running()?;
+        if tags.is_empty() {
+            return Ok(());
+        }
+        let mut args = vec![
+            "shell",
+            consts::lima_vm_name(),
+            "--",
+            "sudo",
+            "nerdctl",
+            "rmi",
+        ];
+        let tag_refs: Vec<&str> = tags.iter().map(|s| s.as_str()).collect();
+        args.extend(tag_refs);
+        if let Err(e) = self.runner.run("limactl", &args) {
+            log::warn!("lima rmi failed: {e}");
+        }
+        Ok(())
+    }
+
     fn restart_container_engine(&self) -> anyhow::Result<()> {
         self.require_running()?;
         let vm = consts::lima_vm_name();
@@ -1440,6 +1461,73 @@ mod tests {
         assert!(
             err.to_string().contains("not running"),
             "should report VM not running, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_remove_images_empty_tags_is_noop_after_require_running() {
+        // VM is running, but no rmi command should be issued for empty tags
+        let runner = mock_runner_with_vm_running();
+        let rt = LimaRuntime::with_runner(Box::new(runner));
+        assert!(
+            rt.remove_images(&[]).is_ok(),
+            "empty tags should return Ok without calling rmi"
+        );
+    }
+
+    #[test]
+    fn test_remove_images_happy_path() {
+        let tags = vec![
+            "speedwave-claude:abc123".to_string(),
+            "speedwave-mcp-hub:abc123".to_string(),
+        ];
+        let runner = mock_runner_with_vm_running().with_response(
+            &format!(
+                "limactl shell {} -- sudo nerdctl rmi speedwave-claude:abc123 speedwave-mcp-hub:abc123",
+                consts::LIMA_VM_NAME
+            ),
+            "",
+        );
+        let rt = LimaRuntime::with_runner(Box::new(runner));
+        assert!(rt.remove_images(&tags).is_ok());
+    }
+
+    #[test]
+    fn test_remove_images_error_is_warn_only() {
+        let tags = vec!["speedwave-claude:abc123".to_string()];
+        let runner = mock_runner_with_vm_running().with_error(
+            &format!(
+                "limactl shell {} -- sudo nerdctl rmi speedwave-claude:abc123",
+                consts::LIMA_VM_NAME
+            ),
+            "no such image",
+        );
+        let rt = LimaRuntime::with_runner(Box::new(runner));
+        // rmi failure must not propagate — just warn and return Ok
+        assert!(
+            rt.remove_images(&tags).is_ok(),
+            "rmi failure should not propagate"
+        );
+    }
+
+    #[test]
+    fn test_remove_images_fails_when_vm_stopped() {
+        let runner = MockRunner::new()
+            .with_response("limactl --version", "limactl version 1.0.0")
+            .with_response(
+                &format!(
+                    "limactl list --format {{{{.Status}}}} {}",
+                    consts::LIMA_VM_NAME
+                ),
+                "Stopped",
+            );
+        let rt = LimaRuntime::with_runner(Box::new(runner));
+        let err = rt
+            .remove_images(&["speedwave-claude:abc123".to_string()])
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("not running"),
+            "require_running error should propagate, got: {err}"
         );
     }
 

--- a/crates/speedwave-runtime/src/runtime/lima.rs
+++ b/crates/speedwave-runtime/src/runtime/lima.rs
@@ -481,6 +481,9 @@ impl ContainerRuntime for LimaRuntime {
         ];
         let tag_refs: Vec<&str> = tags.iter().map(|s| s.as_str()).collect();
         args.extend(tag_refs);
+        // Intentionally no --force: if an old image is still referenced by a
+        // running container rmi fails, caller logs warn-only and the image
+        // gets retried on the next update cycle once the container is gone.
         if let Err(e) = self.runner.run("limactl", &args) {
             log::warn!("lima rmi failed: {e}");
         }

--- a/crates/speedwave-runtime/src/runtime/mod.rs
+++ b/crates/speedwave-runtime/src/runtime/mod.rs
@@ -101,6 +101,13 @@ pub trait ContainerRuntime: Send + Sync {
         Ok(())
     }
 
+    /// Remove container images by their full tags.
+    fn remove_images(&self, tags: &[String]) -> anyhow::Result<()> {
+        let _ = tags;
+        log::debug!("remove_images: not implemented for this runtime, skipping");
+        Ok(())
+    }
+
     /// Restarts the container engine (containerd + buildkitd) and waits for readiness.
     ///
     /// Implementations MUST restart containerd, MUST restart buildkit (skip
@@ -1438,6 +1445,21 @@ services:
         assert!(
             elapsed < std::time::Duration::from_secs(9),
             "should not wait for the full 10s, elapsed: {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn test_remove_images_default_impl_is_noop() {
+        // ProbeTestRuntime uses the trait default (no override).
+        let rt = ProbeTestRuntime::healthy();
+        assert!(
+            rt.remove_images(&[]).is_ok(),
+            "default remove_images with empty slice should return Ok"
+        );
+        assert!(
+            rt.remove_images(&["speedwave-claude:old123".to_string()])
+                .is_ok(),
+            "default remove_images with tags should return Ok (no-op)"
         );
     }
 

--- a/crates/speedwave-runtime/src/runtime/nerdctl.rs
+++ b/crates/speedwave-runtime/src/runtime/nerdctl.rs
@@ -219,6 +219,9 @@ impl ContainerRuntime for NerdctlRuntime {
         let mut args = vec!["rmi"];
         let tag_refs: Vec<&str> = tags.iter().map(|s| s.as_str()).collect();
         args.extend(tag_refs);
+        // Intentionally no --force: if an old image is still referenced by a
+        // running container rmi fails, caller logs warn-only and the image
+        // gets retried on the next update cycle once the container is gone.
         if let Err(e) = self.runner.run("nerdctl", &args) {
             log::warn!("nerdctl rmi failed: {e}");
         }

--- a/crates/speedwave-runtime/src/runtime/nerdctl.rs
+++ b/crates/speedwave-runtime/src/runtime/nerdctl.rs
@@ -212,6 +212,19 @@ impl ContainerRuntime for NerdctlRuntime {
         Ok(())
     }
 
+    fn remove_images(&self, tags: &[String]) -> anyhow::Result<()> {
+        if tags.is_empty() {
+            return Ok(());
+        }
+        let mut args = vec!["rmi"];
+        let tag_refs: Vec<&str> = tags.iter().map(|s| s.as_str()).collect();
+        args.extend(tag_refs);
+        if let Err(e) = self.runner.run("nerdctl", &args) {
+            log::warn!("nerdctl rmi failed: {e}");
+        }
+        Ok(())
+    }
+
     fn restart_container_engine(&self) -> anyhow::Result<()> {
         log::info!("restarting containerd (rootless)");
         self.runner
@@ -739,6 +752,44 @@ mod tests {
         let result = rt.system_prune();
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("prune failed"));
+    }
+
+    #[test]
+    fn test_remove_images_empty_tags_is_noop() {
+        // No runner responses set — any run() call would fail with "unexpected command"
+        let runner = MockRunner::new();
+        let rt = NerdctlRuntime::with_runner(Box::new(runner));
+        assert!(
+            rt.remove_images(&[]).is_ok(),
+            "empty tags should return Ok without calling runner"
+        );
+    }
+
+    #[test]
+    fn test_remove_images_happy_path() {
+        let tags = vec![
+            "speedwave-claude:abc123".to_string(),
+            "speedwave-mcp-hub:abc123".to_string(),
+        ];
+        let runner = MockRunner::new().with_response(
+            "nerdctl rmi speedwave-claude:abc123 speedwave-mcp-hub:abc123",
+            "",
+        );
+        let rt = NerdctlRuntime::with_runner(Box::new(runner));
+        assert!(rt.remove_images(&tags).is_ok());
+    }
+
+    #[test]
+    fn test_remove_images_error_is_warn_only() {
+        let tags = vec!["speedwave-claude:abc123".to_string()];
+        let runner =
+            MockRunner::new().with_error("nerdctl rmi speedwave-claude:abc123", "no such image");
+        let rt = NerdctlRuntime::with_runner(Box::new(runner));
+        // rmi failure must not propagate — just warn and return Ok
+        assert!(
+            rt.remove_images(&tags).is_ok(),
+            "rmi failure should not propagate"
+        );
     }
 
     #[test]

--- a/crates/speedwave-runtime/src/runtime/wsl.rs
+++ b/crates/speedwave-runtime/src/runtime/wsl.rs
@@ -467,6 +467,19 @@ impl ContainerRuntime for WslRuntime {
         Ok(())
     }
 
+    fn remove_images(&self, tags: &[String]) -> anyhow::Result<()> {
+        if tags.is_empty() {
+            return Ok(());
+        }
+        let mut args = vec!["-d", consts::WSL_DISTRO_NAME, "--", "nerdctl", "rmi"];
+        let tag_refs: Vec<&str> = tags.iter().map(|s| s.as_str()).collect();
+        args.extend(tag_refs);
+        if let Err(e) = self.runner.run("wsl.exe", &args) {
+            log::warn!("wsl rmi failed: {e}");
+        }
+        Ok(())
+    }
+
     fn restart_container_engine(&self) -> anyhow::Result<()> {
         let distro = consts::WSL_DISTRO_NAME;
 
@@ -981,6 +994,46 @@ mod tests {
         let result = rt.system_prune();
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("prune failed"));
+    }
+
+    #[test]
+    fn test_remove_images_empty_tags_is_noop() {
+        // No runner responses set — any run() call would fail with "unexpected command"
+        let runner = MockRunner::new();
+        let rt = WslRuntime::with_runner(Box::new(runner));
+        assert!(
+            rt.remove_images(&[]).is_ok(),
+            "empty tags should return Ok without calling runner"
+        );
+    }
+
+    #[test]
+    fn test_remove_images_happy_path() {
+        let tags = vec![
+            "speedwave-claude:abc123".to_string(),
+            "speedwave-mcp-hub:abc123".to_string(),
+        ];
+        let runner = MockRunner::new().with_response(
+            "wsl.exe -d Speedwave -- nerdctl rmi speedwave-claude:abc123 speedwave-mcp-hub:abc123",
+            "",
+        );
+        let rt = WslRuntime::with_runner(Box::new(runner));
+        assert!(rt.remove_images(&tags).is_ok());
+    }
+
+    #[test]
+    fn test_remove_images_error_is_warn_only() {
+        let tags = vec!["speedwave-claude:abc123".to_string()];
+        let runner = MockRunner::new().with_error(
+            "wsl.exe -d Speedwave -- nerdctl rmi speedwave-claude:abc123",
+            "no such image",
+        );
+        let rt = WslRuntime::with_runner(Box::new(runner));
+        // rmi failure must not propagate — just warn and return Ok
+        assert!(
+            rt.remove_images(&tags).is_ok(),
+            "rmi failure should not propagate"
+        );
     }
 
     #[test]

--- a/crates/speedwave-runtime/src/runtime/wsl.rs
+++ b/crates/speedwave-runtime/src/runtime/wsl.rs
@@ -474,6 +474,9 @@ impl ContainerRuntime for WslRuntime {
         let mut args = vec!["-d", consts::WSL_DISTRO_NAME, "--", "nerdctl", "rmi"];
         let tag_refs: Vec<&str> = tags.iter().map(|s| s.as_str()).collect();
         args.extend(tag_refs);
+        // Intentionally no --force: if an old image is still referenced by a
+        // running container rmi fails, caller logs warn-only and the image
+        // gets retried on the next update cycle once the container is gone.
         if let Err(e) = self.runner.run("wsl.exe", &args) {
             log::warn!("wsl rmi failed: {e}");
         }

--- a/crates/speedwave-runtime/src/update.rs
+++ b/crates/speedwave-runtime/src/update.rs
@@ -1,4 +1,5 @@
 use crate::build;
+use crate::bundle;
 use crate::compose::{self, SecurityCheck};
 use crate::config;
 use crate::consts;
@@ -233,6 +234,15 @@ pub fn update_containers(
     // 6. Rebuild images from local Containerfiles BEFORE stopping containers.
     //    If the build fails, containers keep running with the previous version.
     //    containerd uses content-addressable storage — new builds don't affect running containers.
+    let bundle_state = bundle::load_bundle_state();
+    if let Some(ref old_id) = bundle_state.applied_bundle_id {
+        let new_manifest = bundle::load_current_bundle_manifest()?;
+        if old_id != &new_manifest.bundle_id {
+            if let Err(e) = build::prune_old_bundle_images(runtime, old_id) {
+                log::warn!("Failed to prune old bundle images: {e}");
+            }
+        }
+    }
     let images_rebuilt = build::build_all_images(runtime).map_err(|e| {
         anyhow::anyhow!(
             "Image rebuild failed: {}. Containers are still running with the previous version.",
@@ -717,6 +727,32 @@ mod tests {
         assert!(
             consts::CONTAINER_STABILIZATION_DELAY_SECS <= 10,
             "stabilization delay must not exceed 10 seconds"
+        );
+    }
+
+    #[test]
+    fn test_prune_before_build_in_update_containers() {
+        // Structural test: prune_old_bundle_images must appear BEFORE build_all_images
+        // inside update_containers — pruning first means old images are removed before
+        // new ones are built, with no risk of removing newly-built images.
+        let source = include_str!("update.rs");
+
+        let fn_start = source
+            .find("fn update_containers(")
+            .expect("update_containers function must exist in update.rs");
+        let fn_body = &source[fn_start..];
+
+        let prune_pos = fn_body
+            .find("prune_old_bundle_images")
+            .expect("prune_old_bundle_images call must exist in update_containers");
+        let build_pos = fn_body
+            .find("build::build_all_images")
+            .expect("build_all_images call must exist in update_containers");
+
+        assert!(
+            prune_pos < build_pos,
+            "prune_old_bundle_images (at byte {prune_pos}) must appear before \
+             build_all_images (at byte {build_pos}) in update_containers"
         );
     }
 }

--- a/crates/speedwave-runtime/src/update.rs
+++ b/crates/speedwave-runtime/src/update.rs
@@ -234,21 +234,23 @@ pub fn update_containers(
     // 6. Rebuild images from local Containerfiles BEFORE stopping containers.
     //    If the build fails, containers keep running with the previous version.
     //    containerd uses content-addressable storage — new builds don't affect running containers.
+    let new_manifest = bundle::load_current_bundle_manifest()?;
     let bundle_state = bundle::load_bundle_state();
-    if let Some(ref old_id) = bundle_state.applied_bundle_id {
-        let new_manifest = bundle::load_current_bundle_manifest()?;
-        if old_id != &new_manifest.bundle_id {
-            if let Err(e) = build::prune_old_bundle_images(runtime, old_id) {
-                log::warn!("Failed to prune old bundle images: {e}");
-            }
+    if let Some(old_id) = build::should_prune_bundle(
+        bundle_state.applied_bundle_id.as_deref(),
+        &new_manifest.bundle_id,
+    ) {
+        if let Err(e) = build::prune_old_bundle_images(runtime, old_id) {
+            log::warn!("Failed to prune old bundle images: {e}");
         }
     }
-    let images_rebuilt = build::build_all_images(runtime).map_err(|e| {
-        anyhow::anyhow!(
-            "Image rebuild failed: {}. Containers are still running with the previous version.",
-            e
-        )
-    })?;
+    let images_rebuilt = build::build_all_images_for_bundle(runtime, &new_manifest.bundle_id)
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "Image rebuild failed: {}. Containers are still running with the previous version.",
+                e
+            )
+        })?;
 
     // 7. Graceful shutdown — stop running containers before recreate.
     //    SIGTERM + timeout (compose default 10s) prevents killing active Claude sessions.

--- a/desktop/src-tauri/src/reconcile.rs
+++ b/desktop/src-tauri/src/reconcile.rs
@@ -316,11 +316,11 @@ fn reconcile_bundle_update_inner(app_handle: &tauri::AppHandle) -> Result<(), St
             "reconcile_bundle: building images for bundle {}",
             manifest.bundle_id,
         );
-        if let Some(ref old_id) = state.applied_bundle_id {
-            if old_id != &manifest.bundle_id {
-                if let Err(e) = build::prune_old_bundle_images(rt.as_ref(), old_id) {
-                    log::warn!("Failed to prune old bundle images: {e}");
-                }
+        if let Some(old_id) =
+            build::should_prune_bundle(state.applied_bundle_id.as_deref(), &manifest.bundle_id)
+        {
+            if let Err(e) = build::prune_old_bundle_images(rt.as_ref(), old_id) {
+                log::warn!("Failed to prune old bundle images: {e}");
             }
         }
         // build.rs handles: build → fail → prune → retry → SnapshotterRecoveryFailed.

--- a/desktop/src-tauri/src/reconcile.rs
+++ b/desktop/src-tauri/src/reconcile.rs
@@ -316,6 +316,13 @@ fn reconcile_bundle_update_inner(app_handle: &tauri::AppHandle) -> Result<(), St
             "reconcile_bundle: building images for bundle {}",
             manifest.bundle_id,
         );
+        if let Some(ref old_id) = state.applied_bundle_id {
+            if old_id != &manifest.bundle_id {
+                if let Err(e) = build::prune_old_bundle_images(rt.as_ref(), old_id) {
+                    log::warn!("Failed to prune old bundle images: {e}");
+                }
+            }
+        }
         // build.rs handles: build → fail → prune → retry → SnapshotterRecoveryFailed.
         // Here we escalate: restart engine → retry build. Safe because we are in the
         // pre-restore phase — no containers are running yet (see ContainerRuntime
@@ -1388,6 +1395,34 @@ mod tests {
         assert!(
             images_pos < ready_pos,
             "images_exist check must come before set_image_readiness(Ready)"
+        );
+    }
+
+    /// Structural test: verifies that `prune_old_bundle_images` is called BEFORE
+    /// `build_all_images_for_bundle` inside `reconcile_bundle_update_inner`.
+    /// Pruning before building ensures old images are cleaned up first — no data
+    /// loss possible since new images haven't been built yet at prune time.
+    #[test]
+    fn reconcile_prunes_old_images_before_building_new_ones() {
+        let source = include_str!("reconcile.rs");
+        let inner_fn = source
+            .split("fn reconcile_bundle_update_inner(")
+            .nth(1)
+            .expect("reconcile_bundle_update_inner function should exist");
+
+        let prune_pos = inner_fn
+            .find("prune_old_bundle_images")
+            .expect("prune_old_bundle_images call must exist in reconcile_bundle_update_inner");
+        let build_pos = inner_fn
+            .find("build_all_images_for_bundle")
+            .expect("build_all_images_for_bundle call must exist in reconcile_bundle_update_inner");
+
+        assert!(
+            prune_pos < build_pos,
+            "prune_old_bundle_images (at byte {prune_pos}) must appear before \
+             build_all_images_for_bundle (at byte {build_pos}) in \
+             reconcile_bundle_update_inner — pruning first ensures old images are \
+             removed before building new ones"
         );
     }
 }

--- a/docs/architecture/containers.md
+++ b/docs/architecture/containers.md
@@ -82,6 +82,19 @@ Existing projects receive the new Claude container memory limit on next containe
 - The `IMAGES` constant in `crates/speedwave-runtime/src/build.rs` must stay aligned with `scripts/bundle-build-context.sh`
 - All binary downloads in Containerfiles are **SHA256-verified** for supply chain security
 
+### Image pruning on update
+
+When the bundle ID changes (app version bump or build-context change), the previous bundle's 6 images are removed via `nerdctl rmi` **before** building the new set. This reclaims ~4–6 GiB of disk space per update cycle on the Lima VM diffdisk (50 GiB cap).
+
+Both update paths perform this pruning:
+
+- **Desktop** (`reconcile_bundle_update_inner` in `desktop/src-tauri/src/reconcile.rs`) — prunes before calling `build_all_images_for_bundle`
+- **CLI** (`update_containers` in `crates/speedwave-runtime/src/update.rs`) — prunes before calling `build_all_images`
+
+The guard condition is: `applied_bundle_id` exists **and** differs from the new bundle ID. Fresh installs (no `applied_bundle_id`) and rebuilds without a version change produce no prune call.
+
+Failure to prune is warn-only and never blocks the update — the build proceeds regardless.
+
 ## Dynamic Port Reconciliation (mcp-os)
 
 The mcp-os process runs on the host (not in a container) and binds to a dynamic port at startup. When the Desktop app starts — or when the mcp-os watchdog respawns a crashed process — the new port may differ from the `WORKER_OS_URL` baked into the running compose configuration.


### PR DESCRIPTION
## Summary

- Fixes #479 — Lima VM diffdisk filled up because old `<image>:<bundle_id>` tags accumulated. `system_prune()` only removes dangling images; tagged-but-superseded images stayed. Adds `remove_images()` to the `ContainerRuntime` trait (Nerdctl/Lima/WSL impls) and `build::prune_old_bundle_images()`, called from Desktop reconcile and CLI update before building the new image set. Guarded by "applied_bundle_id is Some and != new"; warn-only on failure so a prune hiccup never blocks an update.
- Hardens the `/speedwave-plan-loop` automation after observing it ship a "VERIFIED" run that actually had `make check: FAIL` and `make test: FAIL`:
  - Orchestrator gates success on `VERIFIED && make_check && make_test` (not just the verdict enum) and demotes contradictory verdicts (`VERIFIED` with failing check/test or partial steps, `READY_TO_IMPLEMENT` with blockers) instead of accepting them.
  - Skills gain explicit, non-negotiable verdict-correlation rules so the model cannot silently disagree with its own numeric fields.
  - Worktree provisioning delegates to `make install-deps` instead of a hand-rolled 4-directory `npm ci` loop that missed `mcp-servers/*` sub-packages and caused `tsc: command not found` at build-mcp.
- `make setup-dev` now uses `npm ci` instead of `npm install` so `package-lock.json` stays immutable during bootstrap (verified: clean `node_modules` → `make install-deps` → locks and `git status` unchanged).

## Test plan

- [x] `make check` in worktree — clippy 0 warnings, fmt clean
- [x] `make test` in worktree — Rust 792/792, Desktop 812/812, Angular/MCP/entrypoint green
- [x] Clean install: `rm -rf */node_modules && make install-deps` — no lockfile diff, no git status changes
- [ ] CI