### PR TITLE
feat(runtime): enforce speedwave_compat semver validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1726,6 +1726,7 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "regex",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml_ng",

--- a/crates/speedwave-runtime/Cargo.toml
+++ b/crates/speedwave-runtime/Cargo.toml
@@ -24,6 +24,7 @@ ed25519-dalek = { version = "2", features = ["rand_core"] }
 sha2 = "0.11"
 base64 = "0.22"
 rand = "0.8"
+semver = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/speedwave-runtime/src/plugin.rs
+++ b/crates/speedwave-runtime/src/plugin.rs
@@ -241,16 +241,12 @@ fn validate_slug(slug: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Validates the `speedwave_compat` field against the current crate version.
-///
-/// The empty-string guard is first because `semver::VersionReq::parse("")` returns
-/// `Ok(VersionReq { comparators: [] })` which matches any version — without this guard
-/// a manifest with `"speedwave_compat": ""` would silently pass.
 fn validate_speedwave_compat(compat: Option<&str>) -> anyhow::Result<()> {
     let s = match compat {
         None => return Ok(()),
         Some(s) => s,
     };
+    // `VersionReq::parse("")` returns a match-all comparator list — guard before calling it.
     if s.trim().is_empty() {
         anyhow::bail!(
             "speedwave_compat must not be empty — omit the field to disable the compatibility check"
@@ -283,6 +279,7 @@ fn validate_speedwave_compat(compat: Option<&str>) -> anyhow::Result<()> {
 /// Validates manifest constraints at install time.
 fn validate_manifest(manifest: &PluginManifest, plugin_dir: &Path) -> anyhow::Result<()> {
     validate_slug(&manifest.slug)?;
+    validate_speedwave_compat(manifest.speedwave_compat.as_deref())?;
 
     // If service_id present, slug must equal service_id
     if let Some(ref sid) = manifest.service_id {
@@ -436,8 +433,6 @@ fn validate_manifest(manifest: &PluginManifest, plugin_dir: &Path) -> anyhow::Re
             anyhow::bail!("ReadWrite token mount requires a non-empty justification");
         }
     }
-
-    validate_speedwave_compat(manifest.speedwave_compat.as_deref())?;
 
     Ok(())
 }

--- a/crates/speedwave-runtime/src/plugin.rs
+++ b/crates/speedwave-runtime/src/plugin.rs
@@ -241,6 +241,45 @@ fn validate_slug(slug: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Validates the `speedwave_compat` field against the current crate version.
+///
+/// The empty-string guard is first because `semver::VersionReq::parse("")` returns
+/// `Ok(VersionReq { comparators: [] })` which matches any version — without this guard
+/// a manifest with `"speedwave_compat": ""` would silently pass.
+fn validate_speedwave_compat(compat: Option<&str>) -> anyhow::Result<()> {
+    let s = match compat {
+        None => return Ok(()),
+        Some(s) => s,
+    };
+    if s.trim().is_empty() {
+        anyhow::bail!(
+            "speedwave_compat must not be empty — omit the field to disable the compatibility check"
+        );
+    }
+    let req = semver::VersionReq::parse(s).map_err(|e| {
+        anyhow::anyhow!(
+            "Invalid speedwave_compat '{}': must be a valid semver version requirement (e.g. '>=0.8, <1', '^0.8'): {}",
+            s,
+            e
+        )
+    })?;
+    let current_version = semver::Version::parse(env!("CARGO_PKG_VERSION")).map_err(|e| {
+        anyhow::anyhow!(
+            "internal: CARGO_PKG_VERSION '{}' is not valid semver: {}",
+            env!("CARGO_PKG_VERSION"),
+            e
+        )
+    })?;
+    if !req.matches(&current_version) {
+        anyhow::bail!(
+            "Plugin requires Speedwave version matching '{}', but this Speedwave is {}. Upgrade Speedwave or install an older plugin version.",
+            s,
+            current_version
+        );
+    }
+    Ok(())
+}
+
 /// Validates manifest constraints at install time.
 fn validate_manifest(manifest: &PluginManifest, plugin_dir: &Path) -> anyhow::Result<()> {
     validate_slug(&manifest.slug)?;
@@ -397,6 +436,8 @@ fn validate_manifest(manifest: &PluginManifest, plugin_dir: &Path) -> anyhow::Re
             anyhow::bail!("ReadWrite token mount requires a non-empty justification");
         }
     }
+
+    validate_speedwave_compat(manifest.speedwave_compat.as_deref())?;
 
     Ok(())
 }
@@ -3655,5 +3696,149 @@ mod tests {
             project_a_result.is_err(),
             "project using plugin-a should fail when plugin-a cannot be rebuilt"
         );
+    }
+
+    // --- validate_speedwave_compat unit tests ---
+
+    fn minimal_resource_only_manifest(compat: Option<String>) -> PluginManifest {
+        PluginManifest {
+            name: "Test Plugin".to_string(),
+            service_id: None,
+            slug: "test-plugin".to_string(),
+            version: "1.0.0".to_string(),
+            description: "test".to_string(),
+            port: None,
+            image_tag: None,
+            resources: vec![],
+            token_mount: TokenMount::ReadOnly,
+            auth_fields: vec![],
+            settings_schema: None,
+            speedwave_compat: compat,
+            extra_env: None,
+            mem_limit: None,
+            cpu_limit: None,
+            requires_integrations: vec![],
+        }
+    }
+
+    #[test]
+    fn test_compat_none_is_ok() {
+        assert!(validate_speedwave_compat(None).is_ok());
+    }
+
+    #[test]
+    fn test_compat_exact_current_version_matches() {
+        let range = format!("={}", env!("CARGO_PKG_VERSION"));
+        assert!(validate_speedwave_compat(Some(&range)).is_ok());
+    }
+
+    #[test]
+    fn test_compat_lower_bound_current_version_matches() {
+        let range = format!(">={}", env!("CARGO_PKG_VERSION"));
+        assert!(validate_speedwave_compat(Some(&range)).is_ok());
+    }
+
+    #[test]
+    fn test_compat_current_major_minor_range_matches() {
+        let v = semver::Version::parse(env!("CARGO_PKG_VERSION")).unwrap();
+        let next_major = v.major + 1;
+        let range = format!(">={}.{}, <{}", v.major, v.minor, next_major);
+        assert!(validate_speedwave_compat(Some(&range)).is_ok());
+    }
+
+    #[test]
+    fn test_compat_legacy_wide_range_matches() {
+        assert!(validate_speedwave_compat(Some(">=0.1.0")).is_ok());
+    }
+
+    #[test]
+    fn test_compat_empty_string_rejected() {
+        let result = validate_speedwave_compat(Some(""));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("speedwave_compat"));
+    }
+
+    #[test]
+    fn test_compat_whitespace_only_rejected() {
+        let result = validate_speedwave_compat(Some("   "));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("speedwave_compat"));
+    }
+
+    #[test]
+    fn test_compat_garbage_rejected() {
+        let result = validate_speedwave_compat(Some("banana"));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("banana"));
+    }
+
+    #[test]
+    fn test_compat_unsatisfied_range_rejected() {
+        let result = validate_speedwave_compat(Some(">=99.0.0"));
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains(">=99.0.0"));
+        assert!(msg.contains(env!("CARGO_PKG_VERSION")));
+    }
+
+    #[test]
+    fn test_compat_unsatisfied_upper_bound_rejected() {
+        let result = validate_speedwave_compat(Some("<0.1"));
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("<0.1"));
+        assert!(msg.contains(env!("CARGO_PKG_VERSION")));
+    }
+
+    #[test]
+    fn test_compat_error_message_contains_upgrade_guidance() {
+        let result = validate_speedwave_compat(Some(">=99.0.0"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Upgrade Speedwave"));
+    }
+
+    // --- validate_manifest integration tests for speedwave_compat ---
+
+    #[test]
+    fn test_validate_manifest_rejects_invalid_compat() {
+        let manifest = minimal_resource_only_manifest(Some("banana".to_string()));
+        let tmp = tempfile::tempdir().unwrap();
+        let result = validate_manifest(&manifest, tmp.path());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("banana"));
+    }
+
+    #[test]
+    fn test_validate_manifest_rejects_unsatisfied_compat() {
+        let manifest = minimal_resource_only_manifest(Some(">=99.0.0".to_string()));
+        let tmp = tempfile::tempdir().unwrap();
+        let result = validate_manifest(&manifest, tmp.path());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains(">=99.0.0"));
+    }
+
+    #[test]
+    fn test_validate_manifest_rejects_empty_compat() {
+        let manifest = minimal_resource_only_manifest(Some(String::new()));
+        let tmp = tempfile::tempdir().unwrap();
+        let result = validate_manifest(&manifest, tmp.path());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_manifest_accepts_compatible_compat() {
+        let range = format!(">={}", env!("CARGO_PKG_VERSION"));
+        let manifest = minimal_resource_only_manifest(Some(range));
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(validate_manifest(&manifest, tmp.path()).is_ok());
+    }
+
+    #[test]
+    fn test_validate_manifest_accepts_missing_compat() {
+        let manifest = minimal_resource_only_manifest(None);
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(validate_manifest(&manifest, tmp.path()).is_ok());
     }
 }

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -4744,6 +4744,7 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "regex",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml_ng",

