### PR TITLE
fix(desktop): correct data: and vbscript: sanitizer tests (dev is red)

### DIFF
--- a/desktop/src/src/app/chat/blocks/text-block.component.spec.ts
+++ b/desktop/src/src/app/chat/blocks/text-block.component.spec.ts
@@ -72,22 +72,21 @@ describe('TextBlockComponent', () => {
     expect(href).toBe('unsafe:javascript:alert(1)');
   });
 
-  it('rewrites data: URLs in links via Angular DomSanitizer', () => {
-    component.content = '[click](data:text/html,<script>alert(1)</script>)';
+  it('does NOT rewrite data: or vbscript: URLs — only javascript: is prefixed with unsafe:', () => {
+    // Angular's URL sanitizer for [innerHTML] anchors only rewrites the
+    // javascript: scheme (SRC_URL_SANITIZATION_REGEX = /^(?!javascript:)/i).
+    // data: and vbscript: pass through unchanged. Any future user-facing
+    // render path that can receive attacker-controlled URLs must rely on
+    // CSP (img-src/frame-src restrictions) or its own pre-sanitization —
+    // it cannot assume Angular's HTML sanitizer will block these schemes.
+    // This test locks that contract in so a future refactor can't silently
+    // widen the trust boundary.
+    component.content = '[d](data:text/html,x) [v](vbscript:MsgBox(1))';
     fixture.detectChanges();
 
-    const el = fixture.nativeElement as HTMLElement;
-    const href = el.querySelector('a')?.getAttribute('href') ?? '';
-    expect(href).toMatch(/^unsafe:data:/);
-  });
-
-  it('rewrites vbscript: URLs in links via Angular DomSanitizer', () => {
-    component.content = '[click](vbscript:MsgBox(1))';
-    fixture.detectChanges();
-
-    const el = fixture.nativeElement as HTMLElement;
-    const href = el.querySelector('a')?.getAttribute('href') ?? '';
-    expect(href).toMatch(/^unsafe:vbscript:/);
+    const anchors = fixture.nativeElement.querySelectorAll('a');
+    expect(anchors[0]?.getAttribute('href')).toMatch(/^data:/);
+    expect(anchors[1]?.getAttribute('href')).toMatch(/^vbscript:/);
   });
 
   it('rendered getter returns unsanitized HTML containing script tags', () => {

--- a/desktop/src/src/app/chat/blocks/text-block.component.ts
+++ b/desktop/src/src/app/chat/blocks/text-block.component.ts
@@ -10,6 +10,12 @@ import { marked } from 'marked';
  * tags, event-handler attributes (`onerror`, `onclick`, etc.), and rewriting `javascript:`
  * URLs to the inert `unsafe:javascript:` prefix so they cannot execute.
  *
+ * SCOPE LIMIT: Angular's HTML sanitizer only rewrites the `javascript:` scheme; `data:`
+ * and `vbscript:` URLs pass through unchanged. Speedwave relies on assistant-controlled
+ * (not user-controlled) chat content here, so those schemes are not an active threat —
+ * but any future render path that accepts attacker-controlled markdown must add its own
+ * scheme filtering or rely on CSP, not on this component alone.
+ *
  * WARNING: Do not switch this binding to a `SafeHtml` produced by
  * `DomSanitizer.bypassSecurityTrustHtml(...)` — doing so disables all sanitization and
  * would make `<script>` tags, event-handler attributes, and `javascript:` URLs executable.


### PR DESCRIPTION
## Summary
- PR #511 was merged with tests asserting that Angular rewrites `data:` / `vbscript:` URLs to `unsafe:data:` / `unsafe:vbscript:`. That is **not** what Angular's DomSanitizer does — its `SRC_URL_SANITIZATION_REGEX` is `/^(?!javascript:)/i`, so only `javascript:` is rewritten; `data:` and `vbscript:` pass through the `[innerHTML]` binding unchanged.
- Result: `dev` is currently red — `make test` fails on `TextBlockComponent > rewrites data: URLs…` and `…rewrites vbscript: URLs…`.
- Fix: replace the two broken tests with a single test that locks in the real contract (data/vbscript pass through unchanged). Extend the class JSDoc with a `SCOPE LIMIT` section naming the gap explicitly, so future contributors don't assume Angular blocks these schemes.

**Why no scheme filtering is added:** Speedwave chat content is assistant-controlled, not user-controlled — no attacker input reaches this binding today. A test that documents the sanitizer's real boundary is the right tool; extending the boundary belongs in a separate PR if/when the trust model changes.

## Test plan
- [x] `npx vitest run src/app/chat/blocks/text-block.component.spec.ts` — 10/10 pass
- [x] `make check` — lint/clippy/fmt clean
- [ ] CI on `dev` goes green again after merge