### PR TITLE
refactor(runtime): collapse worker ports onto PORT_WORKER (ADR-038)

### DIFF
--- a/containers/compose.template.yml
+++ b/containers/compose.template.yml
@@ -53,10 +53,10 @@ services:
       - /tmp:noexec,nosuid,size=64m
     environment:
       - PORT=${PORT_HUB}
-      - WORKER_SLACK_URL=http://mcp-slack:${PORT_SLACK}
-      - WORKER_SHAREPOINT_URL=http://mcp-sharepoint:${PORT_SHAREPOINT}
-      - WORKER_REDMINE_URL=http://mcp-redmine:${PORT_REDMINE}
-      - WORKER_GITLAB_URL=http://mcp-gitlab:${PORT_GITLAB}
+      - WORKER_SLACK_URL=http://mcp-slack:${PORT_WORKER}
+      - WORKER_SHAREPOINT_URL=http://mcp-sharepoint:${PORT_WORKER}
+      - WORKER_REDMINE_URL=http://mcp-redmine:${PORT_WORKER}
+      - WORKER_GITLAB_URL=http://mcp-gitlab:${PORT_WORKER}
     networks:
       - ${NETWORK_NAME}
     deploy:
@@ -80,7 +80,7 @@ services:
     volumes:
       - ${TOKENS_DIR}/slack:/tokens:ro
     environment:
-      - PORT=${PORT_SLACK}
+      - PORT=${PORT_WORKER}
     networks:
       - ${NETWORK_NAME}
     deploy:
@@ -107,7 +107,7 @@ services:
       - ${TOKENS_DIR}/sharepoint:/tokens:rw
       - ${PROJECT_DIR}:/workspace:rw
     environment:
-      - PORT=${PORT_SHAREPOINT}
+      - PORT=${PORT_WORKER}
     networks:
       - ${NETWORK_NAME}
     deploy:
@@ -131,7 +131,7 @@ services:
     volumes:
       - ${TOKENS_DIR}/redmine:/tokens:ro
     environment:
-      - PORT=${PORT_REDMINE}
+      - PORT=${PORT_WORKER}
     networks:
       - ${NETWORK_NAME}
     deploy:
@@ -155,7 +155,7 @@ services:
     volumes:
       - ${TOKENS_DIR}/gitlab:/tokens:ro
     environment:
-      - PORT=${PORT_GITLAB}
+      - PORT=${PORT_WORKER}
     networks:
       - ${NETWORK_NAME}
     deploy:

