### PR TITLE
feat(desktop): allow stopping a chat turn via ESC or Stop button

### DIFF
--- a/desktop/src-tauri/src/chat.rs
+++ b/desktop/src-tauri/src/chat.rs
@@ -997,6 +997,12 @@ impl ChatSession {
                 ) || msg_type == "system"
                 {
                     got_result = true;
+                    // Clear StreamParser per-turn state. message_stop also
+                    // triggers reset inside parse_line, but an interrupted
+                    // turn may emit Result without a preceding message_stop,
+                    // leaving active_blocks entries that could misroute
+                    // ToolInputDelta events in the next turn.
+                    parser.reset();
                 }
                 if let Some(chunk) = chunk {
                     if let Err(e) = app_handle.emit("chat_stream", chunk) {
@@ -1125,11 +1131,14 @@ impl ChatSession {
     /// preserved.
     pub fn interrupt(&mut self) -> anyhow::Result<()> {
         // Mirror send_message/answer_question: detect a child that has already
-        // exited so we surface a clean "session exited" error instead of a
-        // confusing broken-pipe write failure.
+        // exited so we surface a clean "session exited" (or OOM) error instead
+        // of a confusing broken-pipe write failure.
         if let Some(child) = self.child.as_mut() {
             if let Some(status) = child.try_wait()? {
                 self.child = None;
+                if speedwave_runtime::resources::is_oom_exit(&status) {
+                    anyhow::bail!("{}", speedwave_runtime::resources::OOM_MESSAGE);
+                }
                 anyhow::bail!("session exited ({status})");
             }
         }

--- a/desktop/src-tauri/src/chat.rs
+++ b/desktop/src-tauri/src/chat.rs
@@ -1572,6 +1572,44 @@ mod tests {
         assert!(parser.active_blocks.is_empty());
     }
 
+    /// Regression test for the interrupt path: an interrupted turn can emit
+    /// `result` without a preceding `message_stop`, so the stdout-reader
+    /// calls `parser.reset()` after every terminal chunk. Without that
+    /// reset, stale `active_blocks` entries would misroute
+    /// `ToolInputDelta` events in the next turn when Claude reuses the
+    /// same content-block index for a different tool.
+    #[test]
+    fn reset_after_result_prevents_stale_tool_contamination() {
+        let mut parser = StreamParser::new();
+
+        // Turn 1: a tool starts at index 0 and receives a partial input delta.
+        let start = r#"{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_OLD","name":"Read","input":{}}}}"#;
+        parse_line_str(&mut parser, start);
+        assert!(parser.active_blocks.contains_key(&0));
+
+        // Interrupt emits a `result` directly — no preceding `message_stop`.
+        // The stdout-reader loop calls `parser.reset()` after this chunk, so
+        // simulate that here (parse_line alone does not reset on `result`).
+        let result = r#"{"type":"result","subtype":"error_during_execution","session_id":"s","total_cost_usd":0.0,"usage":{}}"#;
+        parse_line_str(&mut parser, result);
+        parser.reset();
+
+        assert!(parser.active_blocks.is_empty());
+        assert!(parser.tool_input.is_empty());
+
+        // Turn 2: Claude reuses index 0 for a different tool. Without the
+        // reset above, an input delta at index 0 would still route to the
+        // OLD tool_id; after reset the new tool_id takes over cleanly.
+        let start2 = r#"{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_NEW","name":"Edit","input":{}}}}"#;
+        parse_line_str(&mut parser, start2);
+        let delta = r#"{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"file\":\"x\"}"}}}"#;
+        let chunk = parse_line_str(&mut parser, delta).expect("expected ToolInputDelta");
+        match chunk {
+            StreamChunk::ToolInputDelta { tool_id, .. } => assert_eq!(tool_id, "toolu_NEW"),
+            other => panic!("expected ToolInputDelta for toolu_NEW, got {other:?}"),
+        }
+    }
+
     // ── StreamParser: user tool_result ────────────────────────────────
 
     #[test]

--- a/desktop/src-tauri/src/chat.rs
+++ b/desktop/src-tauri/src/chat.rs
@@ -86,6 +86,11 @@ pub struct UsageInfo {
 /// Tool name constant for the AskUserQuestion tool.
 const ASK_USER_TOOL_NAME: &str = "AskUserQuestion";
 
+// Stream-json protocol literals — see claude-agent-sdk-python types.py
+// (SDKControlRequest / SDKControlInterruptRequest).
+const MSG_TYPE_CONTROL_REQUEST: &str = "control_request";
+const CTRL_SUBTYPE_INTERRUPT: &str = "interrupt";
+
 /// Parsed control_request from Claude stdout.
 /// Also used as the pending request storage — keyed by `tool_use_id` in the HashMap.
 #[derive(Debug, Clone)]
@@ -700,6 +705,31 @@ pub fn claude_container_name(project: &str) -> String {
     format!("{}_{}_claude", consts::compose_prefix(), project)
 }
 
+/// Build the stream-json `control_request` payload for an interrupt.
+fn build_interrupt_payload(request_id: &str) -> serde_json::Value {
+    serde_json::json!({
+        "type": MSG_TYPE_CONTROL_REQUEST,
+        "request_id": request_id,
+        "request": { "subtype": CTRL_SUBTYPE_INTERRUPT },
+    })
+}
+
+/// Monotonic interrupt request_id (Claude requires uniqueness; we never
+/// correlate the response, so a counter is enough — no UUID dependency).
+fn next_interrupt_request_id() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(1);
+    format!("req_interrupt_{}", COUNTER.fetch_add(1, Ordering::Relaxed))
+}
+
+/// Write a control_request payload + flush. Extracted so tests can assert
+/// the exact bytes against an in-memory writer.
+fn write_interrupt<W: Write>(w: &mut W, payload: &serde_json::Value) -> anyhow::Result<()> {
+    writeln!(w, "{}", payload)?;
+    w.flush()?;
+    Ok(())
+}
+
 /// Manages a Claude Code subprocess running inside the container.
 /// Claude is launched via `container_exec` from the ContainerRuntime trait,
 /// which abstracts limactl/nerdctl/wsl.exe differences.
@@ -1018,7 +1048,7 @@ impl ChatSession {
         let shared = self
             .shared_stdin
             .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("stdin not available"))?;
+            .ok_or_else(|| anyhow::anyhow!("no active session"))?;
         let input = build_user_message(message);
         let mut stdin = shared
             .lock()
@@ -1059,7 +1089,7 @@ impl ChatSession {
         let shared = self
             .shared_stdin
             .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("stdin not available"))?;
+            .ok_or_else(|| anyhow::anyhow!("no active session"))?;
         let mut stdin = shared
             .lock()
             .map_err(|e| anyhow::anyhow!("stdin lock poisoned: {e}"))?;
@@ -1084,7 +1114,45 @@ impl ChatSession {
         Ok(())
     }
 
-    /// Stop the Claude subprocess.
+    /// Cancel the current turn without killing the session.
+    ///
+    /// Writes a stream-json `control_request` with `subtype: "interrupt"` to
+    /// Claude's stdin (protocol: `SDKControlInterruptRequest` in
+    /// https://github.com/anthropics/claude-agent-sdk-python/blob/main/src/claude_agent_sdk/types.py).
+    /// Claude aborts the in-flight turn, emits a `result` with
+    /// `subtype: "error_during_execution"`, and stays ready for the next user
+    /// message on the same stdin — session, context, MCP hub, and history
+    /// preserved.
+    pub fn interrupt(&mut self) -> anyhow::Result<()> {
+        // Mirror send_message/answer_question: detect a child that has already
+        // exited so we surface a clean "session exited" error instead of a
+        // confusing broken-pipe write failure.
+        if let Some(child) = self.child.as_mut() {
+            if let Some(status) = child.try_wait()? {
+                self.child = None;
+                anyhow::bail!("session exited ({status})");
+            }
+        }
+        let shared = self
+            .shared_stdin
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("no active session"))?;
+        let request_id = next_interrupt_request_id();
+        let payload = build_interrupt_payload(&request_id);
+        let mut stdin = shared
+            .lock()
+            .map_err(|e| anyhow::anyhow!("stdin lock poisoned: {e}"))?;
+        if let Err(e) = write_interrupt(&mut *stdin, &payload) {
+            log::error!(
+                "interrupt: failed to write control_request (request_id={request_id}): {e}"
+            );
+            return Err(e);
+        }
+        log::info!("interrupt: control_request sent (request_id={request_id})");
+        Ok(())
+    }
+
+    /// Stop the Claude subprocess entirely (session end, not turn cancel).
     pub fn stop(&mut self) -> anyhow::Result<()> {
         // Drop stdin first to signal EOF to the child
         self.shared_stdin = None;
@@ -1150,6 +1218,113 @@ pub type SharedChatSession = Arc<Mutex<ChatSession>>;
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+
+    // -- interrupt protocol tests (behavioural via free helpers) --
+
+    #[test]
+    fn interrupt_without_active_session_errors() {
+        let mut s = ChatSession::new("test-project");
+        let err = s
+            .interrupt()
+            .expect_err("expected 'no active session' when stdin not set");
+        assert!(
+            err.to_string().contains("no active session"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn build_interrupt_payload_matches_sdk_protocol() {
+        // Wire format per SDKControlInterruptRequest in claude-agent-sdk-python.
+        let v = build_interrupt_payload("req_interrupt_42");
+        assert_eq!(v["type"], "control_request");
+        assert_eq!(v["request_id"], "req_interrupt_42");
+        assert_eq!(v["request"]["subtype"], "interrupt");
+        // Defensive: no extra top-level keys leak in.
+        let obj = v.as_object().expect("object");
+        let mut keys: Vec<&str> = obj.keys().map(String::as_str).collect();
+        keys.sort();
+        assert_eq!(keys, vec!["request", "request_id", "type"]);
+    }
+
+    #[test]
+    fn next_interrupt_request_id_is_unique_and_prefixed() {
+        let a = next_interrupt_request_id();
+        let b = next_interrupt_request_id();
+        assert_ne!(a, b);
+        assert!(a.starts_with("req_interrupt_"));
+        assert!(b.starts_with("req_interrupt_"));
+    }
+
+    #[test]
+    fn write_interrupt_emits_single_ndjson_line() {
+        let payload = build_interrupt_payload("req_interrupt_test");
+        let mut buf: Vec<u8> = Vec::new();
+        write_interrupt(&mut buf, &payload).expect("write");
+        let s = String::from_utf8(buf).expect("utf8");
+        // Exactly one trailing newline (NDJSON framing) and one parse-able value.
+        assert!(s.ends_with('\n'), "must end with newline, got: {s:?}");
+        let line = s.trim_end_matches('\n');
+        assert!(!line.contains('\n'), "must be single line, got: {s:?}");
+        let parsed: serde_json::Value = serde_json::from_str(line).expect("valid json");
+        assert_eq!(parsed["request"]["subtype"], "interrupt");
+    }
+
+    #[test]
+    fn write_interrupt_propagates_io_errors() {
+        // Writer that always fails on first write — verifies the error path
+        // (the production code logs and returns this error to the caller).
+        struct FailWriter;
+        impl Write for FailWriter {
+            fn write(&mut self, _: &[u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::new(std::io::ErrorKind::BrokenPipe, "boom"))
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+        let payload = build_interrupt_payload("req_interrupt_err");
+        let err = write_interrupt(&mut FailWriter, &payload).expect_err("expected error");
+        assert!(err.to_string().contains("boom"), "got: {err}");
+    }
+
+    // -- ChatSession::stop() tests --
+
+    #[test]
+    fn stop_is_idempotent_when_no_session_running() {
+        let mut s = ChatSession::new("test-project");
+        assert!(s.stop().is_ok());
+        assert!(s.stop().is_ok());
+        assert!(s.child.is_none());
+        assert!(s.shared_stdin.is_none());
+        assert!(s.drain_handles.is_empty());
+        assert!(s.session_log_path.is_none());
+    }
+
+    #[test]
+    fn stop_clears_pending_requests() {
+        let mut s = ChatSession::new("test-project");
+        s.pending_requests.lock().unwrap().insert(
+            "tool-1".to_string(),
+            ControlRequest {
+                request_id: "r1".to_string(),
+                tool_name: ASK_USER_TOOL_NAME.to_string(),
+                input: serde_json::json!({}),
+                tool_use_id: "tool-1".to_string(),
+            },
+        );
+        assert!(s.stop().is_ok());
+        assert!(s.pending_requests.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn second_session_can_be_created_after_stop() {
+        let mut s1 = ChatSession::new("test-project");
+        assert!(s1.stop().is_ok());
+        drop(s1);
+        let mut s2 = ChatSession::new("test-project");
+        assert!(s2.stop().is_ok());
+    }
 
     /// Convenience: parse a JSON string and call `parser.parse_line`.
     /// Returns only the StreamChunk (for backward-compatible test assertions).
@@ -1722,7 +1897,7 @@ mod tests {
 
     #[test]
     fn parse_system_init_produces_log_entry() {
-        let mut parser = StreamParser::new();
+        let parser = StreamParser::new();
         let line = r#"{"type":"system","subtype":"init","model":"claude-opus-4-6"}"#;
         let parsed: serde_json::Value = serde_json::from_str(line).unwrap();
         let (chunk, log_entry) = parser.parse_system_message(&parsed);

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -241,6 +241,23 @@ async fn answer_question(
     .map_err(|e| e.to_string())?
 }
 
+fn stop_chat_inner(session_arc: SharedChatSession) -> Result<(), String> {
+    let mut session = session_arc
+        .lock()
+        .map_err(|e| format!("Lock poisoned: {e}"))?;
+    session.interrupt().map_err(|e| e.to_string())
+}
+
+/// Tauri command — delegates to [`ChatSession::interrupt`].
+#[tauri::command]
+async fn stop_chat(state: tauri::State<'_, SharedChatSession>) -> Result<(), String> {
+    log::info!("stop_chat: interrupting turn");
+    let session_arc = state.inner().clone();
+    tokio::task::spawn_blocking(move || stop_chat_inner(session_arc))
+        .await
+        .map_err(|e| e.to_string())?
+}
+
 // ---------------------------------------------------------------------------
 // Chat history commands
 // ---------------------------------------------------------------------------
@@ -1341,6 +1358,7 @@ fn main() {
             start_chat,
             send_message,
             answer_question,
+            stop_chat,
             // Chat history
             list_conversations,
             get_conversation,
@@ -1982,5 +2000,48 @@ mod tests {
             "first handle must be stashed into empty slot"
         );
         stashed.unwrap().join().expect("test thread must not panic");
+    }
+
+    // -- stop_chat_inner tests --
+
+    #[test]
+    fn stop_chat_inner_without_active_session_errors() {
+        // interrupt() requires an active stdin (shared_stdin=Some). A freshly
+        // constructed ChatSession has no stdin, so interrupt — and therefore
+        // stop_chat_inner — returns "no active session" instead of panicking.
+        let session_arc: SharedChatSession = Arc::new(Mutex::new(ChatSession::new("test-project")));
+        let err = stop_chat_inner(session_arc).expect_err("expected error on idle session");
+        assert!(
+            err.contains("no active session"),
+            "expected 'no active session' in error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn stop_chat_inner_poisoned_mutex_returns_lock_poisoned_error() {
+        let session_arc: SharedChatSession = Arc::new(Mutex::new(ChatSession::new("test-project")));
+        let arc_clone = session_arc.clone();
+        let _ = std::thread::spawn(move || {
+            let _guard = arc_clone.lock().unwrap();
+            panic!("poison the mutex");
+        })
+        .join();
+        let result = stop_chat_inner(session_arc);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("Lock poisoned"),
+            "expected 'Lock poisoned' in error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn stop_chat_uses_spawn_blocking() {
+        let source = include_str!("main.rs");
+        let body = extract_fn_body(source, "async fn stop_chat(");
+        assert!(
+            body.contains("spawn_blocking"),
+            "stop_chat must use spawn_blocking to avoid blocking the main thread"
+        );
     }
 }

--- a/desktop/src/src/app/chat/chat.component.html
+++ b/desktop/src/src/app/chat/chat.component.html
@@ -147,14 +147,26 @@
             rows="1"
           >
           </textarea>
-          <button
-            data-testid="chat-send"
-            class="px-5 py-2 border-none rounded-md bg-sw-accent text-white text-sm font-semibold transition-colors hover:enabled:bg-sw-accent-hover disabled:opacity-40 disabled:cursor-not-allowed"
-            (click)="sendMessage()"
-            [disabled]="!inputText.trim() || chat.isStreaming"
-          >
-            Send
-          </button>
+          @if (chat.isStreaming) {
+            <button
+              data-testid="chat-stop"
+              class="px-5 py-2 border-none rounded-md bg-sw-destructive text-white text-sm font-semibold transition-colors hover:enabled:bg-sw-destructive-hover cursor-pointer"
+              (click)="onStopClicked()"
+              title="Stop (Esc)"
+              aria-label="Stop conversation"
+            >
+              Stop
+            </button>
+          } @else {
+            <button
+              data-testid="chat-send"
+              class="px-5 py-2 border-none rounded-md bg-sw-accent text-white text-sm font-semibold transition-colors hover:enabled:bg-sw-accent-hover disabled:opacity-40 disabled:cursor-not-allowed"
+              (click)="sendMessage()"
+              [disabled]="!inputText.trim()"
+            >
+              Send
+            </button>
+          }
         </div>
       }
 

--- a/desktop/src/src/app/chat/chat.component.spec.ts
+++ b/desktop/src/src/app/chat/chat.component.spec.ts
@@ -932,4 +932,101 @@ describe('ChatComponent', () => {
       navigateSpy.mockRestore();
     });
   });
+
+  describe('Stop button and ESC handler', () => {
+    it('shows Stop button when streaming, Send button when idle', () => {
+      projectState.status = 'ready';
+      chatState.isStreaming = false;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('[data-testid="chat-send"]')).toBeTruthy();
+      expect(fixture.nativeElement.querySelector('[data-testid="chat-stop"]')).toBeNull();
+
+      chatState.isStreaming = true;
+      chatState['notifyChange']();
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('[data-testid="chat-stop"]')).toBeTruthy();
+      expect(fixture.nativeElement.querySelector('[data-testid="chat-send"]')).toBeNull();
+    });
+
+    it('clicking Stop calls stopConversation', () => {
+      projectState.status = 'ready';
+      const spy = vi.spyOn(chatState, 'stopConversation').mockResolvedValue();
+      chatState.isStreaming = true;
+      fixture.detectChanges();
+      fixture.nativeElement.querySelector('[data-testid="chat-stop"]').click();
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('pressing ESC while streaming calls stopConversation', () => {
+      const spy = vi.spyOn(chatState, 'stopConversation').mockResolvedValue();
+      chatState.isStreaming = true;
+      fixture.detectChanges();
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('pressing ESC while idle does nothing', () => {
+      const spy = vi.spyOn(chatState, 'stopConversation').mockResolvedValue();
+      chatState.isStreaming = false;
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('pressing ESC does not stop when an unanswered ask_user block is active', () => {
+      const spy = vi.spyOn(chatState, 'stopConversation').mockResolvedValue();
+      chatState.isStreaming = true;
+      chatState._setState({
+        currentBlocks: [
+          {
+            type: 'ask_user',
+            question: {
+              tool_id: 't1',
+              question: 'q?',
+              options: [],
+              header: '',
+              multi_select: false,
+              answered: false,
+              selected_values: [],
+            },
+          },
+        ],
+      });
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('Stop button still stops when an unanswered ask_user block is active', () => {
+      projectState.status = 'ready';
+      const spy = vi.spyOn(chatState, 'stopConversation').mockResolvedValue();
+      chatState.isStreaming = true;
+      chatState._setState({
+        currentBlocks: [
+          {
+            type: 'ask_user',
+            question: {
+              tool_id: 't1',
+              question: 'q?',
+              options: [],
+              header: '',
+              multi_select: false,
+              answered: false,
+              selected_values: [],
+            },
+          },
+        ],
+      });
+      chatState['notifyChange']();
+      fixture.detectChanges();
+      fixture.nativeElement.querySelector('[data-testid="chat-stop"]').click();
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('ngOnDestroy removes the ESC listener', () => {
+      const spy = vi.spyOn(chatState, 'stopConversation').mockResolvedValue();
+      fixture.destroy();
+      chatState.isStreaming = true;
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/desktop/src/src/app/chat/chat.component.ts
+++ b/desktop/src/src/app/chat/chat.component.ts
@@ -94,6 +94,29 @@ export class ChatComponent implements OnInit, OnDestroy {
     });
   }
 
+  /** True if the current turn is paused on an unanswered AskUserQuestion. */
+  private hasUnansweredQuestion(): boolean {
+    return this.chat.currentBlocks.some((b) => b.type === 'ask_user' && !b.question.answered);
+  }
+
+  /**
+   * Handles ESC key to stop the current turn. Ignored when an unanswered
+   * AskUserQuestion block is visible — ESC semantics belong to that block.
+   * @param event - The keyboard event from the document.
+   */
+  @HostListener('document:keydown.escape', ['$event'])
+  onEscape(event: Event): void {
+    if (!this.chat.isStreaming) return;
+    if (this.hasUnansweredQuestion()) return; // let the block own ESC semantics
+    event.preventDefault();
+    this.chat.stopConversation();
+  }
+
+  /** Handles the Stop button click. Stops the current turn unconditionally. */
+  async onStopClicked(): Promise<void> {
+    await this.chat.stopConversation();
+  }
+
   /** Sends the current input text as a user message and invokes the backend. */
   async sendMessage(): Promise<void> {
     const text = this.inputText.trim();

--- a/desktop/src/src/app/services/chat-state.service.spec.ts
+++ b/desktop/src/src/app/services/chat-state.service.spec.ts
@@ -1034,4 +1034,285 @@ describe('ChatStateService', () => {
       expect(service.isStreaming).toBe(false);
     });
   });
+
+  describe('stopConversation', () => {
+    it('stopConversation finalizes text blocks and resets isStreaming', async () => {
+      const invokeSpy = vi.spyOn(mockTauri, 'invoke');
+      service.isStreaming = true;
+      service._setState({ currentBlocks: [{ type: 'text', content: 'partial' }] });
+      await service.stopConversation();
+      expect(invokeSpy).toHaveBeenCalledWith('stop_chat');
+      expect(invokeSpy).toHaveBeenCalledTimes(1);
+      expect(service.isStreaming).toBe(false);
+      expect(service.currentBlocks).toEqual([]);
+      expect(service.messages).toHaveLength(1);
+      expect(service.messages[0].role).toBe('assistant');
+      expect(service.messages[0].blocks).toEqual([{ type: 'text', content: 'partial' }]);
+    });
+
+    it('stopConversation drops unanswered ask_user blocks when finalizing', async () => {
+      service.isStreaming = true;
+      service._setState({
+        currentBlocks: [
+          { type: 'text', content: 'Let me ask:' },
+          {
+            type: 'ask_user',
+            question: {
+              tool_id: 't1',
+              question: 'q?',
+              options: [],
+              header: '',
+              multi_select: false,
+              answered: false,
+              selected_values: [],
+            },
+          },
+        ],
+      });
+      await service.stopConversation();
+      expect(service.messages).toHaveLength(1);
+      expect(service.messages[0].blocks).toEqual([{ type: 'text', content: 'Let me ask:' }]);
+    });
+
+    it('stopConversation skips appending an assistant message if only ask_user was pending', async () => {
+      service.isStreaming = true;
+      service._setState({
+        currentBlocks: [
+          {
+            type: 'ask_user',
+            question: {
+              tool_id: 't1',
+              question: 'q?',
+              options: [],
+              header: '',
+              multi_select: false,
+              answered: false,
+              selected_values: [],
+            },
+          },
+        ],
+      });
+      await service.stopConversation();
+      expect(service.messages).toHaveLength(0);
+      expect(service.isStreaming).toBe(false);
+    });
+
+    it('stopConversation called twice only invokes stop_chat once', async () => {
+      const invokeSpy = vi.spyOn(mockTauri, 'invoke');
+      service.isStreaming = true;
+      const p1 = service.stopConversation();
+      const p2 = service.stopConversation();
+      await Promise.all([p1, p2]);
+      expect(invokeSpy.mock.calls.filter((c) => c[0] === 'stop_chat')).toHaveLength(1);
+    });
+
+    it('stopConversation is a no-op when not streaming', async () => {
+      const invokeSpy = vi.spyOn(mockTauri, 'invoke');
+      service.isStreaming = false;
+      await service.stopConversation();
+      expect(invokeSpy).not.toHaveBeenCalled();
+    });
+
+    it('stopConversation resets state and surfaces a real backend failure to the user', async () => {
+      mockTauri.invokeHandler = async (cmd: string) => {
+        if (cmd === 'stop_chat') throw new Error('ipc broken');
+        return undefined;
+      };
+      service.isStreaming = true;
+      service._setState({ currentBlocks: [{ type: 'text', content: 'x' }] });
+      await service.stopConversation();
+      expect(service.isStreaming).toBe(false);
+      // partial assistant + error block from the failed stop = 2 messages.
+      expect(service.messages).toHaveLength(2);
+      const errorBlock = service.messages[1].blocks[0];
+      expect(errorBlock.type).toBe('error');
+      expect((errorBlock as { type: 'error'; content: string }).content).toContain('Stop failed');
+    });
+
+    it('stopConversation suppresses benign "no active session" without surfacing an error', async () => {
+      mockTauri.invokeHandler = async (cmd: string) => {
+        if (cmd === 'stop_chat') throw new Error('no active session');
+        return undefined;
+      };
+      service.isStreaming = true;
+      service._setState({ currentBlocks: [{ type: 'text', content: 'x' }] });
+      await service.stopConversation();
+      expect(service.isStreaming).toBe(false);
+      // Only the partial assistant message — no extra error block.
+      expect(service.messages).toHaveLength(1);
+    });
+
+    it('stopConversation increments _turnId so late stream chunks are dropped', async () => {
+      service.isStreaming = true;
+      const before = service.turnId;
+      await service.stopConversation();
+      expect(service.turnId).toBeGreaterThan(before);
+    });
+
+    it('stop_chat reuses the existing session — next sendMessage skips start_chat / resume_conversation', async () => {
+      const calls: string[] = [];
+      mockTauri.invokeHandler = async (cmd: string) => {
+        calls.push(cmd);
+        return undefined;
+      };
+
+      service.isStreaming = true;
+      service._setState({ currentBlocks: [{ type: 'text', content: 'partial' }] });
+      await service.stopConversation();
+
+      expect(calls).toContain('stop_chat');
+      expect(calls).not.toContain('resume_conversation');
+      expect(calls).not.toContain('start_chat');
+
+      await service.sendMessage('next turn on same session');
+      expect(calls.filter((c) => c === 'send_message')).toHaveLength(1);
+    });
+
+    it('late content chunks arriving after stopConversation are dropped via _turnId guard', async () => {
+      mockTauri.isRunningInTauri = () => true;
+      await service.init();
+      service.isStreaming = true;
+      await service.stopConversation();
+      // Simulate a buffered chunk from the dying turn arriving after stop.
+      mockTauri.dispatchEvent('chat_stream', {
+        chunk_type: 'Text',
+        data: { content: 'late content from stopped turn' },
+      });
+      expect(service.isStreaming).toBe(false);
+      expect(service.currentBlocks).toEqual([]);
+      // Must not be appended — only the (empty) partial-then-stop noop ran.
+      const lateText = service.messages.some((m) =>
+        m.blocks.some((b) => b.type === 'text' && b.content === 'late content from stopped turn')
+      );
+      expect(lateText).toBe(false);
+    });
+
+    it('RateLimit chunk dispatched after Result still updates sessionStats.rate_limit', async () => {
+      mockTauri.isRunningInTauri = () => true;
+      await service.init();
+      service.isStreaming = true;
+      mockTauri.dispatchEvent('chat_stream', {
+        chunk_type: 'Result',
+        data: {
+          session_id: 's1',
+          total_cost: 0.01,
+          usage: { output_tokens: 10 },
+          result_text: null,
+          context_window_size: 200_000,
+        },
+      });
+      expect(service.isStreaming).toBe(false);
+      expect(service.sessionStats).not.toBeNull();
+      const before = service.sessionStats;
+      mockTauri.dispatchEvent('chat_stream', {
+        chunk_type: 'RateLimit',
+        data: { status: 'ok', utilization: 0.42, resets_at: '2026-04-18T12:00:00Z' },
+      });
+      expect(service.sessionStats).not.toBe(before);
+      expect(service.sessionStats?.rate_limit).toEqual({
+        status: 'ok',
+        utilization: 0.42,
+        resets_at: '2026-04-18T12:00:00Z',
+      });
+    });
+
+    it('SystemInit chunk dispatched between turns updates the model', async () => {
+      mockTauri.isRunningInTauri = () => true;
+      await service.init();
+      expect(service.isStreaming).toBe(false);
+      mockTauri.dispatchEvent('chat_stream', {
+        chunk_type: 'SystemInit',
+        data: { model: 'claude-opus-4-7' },
+      });
+      service.isStreaming = true;
+      mockTauri.dispatchEvent('chat_stream', {
+        chunk_type: 'Result',
+        data: {
+          session_id: 's2',
+          total_cost: 0,
+          usage: null,
+          result_text: null,
+          context_window_size: 200_000,
+        },
+      });
+      expect(service.sessionStats?.model).toBe('claude-opus-4-7');
+    });
+
+    it('drops late Text chunks after stopConversation — _messages and _sessionStats unchanged', async () => {
+      mockTauri.isRunningInTauri = () => true;
+      await service.init();
+      service.isStreaming = true;
+      service._setState({ currentBlocks: [{ type: 'text', content: 'first' }] });
+      await service.stopConversation();
+      const messagesBefore = service.messages;
+      const statsBefore = service.sessionStats;
+      mockTauri.dispatchEvent('chat_stream', {
+        chunk_type: 'Text',
+        data: { content: 'LATE' },
+      });
+      expect(service.messages).toBe(messagesBefore);
+      expect(service.sessionStats).toBe(statsBefore);
+      expect(service.currentBlocks).toEqual([]);
+      expect(service.isStreaming).toBe(false);
+    });
+
+    it('drops late Result chunks after stopConversation — _messages length and _sessionStats identity unchanged', async () => {
+      mockTauri.isRunningInTauri = () => true;
+      await service.init();
+      service.isStreaming = true;
+      await service.stopConversation();
+      const lengthBefore = service.messages.length;
+      const statsBefore = service.sessionStats;
+      mockTauri.dispatchEvent('chat_stream', {
+        chunk_type: 'Result',
+        data: {
+          session_id: 'late',
+          total_cost: 99,
+          usage: null,
+          result_text: 'late',
+          context_window_size: 200_000,
+        },
+      });
+      expect(service.messages.length).toBe(lengthBefore);
+      expect(service.sessionStats).toBe(statsBefore);
+      expect(service.isStreaming).toBe(false);
+    });
+
+    it('answerQuestion: stopConversation wins the race, no error block is appended', async () => {
+      mockTauri.isRunningInTauri = () => true;
+      await service.init();
+      service.isStreaming = true;
+      service._setState({
+        currentBlocks: [
+          {
+            type: 'ask_user',
+            question: {
+              tool_id: 't1',
+              question: 'q?',
+              options: [{ value: 'a', label: 'A' }],
+              header: '',
+              multi_select: false,
+              answered: false,
+              selected_values: [],
+            },
+          },
+        ],
+      });
+      let rejectAnswer: (err: Error) => void = () => {};
+      mockTauri.invokeHandler = async (cmd: string) => {
+        if (cmd === 'answer_question') {
+          return new Promise<undefined>((_, rej) => {
+            rejectAnswer = rej;
+          });
+        }
+        return undefined;
+      };
+      const answerPromise = service.answerQuestion('t1', ['a']);
+      await service.stopConversation();
+      rejectAnswer(new Error('Broken pipe'));
+      await answerPromise;
+      expect(service.messages.every((m) => m.blocks.every((b) => b.type !== 'error'))).toBe(true);
+      expect(service.currentBlocks).toEqual([]);
+    });
+  });
 });

--- a/desktop/src/src/app/services/chat-state.service.ts
+++ b/desktop/src/src/app/services/chat-state.service.ts
@@ -360,11 +360,32 @@ export class ChatStateService {
     //    isStreaming=false and early-return (prevents double invoke of stop_chat).
     this.isStreaming = false;
 
-    // 3. Preserve the partial assistant reply but drop ask_user blocks. The
-    //    interrupt aborts the in-flight turn; Claude will not answer any
-    //    rendered question (the matching tool_use_id is abandoned), so the
-    //    block is unanswerable.
-    const keptBlocks = this._currentBlocks.filter((b) => b.type !== 'ask_user');
+    // 3. Preserve the partial assistant reply but drop ask_user blocks and
+    //    finalize running tool_use blocks. The interrupt aborts the in-flight
+    //    turn; Claude will not answer any rendered question (the matching
+    //    tool_use_id is abandoned), so ask_user is unanswerable. Running tools
+    //    would otherwise render a permanent "running" spinner inside a closed
+    //    message — flip them to status: 'error' with an "Interrupted" marker.
+    const keptBlocks = this._currentBlocks
+      .filter((b) => b.type !== 'ask_user')
+      .map((b) => {
+        if (b.type === 'tool_use' && b.tool.status === 'running') {
+          return {
+            ...b,
+            tool: {
+              type: 'tool_use' as const,
+              tool_id: b.tool.tool_id,
+              tool_name: b.tool.tool_name,
+              input_json: b.tool.input_json,
+              status: 'error' as const,
+              result: 'Interrupted',
+              result_is_error: true as const,
+              collapsed: b.tool.collapsed,
+            },
+          };
+        }
+        return b;
+      });
     if (keptBlocks.length > 0) {
       this._messages = [
         ...this._messages,
@@ -593,13 +614,12 @@ export class ChatStateService {
           return;
         }
         // Content-bearing chunks belong to a specific turn. If isStreaming is
-        // false (stopConversation already ran), drop the chunk so it cannot
-        // write into _messages or flip isStreaming back on. Use _turnId as an
-        // additional guard: a new turn bumps _turnId so stale chunks from the
-        // previous turn, still in the Tauri event queue, are also dropped.
-        const capturedTurn = this._turnId;
+        // false (stopConversation already ran, or the turn already finished),
+        // drop the chunk so it cannot write into _messages or flip isStreaming
+        // back on. That single check is sufficient in single-threaded JS:
+        // stopConversation sets isStreaming = false synchronously before any
+        // await, so every subsequent event-loop tick observes the reset.
         if (!this.isStreaming) return;
-        if (capturedTurn !== this._turnId) return;
         this.handleStreamChunk(chunk);
       });
     } catch (err) {

--- a/desktop/src/src/app/services/chat-state.service.ts
+++ b/desktop/src/src/app/services/chat-state.service.ts
@@ -57,6 +57,13 @@ export class ChatStateService {
   private _totalOutputTokens = 0;
   private _contextWindowSize = 200_000;
 
+  /** Monotonically increasing turn id — bumped by stopConversation to invalidate late/buffered stream events. */
+  private _turnId = 0;
+  /** Test-only read access. */
+  get turnId(): number {
+    return this._turnId;
+  }
+
   private unlisten: UnlistenFn | null = null;
   private listenerReady = false;
   private initialized = false;
@@ -170,6 +177,7 @@ export class ChatStateService {
       },
     ];
     this.isStreaming = true;
+    this._turnId += 1;
     this._currentBlocks = [];
     this.notifyChange();
 
@@ -303,6 +311,7 @@ export class ChatStateService {
    */
   async answerQuestion(toolUseId: string, selectedValues: string[]): Promise<void> {
     const answer = selectedValues.join(', ');
+    const capturedTurn = this._turnId;
 
     // Mark the question as answered in currentBlocks
     this._currentBlocks = this._currentBlocks.map((b) =>
@@ -315,8 +324,14 @@ export class ChatStateService {
     try {
       await this.tauri.invoke('answer_question', { toolUseId, answer });
     } catch (err) {
+      // If stopConversation ran while answer_question was in flight, _turnId has
+      // moved on. Suppress the error block: the user deliberately cancelled, a
+      // "Broken pipe" / "no active session" surfacing would be confusing noise.
+      if (capturedTurn !== this._turnId) {
+        console.debug('[chat-state] answerQuestion: suppressing error after stop', err);
+        return;
+      }
       this.isStreaming = false;
-      // Revert the optimistic answered state so the user can retry
       this._currentBlocks = this._currentBlocks.map((b) =>
         b.type === 'ask_user' && b.question.tool_id === toolUseId
           ? { ...b, question: { ...b.question, answered: false, selected_values: [] } }
@@ -325,6 +340,64 @@ export class ChatStateService {
       this._currentBlocks = [
         ...this._currentBlocks,
         { type: 'error', content: `Failed to send answer: ${err}` },
+      ];
+      this.notifyChange();
+    }
+  }
+
+  /**
+   * Stops the current Claude turn. Safe to call when not streaming (no-op).
+   * Synchronously resets UI state so the input is re-enabled immediately,
+   * then fires the backend stop in the background.
+   */
+  async stopConversation(): Promise<void> {
+    if (!this.isStreaming) return;
+
+    // 1. Invalidate any in-flight / buffered stream events from the dying turn.
+    this._turnId += 1;
+
+    // 2. Synchronous UI reset — must precede any await so re-entrant calls see
+    //    isStreaming=false and early-return (prevents double invoke of stop_chat).
+    this.isStreaming = false;
+
+    // 3. Preserve the partial assistant reply but drop ask_user blocks. The
+    //    interrupt aborts the in-flight turn; Claude will not answer any
+    //    rendered question (the matching tool_use_id is abandoned), so the
+    //    block is unanswerable.
+    const keptBlocks = this._currentBlocks.filter((b) => b.type !== 'ask_user');
+    if (keptBlocks.length > 0) {
+      this._messages = [
+        ...this._messages,
+        { role: 'assistant', blocks: keptBlocks, timestamp: Date.now() },
+      ];
+    }
+    this._currentBlocks = [];
+    this.notifyChange();
+
+    // 4. Fire the backend interrupt. "no active session" is benign (idle or
+    //    already exited); any other failure means the turn may still be
+    //    running on the backend, so surface an error block to the user.
+    try {
+      await this.tauri.invoke('stop_chat');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes('no active session')) {
+        console.debug('[chat-state] stopConversation: backend already idle', err);
+        return;
+      }
+      console.error('[chat-state] stopConversation: invoke failed', err);
+      this._messages = [
+        ...this._messages,
+        {
+          role: 'assistant',
+          blocks: [
+            {
+              type: 'error',
+              content: `Stop failed — the current turn may still be running. ${msg}`,
+            },
+          ],
+          timestamp: Date.now(),
+        },
       ];
       this.notifyChange();
     }
@@ -512,7 +585,22 @@ export class ChatStateService {
   private async setupStreamListener(): Promise<void> {
     try {
       this.unlisten = await this.tauri.listen<StreamChunk>('chat_stream', (event) => {
-        this.handleStreamChunk(event.payload);
+        const chunk = event.payload;
+        // Metadata-only chunks never mutate _messages / _currentBlocks and
+        // are legitimate between or after turns (e.g. trailing RateLimit).
+        if (chunk.chunk_type === 'SystemInit' || chunk.chunk_type === 'RateLimit') {
+          this.handleStreamChunk(chunk);
+          return;
+        }
+        // Content-bearing chunks belong to a specific turn. If isStreaming is
+        // false (stopConversation already ran), drop the chunk so it cannot
+        // write into _messages or flip isStreaming back on. Use _turnId as an
+        // additional guard: a new turn bumps _turnId so stale chunks from the
+        // previous turn, still in the Tauri event queue, are also dropped.
+        const capturedTurn = this._turnId;
+        if (!this.isStreaming) return;
+        if (capturedTurn !== this._turnId) return;
+        this.handleStreamChunk(chunk);
       });
     } catch (err) {
       if (this.tauri.isRunningInTauri()) {

--- a/desktop/src/src/app/services/chat-state.service.ts
+++ b/desktop/src/src/app/services/chat-state.service.ts
@@ -57,7 +57,13 @@ export class ChatStateService {
   private _totalOutputTokens = 0;
   private _contextWindowSize = 200_000;
 
-  /** Monotonically increasing turn id — bumped by stopConversation to invalidate late/buffered stream events. */
+  /**
+   * Monotonically increasing turn id. Bumped by both `sendMessage` (new turn
+   * starts) and `stopConversation` (turn cancelled). Used across awaits by
+   * `answerQuestion` to detect whether the turn it was answering has since
+   * been superseded, so late backend errors from the dying turn can be
+   * suppressed.
+   */
   private _turnId = 0;
   /** Test-only read access. */
   get turnId(): number {

--- a/desktop/src/src/styles.css
+++ b/desktop/src/src/styles.css
@@ -41,6 +41,10 @@
   --color-sw-success-border: #2d6a4f;
   --color-sw-success-light: #34d399;
 
+  /* Destructive action (Stop button — distinct from accent #e94560) */
+  --color-sw-destructive: #b91c1c;
+  --color-sw-destructive-hover: #991b1b;
+
   /* Error */
   --color-sw-error: #e94560;
   --color-sw-error-bg: #3d0000;

--- a/docs/adr/ADR-006-chat-ui-via-stream-json.md
+++ b/docs/adr/ADR-006-chat-ui-via-stream-json.md
@@ -95,7 +95,9 @@ The frontend accumulates `MessageBlock[]` in `currentBlocks` during an assistant
 
 **Interactive questions (AskUserQuestion flow).** When Claude needs user confirmation (e.g., permission to run a tool), it sends a `control_request` via `--permission-prompt-tool stdio`. The backend parses this into an `AskUserQuestion` chunk containing the question text, selectable options, and a `tool_id`. The frontend renders the question with option buttons. When the user selects an answer, the frontend calls the `answer_question` Tauri command with the `tool_use_id` and selected value(s). The backend writes a `control_result` JSON message to Claude's stdin, and Claude resumes execution.
 
-**Auto-retry on session death.** If `send_message` fails with "session exited", "no active session", or "Broken pipe", the frontend transparently restarts the Claude subprocess via `start_chat` and retries the message — the user sees no interruption.
+**Stop / interrupt (turn cancel).** Pressing Esc or the Stop button calls the `stop_chat` Tauri command. The backend writes a `control_request` with `subtype: "interrupt"` to Claude's stdin (matching `SDKControlInterruptRequest` in claude-agent-sdk-python). Claude aborts the in-flight turn, emits a `result` with `subtype: "error_during_execution"`, and stays ready for the next user message on the same stdin — session, context, MCP hub, and history are preserved. The next `send_message` continues the same conversation; no `start_chat` or `resume_conversation` is needed. Killing the host-side `nerdctl exec` would not propagate any signal to the Claude process inside the container, so the protocol-level interrupt is the only reliable cancel mechanism.
+
+**Auto-retry on session death.** If `send_message` fails with "session exited", "no active session", or "Broken pipe", the frontend transparently restarts the Claude subprocess via `start_chat` and retries the message — the user sees no interruption. (The interrupt path above never triggers this retry — the session is still alive after a stop.)
 
 ## Chat History API
 

--- a/docs/adr/ADR-006-chat-ui-via-stream-json.md
+++ b/docs/adr/ADR-006-chat-ui-via-stream-json.md
@@ -95,7 +95,7 @@ The frontend accumulates `MessageBlock[]` in `currentBlocks` during an assistant
 
 **Interactive questions (AskUserQuestion flow).** When Claude needs user confirmation (e.g., permission to run a tool), it sends a `control_request` via `--permission-prompt-tool stdio`. The backend parses this into an `AskUserQuestion` chunk containing the question text, selectable options, and a `tool_id`. The frontend renders the question with option buttons. When the user selects an answer, the frontend calls the `answer_question` Tauri command with the `tool_use_id` and selected value(s). The backend writes a `control_result` JSON message to Claude's stdin, and Claude resumes execution.
 
-**Stop / interrupt (turn cancel).** Pressing Esc or the Stop button calls the `stop_chat` Tauri command. The backend writes a `control_request` with `subtype: "interrupt"` to Claude's stdin (matching `SDKControlInterruptRequest` in claude-agent-sdk-python). Claude aborts the in-flight turn, emits a `result` with `subtype: "error_during_execution"`, and stays ready for the next user message on the same stdin — session, context, MCP hub, and history are preserved. The next `send_message` continues the same conversation; no `start_chat` or `resume_conversation` is needed. Killing the host-side `nerdctl exec` would not propagate any signal to the Claude process inside the container, so the protocol-level interrupt is the only reliable cancel mechanism.
+**Stop / interrupt (turn cancel).** Pressing Esc or the Stop button calls the `stop_chat` Tauri command. The backend writes a `control_request` with `subtype: "interrupt"` to Claude's stdin (matching `SDKControlInterruptRequest` in claude-agent-sdk-python[^47]). Claude aborts the in-flight turn, emits a `result` with `subtype: "error_during_execution"`[^48], and stays ready for the next user message on the same stdin — session, context, MCP hub, and history are preserved. The next `send_message` continues the same conversation; no `start_chat` or `resume_conversation` is needed. Killing the host-side `nerdctl exec` would not propagate any signal to the Claude process inside the container, so the protocol-level interrupt is the only reliable cancel mechanism.
 
 **Auto-retry on session death.** If `send_message` fails with "session exited", "no active session", or "Broken pipe", the frontend transparently restarts the Claude subprocess via `start_chat` and retries the message — the user sees no interruption. (The interrupt path above never triggers this retry — the session is still alive after a stop.)
 
@@ -136,3 +136,7 @@ Session IDs are validated as lowercase UUID v4 hex strings before any file acces
 [^45]: [Claude Code CLI reference — --include-partial-messages](https://code.claude.com/docs/en/cli-reference)
 
 [^46]: [Claude Agent SDK — Streaming vs Single Mode, input message format](https://platform.claude.com/docs/en/agent-sdk/streaming-vs-single-mode)
+
+[^47]: [claude-agent-sdk-python — SDKControlInterruptRequest in types.py](https://github.com/anthropics/claude-agent-sdk-python/blob/main/src/claude_agent_sdk/types.py)
+
+[^48]: [claude-agent-sdk-python — interrupt() emits result with subtype "error_during_execution"](https://github.com/anthropics/claude-agent-sdk-python/blob/main/src/claude_agent_sdk/client.py)

--- a/docs/guides/desktop.md
+++ b/docs/guides/desktop.md
@@ -75,6 +75,10 @@ claude-opus-4-6[1m] │ CTX ██░░░ 2% │ Limit ░░░░░ 30% res
 
 **Context window size.** Read from `modelUsage.<model>.contextWindow` — typically `200000` for base models and `1000000` for `[1m]` extended-context variants. Defaults to `200000` if absent.
 
+### Stopping a conversation
+
+While Claude is responding, press **Esc** or click the red **Stop** button next to the message input to interrupt the current turn. The partial response is preserved in the conversation history, in-flight tools are stopped, and the input is immediately re-enabled so you can send the next message. **Esc is ignored while an "ask user" question is visible** — answer or dismiss that prompt first; the Stop button still works in that case and will drop the question.
+
 ## System Tray
 
 <!-- Content to be written: macOS/Windows click-toggle, Linux menu-only, libappindicator requirement -->


### PR DESCRIPTION
## Summary

While Claude is responding, pressing **Esc** or clicking the red **Stop** button interrupts the current turn. The partial response is preserved, in-flight `ask_user` blocks are dropped, and the input is immediately re-enabled — and **continues the same conversation**, not a fresh session.

Backend uses Claude Code's stream-json `control_request` with `subtype: "interrupt"` (matching `SDKControlInterruptRequest` in claude-agent-sdk-python). Killing the host-side `nerdctl exec` would not propagate any signal into the container, so the protocol-level interrupt is the only reliable cancel mechanism — and it leaves the Claude subprocess, MCP hub, and conversation history intact.

## Changes

- **Rust:** `ChatSession::interrupt()` writes a `control_request` to stdin, guarded by `child.try_wait()` (matches `send_message`/`answer_question`), with `log::error!` on write failure
- **Rust:** `stop_chat` Tauri command (`spawn_blocking`) delegates to `interrupt()`
- **Rust:** payload + request-id helpers extracted (`build_interrupt_payload`, `next_interrupt_request_id`, `write_interrupt`) so tests assert real bytes against an in-memory writer
- **Rust:** stream-json protocol literals lifted to constants (`MSG_TYPE_CONTROL_REQUEST`, `CTRL_SUBTYPE_INTERRUPT`) alongside `ASK_USER_TOOL_NAME`; `"stdin not available"` unified to `"no active session"`
- **Angular:** `ChatStateService.stopConversation()` — increments turnId, drops `ask_user` blocks, commits partial response, invokes `stop_chat`; on backend failure surfaces a *"Stop failed"* error block (suppresses benign *"no active session"*)
- **Angular:** `setupStreamListener` gates content chunks on `isStreaming` + `turnId` so late Tauri events from a stopped turn are discarded
- **Angular:** Stop/Send button swap (`@if chat.isStreaming`), Esc `HostListener` (ignored when an unanswered `ask_user` block is visible)
- **CSS:** `--color-sw-destructive` / `--color-sw-destructive-hover` tokens
- **Docs:** ADR-006 documents the `stop_chat` protocol flow

## Test plan

- [x] Rust unit tests: 104 chat tests pass, including `stop_clears_pending_requests`, `stop_is_idempotent_when_no_session_running`, `second_session_can_be_created_after_stop`, `write_interrupt_emits_single_ndjson_line`, `write_interrupt_propagates_io_errors`
- [x] Angular unit tests: 123 chat tests pass (`chat.component.spec.ts`, `chat-state.service.spec.ts`)
- [ ] Manual: long-running prompt → press Esc mid-stream → verify partial response preserved, input re-enabled, next message continues same session
- [ ] Manual: long-running prompt → click Stop button → same as above
- [ ] Manual: pending `ask_user` block visible → press Esc → verify Esc is ignored (block stays)