--- a/docs/adr/ADR-015-plugin-system.md
+++ b/docs/adr/ADR-015-plugin-system.md
@@ -80,7 +80,7 @@ presale-1.2.0/
     }
   ],
   "settings_schema": null,
-  "speedwave_compat": ">=2.0.0",
+  "speedwave_compat": ">=0.8, <1",
   "extra_env": null,
   "mem_limit": "128m"
 }
@@ -100,23 +100,31 @@ presale-1.2.0/
 
 ### Field Reference
 
-| Field                   | Type     | Required | Description                                                                           |
-| ----------------------- | -------- | -------- | ------------------------------------------------------------------------------------- |
-| `name`                  | string   | Yes      | Human-readable display name                                                           |
-| `slug`                  | string   | Yes      | Unique identifier, `^[a-z][a-z0-9-]{0,63}$`                                           |
-| `service_id`            | string?  | MCP only | Must equal `slug` when present                                                        |
-| `version`               | string   | Yes      | Semantic version                                                                      |
-| `description`           | string   | Yes      | Short description                                                                     |
-| `port`                  | u16?     | MCP only | Container listening port                                                              |
-| `image_tag`             | string?  | No       | Custom image tag (default: `version`)                                                 |
-| `resources`             | string[] | No       | Subset of `["skills", "commands", "agents", "hooks"]`                                 |
-| `token_mount`           | object   | No       | `{"mode": "read_only"}` (default) or `{"mode": "read_write", "justification": "..."}` |
-| `auth_fields`           | object[] | No       | Credential field definitions for the Desktop UI                                       |
-| `settings_schema`       | JSON?    | No       | JSON Schema for per-project plugin settings                                           |
-| `speedwave_compat`      | string?  | No       | Required Speedwave version range                                                      |
-| `extra_env`             | map?     | No       | Additional environment variables for the container                                    |
-| `mem_limit`             | string?  | No       | Container memory limit (default: `128m`)                                              |
-| `requires_integrations` | string[] | No       | Core integrations the plugin depends on (e.g. `["sharepoint"]`)                       |
+| Field                   | Type     | Required | Description                                                                                   |
+| ----------------------- | -------- | -------- | --------------------------------------------------------------------------------------------- |
+| `name`                  | string   | Yes      | Human-readable display name                                                                   |
+| `slug`                  | string   | Yes      | Unique identifier, `^[a-z][a-z0-9-]{0,63}$`                                                   |
+| `service_id`            | string?  | MCP only | Must equal `slug` when present                                                                |
+| `version`               | string   | Yes      | Semantic version                                                                              |
+| `description`           | string   | Yes      | Short description                                                                             |
+| `port`                  | u16?     | MCP only | Container listening port                                                                      |
+| `image_tag`             | string?  | No       | Custom image tag (default: `version`)                                                         |
+| `resources`             | string[] | No       | Subset of `["skills", "commands", "agents", "hooks"]`                                         |
+| `token_mount`           | object   | No       | `{"mode": "read_only"}` (default) or `{"mode": "read_write", "justification": "..."}`         |
+| `auth_fields`           | object[] | No       | Credential field definitions for the Desktop UI                                               |
+| `settings_schema`       | JSON?    | No       | JSON Schema for per-project plugin settings                                                   |
+| `speedwave_compat`      | string?  | No       | Semver `VersionReq` (e.g. `">=0.8, <1"`). Validated at install; mismatch rejects the install. |
+| `extra_env`             | map?     | No       | Additional environment variables for the container                                            |
+| `mem_limit`             | string?  | No       | Container memory limit (default: `128m`)                                                      |
+| `requires_integrations` | string[] | No       | Core integrations the plugin depends on (e.g. `["sharepoint"]`)                               |
+
+### Compatibility enforcement
+
+The `speedwave_compat` field is optional. Omitting it disables the check and preserves backward compatibility for legacy plugins.
+
+If present, the value MUST NOT be empty or whitespace, and MUST parse as a `semver::VersionReq`[^11]. If the running Speedwave version does not satisfy the declared range, `install_plugin()` rejects the ZIP with a clear error before any file is copied into `~/.speedwave/plugins/`.
+
+**Recommended pattern for plugin authors:** declare `">=<current_minor>, <<next_major>"`. A plugin built and tested against Speedwave 0.8.x should declare `"speedwave_compat": ">=0.8, <1"`. Bump this range on every Speedwave major release, after re-testing the plugin against the new major. See Cargo version-requirement syntax[^12] for the full range language.
 
 ### auth_fields entry
 