--- a/crates/speedwave-runtime/src/compose.rs
+++ b/crates/speedwave-runtime/src/compose.rs
@@ -52,10 +52,7 @@ pub fn render_compose(
     let network_name = format!("{}_{}_network", consts::compose_prefix(), project_name);
 
     let port_hub = consts::PORT_BASE;
-    let port_slack = consts::PORT_BASE + 1;
-    let port_sharepoint = consts::PORT_BASE + 2;
-    let port_redmine = consts::PORT_BASE + 3;
-    let port_gitlab = consts::PORT_BASE + 4;
+    let port_worker = consts::PORT_WORKER;
     let bundle_manifest = bundle::load_current_bundle_manifest()?;
 
     let mut yaml = COMPOSE_TEMPLATE.to_string();
@@ -68,10 +65,7 @@ pub fn render_compose(
     yaml = yaml.replace("${NETWORK_NAME}", &network_name);
     yaml = yaml.replace("${CLAUDE_VERSION}", defaults::CLAUDE_VERSION);
     yaml = yaml.replace("${PORT_HUB}", &port_hub.to_string());
-    yaml = yaml.replace("${PORT_SLACK}", &port_slack.to_string());
-    yaml = yaml.replace("${PORT_SHAREPOINT}", &port_sharepoint.to_string());
-    yaml = yaml.replace("${PORT_REDMINE}", &port_redmine.to_string());
-    yaml = yaml.replace("${PORT_GITLAB}", &port_gitlab.to_string());
+    yaml = yaml.replace("${PORT_WORKER}", &port_worker.to_string());
     yaml = yaml.replace(
         "${IMAGE_CLAUDE}",
         &build::image_ref(build::IMAGE_CLAUDE, &bundle_manifest.bundle_id),
@@ -261,7 +255,7 @@ fn apply_llm_config(yaml: &str, project_name: &str, llm: &LlmConfig) -> anyhow::
         _ => {
             // External provider: add llm-proxy container (LiteLLM)
             let proxy_token = uuid::Uuid::new_v4().to_string();
-            let proxy_port = consts::PORT_LLM_PROXY;
+            let proxy_port = consts::PORT_WORKER;
 
             let secrets_dir = consts::data_dir().join("secrets").join(project_name);
             let llm_env_file = secrets_dir.join("llm.env");
@@ -383,12 +377,25 @@ fn apply_plugins(
                     service_value,
                 );
             }
-            // Inject WORKER_*_URL into hub
+            // Inject WORKER_*_URL into hub. All workers share PORT_WORKER —
+            // each container has its own network namespace, so port reuse is
+            // safe and DNS disambiguates. See ADR-038.
+            if let Some(declared) = manifest.port {
+                if declared != consts::PORT_WORKER {
+                    log::warn!(
+                        "plugin '{}' sets deprecated 'port' field ({}); ignored — \
+                         all workers use port {}. See ADR-038",
+                        slug,
+                        declared,
+                        consts::PORT_WORKER
+                    );
+                }
+            }
             let worker_env = plugin::derive_worker_env(sid);
             let url = format!(
                 "http://{}:{}",
                 plugin::derive_compose_name(sid),
-                manifest.port.unwrap_or(0)
+                consts::PORT_WORKER
             );
             inject_worker_env(&mut doc, &worker_env, &url);
         }
@@ -2207,10 +2214,10 @@ services:
       - /tmp:noexec,nosuid,size=64m
     environment:
       - PORT=4000
-      - WORKER_SLACK_URL=http://mcp-slack:4001
-      - WORKER_SHAREPOINT_URL=http://mcp-sharepoint:4002
-      - WORKER_REDMINE_URL=http://mcp-redmine:4003
-      - WORKER_GITLAB_URL=http://mcp-gitlab:4004
+      - WORKER_SLACK_URL=http://mcp-slack:3000
+      - WORKER_SHAREPOINT_URL=http://mcp-sharepoint:3000
+      - WORKER_REDMINE_URL=http://mcp-redmine:3000
+      - WORKER_GITLAB_URL=http://mcp-gitlab:3000
     networks:
       - speedwave_test_network
 
@@ -2225,7 +2232,7 @@ services:
     volumes:
       - /home/user/.speedwave/tokens/test/slack:/tokens:ro
     environment:
-      - PORT=4001
+      - PORT=3000
     networks:
       - speedwave_test_network
 
@@ -2596,6 +2603,176 @@ services:
             yaml.contains(&expected),
             "MCP_HUB_PORT must equal PORT_BASE ({})",
             crate::consts::PORT_BASE
+        );
+    }
+
+    /// ADR-038: every non-hub service in the rendered compose must listen on
+    /// `PORT_WORKER` (3000). The hub itself is exempt — it listens on
+    /// `PORT_BASE` (4000).
+    #[test]
+    fn test_all_workers_use_port_worker() {
+        let config = ResolvedClaudeConfig {
+            env: crate::defaults::base_env(),
+            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            llm: LlmConfig::default(),
+        };
+        let yaml = render_compose(
+            "test-project",
+            "/home/user/projects/test",
+            &config,
+            &all_enabled_integrations(),
+            None,
+        )
+        .unwrap();
+
+        let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(&yaml).unwrap();
+        let services = doc
+            .get("services")
+            .and_then(|s| s.as_mapping())
+            .expect("services mapping");
+
+        let worker_port_line = format!("PORT={}", crate::consts::PORT_WORKER);
+        for (name_value, svc) in services {
+            let name = name_value.as_str().unwrap_or("");
+            // Only workers have PORT=; claude does not define PORT.
+            if name == "claude" || name == "mcp-hub" {
+                continue;
+            }
+            let env = svc
+                .get("environment")
+                .and_then(|e| e.as_sequence())
+                .unwrap_or_else(|| panic!("service '{name}' missing environment"));
+            let has_worker_port = env
+                .iter()
+                .any(|v| v.as_str().is_some_and(|s| s == worker_port_line));
+            assert!(
+                has_worker_port,
+                "service '{name}' must set {worker_port_line}, got: {env:?}"
+            );
+        }
+    }
+
+    /// ADR-038: every WORKER_*_URL entry in mcp-hub environment must point at
+    /// `:{PORT_WORKER}`.
+    #[test]
+    fn test_hub_worker_urls_use_port_worker() {
+        let config = ResolvedClaudeConfig {
+            env: crate::defaults::base_env(),
+            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            llm: LlmConfig::default(),
+        };
+        let yaml = render_compose(
+            "test-project",
+            "/home/user/projects/test",
+            &config,
+            &all_enabled_integrations(),
+            None,
+        )
+        .unwrap();
+
+        let expected_suffix = format!(":{}", crate::consts::PORT_WORKER);
+        for entry in get_hub_env_seq(&serde_yaml_ng::from_str(&yaml).unwrap()) {
+            if let Some((key, value)) = entry.split_once('=') {
+                if key.starts_with("WORKER_") && key.ends_with("_URL") {
+                    assert!(
+                        value.ends_with(&expected_suffix),
+                        "{key} must point at :{} (ADR-038), got: {value}",
+                        crate::consts::PORT_WORKER
+                    );
+                }
+            }
+        }
+    }
+
+    /// ADR-038: the llm-proxy container, when added for external providers,
+    /// must also listen on `PORT_WORKER` and be reached by claude at that port.
+    #[test]
+    fn test_llm_proxy_uses_port_worker() {
+        let config = ResolvedClaudeConfig {
+            env: crate::defaults::base_env(),
+            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            llm: LlmConfig {
+                provider: Some("openai".to_string()),
+                base_url: Some("https://api.openai.com/v1".to_string()),
+                ..Default::default()
+            },
+        };
+        let yaml = render_compose(
+            "test-project",
+            "/home/user/projects/test",
+            &config,
+            &ResolvedIntegrationsConfig::default(),
+            None,
+        )
+        .unwrap();
+
+        let worker_port = crate::consts::PORT_WORKER;
+        assert!(
+            yaml.contains(&format!("PORT={worker_port}")),
+            "llm-proxy must set PORT={worker_port}"
+        );
+        assert!(
+            yaml.contains(&format!("http://llm-proxy:{worker_port}")),
+            "ANTHROPIC_BASE_URL must point at http://llm-proxy:{worker_port}"
+        );
+    }
+
+    /// ADR-038: `plugin.json.port` is deprecated and ignored. A plugin
+    /// manifest that requests a non-`PORT_WORKER` port must still be wired up
+    /// at `:{PORT_WORKER}` without failing.
+    #[test]
+    fn test_plugin_manifest_port_is_ignored() {
+        use crate::plugin::{generate_plugin_service, PluginManifest, TokenMount};
+
+        let manifest = PluginManifest {
+            name: "Legacy".to_string(),
+            service_id: Some("legacy".to_string()),
+            slug: "legacy".to_string(),
+            version: "1.0.0".to_string(),
+            description: "legacy port".to_string(),
+            port: Some(9999), // deprecated, must be ignored
+            image_tag: Some("speedwave-mcp-legacy:latest".to_string()),
+            resources: vec![],
+            token_mount: TokenMount::ReadOnly,
+            auth_fields: vec![],
+            settings_schema: None,
+            speedwave_compat: None,
+            extra_env: None,
+            mem_limit: None,
+            cpu_limit: None,
+            requires_integrations: vec![],
+        };
+
+        let tokens_dir = std::path::Path::new("/home/user/.speedwave/tokens/test-project");
+        let service = generate_plugin_service(
+            &manifest,
+            "test-project",
+            "speedwave_test-project_network",
+            tokens_dir,
+            "/home/user/projects/test",
+        )
+        .unwrap();
+
+        let env = service
+            .get("environment")
+            .and_then(|v| v.as_sequence())
+            .expect("plugin service must have environment");
+        let has_worker_port = env.iter().any(|v| {
+            v.as_str()
+                .is_some_and(|s| s == format!("PORT={}", crate::consts::PORT_WORKER))
+        });
+        assert!(
+            has_worker_port,
+            "plugin service must use PORT={} regardless of manifest.port (ADR-038)",
+            crate::consts::PORT_WORKER
+        );
+        let has_deprecated_port = env.iter().any(|v| {
+            v.as_str()
+                .is_some_and(|s| s == format!("PORT={}", manifest.port.unwrap()))
+        });
+        assert!(
+            !has_deprecated_port,
+            "plugin service must not honour deprecated manifest.port"
         );
     }
 
@@ -3376,7 +3553,7 @@ services:
       - /tmp:noexec,nosuid,size=64m
     environment:
       - PORT=4000
-      - WORKER_SLACK_URL=http://mcp-slack:4001
+      - WORKER_SLACK_URL=http://mcp-slack:3000
       - SLACK_TOKEN=xoxb-12345
 "#;
         let violations = SecurityCheck::run(yaml, "test", &[], &test_expected_paths());
@@ -3817,7 +3994,7 @@ services:
     security_opt: [no-new-privileges:true]
     tmpfs: ["/tmp:noexec,nosuid,size=64m"]
     environment:
