### PR TITLE
fix(ci): reject chore as PR title for dev→main merges

### DIFF
--- a/.github/workflows/merge-strategy-check.yml
+++ b/.github/workflows/merge-strategy-check.yml
@@ -2,6 +2,8 @@
 #
 # - Release-please and backmerge PRs are exempt
 # - All other PRs must have conventional commit titles (for squash merge)
+# - `chore` is intentionally rejected here (see scripts/validate-pr-title-main.sh
+#   header and issue #371) because release-please ignores `chore` commits.
 
 name: Merge Strategy Check
 
@@ -17,37 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
+      - uses: actions/checkout@v4
       - name: Validate PR title for squash merge
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
           HEAD_REF: ${{ github.head_ref }}
-        run: |
-          set -e
-
-          # Release-please PRs are exempt (they manage their own titles)
-          if [[ "$HEAD_REF" == release-please--* ]]; then
-            echo "Release-please PR — skipping title check"
-            exit 0
-          fi
-
-          # Backmerge PRs are exempt (fallback merge when dev has new commits)
-          if [[ "$HEAD_REF" == chore/backmerge-* ]]; then
-            echo "Backmerge PR — skipping title check"
-            exit 0
-          fi
-
-          # Validate conventional commit format
-          # Pattern: type(optional-scope): description
-          if [[ "$PR_TITLE" =~ ^(feat|fix|perf|refactor|docs|ci|test|chore|build|style|revert)(\(.+\))?\!?:\ .+ ]]; then
-            echo "PR title follows conventional commits: $PR_TITLE"
-          else
-            echo "::error::PR title does not follow conventional commits format."
-            echo "::error::Expected: type(scope): description"
-            echo "::error::Examples: feat(runtime): add logging, fix(ci): correct build path"
-            echo "::error::Valid types: feat, fix, perf, refactor, docs, ci, test, chore, build, style, revert"
-            echo ""
-            echo "::error::PRs to main must use SQUASH MERGE with a conventional commit title."
-            echo "::error::The PR title becomes the commit message on main, which release-please"
-            echo "::error::uses to determine version bumps."
-            exit 1
-          fi
+        run: ./scripts/validate-pr-title-main.sh

--- a/.github/workflows/merge-strategy-check.yml
+++ b/.github/workflows/merge-strategy-check.yml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Validate PR title for squash merge
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}

