### PR TITLE
fix(runtime): prune BuildKit cache during bundle rebuild to prevent ENOSPC

### DIFF
--- a/crates/speedwave-runtime/src/build.rs
+++ b/crates/speedwave-runtime/src/build.rs
@@ -1905,6 +1905,7 @@ mod tests {
     struct PruneMockRuntime {
         removed_tags: Arc<Mutex<Vec<String>>>,
         buildkit_pruned: Arc<std::sync::atomic::AtomicU32>,
+        buildkit_should_fail: bool,
     }
 
     impl PruneMockRuntime {
@@ -1912,6 +1913,14 @@ mod tests {
             Self {
                 removed_tags: Arc::new(Mutex::new(Vec::new())),
                 buildkit_pruned: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+                buildkit_should_fail: false,
+            }
+        }
+
+        fn with_failing_buildkit() -> Self {
+            Self {
+                buildkit_should_fail: true,
+                ..Self::new()
             }
         }
     }
@@ -1960,6 +1969,9 @@ mod tests {
         fn prune_buildkit_cache(&self) -> anyhow::Result<()> {
             self.buildkit_pruned
                 .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            if self.buildkit_should_fail {
+                anyhow::bail!("buildkit prune failed");
+            }
             Ok(())
         }
     }
@@ -2009,61 +2021,7 @@ mod tests {
     fn test_prune_old_bundle_images_buildkit_failure_is_warn_only() {
         // A runtime where prune_buildkit_cache fails should NOT cause
         // prune_old_bundle_images to return an error.
-        struct FailingBuildkitPruneRuntime;
-
-        impl ContainerRuntime for FailingBuildkitPruneRuntime {
-            fn compose_up(&self, _: &str) -> anyhow::Result<()> {
-                Ok(())
-            }
-            fn compose_down(&self, _: &str) -> anyhow::Result<()> {
-                Ok(())
-            }
-            fn compose_ps(&self, _: &str) -> anyhow::Result<Vec<serde_json::Value>> {
-                Ok(vec![])
-            }
-            fn container_exec(&self, _: &str, _: &[&str]) -> Command {
-                Command::new("true")
-            }
-            fn container_exec_piped(&self, _: &str, _: &[&str]) -> anyhow::Result<Command> {
-                Ok(Command::new("true"))
-            }
-            fn is_available(&self) -> bool {
-                true
-            }
-            fn ensure_ready(&self) -> anyhow::Result<()> {
-                Ok(())
-            }
-            fn build_image(
-                &self,
-                _: &str,
-                _: &str,
-                _: &str,
-                _: &[(&str, &str)],
-            ) -> anyhow::Result<()> {
-                Ok(())
-            }
-            fn container_logs(&self, _: &str, _: u32) -> anyhow::Result<String> {
-                Ok(String::new())
-            }
-            fn compose_logs(&self, _: &str, _: u32) -> anyhow::Result<String> {
-                Ok(String::new())
-            }
-            fn compose_up_recreate(&self, _: &str) -> anyhow::Result<()> {
-                Ok(())
-            }
-            fn image_exists(&self, _: &str) -> anyhow::Result<bool> {
-                Ok(true)
-            }
-            fn remove_images(&self, _: &[String]) -> anyhow::Result<()> {
-                Ok(())
-            }
-            fn prune_buildkit_cache(&self) -> anyhow::Result<()> {
-                anyhow::bail!("buildkit prune failed")
-            }
-        }
-
-        let rt = FailingBuildkitPruneRuntime;
-        // prune_old_bundle_images should succeed despite BuildKit prune failure
+        let rt = PruneMockRuntime::with_failing_buildkit();
         assert!(prune_old_bundle_images(&rt, "abc123").is_ok());
     }
 

--- a/crates/speedwave-runtime/src/build.rs
+++ b/crates/speedwave-runtime/src/build.rs
@@ -403,7 +403,13 @@ pub fn prune_old_bundle_images(
         "Pruning {} images from old bundle {old_bundle_id}",
         tags.len()
     );
-    runtime.remove_images(&tags)
+    runtime.remove_images(&tags)?;
+
+    log::info!("Pruning BuildKit cache");
+    if let Err(e) = runtime.prune_buildkit_cache() {
+        log::warn!("Failed to prune BuildKit cache: {e}");
+    }
+    Ok(())
 }
 
 pub fn build_all_images_for_bundle(
@@ -1895,15 +1901,17 @@ mod tests {
 
     // ── prune_old_bundle_images tests ─────────────────────────────────────
 
-    /// Minimal mock runtime that records remove_images calls.
+    /// Minimal mock runtime that records remove_images and prune_buildkit_cache calls.
     struct PruneMockRuntime {
         removed_tags: Arc<Mutex<Vec<String>>>,
+        buildkit_pruned: Arc<std::sync::atomic::AtomicU32>,
     }
 
     impl PruneMockRuntime {
         fn new() -> Self {
             Self {
                 removed_tags: Arc::new(Mutex::new(Vec::new())),
+                buildkit_pruned: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             }
         }
     }
@@ -1949,6 +1957,11 @@ mod tests {
             self.removed_tags.lock().unwrap().extend_from_slice(tags);
             Ok(())
         }
+        fn prune_buildkit_cache(&self) -> anyhow::Result<()> {
+            self.buildkit_pruned
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(())
+        }
     }
 
     #[test]
@@ -1978,6 +1991,80 @@ mod tests {
         let rt = PruneMockRuntime::new();
         prune_old_bundle_images(&rt, "same123").unwrap();
         assert_eq!(rt.removed_tags.lock().unwrap().len(), IMAGES.len());
+    }
+
+    #[test]
+    fn test_prune_old_bundle_images_also_prunes_buildkit_cache() {
+        let rt = PruneMockRuntime::new();
+        prune_old_bundle_images(&rt, "abc123").unwrap();
+
+        let pruned = rt.buildkit_pruned.load(std::sync::atomic::Ordering::SeqCst);
+        assert_eq!(
+            pruned, 1,
+            "prune_buildkit_cache should be called exactly once"
+        );
+    }
+
+    #[test]
+    fn test_prune_old_bundle_images_buildkit_failure_is_warn_only() {
+        // A runtime where prune_buildkit_cache fails should NOT cause
+        // prune_old_bundle_images to return an error.
+        struct FailingBuildkitPruneRuntime;
+
+        impl ContainerRuntime for FailingBuildkitPruneRuntime {
+            fn compose_up(&self, _: &str) -> anyhow::Result<()> {
+                Ok(())
+            }
+            fn compose_down(&self, _: &str) -> anyhow::Result<()> {
+                Ok(())
+            }
+            fn compose_ps(&self, _: &str) -> anyhow::Result<Vec<serde_json::Value>> {
+                Ok(vec![])
+            }
+            fn container_exec(&self, _: &str, _: &[&str]) -> Command {
+                Command::new("true")
+            }
+            fn container_exec_piped(&self, _: &str, _: &[&str]) -> anyhow::Result<Command> {
+                Ok(Command::new("true"))
+            }
+            fn is_available(&self) -> bool {
+                true
+            }
+            fn ensure_ready(&self) -> anyhow::Result<()> {
+                Ok(())
+            }
+            fn build_image(
+                &self,
+                _: &str,
+                _: &str,
+                _: &str,
+                _: &[(&str, &str)],
+            ) -> anyhow::Result<()> {
+                Ok(())
+            }
+            fn container_logs(&self, _: &str, _: u32) -> anyhow::Result<String> {
+                Ok(String::new())
+            }
+            fn compose_logs(&self, _: &str, _: u32) -> anyhow::Result<String> {
+                Ok(String::new())
+            }
+            fn compose_up_recreate(&self, _: &str) -> anyhow::Result<()> {
+                Ok(())
+            }
+            fn image_exists(&self, _: &str) -> anyhow::Result<bool> {
+                Ok(true)
+            }
+            fn remove_images(&self, _: &[String]) -> anyhow::Result<()> {
+                Ok(())
+            }
+            fn prune_buildkit_cache(&self) -> anyhow::Result<()> {
+                anyhow::bail!("buildkit prune failed")
+            }
+        }
+
+        let rt = FailingBuildkitPruneRuntime;
+        // prune_old_bundle_images should succeed despite BuildKit prune failure
+        assert!(prune_old_bundle_images(&rt, "abc123").is_ok());
     }
 
     #[test]

--- a/crates/speedwave-runtime/src/runtime/lima.rs
+++ b/crates/speedwave-runtime/src/runtime/lima.rs
@@ -1528,6 +1528,27 @@ mod tests {
     }
 
     #[test]
+    fn test_prune_buildkit_cache_propagates_command_error() {
+        let runner = mock_runner_with_vm_running().with_error(
+            &format!(
+                "limactl shell {} -- sudo nerdctl builder prune --all --force",
+                consts::LIMA_VM_NAME
+            ),
+            "buildkit prune failed",
+        );
+        let rt = LimaRuntime::with_runner(Box::new(runner));
+        let result = rt.prune_buildkit_cache();
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("buildkit prune failed"),
+            "should propagate the command error message"
+        );
+    }
+
+    #[test]
     fn test_remove_images_empty_tags_is_noop_after_require_running() {
         // VM is running, but no rmi command should be issued for empty tags
         let runner = mock_runner_with_vm_running();

--- a/crates/speedwave-runtime/src/runtime/lima.rs
+++ b/crates/speedwave-runtime/src/runtime/lima.rs
@@ -490,6 +490,25 @@ impl ContainerRuntime for LimaRuntime {
         Ok(())
     }
 
+    fn prune_buildkit_cache(&self) -> anyhow::Result<()> {
+        self.require_running()?;
+        self.runner.run(
+            "limactl",
+            &[
+                "shell",
+                consts::lima_vm_name(),
+                "--",
+                "sudo",
+                "nerdctl",
+                "builder",
+                "prune",
+                "--all",
+                "--force",
+            ],
+        )?;
+        Ok(())
+    }
+
     fn restart_container_engine(&self) -> anyhow::Result<()> {
         self.require_running()?;
         let vm = consts::lima_vm_name();
@@ -1464,6 +1483,47 @@ mod tests {
         assert!(
             err.to_string().contains("not running"),
             "should report VM not running, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_prune_buildkit_cache_shells_out_to_lima() {
+        let (recorded, runner) = make_recording_runner();
+        let rt = LimaRuntime::with_runner(runner);
+        assert!(
+            rt.prune_buildkit_cache().is_ok(),
+            "LimaRuntime::prune_buildkit_cache should succeed"
+        );
+        let commands = recorded.lock().unwrap();
+        assert_eq!(
+            commands.len(),
+            1,
+            "prune_buildkit_cache should issue exactly 1 command, got: {:?}",
+            *commands
+        );
+        assert!(
+            commands[0].contains("nerdctl builder prune --all --force"),
+            "prune_buildkit_cache should run nerdctl builder prune --all --force, got: {}",
+            commands[0]
+        );
+    }
+
+    #[test]
+    fn test_prune_buildkit_cache_fails_when_vm_stopped() {
+        let runner = MockRunner::new()
+            .with_response("limactl --version", "limactl version 1.0.0")
+            .with_response(
+                &format!(
+                    "limactl list --format {{{{.Status}}}} {}",
+                    consts::LIMA_VM_NAME
+                ),
+                "Stopped",
+            );
+        let rt = LimaRuntime::with_runner(Box::new(runner));
+        let err = rt.prune_buildkit_cache().unwrap_err();
+        assert!(
+            err.to_string().contains("not running"),
+            "should fail with VM-not-running error, got: {err}"
         );
     }
 

--- a/crates/speedwave-runtime/src/runtime/mod.rs
+++ b/crates/speedwave-runtime/src/runtime/mod.rs
@@ -108,6 +108,20 @@ pub trait ContainerRuntime: Send + Sync {
         Ok(())
     }
 
+    /// Removes BuildKit build cache.
+    ///
+    /// BuildKit cache mounts (`--mount=type=cache`) are stored separately
+    /// from container images and are not affected by `remove_images()` or
+    /// `system_prune()`. This method runs `nerdctl builder prune --all --force`
+    /// to reclaim that space.
+    ///
+    /// Called by `prune_old_bundle_images()` after removing old tagged images,
+    /// before building new ones for the updated bundle.
+    fn prune_buildkit_cache(&self) -> anyhow::Result<()> {
+        log::debug!("prune_buildkit_cache: not implemented for this runtime, skipping");
+        Ok(())
+    }
+
     /// Restarts the container engine (containerd + buildkitd) and waits for readiness.
     ///
     /// Implementations MUST restart containerd, MUST restart buildkit (skip

--- a/crates/speedwave-runtime/src/runtime/nerdctl.rs
+++ b/crates/speedwave-runtime/src/runtime/nerdctl.rs
@@ -228,6 +228,12 @@ impl ContainerRuntime for NerdctlRuntime {
         Ok(())
     }
 
+    fn prune_buildkit_cache(&self) -> anyhow::Result<()> {
+        self.runner
+            .run("nerdctl", &["builder", "prune", "--all", "--force"])?;
+        Ok(())
+    }
+
     fn restart_container_engine(&self) -> anyhow::Result<()> {
         log::info!("restarting containerd (rootless)");
         self.runner
@@ -753,6 +759,23 @@ mod tests {
         let runner = MockRunner::new().with_error("nerdctl system prune --force", "prune failed");
         let rt = NerdctlRuntime::with_runner(Box::new(runner));
         let result = rt.system_prune();
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("prune failed"));
+    }
+
+    #[test]
+    fn test_prune_buildkit_cache() {
+        let runner = MockRunner::new().with_response("nerdctl builder prune --all --force", "");
+        let rt = NerdctlRuntime::with_runner(Box::new(runner));
+        assert!(rt.prune_buildkit_cache().is_ok());
+    }
+
+    #[test]
+    fn test_prune_buildkit_cache_propagates_error() {
+        let runner =
+            MockRunner::new().with_error("nerdctl builder prune --all --force", "prune failed");
+        let rt = NerdctlRuntime::with_runner(Box::new(runner));
+        let result = rt.prune_buildkit_cache();
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("prune failed"));
     }

--- a/crates/speedwave-runtime/src/runtime/wsl.rs
+++ b/crates/speedwave-runtime/src/runtime/wsl.rs
@@ -483,6 +483,23 @@ impl ContainerRuntime for WslRuntime {
         Ok(())
     }
 
+    fn prune_buildkit_cache(&self) -> anyhow::Result<()> {
+        self.runner.run(
+            "wsl.exe",
+            &[
+                "-d",
+                consts::WSL_DISTRO_NAME,
+                "--",
+                "nerdctl",
+                "builder",
+                "prune",
+                "--all",
+                "--force",
+            ],
+        )?;
+        Ok(())
+    }
+
     fn restart_container_engine(&self) -> anyhow::Result<()> {
         let distro = consts::WSL_DISTRO_NAME;
 
@@ -995,6 +1012,31 @@ mod tests {
         );
         let rt = WslRuntime::with_runner(Box::new(runner));
         let result = rt.system_prune();
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("prune failed"));
+    }
+
+    #[test]
+    fn test_prune_buildkit_cache_calls_nerdctl_in_wsl() {
+        let runner = MockRunner::new().with_response(
+            "wsl.exe -d Speedwave -- nerdctl builder prune --all --force",
+            "",
+        );
+        let rt = WslRuntime::with_runner(Box::new(runner));
+        assert!(
+            rt.prune_buildkit_cache().is_ok(),
+            "WslRuntime::prune_buildkit_cache should succeed"
+        );
+    }
+
+    #[test]
+    fn test_prune_buildkit_cache_propagates_error() {
+        let runner = MockRunner::new().with_error(
+            "wsl.exe -d Speedwave -- nerdctl builder prune --all --force",
+            "prune failed",
+        );
+        let rt = WslRuntime::with_runner(Box::new(runner));
+        let result = rt.prune_buildkit_cache();
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("prune failed"));
     }

--- a/crates/speedwave-runtime/src/update.rs
+++ b/crates/speedwave-runtime/src/update.rs
@@ -827,4 +827,29 @@ mod tests {
              from update_containers depends on this"
         );
     }