-      - PORT=4001
+      - PORT=3000
 "#;
         let violations = SecurityCheck::run(yaml, "test", &[], &test_expected_paths());
         assert!(
@@ -5193,10 +5370,10 @@ services:
       - /tmp:noexec,nosuid,size=64m
     environment:
       - PORT=4000
-      - WORKER_SLACK_URL=http://mcp-slack:4001
-      - WORKER_SHAREPOINT_URL=http://mcp-sharepoint:4002
-      - WORKER_REDMINE_URL=http://mcp-redmine:4003
-      - WORKER_GITLAB_URL=http://mcp-gitlab:4004
+      - WORKER_SLACK_URL=http://mcp-slack:3000
+      - WORKER_SHAREPOINT_URL=http://mcp-sharepoint:3000
+      - WORKER_REDMINE_URL=http://mcp-redmine:3000
+      - WORKER_GITLAB_URL=http://mcp-gitlab:3000
     networks:
       - speedwave_test_network
 
@@ -5211,7 +5388,7 @@ services:
     volumes:
       - /home/user/.speedwave/tokens/test/slack:/tokens:ro
     environment:
-      - PORT=4001
+      - PORT=3000
     networks:
       - speedwave_test_network
 
@@ -5227,7 +5404,7 @@ services:
       - /home/user/.speedwave/tokens/test/sharepoint:/tokens:rw
       - /home/user/projects/test:/workspace:rw
     environment:
-      - PORT=4002
+      - PORT=3000
     networks:
       - speedwave_test_network
 
@@ -5242,7 +5419,7 @@ services:
     volumes:
       - /home/user/.speedwave/tokens/test/redmine:/tokens:ro
     environment:
-      - PORT=4003
+      - PORT=3000
     networks:
       - speedwave_test_network
 
@@ -5257,7 +5434,7 @@ services:
     volumes:
       - /home/user/.speedwave/tokens/test/gitlab:/tokens:ro
     environment:
-      - PORT=4004
+      - PORT=3000
     networks:
       - speedwave_test_network
 

--- a/crates/speedwave-runtime/src/consts.rs
+++ b/crates/speedwave-runtime/src/consts.rs
@@ -13,11 +13,11 @@ pub const PORT_BASE: u16 = 4000;
 
 /// Port on which every MCP worker listens inside its own container.
 ///
-/// All workers — built-in services (slack, sharepoint, redmine, gitlab,
-/// playwright), the optional `llm-proxy`, and plugin workers — share this
-/// port. Each container has its own network namespace, so port reuse is safe;
-/// the compose network disambiguates by DNS service name
-/// (`http://mcp-slack:3000`, `http://mcp-playwright:3000`, etc.).
+/// All workers — built-in services (slack, sharepoint, redmine, gitlab),
+/// the optional `llm-proxy`, and plugin workers — share this port. Each
+/// container has its own network namespace, so port reuse is safe; the
+/// compose network disambiguates by DNS service name
+/// (`http://mcp-slack:3000`, `http://mcp-gitlab:3000`, etc.).
 ///
 /// See ADR-038 for the rationale behind the single-internal-port model.
 pub const PORT_WORKER: u16 = 3000;

--- a/crates/speedwave-runtime/src/consts.rs
+++ b/crates/speedwave-runtime/src/consts.rs
@@ -5,9 +5,22 @@ pub const LIMA_SUBDIR: &str = "lima";
 pub const DATA_DIR: &str = ".speedwave";
 pub const CLI_BINARY: &str = "speedwave";
 pub const COMPOSE_PREFIX: &str = "speedwave";
+/// Port on which `mcp-hub` listens inside the compose network.
+///
+/// This is the single external contract: the `claude` container reaches the
+/// hub at `http://mcp-hub:4000`. See ADR-038.
 pub const PORT_BASE: u16 = 4000;
-/// Port reserved for the optional LLM proxy container (PORT_BASE + 9).
-pub const PORT_LLM_PROXY: u16 = PORT_BASE + 9;
+
+/// Port on which every MCP worker listens inside its own container.
+///
+/// All workers — built-in services (slack, sharepoint, redmine, gitlab,
+/// playwright), the optional `llm-proxy`, and plugin workers — share this
+/// port. Each container has its own network namespace, so port reuse is safe;
+/// the compose network disambiguates by DNS service name
+/// (`http://mcp-slack:3000`, `http://mcp-playwright:3000`, etc.).
+///
+/// See ADR-038 for the rationale behind the single-internal-port model.
+pub const PORT_WORKER: u16 = 3000;
 pub const MCP_OS_AUTH_TOKEN_FILE: &str = "mcp-os-auth-token";
 pub const MCP_OS_PORT_FILE: &str = "mcp-os-port";
 pub const MCP_OS_PID_FILE: &str = "mcp-os-pid";

--- a/crates/speedwave-runtime/src/plugin.rs
+++ b/crates/speedwave-runtime/src/plugin.rs
@@ -54,6 +54,12 @@ pub struct PluginManifest {
     pub slug: String,
     pub version: String,
     pub description: String,
+    /// DEPRECATED — ignored by compose emitter since ADR-038.
+    ///
+    /// All workers (built-in and plugin) now listen on the same internal
+    /// port ([`consts::PORT_WORKER`]). Kept `Option<u16>` for backward
+    /// compatibility with already-signed plugin manifests; setting a non-zero
+    /// value merely emits a warning at compose render time.
     #[serde(default)]
     pub port: Option<u16>,
     #[serde(default)]
@@ -308,14 +314,6 @@ fn validate_manifest(manifest: &PluginManifest, plugin_dir: &Path) -> anyhow::Re
         );
     }
 
-    // MCP plugins must specify a port
-    if manifest.service_id.is_some() && manifest.port.is_none() {
-        anyhow::bail!(
-            "MCP plugins (service_id='{}') must specify a port",
-            manifest.service_id.as_deref().unwrap_or("")
-        );
-    }
-
     // Validate mem_limit format (e.g. "256m", "1g", "512000")
     if let Some(ref limit) = manifest.mem_limit {
         static MEM_RE: std::sync::OnceLock<Result<regex::Regex, regex::Error>> =
@@ -437,38 +435,6 @@ fn validate_manifest(manifest: &PluginManifest, plugin_dir: &Path) -> anyhow::Re
     Ok(())
 }
 
-/// Checks that a plugin port doesn't collide with built-in services or other plugins.
-fn validate_plugin_port(port: u16, slug: &str, existing: &[PluginManifest]) -> anyhow::Result<()> {
-    let builtin_count = consts::TOGGLEABLE_MCP_SERVICES.len() as u16;
-    let builtin_end = consts::PORT_BASE + builtin_count;
-    if (consts::PORT_BASE..=builtin_end).contains(&port) {
-        anyhow::bail!(
-            "Port {} is reserved for built-in services (range {}-{})",
-            port,
-            consts::PORT_BASE,
-            builtin_end
-        );
-    }
-    if port == consts::PORT_LLM_PROXY {
-        anyhow::bail!(
-            "Port {} is reserved for the LLM proxy",
-            consts::PORT_LLM_PROXY
-        );
-    }
-    for existing_manifest in existing {
-        if let Some(existing_port) = existing_manifest.port {
-            if existing_port == port && existing_manifest.slug != slug {
-                anyhow::bail!(
-                    "Port {} is already claimed by plugin '{}'",
-                    port,
-                    existing_manifest.slug
-                );
-            }
-        }
-    }
-    Ok(())
-}
-
 /// Install a plugin from a ZIP file into `~/.speedwave/plugins/<slug>/`.
 /// Verifies signature, validates manifest, and creates `.image_pending` marker
 /// for deferred image build.
@@ -516,10 +482,6 @@ pub fn install_plugin(
             }
         }
     }
