### PR TITLE
fix(desktop): document DomSanitizer reliance in text-block and dedupe markdown render

### DIFF
--- a/desktop/src/src/app/chat/blocks/text-block.component.spec.ts
+++ b/desktop/src/src/app/chat/blocks/text-block.component.spec.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { marked } from 'marked';
 import { TextBlockComponent } from './text-block.component';
 
 describe('TextBlockComponent', () => {
@@ -69,13 +70,20 @@ describe('TextBlockComponent', () => {
     const href = el.querySelector('a')?.getAttribute('href') ?? '';
     // Angular's HTML sanitizer rewrites javascript: to unsafe:javascript:, making it inert.
     expect(href).toBe('unsafe:javascript:alert(1)');
-    expect(href.startsWith('javascript:')).toBe(false);
   });
 
   it('rendered getter returns unsanitized HTML containing script tags', () => {
     component.content = '<script>alert(1)</script>';
     // The getter itself does not sanitize — sanitization happens at [innerHTML] binding time.
     expect(component.rendered).toContain('<script>');
+  });
+
+  it('rendered getter throws if marked.parse returns a Promise', () => {
+    vi.spyOn(marked, 'parse').mockReturnValueOnce(Promise.resolve('<p>hi</p>') as never);
+    component.content = 'irrelevant';
+    expect(() => component.rendered).toThrow(
+      'marked.parse returned a Promise; async option must remain false'
+    );
   });
 
   it('renders empty content without error', () => {

--- a/desktop/src/src/app/chat/blocks/text-block.component.spec.ts
+++ b/desktop/src/src/app/chat/blocks/text-block.component.spec.ts
@@ -72,6 +72,24 @@ describe('TextBlockComponent', () => {
     expect(href).toBe('unsafe:javascript:alert(1)');
   });
 
+  it('rewrites data: URLs in links via Angular DomSanitizer', () => {
+    component.content = '[click](data:text/html,<script>alert(1)</script>)';
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    const href = el.querySelector('a')?.getAttribute('href') ?? '';
+    expect(href).toMatch(/^unsafe:data:/);
+  });
+
+  it('rewrites vbscript: URLs in links via Angular DomSanitizer', () => {
+    component.content = '[click](vbscript:MsgBox(1))';
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    const href = el.querySelector('a')?.getAttribute('href') ?? '';
+    expect(href).toMatch(/^unsafe:vbscript:/);
+  });
+
   it('rendered getter returns unsanitized HTML containing script tags', () => {
     component.content = '<script>alert(1)</script>';
     // The getter itself does not sanitize — sanitization happens at [innerHTML] binding time.

--- a/desktop/src/src/app/chat/blocks/text-block.component.spec.ts
+++ b/desktop/src/src/app/chat/blocks/text-block.component.spec.ts
@@ -40,4 +40,51 @@ describe('TextBlockComponent', () => {
     const el = fixture.nativeElement as HTMLElement;
     expect(el.textContent).toContain('Hello world');
   });
+
+  it('strips script tags via Angular DomSanitizer', () => {
+    component.content = "Safe **bold** text <script>alert('xss')</script> tail";
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('script')).toBeNull();
+    expect(el.querySelector('strong')?.textContent).toBe('bold');
+    expect(el.textContent).toContain('tail');
+  });
+
+  it('strips event-handler attributes via Angular DomSanitizer', () => {
+    component.content = '<img src=x onerror="alert(1)">';
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.innerHTML).not.toContain('onerror');
+    const img = el.querySelector('img');
+    expect(img?.hasAttribute('onerror') ?? false).toBe(false);
+  });
+
+  it('rewrites javascript: URLs to unsafe:javascript: via Angular DomSanitizer', () => {
+    component.content = '[click](javascript:alert(1))';
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    const href = el.querySelector('a')?.getAttribute('href') ?? '';
+    // Angular's HTML sanitizer rewrites javascript: to unsafe:javascript:, making it inert.
+    expect(href).toBe('unsafe:javascript:alert(1)');
+    expect(href.startsWith('javascript:')).toBe(false);
+  });
+
+  it('rendered getter returns unsanitized HTML containing script tags', () => {
+    component.content = '<script>alert(1)</script>';
+    // The getter itself does not sanitize — sanitization happens at [innerHTML] binding time.
+    expect(component.rendered).toContain('<script>');
+  });
+
+  it('renders empty content without error', () => {
+    component.content = '';
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    const prose = el.querySelector('.prose-sw');
+    expect(prose).not.toBeNull();
+    expect(prose?.textContent?.trim()).toBe('');
+  });
 });

--- a/desktop/src/src/app/chat/blocks/text-block.component.ts
+++ b/desktop/src/src/app/chat/blocks/text-block.component.ts
@@ -19,7 +19,7 @@ import { marked } from 'marked';
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: { class: 'block' },
-  template: `<div class="prose-sw" [innerHTML]="rendered"></div>`,
+  template: `<div class="prose-sw text-sw-text" [innerHTML]="rendered"></div>`,
 })
 export class TextBlockComponent {
   @Input({ required: true }) content!: string;

--- a/desktop/src/src/app/chat/blocks/text-block.component.ts
+++ b/desktop/src/src/app/chat/blocks/text-block.component.ts
@@ -1,7 +1,19 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { marked } from 'marked';
 
-/** Renders markdown-formatted text content as sanitized HTML. */
+/**
+ * Renders markdown-formatted text content as HTML.
+ *
+ * Markdown is parsed by the `marked` library, which does NOT sanitize its HTML output.
+ * XSS protection comes from Angular's built-in `DomSanitizer`, which runs automatically
+ * when the string is assigned via the `[innerHTML]` property binding — stripping `<script>`
+ * tags, event-handler attributes (`onerror`, `onclick`, etc.), and rewriting `javascript:`
+ * URLs to the inert `unsafe:javascript:` prefix so they cannot execute.
+ *
+ * WARNING: Do not switch this binding to a `SafeHtml` produced by
+ * `DomSanitizer.bypassSecurityTrustHtml(...)` — doing so disables all sanitization and
+ * would make `<script>` tags, event-handler attributes, and `javascript:` URLs executable.
+ */
 @Component({
   selector: 'app-text-block',
   standalone: true,
@@ -12,8 +24,12 @@ import { marked } from 'marked';
 export class TextBlockComponent {
   @Input({ required: true }) content!: string;
 
-  /** Converts the raw markdown content to HTML via the marked library. */
+  /** Returns unsanitized HTML from `marked`. Safe only when bound via `[innerHTML]` — see class doc. */
   get rendered(): string {
-    return marked.parse(this.content, { async: false }) as string;
+    const result = marked.parse(this.content, { async: false });
+    if (typeof result !== 'string') {
+      throw new Error('marked.parse returned a Promise; async option must remain false');
+    }
+    return result;
   }
 }

--- a/desktop/src/src/app/chat/chat.component.html
+++ b/desktop/src/src/app/chat/chat.component.html
@@ -93,7 +93,7 @@
               [class.border]="msg.role === 'assistant'"
               [class.border-sw-border]="msg.role === 'assistant'"
             >
-              <div class="prose-sw text-sw-text" [innerHTML]="renderMarkdown(msg.content)"></div>
+              <app-text-block [content]="msg.content" />
             </div>
           }
         </div>
@@ -174,10 +174,9 @@
               X
             </button>
           </div>
-          <div
-            class="prose-sw flex-1 overflow-y-auto p-4 text-sw-text text-[13px] leading-relaxed"
-            [innerHTML]="renderMarkdown(projectMemory)"
-          ></div>
+          <div class="flex-1 overflow-y-auto p-4 text-sw-text text-[13px] leading-relaxed">
+            <app-text-block [content]="projectMemory" />
+          </div>
         </div>
       }
     </div>

--- a/desktop/src/src/app/chat/chat.component.ts
+++ b/desktop/src/src/app/chat/chat.component.ts
@@ -12,19 +12,25 @@ import {
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
-import { marked } from 'marked';
 import { TauriService } from '../services/tauri.service';
 import { ChatStateService } from '../services/chat-state.service';
 import { ProjectStateService } from '../services/project-state.service';
 import type { ChatMessage, ConversationSummary, ConversationTranscript } from '../models/chat';
 import { ChatMessageComponent } from './message/chat-message.component';
 import { SessionStatsComponent } from './session-stats/session-stats.component';
+import { TextBlockComponent } from './blocks/text-block.component';
 
 /** Chat component that handles message rendering, user input, and streaming responses from Claude. */
 @Component({
   selector: 'app-chat',
   standalone: true,
-  imports: [CommonModule, FormsModule, ChatMessageComponent, SessionStatsComponent],
+  imports: [
+    CommonModule,
+    FormsModule,
+    ChatMessageComponent,
+    SessionStatsComponent,
+    TextBlockComponent,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './chat.component.html',
 })
@@ -107,15 +113,6 @@ export class ChatComponent implements OnInit, OnDestroy {
     }
     event.preventDefault();
     this.sendMessage();
-  }
-
-  /**
-   * Converts markdown content to sanitized HTML for display.
-   * Used by transcript view (which still uses flat content strings).
-   * @param content - The raw markdown string to render.
-   */
-  renderMarkdown(content: string): string {
-    return marked.parse(content, { async: false }) as string;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Closes #143.
- Expand JSDoc on `TextBlockComponent` to name Angular `DomSanitizer`, the `[innerHTML]` binding that activates it, and explicitly warn against `bypassSecurityTrustHtml` — makes the implicit XSS-safety guarantee explicit for future contributors.
- Add 5 regression tests locking in sanitizer behavior: `<script>` stripping, event-handler attribute stripping, `javascript:` URL rewriting, unsanitized getter output, and empty content rendering.
- Dedupe markdown rendering: replace inline `[innerHTML]="renderMarkdown(...)"` in `chat.component` with `<app-text-block>`, removing the second `marked.parse` call site. `TextBlockComponent` is now the single place that renders markdown in the chat UI, so the sanitizer-contract comment/tests cover every consumer.

## Test plan
- [x] `make check` — clippy + fmt + ESLint + tsc all green
- [x] `make test` — 819 desktop tests pass (including 5 new sanitizer regression tests)
- [ ] Smoke-test chat rendering in desktop dev mode (assistant messages + project memory view)