+
+    #[test]
+    fn test_buildkit_prune_in_prune_old_bundle_images() {
+        // Structural test: prune_buildkit_cache must be called inside
+        // prune_old_bundle_images — this ensures BuildKit cache is cleaned
+        // alongside old tagged images during bundle updates.
+        let source = include_str!("build.rs");
+
+        let fn_start = source
+            .find("fn prune_old_bundle_images(")
+            .expect("prune_old_bundle_images function must exist in build.rs");
+        let fn_body = &source[fn_start..];
+
+        // Find the end of the function (next `pub fn` or `fn ` at top level)
+        let fn_end = fn_body[1..]
+            .find("\npub fn ")
+            .or_else(|| fn_body[1..].find("\nfn "))
+            .unwrap_or(fn_body.len());
+        let fn_body = &fn_body[..fn_end];
+
+        assert!(
+            fn_body.contains("prune_buildkit_cache"),
+            "prune_old_bundle_images must call prune_buildkit_cache to clear BuildKit cache"
+        );
+    }
 }

--- a/docs/architecture/containers.md
+++ b/docs/architecture/containers.md
@@ -84,7 +84,12 @@ Existing projects receive the new Claude container memory limit on next containe
 
 ### Image pruning on update
 
-When the bundle ID changes (app version bump or build-context change), the previous bundle's 6 images are removed via `nerdctl rmi` **before** building the new set. This reclaims ~4–6 GiB of disk space per update cycle on the Lima VM diffdisk (50 GiB cap).
+When the bundle ID changes (app version bump or build-context change), disk space is reclaimed in two steps **before** building the new image set:
+
+1. The previous bundle's 6 tagged images are removed via `nerdctl rmi`, reclaiming ~4–6 GiB.
+2. BuildKit build cache is pruned via `nerdctl builder prune --all --force`, reclaiming an additional ~5–15 GiB of transient layers from `--mount=type=cache` steps.
+
+This two-step cleanup ensures the Lima VM diffdisk (50 GiB cap) has sufficient space for the new build.
 
 Both update paths perform this pruning:
 


### PR DESCRIPTION
## Summary

- Add `prune_buildkit_cache()` to `ContainerRuntime` trait with implementations for Lima, Nerdctl, and WSL — runs `nerdctl builder prune --all --force` after removing old tagged images
- BuildKit cache mounts (`--mount=type=cache`) are stored separately from container images and were not cleared by `remove_images()` or `system_prune()`, causing ENOSPC after repeated bundle rebuilds
- BuildKit prune failure is non-fatal (logged as warning) to avoid blocking updates
- Updated `docs/architecture/containers.md` to document the two-step cleanup (tagged images + BuildKit cache)

Closes #493

## Test plan

- [x] `make check` passes (clippy, lint, format, type-check)
- [x] `make test` passes (814 tests, 0 failures)
- [x] New tests for `prune_buildkit_cache()` on all 3 runtimes:
  - Happy path (command runs correctly)
  - Error propagation (command fails → error returned)
  - VM-stopped guard (Lima only)
- [x] Integration test: `prune_old_bundle_images()` calls `prune_buildkit_cache()` exactly once
- [x] Failure isolation test: BuildKit prune failure does not cause `prune_old_bundle_images()` to fail