-    if let Some(new_port) = manifest.port {
-        validate_plugin_port(new_port, &manifest.slug, &existing)?;
-    }
-
     // Move to final location
     let dest = plugins_dir.join(&manifest.slug);
     if dest.exists() {
@@ -871,9 +833,8 @@ pub fn generate_plugin_service(
         "mcp",
         sid.replace('-', "_")
     );
-    let port = manifest
-        .port
-        .ok_or_else(|| anyhow::anyhow!("MCP plugin '{}' must specify a port", sid))?;
+    // All workers use a single internal port — see ADR-038.
+    let port = consts::PORT_WORKER;
 
     let token_mount_mode = match &manifest.token_mount {
         TokenMount::ReadOnly => "ro",
@@ -1072,7 +1033,7 @@ mod tests {
             slug: "presale".to_string(),
             version: "1.2.0".to_string(),
             description: "Presale CRM integration".to_string(),
-            port: Some(4010),
+            port: None,
             image_tag: None,
             resources: vec!["skills".to_string(), "commands".to_string()],
             token_mount: TokenMount::ReadOnly,
@@ -1096,7 +1057,7 @@ mod tests {
         assert_eq!(parsed.service_id.as_deref(), Some("presale"));
         assert_eq!(parsed.slug, "presale");
         assert_eq!(parsed.version, "1.2.0");
-        assert_eq!(parsed.port, Some(4010));
+        assert_eq!(parsed.port, None);
         assert_eq!(parsed.resources.len(), 2);
         assert!(matches!(parsed.token_mount, TokenMount::ReadOnly));
         assert_eq!(parsed.requires_integrations, vec!["sharepoint"]);
@@ -1217,7 +1178,7 @@ mod tests {
             slug: "different-slug".to_string(),
             version: "1.0.0".to_string(),
             description: "test".to_string(),
-            port: Some(4010),
+            port: None,
             image_tag: None,
             resources: vec![],
             token_mount: TokenMount::ReadOnly,
@@ -1243,7 +1204,7 @@ mod tests {
             slug: "test-mcp".to_string(),
             version: "1.0.0".to_string(),
             description: "test".to_string(),
-            port: Some(4010),
+            port: None,
             image_tag: None,
             resources: vec![],
             token_mount: TokenMount::ReadOnly,
@@ -1315,7 +1276,7 @@ mod tests {
             slug: "presale".to_string(),
             version: "1.2.0".to_string(),
             description: "Presale CRM".to_string(),
-            port: Some(4010),
+            port: None,
             image_tag: None,
             resources: vec![],
             token_mount: TokenMount::ReadOnly,
@@ -1359,7 +1320,8 @@ mod tests {
         assert!(yaml.contains("/tmp:noexec,nosuid"), "tmpfs: {yaml}");
         assert!(yaml.contains("/tokens:ro"), "token mount: {yaml}");
         assert!(yaml.contains("/workspace:rw"), "workspace mount: {yaml}");
-        assert!(yaml.contains("PORT=4010"), "PORT env: {yaml}");
+        // ADR-038: every worker — including plugins — uses PORT_WORKER (3000).
+        assert!(yaml.contains("PORT=3000"), "PORT env: {yaml}");
         assert!(
             yaml.contains("speedwave_myproject_network"),
             "network: {yaml}"
@@ -1377,7 +1339,7 @@ mod tests {
             slug: "sp-ext".to_string(),
             version: "1.0.0".to_string(),
             description: "test".to_string(),
-            port: Some(4020),
+            port: None,
             image_tag: None,
             resources: vec![],
             token_mount: TokenMount::ReadWrite {
@@ -1416,7 +1378,7 @@ mod tests {
             slug: "test-env".to_string(),
             version: "1.0.0".to_string(),
             description: "test".to_string(),
-            port: Some(4030),
+            port: None,
             image_tag: None,
             resources: vec![],
             token_mount: TokenMount::ReadOnly,
@@ -1537,7 +1499,7 @@ mod tests {
             slug: "test".to_string(),
             version: "2.0.0".to_string(),
             description: "test".to_string(),
-            port: Some(4010),
+            port: None,
             image_tag: None,
             resources: vec![],
             token_mount: TokenMount::ReadOnly,
@@ -1560,7 +1522,7 @@ mod tests {
             slug: "test".to_string(),
             version: "2.0.0".to_string(),
             description: "test".to_string(),
-            port: Some(4010),
+            port: None,
             image_tag: Some("custom-tag".to_string()),
             resources: vec![],
             token_mount: TokenMount::ReadOnly,
@@ -1701,7 +1663,7 @@ mod tests {
             slug: "test-svc".to_string(),
             version: "1.0.0".to_string(),
             description: "test".to_string(),
-            port: Some(4010),
+            port: None,
             image_tag: None,
             resources: vec![],
             token_mount: TokenMount::ReadOnly,
@@ -1761,7 +1723,7 @@ mod tests {
             slug: "test-svc".to_string(),
             version: "1.0.0".to_string(),
             description: "test".to_string(),
-            port: Some(4010),
+            port: None,
             image_tag: None,
             resources: vec![],
             token_mount: TokenMount::ReadOnly,
@@ -1837,7 +1799,7 @@ mod tests {
             slug: "test-svc".to_string(),
             version: "1.0.0".to_string(),
             description: "test".to_string(),
-            port: Some(4010),
+            port: None,
             image_tag: None,
             resources: vec![],
             token_mount: TokenMount::ReadOnly,
@@ -1880,7 +1842,7 @@ mod tests {
             slug: "test-svc".to_string(),
             version: "1.0.0".to_string(),
             description: "test".to_string(),
-            port: Some(4010),
+            port: None,
             image_tag: None,
             resources: vec![],
             token_mount: TokenMount::ReadOnly,
@@ -1957,7 +1919,7 @@ mod tests {
             slug: "presale".to_string(), // slug == service_id (required by validation)
             version: "2.0.0".to_string(),
             description: "A clone".to_string(),
-            port: Some(4011),
+            port: None,
             image_tag: None,
             resources: vec![],
             token_mount: TokenMount::ReadOnly,
@@ -1993,7 +1955,7 @@ mod tests {
             slug: "presale-fork".to_string(),
             version: "1.0.0".to_string(),
             description: "A fork".to_string(),
-            port: Some(4012),
+            port: None,
             image_tag: None,
             resources: vec![],
             token_mount: TokenMount::ReadOnly,
@@ -2031,7 +1993,7 @@ mod tests {
             slug: "test-special".to_string(),
             version: "1.0.0".to_string(),
             description: "test".to_string(),
-            port: Some(4040),
+            port: None,
             image_tag: None,
             resources: vec![],
             token_mount: TokenMount::ReadOnly,
@@ -2133,14 +2095,16 @@ mod tests {
     }
 
     #[test]
-    fn test_mcp_plugin_requires_port() {
+    fn test_mcp_plugin_without_port_is_accepted() {
+        // Since ADR-038, manifest.port is deprecated/ignored — a missing port
+        // must NOT cause validate_manifest to fail.
         let manifest = PluginManifest {
             name: "test".to_string(),
             service_id: Some("test-mcp".to_string()),
             slug: "test-mcp".to_string(),
             version: "1.0.0".to_string(),
             description: "test".to_string(),
-            port: None, // missing port
+            port: None,
             image_tag: None,
             resources: vec![],
             token_mount: TokenMount::ReadOnly,
@@ -2156,12 +2120,8 @@ mod tests {
         std::fs::write(tmp.path().join("Containerfile"), "FROM node:22").unwrap();
         let result = validate_manifest(&manifest, tmp.path());
         assert!(
-            result.is_err(),
-            "MCP plugin without port should be rejected"
-        );
-        assert!(
-            result.unwrap_err().to_string().contains("port"),
-            "Error should mention port"
+            result.is_ok(),
+            "MCP plugin without port must pass validation (ADR-038)"
         );
     }
 
@@ -2269,7 +2229,7 @@ mod tests {
             slug: "heavy".to_string(),
             version: "1.0.0".to_string(),
             description: "CPU-heavy plugin".to_string(),
-            port: Some(4020),
+            port: None,
             image_tag: None,
             resources: vec![],
             token_mount: TokenMount::ReadOnly,
@@ -2463,76 +2423,6 @@ mod tests {
         assert!(
             err.contains("reserved"),
             "should mention reserved key, got: {err}"
-        );
-    }
-
-    #[test]
-    fn test_install_rejects_duplicate_port() {
-        // Port uniqueness is checked in install_plugin against existing plugins.
-        // We test the logic by simulating the check.
-        let existing = vec![PluginManifest {
-            name: "Existing".to_string(),
-            service_id: Some("existing".to_string()),
-            slug: "existing".to_string(),
-            version: "1.0.0".to_string(),
-            description: "test".to_string(),
-            port: Some(4010),
-            image_tag: None,
-            resources: vec![],
-            token_mount: TokenMount::ReadOnly,
-            auth_fields: vec![],
-            settings_schema: None,
-            speedwave_compat: None,
-            extra_env: None,
-            mem_limit: None,
-            cpu_limit: None,
-            requires_integrations: vec![],
-        }];
-
-        let new_port: u16 = 4010;
-        let new_slug = "new-plugin";
-        let conflict = existing
-            .iter()
-            .any(|m| m.port == Some(new_port) && m.slug != new_slug);
-        assert!(conflict, "Duplicate port should be detected");
-    }
-
-    #[test]
-    fn test_install_rejects_builtin_port_range() {
-        let no_existing: Vec<PluginManifest> = vec![];
-
-        // Hub port (4000) should be rejected
-        let err = validate_plugin_port(consts::PORT_BASE, "test", &no_existing)
-            .unwrap_err()
-            .to_string();
-        assert!(
-            err.contains("reserved"),
-            "PORT_BASE should be reserved, got: {err}"
-        );
-
-        // Last built-in worker port should be rejected
-        let builtin_end = consts::PORT_BASE + consts::TOGGLEABLE_MCP_SERVICES.len() as u16;
-        let err = validate_plugin_port(builtin_end, "test", &no_existing)
-            .unwrap_err()
-            .to_string();
-        assert!(
-            err.contains("reserved"),
-            "builtin_end should be reserved, got: {err}"
-        );
-
-        // First port above the range should be accepted
-        assert!(validate_plugin_port(builtin_end + 1, "test", &no_existing).is_ok());
-    }
-
-    #[test]
-    fn test_install_rejects_llm_proxy_port() {
-        let no_existing: Vec<PluginManifest> = vec![];
-        let err = validate_plugin_port(consts::PORT_LLM_PROXY, "test", &no_existing)
-            .unwrap_err()
-            .to_string();
-        assert!(
-            err.contains("LLM proxy"),
-            "PORT_LLM_PROXY should be reserved, got: {err}"
         );
     }
 
@@ -2858,7 +2748,7 @@ mod tests {
             slug: "test-rw".to_string(),
             version: "1.0.0".to_string(),
             description: "test".to_string(),
-            port: Some(5000),
+            port: None,
             image_tag: None,
             resources: vec![],
             token_mount: TokenMount::ReadWrite {

--- a/crates/speedwave-runtime/src/runtime/mod.rs
+++ b/crates/speedwave-runtime/src/runtime/mod.rs
@@ -798,8 +798,10 @@ mod tests {
 
     #[test]
     fn parse_real_nerdctl_output() {
-        // Real output from `limactl shell speedwave sudo nerdctl compose ps --format json`
-        let input = r#"[{"ID":"076c","Name":"speedwave_myproject_mcp_redmine","Image":"speedwave-mcp-redmine:latest","Command":"docker-entrypoint.sh node dist/index.js","Project":"myproject","Service":"mcp-redmine","State":"running","Health":"","ExitCode":0,"Publishers":[{"URL":"127.0.0.1","TargetPort":4003,"PublishedPort":4003,"Protocol":"tcp"}]},{"ID":"40c1","Name":"speedwave_myproject_claude","Image":"speedwave-claude:latest","Command":"/usr/local/bin/entrypoint.sh","Project":"myproject","Service":"claude","State":"exited","Health":"","ExitCode":1,"Publishers":[]}]"#;
+        // Real output from `limactl shell speedwave sudo nerdctl compose ps --format json`.
+        // Since ADR-038 every worker listens on PORT_WORKER (3000); the test only
+        // checks Name and State so the exact port is immaterial.
+        let input = r#"[{"ID":"076c","Name":"speedwave_myproject_mcp_redmine","Image":"speedwave-mcp-redmine:latest","Command":"docker-entrypoint.sh node dist/index.js","Project":"myproject","Service":"mcp-redmine","State":"running","Health":"","ExitCode":0,"Publishers":[{"URL":"127.0.0.1","TargetPort":3000,"PublishedPort":3000,"Protocol":"tcp"}]},{"ID":"40c1","Name":"speedwave_myproject_claude","Image":"speedwave-claude:latest","Command":"/usr/local/bin/entrypoint.sh","Project":"myproject","Service":"claude","State":"exited","Health":"","ExitCode":1,"Publishers":[]}]"#;
         let result = parse_compose_ps_json(input);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0]["Name"], "speedwave_myproject_mcp_redmine");

--- a/docs/adr/ADR-038-single-internal-worker-port.md
+++ b/docs/adr/ADR-038-single-internal-worker-port.md
@@ -1,0 +1,110 @@
+# ADR-038: Single Internal Worker Port
+
+## Status
+
+Accepted
+
+## Context
+
+Speedwave's compose emitter currently assigns a unique TCP port to every MCP worker it generates:
+
+| Service          | Port |
+| ---------------- | ---- |
+| `mcp-hub`        | 4000 |
+| `mcp-slack`      | 4001 |
+| `mcp-sharepoint` | 4002 |
+| `mcp-redmine`    | 4003 |
+| `mcp-gitlab`     | 4004 |
+| `llm-proxy`      | 4009 |
+
+Plugin workers declared a `port` field in `plugin.json` and Speedwave reserved the range `PORT_BASE..=(PORT_BASE + len(TOGGLEABLE_MCP_SERVICES))` plus `PORT_LLM_PROXY` for built-ins, rejecting any plugin manifest whose port overlapped[^1]. Every new built-in service therefore shifted the reserved range, breaking plugin manifests that happened to claim a port in the newly reserved slice[^2].
+
+The question this ADR answers: **does per-worker port uniqueness carry any security weight, or can we collapse every worker onto a single internal port and let DNS disambiguate?**
+
+### What actually depends on port numbers today
+
+Speedwave's security model is explicit about its three pillars[^3]:
+
+- **Token isolation** — each worker mounts only its own `~/.speedwave/tokens/<project>/<service>/` directory as `/tokens:ro`.
+- **Network isolation** — each project has a dedicated `speedwave_<project>_network`; workers in project A cannot see workers in project B.
+- **Container hardening** — `cap_drop: ALL`, `security_opt: no-new-privileges:true`, `read_only: true`, `tmpfs` with `noexec,nosuid`, per-service resource limits[^4].
+
+None of these pillars references a port. The hub's SSRF protection layer (`validateWorkerUrl()`) checks the _format_ of the port (integer in `1..=65535`) and the _hostname_ (DNS name beginning with `mcp-` or on the gateway allowlist), but does not enforce a per-worker port allowlist[^5]. The compose template does not expose any worker port to the host — every worker is reachable only within the compose network, by DNS service name[^6]. ADR-036 already committed Speedwave to treating all services identically — no `BUILT_IN_SERVICES` list, no `isPluginService()` check[^7] — and port uniqueness was the last remaining field where built-ins and plugins diverged.
+
+### Why port uniqueness stops paying rent
+
+Each container runs in its own network namespace. Two containers listening on the same port is only a conflict when those ports share a namespace (same host, same bridge without NAT). On Speedwave's compose networks, `mcp-slack` and `mcp-playwright` can both bind `:3000` and there is no ambiguity — the hub reaches them as `http://mcp-slack:3000` vs `http://mcp-playwright:3000`. The port number carries no information that the DNS service name does not already carry.
+
+Keeping unique ports therefore costs complexity (template variables, emitter branches, reserved ranges, plugin contract drift) for a benefit (port-based network policies) that Speedwave does not implement and has no roadmap to implement[^8].
+
+## Decision
+
+Collapse worker ports to a single internal constant.
+
+- `PORT_BASE = 4000` — **renamed in docs as `PORT_HUB`** but kept under the same symbol for compatibility. This is the external contract: the `claude` container dials `http://mcp-hub:4000`.
+- `PORT_WORKER = 3000` — every MCP worker listens on this port inside its own container. This includes built-in services (`mcp-slack`, `mcp-sharepoint`, `mcp-redmine`, `mcp-gitlab`, future `mcp-playwright`), the optional `llm-proxy` service, and plugin workers.
+- `PORT_LLM_PROXY` — removed; llm-proxy listens on `PORT_WORKER` like any other worker. Claude reaches it via `ANTHROPIC_BASE_URL=http://llm-proxy:3000`.
+- `plugin.json.port` — deprecated and ignored. The field remains in `PluginManifest` as `Option<u16>` so existing signed manifests still deserialize; setting a non-`PORT_WORKER` value merely emits a `log::warn!` pointing to this ADR. `validate_plugin_port()` is deleted along with the reserved-range logic.
+
+### Impact on plugin contract
+
+Summarised against the plugin contract table in `CLAUDE.md`:
+
+- **`plugin.json` schema** — the `port` field remains structurally valid (optional `u16`), so already-signed plugin ZIPs continue to install. The value is ignored at compose render time with a deprecation warning. Plugin authors should drop the field from new releases.
+- **Hub env var convention** — `WORKER_<SLUG_UPPER>_URL` is still injected into the hub, now always ending in `:3000`. Hub code that parses `WORKER_*_URL` is unchanged.
+- **Token mount, workspace mount, security constraints** — all unchanged.
+- **Coordination** — the `speedwave-plugins` sibling repository updates `template/scaffold/plugin.json`, `presale/plugin.json`, and the `figma` PRD to drop `port`; plugins are re-signed and republished.
+
+## Alternatives rejected
+
+### Reserved ranges (Variant B)
+
+Retain unique ports but carve out a stable reservation: `4001–4019` for built-ins, `4020` for llm-proxy, `4021–4029` for future core services, `4030+` for plugins. This fixes plugin contract drift (the lower bound of the plugin range becomes a stable constant instead of `len(TOGGLEABLE_MCP_SERVICES)`) without touching the per-service port matrix.
+
+Rejected because it only _delays_ the complexity: every built-in addition still requires a reservation decision, the emitter still branches per service, and `plugin.json.port` remains a required field. It trades a rolling breaking change for a structural one, with no compensating benefit in the current threat model.
+
+### Dynamic port allocation
+
+Allocate worker ports at compose render time from a pool. Solves drift without reserving ranges.
+
+Rejected because it adds a discovery mechanism (the hub needs to learn which port was assigned to which service) without removing the per-worker port from the code path. This is more complexity than unique static ports, not less.
+
+## Consequences
+
+### Positive
+
+- **Plugin contract stabilises.** Adding a new built-in MCP service never again forces a plugin repo to republish.
+- **Fewer template variables.** `${PORT_HUB}` + `${PORT_WORKER}` replace `${PORT_HUB}` + `${PORT_SLACK}` + `${PORT_SHAREPOINT}` + `${PORT_REDMINE}` + `${PORT_GITLAB}` — and scales to zero additional vars per future worker.
+- **Smaller emitter surface.** `render_compose()` loses four port locals and three `yaml.replace()` calls; `validate_plugin_port()` and its tests go away entirely.
+- **Consistent with ADR-036.** The self-declaring worker policy already unified built-ins and plugins at the hub layer; this ADR completes that unification at the compose layer.
+
+### Negative
+
+- **Loss of optional port-based debugging heuristic.** Previously one could tell "which worker is on 4002?" from a port number; now every worker says `:3000` and the disambiguator is the service name. This is an ergonomic regression for ad-hoc debugging but has no impact on structured logs (which use service names) or observability (which tags by container name).
+- **Theoretical loss of future port-based network policies.** If Speedwave ever adds firewall rules keyed on worker port, those rules would need to be keyed on DNS/hostname instead. No such feature is planned; if added, the migration is straightforward because container names are already stable.
+
+## Verification
+
+- `test_all_workers_use_port_worker` — renders a full compose with every integration enabled and asserts every worker service (excluding `claude` and `mcp-hub`) has `PORT=3000` in its environment.
+- `test_hub_worker_urls_use_port_worker` — asserts every `WORKER_*_URL` entry in the hub environment ends with `:3000`.
+- `test_llm_proxy_uses_port_worker` — enables an external LLM provider, asserts `llm-proxy` listens on `PORT=3000` and Claude's `ANTHROPIC_BASE_URL=http://llm-proxy:3000`.
+- `test_plugin_manifest_port_is_ignored` — constructs a plugin manifest with `port: Some(9999)`, calls `generate_plugin_service()`, asserts the resulting service uses `PORT=3000`.
+- `test_mcp_plugin_without_port_is_accepted` — validates a plugin manifest with `port: None` and confirms it passes validation.
+
+## References
+
+[^1]: `crates/speedwave-runtime/src/plugin.rs`, function `validate_plugin_port` (pre-this ADR): https://github.com/speednet-software/speedwave/blob/dev/crates/speedwave-runtime/src/plugin.rs
+
+[^2]: Plugin contract table in `CLAUDE.md`: https://github.com/speednet-software/speedwave/blob/dev/CLAUDE.md#plugins
+
+[^3]: Security architecture overview: https://github.com/speednet-software/speedwave/blob/dev/docs/architecture/security.md
+
+[^4]: Container hardening reference: https://github.com/speednet-software/speedwave/blob/dev/docs/architecture/containers.md
+
+[^5]: `mcp-servers/shared/src/security.ts`, function `validateWorkerUrl`: https://github.com/speednet-software/speedwave/blob/dev/mcp-servers/shared/src/security.ts
+
+[^6]: `containers/compose.template.yml` — no worker has a `ports:` mapping to the host: https://github.com/speednet-software/speedwave/blob/dev/containers/compose.template.yml
+
+[^7]: ADR-036, Self-Declaring Worker Policy: https://github.com/speednet-software/speedwave/blob/dev/docs/adr/ADR-036-self-declaring-worker-policy.md
+
+[^8]: OWASP container security guidance — network segmentation operates at the network/namespace level, not per-port within a shared bridge: https://owasp.org/www-project-docker-top-10/

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -44,6 +44,7 @@ This directory contains all Architecture Decision Records (ADRs) for Speedwave. 
 | [ADR-035](ADR-035-mcp-spec-compliance-streamable-http.md)              | MCP Spec Compliance — Streamable HTTP Transport         | Accepted              |
 | [ADR-036](ADR-036-self-declaring-worker-policy.md)                     | Self-Declaring Worker Policy via `_meta`                | Accepted              |
 | [ADR-037](ADR-037-code-signing-and-bundled-binary-signing.md)          | Code Signing and Bundled Binary Signing                 | Accepted              |
+| [ADR-038](ADR-038-single-internal-worker-port.md)                      | Single Internal Worker Port                             | Accepted              |
 
 ## Creating a New ADR
 

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -54,6 +54,8 @@ When implementing any feature, ask these questions:
 - **Container ↔ Container**: per-project network isolation (`speedwave_<project>_network`)
 - **Worker ↔ Worker**: token isolation — each worker has access only to its own service credentials
 
+All MCP workers listen on the same internal port (`PORT_WORKER`, see [ADR-038](../adr/ADR-038-single-internal-worker-port.md)) inside their own container namespaces; the hub disambiguates workers by DNS service name. Port numbers carry no security weight — the three pillars above (token, network, hardening) do not depend on per-worker port uniqueness.
+
 ## Executor Sandbox (MCP Hub)
 
 The MCP Hub executes model-generated JavaScript in a restricted `AsyncFunction` sandbox. Security is provided by multiple layers:

--- a/mcp-servers/gitlab/src/index.ts
+++ b/mcp-servers/gitlab/src/index.ts
@@ -10,7 +10,7 @@ import { createMCPServer, ts, notConfiguredMessage, retryAsync } from '@speedwav
 import { initializeGitLabClient } from './client.js';
 import { createToolDefinitions } from './tools/index.js';
 
-const PORT = parseInt(process.env.PORT || '3004', 10);
+const PORT = parseInt(process.env.PORT || '3000', 10);
 const SERVER_NAME = 'mcp-gitlab';
 const AUTH_TOKEN = process.env.MCP_GITLAB_AUTH_TOKEN;
 

--- a/mcp-servers/hub/src/http-bridge.test.ts
+++ b/mcp-servers/hub/src/http-bridge.test.ts
@@ -1072,7 +1072,7 @@ describe('http-bridge', () => {
     });
 
     it('should reject external hostname in isWorkerAvailable', async () => {
-      process.env.WORKER_SLACK_URL = 'http://evil.com:4001';
+      process.env.WORKER_SLACK_URL = 'http://evil.com:3000';
 
       const result = await isWorkerAvailable('slack');
 
@@ -1081,7 +1081,7 @@ describe('http-bridge', () => {
     });
 
     it('should reject URL with pathname in callWorker', async () => {
-      process.env.WORKER_REDMINE_URL = 'http://mcp-redmine:4001/admin/exec';
+      process.env.WORKER_REDMINE_URL = 'http://mcp-redmine:3000/admin/exec';
 
       await expect(callWorker('redmine', 'list_issues', {})).rejects.toThrow(
         'Unknown service: redmine'

--- a/mcp-servers/redmine/src/index.ts
+++ b/mcp-servers/redmine/src/index.ts
@@ -10,7 +10,7 @@ import { createMCPServer, ts, notConfiguredMessage, retryAsync } from '@speedwav
 import { initializeRedmineClient } from './client.js';
 import { createToolDefinitions } from './tools/index.js';
 
-const PORT = parseInt(process.env.PORT || '3003', 10);
+const PORT = parseInt(process.env.PORT || '3000', 10);
 const SERVER_NAME = 'mcp-redmine';
 const AUTH_TOKEN = process.env.MCP_REDMINE_AUTH_TOKEN;
 

--- a/mcp-servers/shared/src/security.test.ts
+++ b/mcp-servers/shared/src/security.test.ts
@@ -334,13 +334,15 @@ describe('security', () => {
 
   describe('validateWorkerUrl', () => {
     it('accepts core container worker URLs', () => {
-      expect(validateWorkerUrl('http://mcp-slack:4001')).toBe(true);
-      expect(validateWorkerUrl('http://mcp-gitlab:4004')).toBe(true);
+      // ADR-038: all workers share PORT_WORKER (3000) internally.
+      expect(validateWorkerUrl('http://mcp-slack:3000')).toBe(true);
+      expect(validateWorkerUrl('http://mcp-gitlab:3000')).toBe(true);
     });
 
-    it('accepts addon container worker URLs', () => {
-      expect(validateWorkerUrl('http://mcp-presale:4006')).toBe(true);
-      expect(validateWorkerUrl('http://mcp-my-addon:5000')).toBe(true);
+    it('accepts plugin worker URLs', () => {
+      // Plugins also use PORT_WORKER; URLs differ only by DNS service name.
+      expect(validateWorkerUrl('http://mcp-presale:3000')).toBe(true);
+      expect(validateWorkerUrl('http://mcp-my-addon:3000')).toBe(true);
     });
 
     it('accepts minimal valid container URL', () => {

--- a/mcp-servers/shared/src/security.test.ts
+++ b/mcp-servers/shared/src/security.test.ts
@@ -374,31 +374,31 @@ describe('security', () => {
     });
 
     it('rejects IPv4 loopback', () => {
-      expect(validateWorkerUrl('http://127.0.0.1:4001')).toBe(false);
+      expect(validateWorkerUrl('http://127.0.0.1:3000')).toBe(false);
     });
 
     it('rejects IPv6 loopback', () => {
-      expect(validateWorkerUrl('http://[::1]:4001')).toBe(false);
+      expect(validateWorkerUrl('http://[::1]:3000')).toBe(false);
     });
 
     it('rejects unspecified address', () => {
-      expect(validateWorkerUrl('http://0.0.0.0:4001')).toBe(false);
+      expect(validateWorkerUrl('http://0.0.0.0:3000')).toBe(false);
     });
 
     it('rejects raw private IP', () => {
-      expect(validateWorkerUrl('http://192.168.1.1:4001')).toBe(false);
+      expect(validateWorkerUrl('http://192.168.1.1:3000')).toBe(false);
     });
 
     it('rejects external hostname', () => {
-      expect(validateWorkerUrl('http://evil.example.com:4001')).toBe(false);
+      expect(validateWorkerUrl('http://evil.example.com:3000')).toBe(false);
     });
 
     it('rejects https protocol', () => {
-      expect(validateWorkerUrl('https://mcp-slack:4001')).toBe(false);
+      expect(validateWorkerUrl('https://mcp-slack:3000')).toBe(false);
     });
 
     it('rejects ftp protocol', () => {
-      expect(validateWorkerUrl('ftp://mcp-slack:4001')).toBe(false);
+      expect(validateWorkerUrl('ftp://mcp-slack:3000')).toBe(false);
     });
 
     it('rejects container URL without port', () => {
@@ -410,23 +410,23 @@ describe('security', () => {
     });
 
     it('rejects trailing hyphen in hostname', () => {
-      expect(validateWorkerUrl('http://mcp-:4001')).toBe(false);
+      expect(validateWorkerUrl('http://mcp-:3000')).toBe(false);
     });
 
     it('rejects hostname not starting with mcp-', () => {
-      expect(validateWorkerUrl('http://-mcp:4001')).toBe(false);
+      expect(validateWorkerUrl('http://-mcp:3000')).toBe(false);
     });
 
     it('rejects uppercase hostname', () => {
-      expect(validateWorkerUrl('http://MCP-SLACK:4001')).toBe(false);
+      expect(validateWorkerUrl('http://MCP-SLACK:3000')).toBe(false);
     });
 
     it('rejects underscore in hostname', () => {
-      expect(validateWorkerUrl('http://mcp_slack:4001')).toBe(false);
+      expect(validateWorkerUrl('http://mcp_slack:3000')).toBe(false);
     });
 
     it('rejects space in hostname', () => {
-      expect(validateWorkerUrl('http://mcp slack:4001')).toBe(false);
+      expect(validateWorkerUrl('http://mcp slack:3000')).toBe(false);
     });
 
     it('rejects port 0', () => {
@@ -446,23 +446,23 @@ describe('security', () => {
     });
 
     it('rejects pathname beyond /', () => {
-      expect(validateWorkerUrl('http://mcp-slack:4001/admin')).toBe(false);
+      expect(validateWorkerUrl('http://mcp-slack:3000/admin')).toBe(false);
     });
 
     it('rejects query string', () => {
-      expect(validateWorkerUrl('http://mcp-slack:4001?redirect=http://evil.com')).toBe(false);
+      expect(validateWorkerUrl('http://mcp-slack:3000?redirect=http://evil.com')).toBe(false);
     });
 
     it('rejects hostname not on allowlist', () => {
-      expect(validateWorkerUrl('http://host.other.internal:4001')).toBe(false);
+      expect(validateWorkerUrl('http://host.other.internal:3000')).toBe(false);
     });
 
     it('rejects URL with auth credentials', () => {
-      expect(validateWorkerUrl('http://user:pass@mcp-slack:4001')).toBe(false);
+      expect(validateWorkerUrl('http://user:pass@mcp-slack:3000')).toBe(false);
     });
 
     it('rejects URL with fragment', () => {
-      expect(validateWorkerUrl('http://mcp-slack:4001#frag')).toBe(false);
+      expect(validateWorkerUrl('http://mcp-slack:3000#frag')).toBe(false);
     });
   });
 

--- a/mcp-servers/sharepoint/src/index.ts
+++ b/mcp-servers/sharepoint/src/index.ts
@@ -14,7 +14,7 @@ import { createToolDefinitions } from './tools/index.js';
 // Configuration
 //═══════════════════════════════════════════════════════════════════════════════
 
-const PORT = parseInt(process.env.PORT || '3002', 10);
+const PORT = parseInt(process.env.PORT || '3000', 10);
 const SERVER_NAME = 'mcp-sharepoint';
 const SERVER_VERSION = '1.0.0';
 const AUTH_TOKEN = process.env.MCP_SHAREPOINT_AUTH_TOKEN;

--- a/mcp-servers/slack/src/index.ts
+++ b/mcp-servers/slack/src/index.ts
@@ -14,7 +14,7 @@ import { createToolDefinitions } from './tools/index.js';
 // Configuration
 //═══════════════════════════════════════════════════════════════════════════════
 
-const PORT = parseInt(process.env.PORT || '3001', 10);
+const PORT = parseInt(process.env.PORT || '3000', 10);
 const SERVER_NAME = 'mcp-slack';
 const SERVER_VERSION = '1.0.0';
 const AUTH_TOKEN = process.env.MCP_SLACK_AUTH_TOKEN;


### PR DESCRIPTION
## Summary

- Introduce `PORT_WORKER = 3000` in `crates/speedwave-runtime/src/consts.rs`; every MCP worker (built-in services, `llm-proxy`, plugins) now listens on this single internal port.
- `PORT_BASE = 4000` remains as the hub's external contract (`MCP_HUB_PORT`). `PORT_LLM_PROXY` is removed.
- `plugin.json.port` becomes a deprecated/optional field — existing signed manifests continue to load; non-`PORT_WORKER` values produce a `log::warn!` at compose render time and are then ignored.
- `validate_plugin_port()` and its obsolete tests are deleted; the reserved-range check disappears with them.
- Compose template collapses `${PORT_SLACK} / ${PORT_SHAREPOINT} / ${PORT_REDMINE} / ${PORT_GITLAB}` into a single `${PORT_WORKER}` substitution.
- TS worker defaults (`process.env.PORT || '...'`) unified to `'3000'` across slack/sharepoint/redmine/gitlab.
- Full rationale, security analysis, and rejected alternatives in `docs/adr/ADR-038-single-internal-worker-port.md` (with footnoted source URLs per `.claude/rules/documentation.md`).

### Why

Every new built-in MCP service shifted `validate_plugin_port`'s reserved range (`PORT_BASE..=(PORT_BASE + len(TOGGLEABLE_MCP_SERVICES))`), threatening plugins that picked low ports. None of Speedwave's three security pillars (token isolation, network isolation, container hardening) depends on per-worker port uniqueness — `validateWorkerUrl()` only checks port format, no worker has a host-facing `ports:` mapping, and ADR-036 already committed Speedwave to treating built-ins and plugins identically at the hub layer. Moving to `PORT_WORKER = 3000` completes that unification at the compose layer and eliminates plugin-contract drift for every future built-in addition.

### Plugin contract impact

- `PluginManifest.port` remains structurally valid (`Option<u16>`); plugin ZIPs already signed with `port: 4010` install and run, with a single deprecation-warning log line per render.
- `speedwave-plugins` sibling repo coordination tracked separately — template scaffold and `presale` will drop the field in their next signed release.

### Test plan

- [x] `make check` — clippy + fmt + type-check + eslint all green
- [x] `make test` — full Rust + MCP + desktop + CI-workflow suite passes
- [x] New tests added:
  - `test_all_workers_use_port_worker` — every non-hub service in a full render has `PORT=3000`
  - `test_hub_worker_urls_use_port_worker` — every `WORKER_*_URL` entry in the hub env ends with `:3000`
  - `test_llm_proxy_uses_port_worker` — external LLM path, `llm-proxy.PORT=3000` and `ANTHROPIC_BASE_URL=http://llm-proxy:3000`
  - `test_plugin_manifest_port_is_ignored` — plugin manifest with `port: Some(9999)` renders with `PORT=3000`
  - `test_mcp_plugin_without_port_is_accepted` — `port: None` passes validation (replaces the old "requires a port" test)
- [x] Obsolete tests removed: `test_install_rejects_llm_proxy_port`, `test_install_rejects_builtin_port_range`, `test_install_rejects_duplicate_port`, `test_mcp_plugin_requires_port`

Follow-up PR 2 adds `mcp-playwright` core service on top of this refactor (tracked in #519).

Refs #519