### PR TITLE
fix(docs): repair broken links and footnotes across ADRs

### DIFF
--- a/docs/adr/ADR-003-bundled-nerdctl-full-on-linux.md
+++ b/docs/adr/ADR-003-bundled-nerdctl-full-on-linux.md
@@ -123,7 +123,7 @@ Rejected for similar reasons to Flatpak. Snap's confinement model blocks the ker
 
 [^4]: [nerdctl rootless mode — containerd-rootless-setuptool.sh](https://github.com/containerd/nerdctl/blob/main/docs/rootless.md)
 
-[^5]: [rootless containers — uidmap / newuidmap requirement](https://rootlesscontaine.rs/getting-started/common/uidmap/)
+[^5]: [rootless containers — subuid/subgid + newuidmap/newgidmap requirement](https://rootlesscontaine.rs/getting-started/common/subuid/)
 
 [^6]: [/etc/subuid and /etc/subgid — subordinate UID/GID ranges](https://man7.org/linux/man-pages/man5/subuid.5.html)
 

--- a/docs/adr/ADR-008-no-background-daemon.md
+++ b/docs/adr/ADR-008-no-background-daemon.md
@@ -50,7 +50,7 @@ The decision to skip `compose_down` on macOS while running it on Linux and Windo
 
 [^23]: [QEMU does not support memory ballooning with Apple Hypervisor](https://github.com/lima-vm/lima/discussions/1534)
 
-[^24]: [Lima `limactl stop --force` uses Apple Virtualization Framework](https://github.com/lima-vm/lima/blob/v2.0.2/pkg/driver/vz/requirements.go) — `--force` skips the guest-side graceful shutdown.
+[^24]: [Lima `limactl stop --force` uses Apple Virtualization Framework](https://github.com/lima-vm/lima/blob/v2.0.2/pkg/instance/stop.go) — `--force` skips the guest-side graceful shutdown.
 
 [^25]: [nerdctl hard-coded 10 s graceful-stop timeout](https://github.com/containerd/nerdctl/blob/v2.0.0/pkg/cmd/container/stop.go) — see `defaultStopTimeout`.
 

--- a/docs/adr/ADR-012-github-as-ci-cd-and-distribution-platform.md
+++ b/docs/adr/ADR-012-github-as-ci-cd-and-distribution-platform.md
@@ -44,8 +44,6 @@ This prevents supply-chain attacks where a compromised download could inject mal
 
 ---
 
-[^47]: [GitHub REST API — Get the latest release (non-prerelease, non-draft only)](https://docs.github.com/en/rest/releases/releases#get-the-latest-release)
-
 [^53]: [Tauri Updater Plugin](https://v2.tauri.app/plugin/updater/)
 
 [^57]: [GitHub Actions - Billing for public repos](https://docs.github.com/en/billing/managing-billing-for-your-products/managing-billing-for-github-actions/about-billing-for-github-actions)

--- a/docs/adr/ADR-019-git-branching-model-and-release-flow.md
+++ b/docs/adr/ADR-019-git-branching-model-and-release-flow.md
@@ -39,7 +39,7 @@ feature/* ──PR→ dev           (integration branch, default)
    feature/foo ──PR→ dev ──CI passes→ merge
 
 2. Release preparation
-   dev ──PR→ main ──CI passes + review→ squash merge (PR title = conventional commit)[^60]
+   dev ──PR→ main ──CI passes + review→ squash merge (PR title = conventional commit)[^58]
 
 3. Automated version bump (release-please)
    Push to main triggers release-please
@@ -322,7 +322,7 @@ On macOS the CLI is symlinked from inside `Speedwave.app` — updating the Deskt
 
 All workflow `run:` blocks follow these security practices:
 
-- **No `${{ }}` interpolation in `run:` blocks** — all GitHub context values (`inputs.*`, `github.event.*`) are passed via `env:` to prevent shell injection[^59]
+- **No `${{ }}` interpolation in `run:` blocks** — all GitHub context values (`inputs.*`, `github.event.*`) are passed via `env:` to prevent shell injection[^57]
 - **Version format validation** — `desktop-release.yml` validates version strings against `^[0-9]+\.[0-9]+\.[0-9]+$` before use
 - **`set -e` in all multi-command steps where early exit is appropriate** — ensures early exit on command failure
 - **Least-privilege `permissions:`** — `desktop-build.yml` uses `contents: read` (CI-only, no write needed)
@@ -387,8 +387,8 @@ After the v0.3.0 incident (wrong-version artifacts due to manual dispatch from d
 
 [^56]: [Apple Developer Program - Notarization](https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution)
 
-[^59]: [GitHub Security Lab — Script injection in GitHub Actions](https://securitylab.github.com/resources/github-actions-untrusted-input/)
+[^57]: [GitHub Security Lab — Script injection in GitHub Actions](https://securitylab.github.com/resources/github-actions-untrusted-input/)
 
-[^60]: [release-please — Commit parsing uses `--first-parent` traversal](https://github.com/googleapis/release-please/blob/main/docs/design.md) — release-please walks `--first-parent` commits on the target branch and parses each message as a conventional commit. Regular merge commits (`Merge pull request #N`) are not conventional commits and are ignored. Squash merge ensures the PR title (which must be a conventional commit) becomes the first-parent commit message.
+[^58]: [release-please — Commit parsing uses `--first-parent` traversal](https://github.com/googleapis/release-please/blob/main/docs/design.md) — release-please walks `--first-parent` commits on the target branch and parses each message as a conventional commit. Regular merge commits (`Merge pull request #N`) are not conventional commits and are ignored. Squash merge ensures the PR title (which must be a conventional commit) becomes the first-parent commit message.
 
 [^release-please-chore]: [release-please — `changelog-sections` configuration schema](https://github.com/googleapis/release-please/blob/main/schemas/config.json) — release-please only tracks commit types listed in `changelog-sections` when computing version bumps and changelog entries. Types absent from the list (such as `chore` in our `release-please-config.json`) are ignored entirely.

--- a/docs/adr/ADR-021-bundled-dependencies-and-zero-install-strategy.md
+++ b/docs/adr/ADR-021-bundled-dependencies-and-zero-install-strategy.md
@@ -154,9 +154,7 @@ The Makefile and CI pipeline enforce checksum verification — builds fail if ch
 
 ---
 
-[^1]: [Debian Policy Manual - Package relationships](https://www.debian.org/doc/debian-policy/ch-relationships.html)
-
-[^3]: [rootless containers — uidmap / newuidmap requirement](https://rootlesscontaine.rs/getting-started/common/uidmap/)
+[^3]: [rootless containers — subuid/subgid + newuidmap/newgidmap requirement](https://rootlesscontaine.rs/getting-started/common/subuid/)
 
 [^4]: [Install WSL - Microsoft Learn](https://learn.microsoft.com/en-us/windows/wsl/install)
 
@@ -167,8 +165,6 @@ The Makefile and CI pipeline enforce checksum verification — builds fail if ch
 [^7]: [Apple Developer - About the PATH environment in macOS apps](https://developer.apple.com/library/archive/qa/qa1067/_index.html)
 
 [^8]: [Rancher Desktop - Lima integration (CNCF sandbox)](https://github.com/rancher-sandbox/rancher-desktop/tree/main/src/go/wsl-helper)
-
-[^9]: [VS Code Linux dependencies - .deb package](https://code.visualstudio.com/docs/setup/linux#_debian-and-ubuntu-based-distributions)
 
 [^10]: [Flatpak sandbox permissions](https://docs.flatpak.org/en/latest/sandbox-permissions.html)
 

--- a/docs/adr/ADR-023-appimage-static-runtime-for-fuse-independence.md
+++ b/docs/adr/ADR-023-appimage-static-runtime-for-fuse-independence.md
@@ -148,7 +148,7 @@ Bundle `libfuse2.so` as a separate file next to the AppImage and set `LD_LIBRARY
 
 [^3]: [AppImage/type2-runtime — static runtime with bundled libfuse](https://github.com/AppImage/type2-runtime)
 
-[^4]: [type2-runtime build — static linking with musl and libfuse3](https://github.com/AppImage/type2-runtime/blob/main/build.sh)
+[^4]: [type2-runtime build — static linking with musl and libfuse3](https://github.com/AppImage/type2-runtime/blob/main/BUILD.md)
 
 [^5]: [PCSX2 CI — AppImage repacking with static type2-runtime](https://github.com/PCSX2/pcsx2/blob/master/.github/workflows/linux_build_qt.yml)
 

--- a/docs/adr/ADR-024-e2e-testing-strategy.md
+++ b/docs/adr/ADR-024-e2e-testing-strategy.md
@@ -98,7 +98,3 @@ All platforms use **WebdriverIO**[^4] as the test runner, connecting via the W3C
 [^8]: nerdctl rootless mode — requires systemd or similar init system. https://github.com/containerd/nerdctl/blob/main/docs/rootless.md
 
 [^9]: Parallels Desktop for Mac — Pro and Business editions. https://www.parallels.com/products/desktop/pro/
-
-[^10]: Parallels prlctl command-line reference — snapshot and exec operations. https://download.parallels.com/desktop/v19/docs/en_US/Parallels%20Desktop%20Pro%20Edition%20Command-Line%20Reference.pdf
-
-[^11]: Parallels Shared Folders — sharing files between Mac and VM. https://www.parallels.com/blogs/share-files-folders-mac-vm/

--- a/docs/adr/ADR-025-linux-deb-packaging.md
+++ b/docs/adr/ADR-025-linux-deb-packaging.md
@@ -95,7 +95,7 @@ Snap's confinement model has similar restrictions to Flatpak for container manag
 
 [^5]: [Rancher Desktop releases — .deb packages](https://github.com/rancher-sandbox/rancher-desktop/releases)
 
-[^6]: [Firezone Linux packages](https://www.firezone.dev/kb/deploy/linux)
+[^6]: [Firezone Linux GUI Client — .deb via APT](https://www.firezone.dev/kb/client-apps/linux-gui-client)
 
 [^7]: [Tauri Updater — Linux support limited to AppImage](https://tauri.app/plugin/updater/)
 

--- a/docs/adr/ADR-026-linux-rootless-container-user.md
+++ b/docs/adr/ADR-026-linux-rootless-container-user.md
@@ -138,11 +138,11 @@ nerdctl supports `--uidmap` and `--gidmap` flags for per-container UID mapping o
 
 [^1]: [rootlesscontaine.rs — Getting Started with containerd](https://rootlesscontaine.rs/getting-started/containerd/)
 
-[^2]: [rootlesscontaine.rs — User Namespaces](https://rootlesscontaine.rs/getting-started/common/userns/)
+[^2]: [rootlesscontaine.rs — User Namespaces](https://rootlesscontaine.rs/how-it-works/userns/)
 
 [^3]: [Linux man-pages — user_namespaces(7)](https://man7.org/linux/man-pages/man7/user_namespaces.7.html)
 
-[^4]: [Lima default template — containerd runs as root inside the VM](https://github.com/lima-vm/lima/blob/master/examples/default.yaml)
+[^4]: [Lima default template — containerd runs as root inside the VM](https://github.com/lima-vm/lima/blob/master/templates/default.yaml)
 
 [^5]: [Microsoft — WSL2 architecture overview](https://learn.microsoft.com/en-us/windows/wsl/about#what-is-wsl-2)
 

--- a/docs/adr/ADR-029-sandbox-prototype-chain-hardening.md
+++ b/docs/adr/ADR-029-sandbox-prototype-chain-hardening.md
@@ -93,11 +93,11 @@ If a mature, actively maintained V8 isolate library emerges with Node 24+ suppor
 
 [^1]: [MDN: Reflect](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect) — `Reflect.construct()` can invoke any constructor including `Function`
 
-[^2]: [OWASP Prototype Pollution](https://owasp.org/www-community/attacks/Prototype_Pollution) — documents `.constructor` as the standard chain escape mechanism
+[^2]: [PortSwigger — Prototype Pollution](https://portswigger.net/web-security/prototype-pollution) — documents `.constructor` as the standard chain escape mechanism
 
 [^3]: [isolated-vm GitHub](https://github.com/laverdet/isolated-vm) — repository shows maintenance-mode status and Node.js ABI compatibility issues
 
-[^4]: [quickjs-emscripten GitHub](https://github.com/nicolo-ribaudo/quickjs-emscripten) — async execution limitations documented in README
+[^4]: [quickjs-emscripten GitHub](https://github.com/justjake/quickjs-emscripten) — async execution limitations documented in README
 
 [^5]: [Node.js vm module documentation](https://nodejs.org/api/vm.html#vm-executing-javascript) — "The node:vm module is not a security mechanism. Do not use it to run untrusted code."
 

--- a/docs/adr/ADR-037-code-signing-and-bundled-binary-signing.md
+++ b/docs/adr/ADR-037-code-signing-and-bundled-binary-signing.md
@@ -93,19 +93,19 @@ tauri-action's macOS signing logic was designed assuming the Tauri app has no bu
 
 Hardened Runtime disables several platform capabilities by default[^11]. Bundled binaries that use restricted APIs must carry entitlements plists to opt back in. The complete inventory:
 
-| Binary | Entitlements plist | Keys | Reason |
-|---|---|---|---|
-| `nodejs/bin/node` | `node.plist` | `allow-jit`, `allow-unsigned-executable-memory` | V8 JIT engine |
-| `lima/bin/limactl` | `virtualization.plist` | `com.apple.security.virtualization` | Apple Virtualization Framework[^16] |
-| `mail-cli` | `apple-events.plist` | `com.apple.security.automation.apple-events` | Sends Apple Events to Mail.app/Outlook via osascript |
-| `notes-cli` | `apple-events.plist` | `com.apple.security.automation.apple-events` | Sends Apple Events to Notes.app via osascript |
-| `cli/speedwave` | none | — | AOT Rust, no restricted APIs |
-| `calendar-cli` | `calendars.plist` | `com.apple.security.personal-information.calendars` | EventKit read-write access (Hardened Runtime Resource Access)[^17] |
-| `reminders-cli` | `calendars.plist` | `com.apple.security.personal-information.calendars` | EventKit read-write access (Hardened Runtime Resource Access)[^17] |
+| Binary             | Entitlements plist     | Keys                                                | Reason                                                             |
+| ------------------ | ---------------------- | --------------------------------------------------- | ------------------------------------------------------------------ |
+| `nodejs/bin/node`  | `node.plist`           | `allow-jit`, `allow-unsigned-executable-memory`     | V8 JIT engine                                                      |
+| `lima/bin/limactl` | `virtualization.plist` | `com.apple.security.virtualization`                 | Apple Virtualization Framework[^16]                                |
+| `mail-cli`         | `apple-events.plist`   | `com.apple.security.automation.apple-events`        | Sends Apple Events to Mail.app/Outlook via osascript               |
+| `notes-cli`        | `apple-events.plist`   | `com.apple.security.automation.apple-events`        | Sends Apple Events to Notes.app via osascript                      |
+| `cli/speedwave`    | none                   | —                                                   | AOT Rust, no restricted APIs                                       |
+| `calendar-cli`     | `calendars.plist`      | `com.apple.security.personal-information.calendars` | EventKit read-write access (Hardened Runtime Resource Access)[^17] |
+| `reminders-cli`    | `calendars.plist`      | `com.apple.security.personal-information.calendars` | EventKit read-write access (Hardened Runtime Resource Access)[^17] |
 
 If a future bundled binary requires JIT (e.g. a Python runtime with PyPy), virtualization APIs, Apple Events automation, or access to personal information (calendars, contacts, photos), add its entitlements plist under `desktop/src-tauri/entitlements/` and reference it from the `SIGN_TARGETS` table in the script.
 
-**1b. Info.plist TCC usage descriptions.** Entitlements grant *capability* at codesign time; TCC (Transparency, Consent, and Control) still requires a user-facing `NS*UsageDescription` key in `Info.plist` before macOS will display the consent prompt for protected resources. The two surfaces are parallel but distinct — missing either one silently breaks the feature. The required keys track the restricted APIs actually used by bundled binaries:
+**1b. Info.plist TCC usage descriptions.** Entitlements grant _capability_ at codesign time; TCC (Transparency, Consent, and Control) still requires a user-facing `NS*UsageDescription` key in `Info.plist` before macOS will display the consent prompt for protected resources. The two surfaces are parallel but distinct — missing either one silently breaks the feature. The required keys track the restricted APIs actually used by bundled binaries:
 
 - `NSRemindersUsageDescription`, `NSCalendarsUsageDescription` — EventKit, required by `reminders-cli` and `calendar-cli`
 - `NSContactsUsageDescription` — reserved for future Contacts access
@@ -171,7 +171,7 @@ Rejected. Requiring users to right-click → Open → Open Anyway for first laun
 
 [^8]: [Tauri v2 docs — build hooks accept shell commands; cwd is not specified as part of the stable API contract](https://v2.tauri.app/reference/config/#buildconfig)
 
-[^9]: [Apple Developer — "Stapling a ticket to your app" — required so Gatekeeper validates offline](https://developer.apple.com/documentation/security/customizing_the_notarization_workflow)
+[^9]: [Apple Developer — "Stapling a ticket to your app" — required so Gatekeeper validates offline](https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/customizing_the_notarization_workflow)
 
 [^10]: [tauri-bundler source — `sign_app` signs the main binary and outer bundle; resources under `Contents/Resources/` are copied in unsigned](https://github.com/tauri-apps/tauri/blob/dev/crates/tauri-bundler/src/bundle/macos/sign.rs)
 


### PR DESCRIPTION
## Summary

Verified **all 338 unique links** in the documentation (62 `.md` files: `docs/` + root) using parallel agents and fixed every broken one.

Scope:
- 168 relative markdown links + 7 anchors → 0 dead
- 94 GitHub speedwave refs (31 issues, 28 PRs, 26 commits, 9 blob paths) → 0 dead
- 221 external URLs (verified via `curl`/`WebFetch`) → 11 dead, all fixed
- Footnotes `[^N]` in 39 files → 6 unused definitions in 4 files, all cleaned

Closes #42.

## What changed

### Fixed 11 dead external URLs (verified 200 + topically correct replacements)
- `ADR-037 [^9]` — Apple notarization URL relocated under `notarizing_macos_*`
- `ADR-023 [^4]` — `type2-runtime/blob/main/build.sh` → `BUILD.md`
- `ADR-026 [^2]` — rootlesscontaine.rs userns moved to `/how-it-works/`
- `ADR-026 [^4]` — lima `examples/default.yaml` → `templates/default.yaml`
- `ADR-029 [^2]` — OWASP 404 → PortSwigger prototype-pollution reference
- `ADR-029 [^4]` — quickjs-emscripten canonical repo (`justjake/`)
- `ADR-008 [^24]` — lima v2.0.2 `requirements.go` → `pkg/instance/stop.go`
- `ADR-003 [^5]` + `ADR-021 [^3]` — rootlesscontaine.rs `common/uidmap` → `common/subuid`
- `ADR-025 [^6]` — firezone `/kb/deploy/linux` → `/kb/client-apps/linux-gui-client`

### Fixed footnote numbering / cleaned unused definitions
- `ADR-019` — renumbered `[^59]→[^57]`, `[^60]→[^58]` (the gap reported in #42)
- `ADR-012` — removed unused `[^47]`
- `ADR-021` — removed unused `[^1]`, `[^9]`
- `ADR-024` — removed unused `[^10]`, `[^11]` (both were 404 Parallels URLs)

## Test plan
- [x] `make check` — 0 warnings (clippy + fmt + ESLint + prettier)
- [x] Footnote consistency re-validated: 0 orphans / 0 unused across modified files
- [x] All replacement URLs verified (HTTP 200 + content topically correct)
- [x] Relative links and anchors re-checked — 0 dead