@@ -511,3 +519,7 @@ Tauri commands: `get_plugins`, `install_plugin`, `remove_plugin`, `set_plugin_en
 [^8]: [Microsoft identity platform — OAuth 2.0 token refresh](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow#refresh-the-access-token)
 
 [^10]: [OCI Image Format Specification — Containerfile](https://github.com/containers/common/blob/main/docs/Containerfile.5.md)
+
+[^11]: https://docs.rs/semver/1/semver/struct.VersionReq.html
+
+[^12]: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#version-requirement-syntax

--- a/docs/guides/integrations.md
+++ b/docs/guides/integrations.md
@@ -158,6 +158,8 @@ When a bundle update triggers image rebuilds, container restart operations (incl
 
 Plugins that declare `requires_integrations` (e.g. `["sharepoint"]`) display the required integration status on the plugin dashboard. The Desktop UI indicates whether required integrations are configured, linking to the Integrations tab when they are not.
 
+Plugin authors should set `speedwave_compat` in `plugin.json` to declare which Speedwave versions the plugin supports — for example, `"speedwave_compat": ">=0.8, <1"` for plugins targeting the 0.8 series. If the field is present and the running Speedwave version does not satisfy the declared range, installation is rejected with a clear error. Omit the field to disable the check. See [ADR-015](../adr/ADR-015-plugin-system.md) for details on the enforcement model and version-requirement syntax.
+
 ## See Also
 
 - [ADR-010: mcp-os as Host Process Per Platform](../adr/ADR-010-mcp-os-as-host-process-per-platform.md)


### PR DESCRIPTION
Closes #176

## Summary
- `plugin.rs`: new `validate_speedwave_compat()` checks the manifest's `speedwave_compat` field against the running `CARGO_PKG_VERSION` at install time
- Empty/whitespace strings are rejected explicitly (semver's `VersionReq::parse("")` returns a match-all list, which would silently accept `""`)
- Invalid syntax and unsatisfied ranges produce actionable error messages pointing the user at "Upgrade Speedwave" or install an older plugin
- `semver = "1"` added to `speedwave-runtime`
- ADR-015 + `integrations.md` updated to document the validation contract
- 14 new unit tests covering None / exact / range / legacy / empty / whitespace / garbage / unsatisfied lower+upper bounds

## Test plan
- [x] `make check` — 0 warnings
- [x] `make test` — 819 desktop + runtime tests pass
- [ ] CI green