--- a/.github/workflows/merge-strategy-check.yml
+++ b/.github/workflows/merge-strategy-check.yml
@@ -18,8 +18,10 @@ jobs:
   check-pr-title:
     runs-on: ubuntu-latest
     timeout-minutes: 2
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Validate PR title for squash merge
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ git push
 
 - **PRs always target `dev`** — never open a PR directly to `main`
 - **`dev` -> `main`:** always squash merge in GitHub UI. PR title must be a conventional commit (e.g. `feat(runtime): add logging`). See [RELEASING.md](RELEASING.md#why-squash-merge-matters)
+- **`chore(...)` is NOT allowed as a PR title to `main`** — release-please ignores `chore` commits, so a `chore` squash merge would collapse all bundled `feat`/`fix` commits into an invisible release (no version bump). Allowed types for `dev → main`: `feat, fix, perf, refactor, docs, ci, test, build, style, revert`. `chore` remains valid for PRs to `dev`.
 - **Backmerge (`main` -> `dev`):** automated via `backmerge.yml` on release publish. Resets dev to main (force-push) to prevent ghost commit accumulation. Falls back to regular merge PR if dev has new commits since the release
 - **`merge-strategy-check.yml`** enforces conventional commit PR titles on PRs to `main` (release-please and backmerge PRs are exempt)
 - Link commits to GitHub issues when they exist

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ LIMA_VERSION := $(shell cat .lima-version 2>/dev/null || echo 2.0.2)
 .PHONY: all build test check clean dev install-deps setup-dev install-hooks \
         build-runtime build-cli build-desktop build-tauri build-mcp build-angular \
         build-native-macos build-os-cli bundle-native-assets verify-bundled-assets \
-        test-rust test-cli test-desktop test-angular test-mcp test-os test-swift test-e2e test-entrypoint test-desktop-build \
+        test-rust test-cli test-desktop test-angular test-mcp test-os test-swift test-e2e test-entrypoint test-ci test-desktop-build \
         test-e2e-desktop _e2e-macos _e2e-linux _e2e-windows test-e2e-all setup-e2e-vms \
         check-clippy check-desktop-clippy check-angular check-mcp check-fmt \
         check-mcp-lint check-angular-lint check-all \
@@ -164,7 +164,7 @@ all: build
 build: build-runtime build-cli build-os-cli build-mcp build-angular
 	@echo "\n✅ All builds complete"
 
-test: test-rust test-angular test-mcp test-entrypoint test-desktop-build test-desktop
+test: test-rust test-angular test-mcp test-entrypoint test-desktop-build test-desktop test-ci
 	@echo "\n✅ All tests passed"
 
 check: check-clippy check-desktop-clippy check-fmt check-mcp check-mcp-lint check-angular-lint
@@ -355,6 +355,11 @@ test-entrypoint:
 	bats _tests/entrypoint/install-claude.bats
 	bats _tests/entrypoint/statusline.bats
 	@echo "✅ Entrypoint tests passed"
+
+test-ci:
+	@command -v bats >/dev/null 2>&1 || { echo "❌ bats not found. Install: brew install bats-core"; exit 1; }
+	bats _tests/ci/validate-pr-title-main.bats
+	@echo "✅ CI workflow tests passed"
 
 test-desktop-build: build-angular build-mcp
 	@command -v bats >/dev/null 2>&1 || { echo "❌ bats not found. Install: brew install bats-core"; exit 1; }

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -167,6 +167,14 @@ That's it — no manual version bumping, no workflow dispatch, no release type s
 - Release-please also backfills file lists per commit — empty commits (`--allow-empty`) return 0 files and are excluded from path-based detection
 - Squash merge produces a single commit with the PR title as the message — if the PR title follows conventional commits (e.g. `feat(runtime): add logging`), release-please picks it up correctly
 
+#### `chore(...)` is NOT allowed as a PR title to `main`
+
+Release-please only tracks commit types listed in its `changelog-sections` (`release-please-config.json`). `chore` is intentionally absent — a `chore` squash merge from `dev` to `main` would collapse every bundled `feat`/`fix` commit into a single `chore` commit that release-please ignores entirely. Result: no version bump, no release PR, the whole batch vanishes from the release record.
+
+`merge-strategy-check.yml` enforces this by rejecting `chore(...)` PR titles on PRs to `main`. Allowed types for `dev → main`: `feat, fix, perf, refactor, docs, ci, test, build, style, revert`.
+
+If a `dev → main` PR contains only housekeeping, wait for the next `feat`/`fix` before merging — do not promote a `chore`-only batch on its own. `chore` remains valid for PRs targeting `dev`.
+
 #### What happens if you accidentally use a regular merge
 
 A regular merge brings the entire `dev` commit history onto `main` as a merge commit with two parents. Release-please walks both parents and sees all historical commits from `dev` — including ones already released in previous versions — as "new" commits. This causes **phantom release PRs**: release-please opens a new release PR containing duplicate changelog entries for already-released features.

--- a/_tests/ci/validate-pr-title-main.bats
+++ b/_tests/ci/validate-pr-title-main.bats
@@ -123,6 +123,12 @@ run_script() {
     [[ "$output" == *"'chore' is NOT allowed"* ]]
 }
 
+@test "chore with scope and breaking-change marker is REJECTED" {
+    run_script "chore(deps)!: drop legacy dep"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"'chore' is NOT allowed"* ]]
+}
+
 @test "chore error message suggests feat/fix alternative" {
     run_script "chore(deps): bump"
     [ "$status" -eq 1 ]

--- a/_tests/ci/validate-pr-title-main.bats
+++ b/_tests/ci/validate-pr-title-main.bats
@@ -1,0 +1,175 @@
+#!/usr/bin/env bats
+# Tests for scripts/validate-pr-title-main.sh
+#
+# Regression: issue #371 — `chore` as PR title to main makes release-please
+# ignore the merge, collapsing feat/fix commits into an invisible release.
+
+SCRIPT="$BATS_TEST_DIRNAME/../../scripts/validate-pr-title-main.sh"
+
+run_script() {
+    PR_TITLE="$1" HEAD_REF="${2:-feature/branch}" run bash "$SCRIPT"
+}
+
+# ---------------------------------------------------------------------------
+# Happy path — allowed conventional commit types
+# ---------------------------------------------------------------------------
+
+@test "feat with scope passes" {
+    run_script "feat(runtime): add logging"
+    [ "$status" -eq 0 ]
+}
+
+@test "feat without scope passes" {
+    run_script "feat: add thing"
+    [ "$status" -eq 0 ]
+}
+
+@test "fix with scope passes" {
+    run_script "fix(ci): correct build path"
+    [ "$status" -eq 0 ]
+}
+
+@test "fix with breaking-change marker passes" {
+    run_script "fix!: drop legacy API"
+    [ "$status" -eq 0 ]
+}
+
+@test "feat with scope and breaking-change marker passes" {
+    run_script "feat(api)!: redesign surface"
+    [ "$status" -eq 0 ]
+}
+
+@test "perf passes" {
+    run_script "perf(runtime): faster container boot"
+    [ "$status" -eq 0 ]
+}
+
+@test "refactor passes" {
+    run_script "refactor(desktop): extract hub logic"
+    [ "$status" -eq 0 ]
+}
+
+@test "docs passes" {
+    run_script "docs: update ADR index"
+    [ "$status" -eq 0 ]
+}
+
+@test "ci passes" {
+    run_script "ci: bump action version"
+    [ "$status" -eq 0 ]
+}
+
+@test "test passes" {
+    run_script "test(cli): cover edge case"
+    [ "$status" -eq 0 ]
+}
+
+@test "build passes" {
+    run_script "build: update toolchain"
+    [ "$status" -eq 0 ]
+}
+
+@test "style passes" {
+    run_script "style: format Rust sources"
+    [ "$status" -eq 0 ]
+}
+
+@test "revert passes" {
+    run_script "revert: undo feat(runtime): bad change"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Exempt branches — pass regardless of title (even with chore)
+# ---------------------------------------------------------------------------
+
+@test "release-please branch is exempt even with chore title" {
+    run_script "chore(main): release 1.2.3" "release-please--branches--main"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Release-please PR"* ]]
+}
+
+@test "release-please branch is exempt with empty title" {
+    run_script "" "release-please--branches--main--components--root"
+    [ "$status" -eq 0 ]
+}
+
+@test "backmerge branch is exempt with chore title" {
+    run_script "chore: backmerge main into dev after v1.2.3" "chore/backmerge-v1.2.3"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Backmerge PR"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Error paths — the regression guard for issue #371
+# ---------------------------------------------------------------------------
+
+@test "chore with scope is REJECTED (issue #371 regression)" {
+    run_script "chore(deps): bump dependencies"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"'chore' is NOT allowed"* ]]
+    [[ "$output" == *"#371"* ]]
+}
+
+@test "chore without scope is REJECTED" {
+    run_script "chore: cleanup"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"'chore' is NOT allowed"* ]]
+}
+
+@test "chore with breaking-change marker is REJECTED" {
+    run_script "chore!: big cleanup"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"'chore' is NOT allowed"* ]]
+}
+
+@test "chore error message suggests feat/fix alternative" {
+    run_script "chore(deps): bump"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"feat(...)"* ]]
+    [[ "$output" == *"fix(...)"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Edge cases — malformed titles
+# ---------------------------------------------------------------------------
+
+@test "empty title is REJECTED" {
+    run_script ""
+    [ "$status" -eq 1 ]
+}
+
+@test "title without type is REJECTED" {
+    run_script "add logging"
+    [ "$status" -eq 1 ]
+}
+
+@test "title with unknown type is REJECTED" {
+    run_script "wip: in progress"
+    [ "$status" -eq 1 ]
+}
+
+@test "title without colon is REJECTED" {
+    run_script "feat add thing"
+    [ "$status" -eq 1 ]
+}
+
+@test "title without description after colon is REJECTED" {
+    run_script "feat: "
+    [ "$status" -eq 1 ]
+}
+
+@test "title with only type and colon is REJECTED" {
+    run_script "feat:"
+    [ "$status" -eq 1 ]
+}
+
+@test "feat-ish but misspelled is REJECTED" {
+    run_script "feet(runtime): add logging"
+    [ "$status" -eq 1 ]
+}
+
+@test "uppercase type is REJECTED" {
+    run_script "FEAT: add thing"
+    [ "$status" -eq 1 ]
+}

--- a/docs/adr/ADR-019-git-branching-model-and-release-flow.md
+++ b/docs/adr/ADR-019-git-branching-model-and-release-flow.md
@@ -350,7 +350,7 @@ After the v0.3.0 incident (wrong-version artifacts due to manual dispatch from d
 
 - **`backmerge.yml`** — triggered on `release: [published]`. Resets `dev` to `main` via force-push to prevent ghost commit accumulation from squash merge SHA divergence. Falls back to regular merge via PR if `dev` has new commits since the release. Force-push is permitted by a GitHub Repository Ruleset that grants admin role bypass on `dev`.
 
-- **`merge-strategy-check.yml`** — triggered on PRs to `main`. Validates that the PR title follows conventional commits format. Release-please and backmerge PRs are exempt.
+- **`merge-strategy-check.yml`** — triggered on PRs to `main`. Validates that the PR title follows conventional commits format. Release-please and backmerge PRs are exempt. `chore(...)` is explicitly rejected: release-please omits `chore` from its `changelog-sections`[^release-please-chore], so a `chore` squash merge from `dev` would collapse bundled `feat`/`fix` commits into an invisible release (no version bump). Allowed types: `feat, fix, perf, refactor, docs, ci, test, build, style, revert`.
 
 ### Merge strategy clarification
 
@@ -390,3 +390,5 @@ After the v0.3.0 incident (wrong-version artifacts due to manual dispatch from d
 [^59]: [GitHub Security Lab — Script injection in GitHub Actions](https://securitylab.github.com/resources/github-actions-untrusted-input/)
 
 [^60]: [release-please — Commit parsing uses `--first-parent` traversal](https://github.com/googleapis/release-please/blob/main/docs/design.md) — release-please walks `--first-parent` commits on the target branch and parses each message as a conventional commit. Regular merge commits (`Merge pull request #N`) are not conventional commits and are ignored. Squash merge ensures the PR title (which must be a conventional commit) becomes the first-parent commit message.
+
+[^release-please-chore]: [release-please — `changelog-sections` configuration schema](https://github.com/googleapis/release-please/blob/main/schemas/config.json) — release-please only tracks commit types listed in `changelog-sections` when computing version bumps and changelog entries. Types absent from the list (such as `chore` in our `release-please-config.json`) are ignored entirely.

--- a/scripts/validate-pr-title-main.sh
+++ b/scripts/validate-pr-title-main.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Validates PR title for PRs targeting `main`.
+#
+# `chore(...)` is rejected here because release-please does not include
+# `chore` in its changelog-sections (release-please-config.json), so a
+# `chore` squash merge to main collapses feat/fix commits into an invisible
+# release — no version bump, no release PR. See issue #371.
+#
+# Env vars:
+#   PR_TITLE — the PR title to validate
+#   HEAD_REF — the source branch name (for exemption logic)
+#
+# Exit codes:
+#   0 — valid (or exempt)
+#   1 — invalid
+
+set -euo pipefail
+
+PR_TITLE="${PR_TITLE:-}"
+HEAD_REF="${HEAD_REF:-}"
+
+# Release-please PRs are exempt (release-please manages its own titles).
+if [[ "$HEAD_REF" == release-please--* ]]; then
+    echo "Release-please PR — skipping title check"
+    exit 0
+fi
+
+# Backmerge PRs are exempt (fallback merge when dev has diverged from main).
+if [[ "$HEAD_REF" == chore/backmerge-* ]]; then
+    echo "Backmerge PR — skipping title check"
+    exit 0
+fi
+
+# Conventional commit types allowed on `dev → main` squash merges.
+# `chore` is intentionally absent — see header comment and issue #371.
+if [[ "$PR_TITLE" =~ ^(feat|fix|perf|refactor|docs|ci|test|build|style|revert)(\(.+\))?\!?:\ .+ ]]; then
+    echo "PR title follows conventional commits: $PR_TITLE"
+    exit 0
+fi
+
+echo "::error::PR title does not follow the conventions required for dev→main merges."
+echo "::error::Your title: $PR_TITLE"
+echo "::error::"
+echo "::error::Expected format: type(scope): description"
+echo "::error::Allowed types: feat, fix, perf, refactor, docs, ci, test, build, style, revert"
+echo "::error::"
+if [[ "$PR_TITLE" =~ ^chore(\(.+\))?\!?:\ .+ ]]; then
+    echo "::error::'chore' is NOT allowed for PRs to main — release-please ignores chore commits,"
+    echo "::error::so the squash merge would collapse all feat/fix commits from dev into an"
+    echo "::error::invisible release (no version bump, no release PR). See issue #371."
+    echo "::error::"
+    echo "::error::Use 'feat(...)' or 'fix(...)' instead, matching the dominant change in this merge."
+    echo "::error::'chore' is still fine for PRs targeting 'dev'."
+fi
+exit 1


### PR DESCRIPTION
## Summary

- Release-please ignores `chore` commits (omitted from `changelog-sections`), so a `chore(...)` squash merge from `dev` to `main` collapses bundled `feat`/`fix` commits into an invisible release — no version bump, no release PR.
- `merge-strategy-check.yml` now rejects `chore(...)` PR titles for PRs to `main`, with a diagnostic that explains why and points to issue #371. Validation logic extracted into `scripts/validate-pr-title-main.sh` for testability.
- Allowed types for `dev → main`: `feat, fix, perf, refactor, docs, ci, test, build, style, revert`. `chore` remains valid for PRs targeting `dev`.

## Changes

- **`scripts/validate-pr-title-main.sh`** (new) — standalone validator, called by workflow via `env: PR_TITLE, HEAD_REF`. Preserves existing `release-please--*` and `chore/backmerge-*` exemptions.
- **`_tests/ci/validate-pr-title-main.bats`** (new, 28 tests) — happy paths (11 conventional types), exempt branches, `chore` rejection regression guards, edge cases (empty/malformed titles).
- **`.github/workflows/merge-strategy-check.yml`** — inline bash replaced by `run: ./scripts/validate-pr-title-main.sh` + `actions/checkout@v4`.
- **`Makefile`** — new `test-ci` target wired into `make test`.
- **`CLAUDE.md`, `RELEASING.md`, `ADR-019`** — documented the prohibition and rationale; added footnote to release-please `changelog-sections` schema.

## Test plan

- [x] `make test-ci` — 28/28 bats tests pass
- [x] `make test` — full suite passes (Rust, Angular, MCP, desktop 819 tests, entrypoint, new CI tests)
- [x] `make check` — clippy + eslint + fmt all green
- [x] `shellcheck scripts/validate-pr-title-main.sh` — clean
- [ ] CI green on this PR (validates workflow runs without errors against its own title)
- [ ] After merge to `dev`, subsequent `dev → main` PR with `chore(...)` title must fail `merge-strategy-check`; same PR with `fix(ci): ...` must pass

Fixes #371