### PR TITLE
feat(runtime): add Playwright browser automation as built-in MCP service

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -25,6 +25,7 @@ export default {
         'mcp-sharepoint',
         'mcp-redmine',
         'mcp-gitlab',
+        'mcp-playwright',
         'mcp-os',
         'containers',
         'ci',

--- a/containers/claude-resources/skills/playwright-browser/SKILL.md
+++ b/containers/claude-resources/skills/playwright-browser/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: playwright-browser
+description: Browse the web, take screenshots, and interact with pages using Playwright. Triggers on "screenshot", "open page", "browse", "navigate to", "take a screenshot", "full-page screenshot", "check website".
+user-invocable: false
+model: sonnet
+---
+
+# Playwright Browser Automation
+
+You have access to a headless Chromium browser via the `playwright` service in `execute_code`. The browser runs in a hardened container — no filesystem sharing with your workspace.
+
+## Key rules
+
+1. **Screenshots return inline as base64** — they come back as multi-content `[{type:"text",...}, {type:"image", data:"<base64>", mimeType:"image/jpeg"}]`. The `filename` parameter tells Playwright where to write inside its container; you receive the image data directly in the response. Do NOT attempt to access `/tmp/playwright-mcp-output/` as a path in your workspace — it exists only inside the Playwright container.
+
+2. **Always use `browserNavigate` for navigation**, not `browserRunCode`. It's simpler and more reliable.
+
+3. **Always save screenshots to `/tmp/playwright-mcp-output/`** — the only writable path Playwright allows. Example: `filename: "/tmp/playwright-mcp-output/screenshot.jpeg"`
+
+4. **Prefer viewport screenshots over full-page** — full-page (`fullPage: true`) crashes Chromium on heavy pages (news sites, pages with many ads/iframes). Use viewport screenshots by default. Only use `fullPage: true` on simple/lightweight pages when the user explicitly asks.
+
+5. **Use JPEG format** — smaller than PNG, sufficient for most use cases. Set `type: "jpeg"`.
+
+6. **After a crash ("Target crashed" or "Target page, context or browser has been closed")** — call `browserClose({})` first to reset the browser state, then retry with `browserNavigate`.
+
+7. **Handle cookie/consent popups** — many sites show GDPR consent dialogs. After navigating, use `browserSnapshot` to check the page state, then `browserClick` to accept if needed.
+
+## Workflow: Take a screenshot
+
+```javascript
+// Step 1: Navigate
+await playwright.browserNavigate({ url: 'https://example.com' });
+
+// Step 2: Screenshot (viewport)
+const result = await playwright.browserTakeScreenshot({
+  type: 'jpeg',
+  filename: '/tmp/playwright-mcp-output/page.jpeg',
+});
+
+// result is already the image data — return it directly
+return result;
+```
+
+## Workflow: Full-page screenshot (lightweight pages only)
+
+```javascript
+await playwright.browserNavigate({ url: 'https://example.com' });
+
+const result = await playwright.browserTakeScreenshot({
+  type: 'jpeg',
+  filename: '/tmp/playwright-mcp-output/page-full.jpeg',
+  fullPage: true,
+});
+
+return result;
+```
+
+## Workflow: Recover from crash
+
+```javascript
+// Reset browser
+await playwright.browserClose({});
+
+// Fresh navigation
+await playwright.browserNavigate({ url: 'https://example.com' });
+
+// Continue with screenshot or other actions
+```
+
+## Available tools (most common)
+
+| Tool                    | Purpose                                                 |
+| ----------------------- | ------------------------------------------------------- |
+| `browserNavigate`       | Go to URL                                               |
+| `browserTakeScreenshot` | Screenshot (viewport or full-page)                      |
+| `browserSnapshot`       | Accessibility tree (for finding elements to click)      |
+| `browserClick`          | Click an element (needs ref from snapshot)              |
+| `browserType`           | Type text into a field                                  |
+| `browserClose`          | Close page / reset browser                              |
+| `browserTabs`           | Manage tabs (new, close, list, select)                  |
+| `browserRunCode`        | Run arbitrary Playwright code (advanced, use sparingly) |
+| `browserEvaluate`       | Run JS in page context                                  |

--- a/containers/compose.template.yml
+++ b/containers/compose.template.yml
@@ -57,6 +57,7 @@ services:
       - WORKER_SHAREPOINT_URL=http://mcp-sharepoint:${PORT_WORKER}
       - WORKER_REDMINE_URL=http://mcp-redmine:${PORT_WORKER}
       - WORKER_GITLAB_URL=http://mcp-gitlab:${PORT_WORKER}
+      - WORKER_PLAYWRIGHT_URL=http://mcp-playwright:${PORT_WORKER}
     networks:
       - ${NETWORK_NAME}
     deploy:
@@ -163,6 +164,42 @@ services:
         limits:
           cpus: '0.5'
           memory: 128m
+
+  mcp-playwright:
+    image: ${IMAGE_MCP_PLAYWRIGHT}
+    pull_policy: never
+    container_name: ${COMPOSE_PREFIX}_${PROJECT_NAME}_mcp_playwright
+    read_only: true
+    # NOTE: Playwright image pre-creates pwuser (UID 1000); CONTAINER_USER is set
+    # via substitution for consistency with other workers.
+    user: "${CONTAINER_USER}"
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    # Chromium uses /tmp for page caches and screenshot compositing.
+    # tmpfs lives in RAM — keep it lean. Heavy screenshots return inline
+    # as base64, not via /tmp.
+    tmpfs:
+      - /tmp:noexec,nosuid,size=1g
+    # Chromium IPC shared-memory requirement; the 64 MiB default causes ENOMEM
+    # at page load time.
+    shm_size: 2g
+    # No /tokens mount — Playwright accesses only public URLs and has no credentials.
+    # No /workspace mount in v1 — outputs return as base64 to shrink attack surface.
+    environment:
+      - PORT=${PORT_WORKER}
+      # Enable MCP-level request/response logging (uses the `debug` npm package;
+      # output goes to stderr, captured by `nerdctl logs`). Covers every
+      # tools/call, tool responses, and errors. Set to `pw:*` for full verbosity.
+      - DEBUG=pw:mcp:*
+    networks:
+      - ${NETWORK_NAME}
+    deploy:
+      resources:
+        limits:
+          cpus: '2.0'
+          memory: 2048m
 
 networks:
   ${NETWORK_NAME}:

--- a/containers/compose.template.yml
+++ b/containers/compose.template.yml
@@ -189,9 +189,9 @@ services:
     # No /workspace mount in v1 — outputs return as base64 to shrink attack surface.
     environment:
       - PORT=${PORT_WORKER}
-      # Enable MCP-level request/response logging (uses the `debug` npm package;
-      # output goes to stderr, captured by `nerdctl logs`). Covers every
-      # tools/call, tool responses, and errors. Set to `pw:*` for full verbosity.
+      # MCP-level request/response logging (uses the `debug` npm package;
+      # output goes to stderr, visible in Desktop UI → System Health logs).
+      # Covers tools/call, tool responses, and errors. Set to `pw:*` for full verbosity.
       - DEBUG=pw:mcp:*
     networks:
       - ${NETWORK_NAME}

--- a/crates/speedwave-runtime/src/build.rs
+++ b/crates/speedwave-runtime/src/build.rs
@@ -25,6 +25,7 @@ pub const IMAGE_MCP_SLACK: &str = "speedwave-mcp-slack";
 pub const IMAGE_MCP_SHAREPOINT: &str = "speedwave-mcp-sharepoint";
 pub const IMAGE_MCP_REDMINE: &str = "speedwave-mcp-redmine";
 pub const IMAGE_MCP_GITLAB: &str = "speedwave-mcp-gitlab";
+pub const IMAGE_MCP_PLAYWRIGHT: &str = "speedwave-mcp-playwright";
 
 pub const IMAGES: &[ImageDef] = &[
     ImageDef {
@@ -61,6 +62,12 @@ pub const IMAGES: &[ImageDef] = &[
         name: IMAGE_MCP_GITLAB,
         context_dir: "mcp-servers",
         containerfile: "mcp-servers/gitlab/Dockerfile",
+        build_args: &[],
+    },
+    ImageDef {
+        name: IMAGE_MCP_PLAYWRIGHT,
+        context_dir: "mcp-servers",
+        containerfile: "mcp-servers/playwright/Containerfile",
         build_args: &[],
     },
 ];
@@ -1022,7 +1029,7 @@ mod tests {
 
     #[test]
     fn test_images_count() {
-        assert_eq!(IMAGES.len(), 6);
+        assert_eq!(IMAGES.len(), 7);
     }
 
     #[test]

--- a/crates/speedwave-runtime/src/compose.rs
+++ b/crates/speedwave-runtime/src/compose.rs
@@ -90,6 +90,10 @@ pub fn render_compose(
         "${IMAGE_MCP_GITLAB}",
         &build::image_ref(build::IMAGE_MCP_GITLAB, &bundle_manifest.bundle_id),
     );
+    yaml = yaml.replace(
+        "${IMAGE_MCP_PLAYWRIGHT}",
+        &build::image_ref(build::IMAGE_MCP_PLAYWRIGHT, &bundle_manifest.bundle_id),
+    );
 
     // Bridge writes lock files directly to ~/.speedwave/ide-bridge/
     // Mount it as /home/speedwave/.claude/ide/ — no copying needed.
@@ -2218,6 +2222,7 @@ services:
       - WORKER_SHAREPOINT_URL=http://mcp-sharepoint:3000
       - WORKER_REDMINE_URL=http://mcp-redmine:3000
       - WORKER_GITLAB_URL=http://mcp-gitlab:3000
+      - WORKER_PLAYWRIGHT_URL=http://mcp-playwright:3000
     networks:
       - speedwave_test_network
 
@@ -2231,6 +2236,23 @@ services:
       - no-new-privileges:true
     volumes:
       - /home/user/.speedwave/tokens/test/slack:/tokens:ro
+    environment:
+      - PORT=3000
+    networks:
+      - speedwave_test_network
+
+  mcp-playwright:
+    image: speedwave-mcp-playwright:latest
+    container_name: speedwave_test_mcp_playwright
+    read_only: true
+    user: "1000:1000"
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /tmp:noexec,nosuid,size=1g
+    shm_size: 2g
     environment:
       - PORT=3000
     networks:
@@ -2553,6 +2575,203 @@ services:
                 .filter(|l| l.contains("/workspace"))
                 .collect::<Vec<_>>()
                 .join("\n")
+        );
+    }
+
+    /// mcp-playwright appears in a rendered compose when the toggle is enabled,
+    /// carries the hardening profile (cap_drop: ALL, read_only, no-new-privileges,
+    /// shm_size: 2g), and has `PORT=PORT_WORKER`.
+    #[test]
+    fn test_render_compose_playwright_service_present() {
+        let config = ResolvedClaudeConfig {
+            env: crate::defaults::base_env(),
+            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            llm: LlmConfig::default(),
+        };
+        let integrations = ResolvedIntegrationsConfig {
+            playwright: true,
+            ..Default::default()
+        };
+        let yaml = render_compose(
+            "test-project",
+            "/home/user/projects/test",
+            &config,
+            &integrations,
+            None,
+        )
+        .unwrap();
+
+        let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(&yaml).unwrap();
+        let pw = doc
+            .get("services")
+            .and_then(|s| s.get("mcp-playwright"))
+            .expect("mcp-playwright service must be present when enabled");
+
+        assert!(
+            pw.get("read_only")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false),
+            "mcp-playwright must set read_only: true"
+        );
+        assert_eq!(
+            pw.get("shm_size").and_then(|v| v.as_str()),
+            Some("2g"),
+            "mcp-playwright must set shm_size: 2g for Chromium IPC"
+        );
+        let cap_drop = pw
+            .get("cap_drop")
+            .and_then(|v| v.as_sequence())
+            .expect("cap_drop must be present");
+        assert!(cap_drop.iter().any(|c| c.as_str() == Some("ALL")));
+        let sec_opt = pw
+            .get("security_opt")
+            .and_then(|v| v.as_sequence())
+            .expect("security_opt must be present");
+        assert!(sec_opt
+            .iter()
+            .any(|s| s.as_str() == Some("no-new-privileges:true")));
+        let env = pw
+            .get("environment")
+            .and_then(|e| e.as_sequence())
+            .expect("environment must be present");
+        let port_line = format!("PORT={}", crate::consts::PORT_WORKER);
+        assert!(
+            env.iter().any(|v| v.as_str() == Some(port_line.as_str())),
+            "mcp-playwright must set PORT={}",
+            crate::consts::PORT_WORKER
+        );
+    }
+
+    /// mcp-playwright has no credentials — the generated compose must not mount
+    /// any `/tokens` volume (attack-surface reduction per ADR).
+    #[test]
+    fn test_render_compose_playwright_no_token_mount() {
+        let config = ResolvedClaudeConfig {
+            env: crate::defaults::base_env(),
+            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            llm: LlmConfig::default(),
+        };
+        let integrations = ResolvedIntegrationsConfig {
+            playwright: true,
+            ..Default::default()
+        };
+        let yaml = render_compose(
+            "test-project",
+            "/home/user/projects/test",
+            &config,
+            &integrations,
+            None,
+        )
+        .unwrap();
+
+        let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(&yaml).unwrap();
+        let pw = doc
+            .get("services")
+            .and_then(|s| s.get("mcp-playwright"))
+            .expect("mcp-playwright must be present");
+
+        // Playwright block has no `volumes:` key at all.
+        assert!(
+            pw.get("volumes").is_none(),
+            "mcp-playwright must not declare any volumes; got: {:?}",
+            pw.get("volumes")
+        );
+    }
+
+    /// v1 explicitly refuses the `/workspace` mount — outputs return as base64
+    /// so a compromised Chromium cannot exfiltrate repo contents.
+    #[test]
+    fn test_render_compose_playwright_no_workspace_mount() {
+        let config = ResolvedClaudeConfig {
+            env: crate::defaults::base_env(),
+            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            llm: LlmConfig::default(),
+        };
+        let integrations = ResolvedIntegrationsConfig {
+            playwright: true,
+            ..Default::default()
+        };
+        let yaml = render_compose(
+            "test-project",
+            "/home/user/projects/test",
+            &config,
+            &integrations,
+            None,
+        )
+        .unwrap();
+
+        // Scan the mcp-playwright block specifically rather than the whole
+        // document — claude and mcp-sharepoint legitimately mount /workspace.
+        let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(&yaml).unwrap();
+        let pw_yaml = serde_yaml_ng::to_string(
+            doc.get("services")
+                .and_then(|s| s.get("mcp-playwright"))
+                .expect("mcp-playwright must be present"),
+        )
+        .unwrap();
+        assert!(
+            !pw_yaml.contains("/workspace"),
+            "mcp-playwright must not mount /workspace in v1; got block:\n{pw_yaml}"
+        );
+    }
+
+    /// Hub must know where to reach the Playwright worker. The URL is injected
+    /// from the compose template and must point at `:PORT_WORKER`.
+    #[test]
+    fn test_playwright_worker_url_in_hub_env() {
+        let config = ResolvedClaudeConfig {
+            env: crate::defaults::base_env(),
+            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            llm: LlmConfig::default(),
+        };
+        let integrations = ResolvedIntegrationsConfig {
+            playwright: true,
+            ..Default::default()
+        };
+        let yaml = render_compose(
+            "test-project",
+            "/home/user/projects/test",
+            &config,
+            &integrations,
+            None,
+        )
+        .unwrap();
+
+        let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(&yaml).unwrap();
+        let hub_env = get_hub_env_seq(&doc);
+        let expected = format!(
+            "WORKER_PLAYWRIGHT_URL=http://mcp-playwright:{}",
+            crate::consts::PORT_WORKER
+        );
+        assert!(
+            hub_env.iter().any(|s| s == &expected),
+            "hub must have '{expected}' in environment; got: {hub_env:?}"
+        );
+    }
+
+    /// Disabling the Playwright toggle must remove both the service block and
+    /// the WORKER_PLAYWRIGHT_URL hub env entry.
+    #[test]
+    fn test_apply_integrations_filter_disables_playwright() {
+        let mut integrations = ResolvedIntegrationsConfig::default();
+        integrations.playwright = false;
+
+        let filtered = apply_integrations_filter(VALID_COMPOSE, &integrations).unwrap();
+        let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(&filtered).unwrap();
+
+        let services = doc.get("services").and_then(|s| s.as_mapping()).unwrap();
+        assert!(
+            !services.contains_key(&serde_yaml_ng::Value::String("mcp-playwright".into())),
+            "mcp-playwright must be removed when disabled"
+        );
+
+        let hub_env = get_hub_env_seq(&doc);
+        let has_pw_url = hub_env
+            .iter()
+            .any(|s| s.starts_with("WORKER_PLAYWRIGHT_URL="));
+        assert!(
+            !has_pw_url,
+            "WORKER_PLAYWRIGHT_URL must be removed from hub env when disabled; got: {hub_env:?}"
         );
     }
 
@@ -4464,6 +4683,7 @@ services:
             sharepoint: true,
             redmine: true,
             gitlab: true,
+            playwright: true,
             ..ResolvedIntegrationsConfig::default()
         };
         let result =
@@ -5374,6 +5594,7 @@ services:
       - WORKER_SHAREPOINT_URL=http://mcp-sharepoint:3000
       - WORKER_REDMINE_URL=http://mcp-redmine:3000
       - WORKER_GITLAB_URL=http://mcp-gitlab:3000
+      - WORKER_PLAYWRIGHT_URL=http://mcp-playwright:3000
     networks:
       - speedwave_test_network
 
@@ -5438,6 +5659,23 @@ services:
     networks:
       - speedwave_test_network
 
+  mcp-playwright:
+    image: speedwave-mcp-playwright:latest
+    container_name: speedwave_test_mcp_playwright
+    read_only: true
+    user: "1000:1000"
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /tmp:noexec,nosuid,size=1g
+    shm_size: 2g
+    environment:
+      - PORT=3000
+    networks:
+      - speedwave_test_network
+
 networks:
   speedwave_test_network:
     driver: bridge
@@ -5449,6 +5687,7 @@ networks:
             sharepoint: true,
             redmine: true,
             gitlab: true,
+            playwright: true,
             ..Default::default()
         }
     }

--- a/crates/speedwave-runtime/src/config.rs
+++ b/crates/speedwave-runtime/src/config.rs
@@ -53,6 +53,7 @@ pub struct IntegrationsConfig {
     pub sharepoint: Option<IntegrationConfig>,
     pub redmine: Option<IntegrationConfig>,
     pub gitlab: Option<IntegrationConfig>,
+    pub playwright: Option<IntegrationConfig>,
     pub os: Option<OsIntegrationsConfig>,
     #[serde(default)]
     pub plugins: Option<HashMap<String, IntegrationConfig>>,
@@ -67,6 +68,7 @@ impl IntegrationsConfig {
             "sharepoint" => self.sharepoint = Some(cfg),
             "redmine" => self.redmine = Some(cfg),
             "gitlab" => self.gitlab = Some(cfg),
+            "playwright" => self.playwright = Some(cfg),
             _ => return false,
         }
         true
@@ -92,6 +94,7 @@ pub struct ResolvedIntegrationsConfig {
     pub sharepoint: bool,
     pub redmine: bool,
     pub gitlab: bool,
+    pub playwright: bool,
     pub os_reminders: bool,
     pub os_calendar: bool,
     pub os_mail: bool,
@@ -110,6 +113,7 @@ impl ResolvedIntegrationsConfig {
             "sharepoint" => Some(self.sharepoint),
             "redmine" => Some(self.redmine),
             "gitlab" => Some(self.gitlab),
+            "playwright" => Some(self.playwright),
             _ => None,
         }
     }
@@ -279,6 +283,7 @@ fn apply_integrations_layer(result: &mut ResolvedIntegrationsConfig, layer: &Int
     apply_toggle(&mut result.sharepoint, &layer.sharepoint);
     apply_toggle(&mut result.redmine, &layer.redmine);
     apply_toggle(&mut result.gitlab, &layer.gitlab);
+    apply_toggle(&mut result.playwright, &layer.playwright);
     if let Some(ref os) = layer.os {
         apply_toggle(&mut result.os_reminders, &os.reminders);
         apply_toggle(&mut result.os_calendar, &os.calendar);
@@ -738,6 +743,7 @@ mod tests {
         assert!(!r.sharepoint, "sharepoint should be disabled");
         assert!(!r.redmine, "redmine should be disabled");
         assert!(!r.gitlab, "gitlab should be disabled");
+        assert!(!r.playwright, "playwright should be disabled");
         assert!(!r.os_reminders, "os_reminders should be disabled");
         assert!(!r.os_calendar, "os_calendar should be disabled");
         assert!(!r.os_mail, "os_mail should be disabled");
@@ -748,6 +754,128 @@ mod tests {
     fn test_default_integrations_all_disabled() {
         let resolved = ResolvedIntegrationsConfig::default();
         assert_all_integrations_disabled(&resolved);
+    }
+
+    /// Regression guard: `apply_integrations_layer` must propagate *every*
+    /// service listed in `TOGGLEABLE_MCP_SERVICES` to the resolved config.
+    /// If a new descriptor is added to `consts::TOGGLEABLE_MCP_SERVICES` but
+    /// its corresponding `apply_toggle` call is forgotten in
+    /// `apply_integrations_layer`, the toggle gets saved to disk but is
+    /// silently ignored at compose-render time — the exact bug that hit
+    /// Playwright in PR2.
+    #[test]
+    fn test_apply_integrations_layer_propagates_every_toggleable_service() {
+        for svc in crate::consts::TOGGLEABLE_MCP_SERVICES {
+            let mut layer = IntegrationsConfig::default();
+            assert!(
+                layer.set_service(
+                    svc.config_key,
+                    IntegrationConfig {
+                        enabled: Some(true),
+                    }
+                ),
+                "IntegrationsConfig::set_service does not know '{}'",
+                svc.config_key
+            );
+
+            let mut resolved = ResolvedIntegrationsConfig::default();
+            apply_integrations_layer(&mut resolved, &layer);
+
+            let enabled = resolved
+                .is_service_enabled(svc.config_key)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "ResolvedIntegrationsConfig::is_service_enabled returns None for '{}'",
+                        svc.config_key
+                    )
+                });
+            assert!(
+                enabled,
+                "apply_integrations_layer did not propagate '{}' → compose emitter will skip it",
+                svc.config_key
+            );
+        }
+    }
+
+    /// Upgrade path: a user on an older Speedwave version has a `config.json`
+    /// that pre-dates the `playwright` field. After update, deserializing that
+    /// config must still succeed (with `playwright: None`), the UI toggle must
+    /// be able to flip it to enabled, and the save → load round-trip must
+    /// preserve the new value.
+    ///
+    /// If this test breaks, every existing user loses their config on upgrade
+    /// — a silent regression.
+    #[test]
+    fn test_existing_user_config_accepts_new_integration() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_path = tmp.path().join("config.json");
+
+        // Simulate an on-disk config written by an older Speedwave that had no
+        // `playwright` field. Only slack is configured.
+        let legacy_json = r#"{
+            "projects": [
+                {
+                    "name": "acme-corp",
+                    "dir": "/Users/user/projects/acme-corp",
+                    "claude": null,
+                    "integrations": {
+                        "slack": {"enabled": true},
+                        "redmine": {"enabled": false},
+                        "os": null
+                    },
+                    "plugin_settings": null
+                }
+            ],
+            "active_project": "acme-corp",
+            "selected_ide": null,
+            "log_level": null
+        }"#;
+        std::fs::write(&config_path, legacy_json).unwrap();
+
+        // Loading must not fail even though `playwright` is absent.
+        let mut cfg = load_user_config_from(&config_path).unwrap();
+        let project = cfg.find_project_mut("acme-corp").unwrap();
+        let integrations = project.integrations.as_ref().unwrap();
+        assert!(integrations.playwright.is_none());
+        // Existing fields preserved:
+        assert_eq!(
+            integrations.slack.as_ref().unwrap().enabled,
+            Some(true),
+            "legacy slack setting must survive deserialisation"
+        );
+
+        // UI enables Playwright for this project.
+        let integrations = project.integrations.as_mut().unwrap();
+        assert!(integrations.set_service(
+            "playwright",
+            IntegrationConfig {
+                enabled: Some(true),
+            },
+        ));
+
+        // Persist and reload.
+        save_user_config_to(&cfg, &config_path).unwrap();
+        let reloaded = load_user_config_from(&config_path).unwrap();
+        let reloaded_integrations = reloaded
+            .find_project("acme-corp")
+            .unwrap()
+            .integrations
+            .as_ref()
+            .unwrap();
+
+        assert_eq!(
+            reloaded_integrations
+                .playwright
+                .as_ref()
+                .and_then(|c| c.enabled),
+            Some(true),
+            "playwright toggle must persist after upgrade → enable → save → reload"
+        );
+        assert_eq!(
+            reloaded_integrations.slack.as_ref().unwrap().enabled,
+            Some(true),
+            "existing slack setting must still be present after save"
+        );
     }
 
     #[test]
@@ -761,6 +889,7 @@ mod tests {
                 enabled: Some(true),
             }),
             gitlab: None,
+            playwright: None,
             os: Some(OsIntegrationsConfig {
                 reminders: Some(IntegrationConfig {
                     enabled: Some(false),
@@ -814,6 +943,7 @@ mod tests {
                     sharepoint: None,
                     redmine: None,
                     gitlab: None,
+                    playwright: None,
                     os: None,
                     plugins: None,
                 }),
@@ -842,6 +972,7 @@ mod tests {
                     sharepoint: None,
                     redmine: None,
                     gitlab: None,
+                    playwright: None,
                     os: Some(OsIntegrationsConfig {
                         reminders: Some(IntegrationConfig {
                             enabled: Some(false),
@@ -883,6 +1014,7 @@ mod tests {
                     sharepoint: None,
                     redmine: None,
                     gitlab: None,
+                    playwright: None,
                     os: None,
                     plugins: None,
                 }),
@@ -1144,6 +1276,7 @@ mod tests {
                     sharepoint: None,
                     redmine: None,
                     gitlab: None,
+                    playwright: None,
                     os: None,
                     plugins: Some(HashMap::from([(
                         "presale".to_string(),

--- a/crates/speedwave-runtime/src/consts.rs
+++ b/crates/speedwave-runtime/src/consts.rs
@@ -236,6 +236,8 @@ pub struct McpServiceDescriptor {
     /// Credential file names allowed for this service (superset of auth field keys,
     /// may include extra files like "config.json").
     pub credential_files: &'static [&'static str],
+    /// Optional UI badge label (e.g. "BETA", "NEW"). `None` = no badge.
+    pub badge: Option<&'static str>,
 }
 
 /// Toggleable MCP services — Single Source of Truth for service metadata.
@@ -270,6 +272,7 @@ pub const TOGGLEABLE_MCP_SERVICES: &[McpServiceDescriptor] = &[
             },
         ],
         credential_files: &["bot_token", "user_token"],
+        badge: None,
     },
     McpServiceDescriptor {
         config_key: "sharepoint",
@@ -347,6 +350,7 @@ pub const TOGGLEABLE_MCP_SERVICES: &[McpServiceDescriptor] = &[
             "site_id",
             "base_path",
         ],
+        badge: None,
     },
     McpServiceDescriptor {
         config_key: "redmine",
@@ -393,6 +397,7 @@ pub const TOGGLEABLE_MCP_SERVICES: &[McpServiceDescriptor] = &[
             "project_id",
             "project_name",
         ],
+        badge: None,
     },
     McpServiceDescriptor {
         config_key: "gitlab",
@@ -423,6 +428,7 @@ pub const TOGGLEABLE_MCP_SERVICES: &[McpServiceDescriptor] = &[
             },
         ],
         credential_files: &["token", "host_url"],
+        badge: None,
     },
     McpServiceDescriptor {
         config_key: "playwright",
@@ -433,6 +439,7 @@ pub const TOGGLEABLE_MCP_SERVICES: &[McpServiceDescriptor] = &[
         // Playwright has no credentials — it scrapes public URLs only.
         auth_fields: &[],
         credential_files: &[],
+        badge: Some("BETA"),
     },
 ];
 

--- a/crates/speedwave-runtime/src/consts.rs
+++ b/crates/speedwave-runtime/src/consts.rs
@@ -424,6 +424,16 @@ pub const TOGGLEABLE_MCP_SERVICES: &[McpServiceDescriptor] = &[
         ],
         credential_files: &["token", "host_url"],
     },
+    McpServiceDescriptor {
+        config_key: "playwright",
+        compose_name: "mcp-playwright",
+        worker_env: "WORKER_PLAYWRIGHT_URL",
+        display_name: "Playwright",
+        description: "Headless browser automation (Chromium via Playwright)",
+        // Playwright has no credentials — it scrapes public URLs only.
+        auth_fields: &[],
+        credential_files: &[],
+    },
 ];
 
 /// Descriptor for a toggleable OS integration service (macOS only).
@@ -494,11 +504,19 @@ pub const BUILT_IN_SERVICES: &[&str] = &[
     "mcp-sharepoint",
     "mcp-redmine",
     "mcp-gitlab",
+    "mcp-playwright",
 ];
 
 /// Built-in service IDs (logical names, not compose names).
 /// Used by plugin install to prevent slug collisions.
-pub const BUILT_IN_SERVICE_IDS: &[&str] = &["slack", "sharepoint", "redmine", "gitlab", "os"];
+pub const BUILT_IN_SERVICE_IDS: &[&str] = &[
+    "slack",
+    "sharepoint",
+    "redmine",
+    "gitlab",
+    "playwright",
+    "os",
+];
 
 /// Pure, testable function for resolving the data directory.
 /// `env_val` = None or empty string → `home.join(DATA_DIR)` (empty string treated as unset)
@@ -687,12 +705,13 @@ mod tests {
         let resolved = crate::config::ResolvedIntegrationsConfig::default();
         // Explicit field enumeration — update this when adding/removing MCP fields.
         // Using a const to force a compile-time reminder when struct changes.
-        const EXPECTED_MCP_FIELDS: usize = 4; // slack, sharepoint, redmine, gitlab
+        const EXPECTED_MCP_FIELDS: usize = 5; // slack, sharepoint, redmine, gitlab, playwright
         let _ = (
             resolved.slack,
             resolved.sharepoint,
             resolved.redmine,
             resolved.gitlab,
+            resolved.playwright,
         );
         assert_eq!(
             TOGGLEABLE_MCP_SERVICES.len(),
@@ -761,6 +780,7 @@ mod tests {
             ("sharepoint", 6),
             ("redmine", 3),
             ("gitlab", 2),
+            ("playwright", 0),
         ];
         for &(key, count) in expected {
             let svc =
@@ -776,9 +796,24 @@ mod tests {
         }
     }
 
+    /// Services that intentionally have no credentials — they access only
+    /// public resources (e.g. Playwright scrapes public URLs). Kept as a
+    /// small explicit allowlist so forgetting to declare auth for a new
+    /// service that actually needs it still fails this test.
+    const CREDENTIAL_LESS_SERVICES: &[&str] = &["playwright"];
+
     #[test]
     fn test_every_service_has_auth_fields() {
         for svc in TOGGLEABLE_MCP_SERVICES {
+            if CREDENTIAL_LESS_SERVICES.contains(&svc.config_key) {
+                assert!(
+                    svc.auth_fields.is_empty(),
+                    "service '{}' is in CREDENTIAL_LESS_SERVICES but declares auth fields — \
+                     move it out of the allowlist or remove the fields",
+                    svc.config_key
+                );
+                continue;
+            }
             assert!(
                 !svc.auth_fields.is_empty(),
                 "service '{}' must have at least one auth field",
@@ -790,6 +825,14 @@ mod tests {
     #[test]
     fn test_every_service_has_credential_files() {
         for svc in TOGGLEABLE_MCP_SERVICES {
+            if CREDENTIAL_LESS_SERVICES.contains(&svc.config_key) {
+                assert!(
+                    svc.credential_files.is_empty(),
+                    "service '{}' is in CREDENTIAL_LESS_SERVICES but declares credential files",
+                    svc.config_key
+                );
+                continue;
+            }
             assert!(
                 !svc.credential_files.is_empty(),
                 "service '{}' must have at least one credential file",

--- a/crates/speedwave-runtime/src/consts.rs
+++ b/crates/speedwave-runtime/src/consts.rs
@@ -1293,4 +1293,23 @@ mod tests {
             "LIMA_VM_STOP_TIMEOUT_SECS must be positive"
         );
     }
+
+    #[test]
+    fn test_playwright_has_beta_badge() {
+        let svc = find_mcp_service("playwright").expect("playwright service must exist");
+        assert_eq!(svc.badge, Some("BETA"));
+    }
+
+    #[test]
+    fn test_credential_services_have_no_badge() {
+        for svc in TOGGLEABLE_MCP_SERVICES {
+            if !svc.auth_fields.is_empty() {
+                assert_eq!(
+                    svc.badge, None,
+                    "service '{}' with credentials should not have a badge",
+                    svc.config_key
+                );
+            }
+        }
+    }
 }

--- a/desktop/src-tauri/src/integrations_cmd.rs
+++ b/desktop/src-tauri/src/integrations_cmd.rs
@@ -232,8 +232,10 @@ pub(crate) fn is_service_configured(project: &str, service: &str) -> bool {
         Some(d) => d,
         None => return false,
     };
+    // Services with no auth fields have nothing to configure — they're
+    // always "configured" (e.g. Playwright scrapes public URLs).
     if svc_desc.auth_fields.is_empty() {
-        return false;
+        return true;
     }
     let svc_token_dir = speedwave_runtime::consts::data_dir()
         .join("tokens")
@@ -275,8 +277,10 @@ fn is_service_configured_with_home(home: &std::path::Path, project: &str, servic
         Some(d) => d,
         None => return false,
     };
+    // Services with no auth fields have nothing to configure — they're
+    // always "configured" (e.g. Playwright scrapes public URLs).
     if svc_desc.auth_fields.is_empty() {
-        return false;
+        return true;
     }
     let svc_token_dir = home
         .join(speedwave_runtime::consts::DATA_DIR)
@@ -1105,6 +1109,17 @@ mod tests {
         assert!(
             !is_service_configured_with_home(tmp.path(), "proj", "redmine"),
             "should be false when required config.json field (host_url) is empty"
+        );
+    }
+
+    #[test]
+    fn is_service_configured_returns_true_for_credential_less_service() {
+        // Services like Playwright have no auth_fields; they scrape public URLs.
+        // They must be treated as always-configured so the UI toggle is enabled.
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(
+            is_service_configured_with_home(tmp.path(), "proj", "playwright"),
+            "credential-less service (playwright) should be always-configured"
         );
     }
 

--- a/desktop/src-tauri/src/integrations_cmd.rs
+++ b/desktop/src-tauri/src/integrations_cmd.rs
@@ -202,6 +202,7 @@ pub fn get_integrations(project: String) -> Result<IntegrationsResponse, String>
             auth_fields: auth_fields.clone(),
             current_values,
             mappings,
+            badge: svc_desc.badge.map(|b| b.to_string()),
         });
     }
 

--- a/desktop/src-tauri/src/integrations_cmd.rs
+++ b/desktop/src-tauri/src/integrations_cmd.rs
@@ -1373,6 +1373,30 @@ mod tests {
     }
 
     #[test]
+    fn badge_propagated_for_playwright() {
+        let svc_desc = speedwave_runtime::consts::find_mcp_service("playwright")
+            .expect("playwright must exist");
+        assert_eq!(
+            svc_desc.badge,
+            Some("BETA"),
+            "playwright must have BETA badge"
+        );
+    }
+
+    #[test]
+    fn badge_none_for_credential_services() {
+        for key in &["slack", "sharepoint", "redmine", "gitlab"] {
+            let svc_desc = speedwave_runtime::consts::find_mcp_service(key)
+                .unwrap_or_else(|| panic!("service '{}' must exist", key));
+            assert_eq!(
+                svc_desc.badge, None,
+                "service '{}' should have no badge",
+                key
+            );
+        }
+    }
+
+    #[test]
     fn credential_files_allowlist_covers_legacy_project_name_file() {
         // project_name was removed from auth_fields (UI no longer shows it),
         // but credential_files still includes it so delete_integration_credentials

--- a/desktop/src-tauri/src/integrations_cmd.rs
+++ b/desktop/src-tauri/src/integrations_cmd.rs
@@ -736,7 +736,7 @@ mod tests {
 
     #[test]
     fn set_service_all_known_keys() {
-        for key in &["slack", "sharepoint", "redmine", "gitlab"] {
+        for key in &["slack", "sharepoint", "redmine", "gitlab", "playwright"] {
             let mut cfg = config::IntegrationsConfig::default();
             let ic = config::IntegrationConfig {
                 enabled: Some(true),

--- a/desktop/src-tauri/src/types.rs
+++ b/desktop/src-tauri/src/types.rs
@@ -300,6 +300,19 @@ mod tests {
     fn toggleable_services_have_auth_fields() {
         for svc in speedwave_runtime::consts::TOGGLEABLE_MCP_SERVICES {
             let fields = get_auth_fields(svc.config_key);
+            // Credential-less services (e.g. Playwright) declare `auth_fields: &[]`
+            // in their descriptor; `get_auth_fields` faithfully returns an empty vec.
+            // Only fail if the descriptor says the service has auth fields but the
+            // getter returns nothing — a real bug.
+            if svc.auth_fields.is_empty() {
+                assert!(
+                    fields.is_empty(),
+                    "service '{}' has no descriptor auth_fields but get_auth_fields returned {}",
+                    svc.config_key,
+                    fields.len()
+                );
+                continue;
+            }
             assert!(
                 !fields.is_empty(),
                 "TOGGLEABLE service '{}' has no auth_fields defined",

--- a/desktop/src-tauri/src/types.rs
+++ b/desktop/src-tauri/src/types.rs
@@ -64,6 +64,7 @@ pub(crate) struct IntegrationStatusEntry {
     pub(crate) auth_fields: Vec<AuthField>,
     pub(crate) current_values: std::collections::HashMap<String, String>,
     pub(crate) mappings: Option<std::collections::HashMap<String, serde_json::Value>>,
+    pub(crate) badge: Option<String>,
 }
 
 #[derive(Serialize, Clone)]

--- a/desktop/src/src/app/integrations/service-card/service-card.component.spec.ts
+++ b/desktop/src/src/app/integrations/service-card/service-card.component.spec.ts
@@ -161,6 +161,22 @@ describe('ServiceCardComponent', () => {
     );
   });
 
+  describe('service-badge', () => {
+    it('renders badge span with text when badge is set', () => {
+      component.svc = { ...makeGitlabSvc(), badge: 'BETA' };
+      fixture.detectChanges();
+      const badgeEl = fixture.nativeElement.querySelector('[data-testid="service-badge"]');
+      expect(badgeEl).not.toBeNull();
+      expect(badgeEl.textContent.trim()).toBe('BETA');
+    });
+
+    it('does not render badge span when badge is absent', () => {
+      component.svc = { ...makeGitlabSvc(), badge: undefined };
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('[data-testid="service-badge"]')).toBeNull();
+    });
+  });
+
   it('should show configured badge when configured', () => {
     fixture.detectChanges();
     const badge = fixture.nativeElement.querySelector('[data-testid="badge"]');

--- a/desktop/src/src/app/integrations/service-card/service-card.component.ts
+++ b/desktop/src/src/app/integrations/service-card/service-card.component.ts
@@ -31,6 +31,14 @@ export interface SaveCredentialsEvent {
           <span class="font-semibold text-base" data-testid="service-name">{{
             svc.display_name
           }}</span>
+          @if (svc.badge) {
+            <span
+              class="text-[10px] px-1.5 py-0.5 rounded font-semibold uppercase tracking-wide bg-amber-500/20 text-amber-400 border border-amber-500/30"
+              data-testid="service-badge"
+            >
+              {{ svc.badge }}
+            </span>
+          }
           <span
             class="text-[11px] px-2 py-0.5 rounded font-medium"
             data-testid="badge"

--- a/desktop/src/src/app/integrations/service-card/service-card.component.ts
+++ b/desktop/src/src/app/integrations/service-card/service-card.component.ts
@@ -63,7 +63,7 @@ export interface SaveCredentialsEvent {
         {{ svc.description }}
       </p>
 
-      @if (!svc.configured && !expanded) {
+      @if (!svc.configured && !expanded && hasConfigurableFields) {
         <p
           class="px-5 pb-3 text-sw-accent text-[12px] m-0 cursor-pointer"
           data-testid="setup-hint"
@@ -77,7 +77,7 @@ export interface SaveCredentialsEvent {
         </p>
       }
 
-      @if (expanded) {
+      @if (expanded && hasConfigurableFields) {
         <div class="px-5 pb-5 border-t border-sw-border" data-testid="card-body">
           <form (submit)="onSave($event)">
             @for (field of svc.auth_fields; track field.key) {
@@ -221,6 +221,17 @@ export class ServiceCardComponent {
   @Output() openVerificationUrl = new EventEmitter<string>();
 
   editedValues: Record<string, string> = {};
+
+  /**
+   * Whether this service has anything the user can configure in the card body.
+   * Services with an empty `auth_fields` list (e.g. Playwright, which only
+   * reaches public URLs) have nothing to enter — the toggle header is the
+   * entire UI surface, so we hide the form, setup hint, and the Save / Remove
+   * Credentials buttons to avoid nonsensical empty prompts.
+   */
+  get hasConfigurableFields(): boolean {
+    return this.svc.auth_fields.length > 0;
+  }
 
   /**
    * Returns whether any auth fields use the OAuth flow.

--- a/desktop/src/src/app/models/integration.ts
+++ b/desktop/src/src/app/models/integration.ts
@@ -18,6 +18,7 @@ export interface IntegrationStatusEntry {
   auth_fields: AuthField[];
   current_values: Record<string, string>;
   mappings?: Record<string, unknown>;
+  badge?: string;
 }
 
 /** Status and configuration details for a native OS integration. */

--- a/docs/adr/ADR-039-playwright-shared-browser-service.md
+++ b/docs/adr/ADR-039-playwright-shared-browser-service.md
@@ -1,0 +1,131 @@
+# ADR-039: Playwright Shared Browser Service
+
+## Status
+
+Accepted
+
+## Context
+
+Speedwave's existing MCP workers (Slack, SharePoint, Redmine, GitLab) all require per-project credentials stored under `~/.speedwave/tokens/<project>/<service>/`. The infrastructure around those workers — `is_service_configured`, `TOGGLEABLE_MCP_SERVICES`, and the Desktop service-card UI — was designed with credential-bearing services as the only case.
+
+Adding a browser automation capability via Microsoft's `@playwright/mcp` package[^1] introduces a qualitatively different kind of service: one that accesses only public URLs and carries no credentials at all. This ADR records the three non-obvious design decisions that arose from that difference, plus the choices made for container security and transport-layer compatibility.
+
+### Why a shared service rather than a plugin
+
+Browser automation is general-purpose infrastructure, not domain-specific integration. Multiple plugins (`figma`, `accessibility-audit`, `visual-regression`, `site-analyzer`) and Claude directly all benefit from the same browser instance. Shipping it as a built-in worker keeps the image out of individual plugin ZIPs (avoiding multi-MB duplication), lets it share the compose network with all workers, and removes the need for each consumer to manage their own Chromium installation.
+
+## Decision
+
+### 1 — Credential-less service contract
+
+Playwright has no credentials: it contacts only URLs supplied at call time by Claude or a plugin. The service therefore must never receive a `/tokens` mount, must always be treated as configured (no setup wizard step), and must expose no configuration form in the Desktop UI.
+
+Four concrete changes implement this contract:
+
+**No `/tokens` mount.** The compose template entry for `mcp-playwright` has no `volumes:` stanza for credentials, unlike every other worker. This is an intentional absence documented in the template comment, not an oversight.[^2]
+
+**`is_service_configured` returns `true` for empty `auth_fields`.** The Tauri command that reports integration status short-circuits to `true` when a service descriptor has an empty `auth_fields` list.[^3] Playwright's `McpServiceDesc` entry in `TOGGLEABLE_MCP_SERVICES` declares `auth_fields: &[]`, so the function never attempts to read a token directory.
+
+**Desktop UI hides the configuration form.** `ServiceCardComponent.hasConfigurableFields` returns `auth_fields.length > 0`.[^4] When it returns `false`, the card body — setup hint, form fields, Save / Remove Credentials buttons — is entirely suppressed via `@if (!svc.configured && !expanded && hasConfigurableFields)` guards. The toggle remains as the sole interactive element. A credential-less service therefore presents as: "toggle to enable, nothing else needed."
+
+**`CREDENTIAL_LESS_SERVICES` test allowlist.** A dedicated constant in the test module of `consts.rs` holds the exhaustive list of credential-less services (`["playwright"]` at the time of writing).[^5] Two tests enforce the contract for every entry in `TOGGLEABLE_MCP_SERVICES`:
+
+- `test_every_service_has_auth_fields` — fails if a service not in the allowlist has an empty `auth_fields`.
+- `test_every_service_has_credential_files` — fails if a service not in the allowlist has an empty `credential_files`.
+
+These tests serve as a tripwire: if a future built-in service accidentally omits auth fields, CI fails loudly rather than silently shipping an unauthenticated service that should have required credentials.
+
+### 2 — Container security profile and `--no-sandbox`
+
+The Playwright container runs under Speedwave's standard hardening profile (`cap_drop: ALL`, `security_opt: no-new-privileges:true`, `read_only: true`) with two Chromium-specific additions: `shm_size: 2g` and a larger `tmpfs /tmp`.
+
+**`--no-sandbox` is safe in this context.** Chromium's built-in process sandbox uses Linux namespaces and `seccomp-bpf` to isolate renderer processes from the browser process.[^6] Enabling it inside a container requires either `SYS_ADMIN` capability (to create user namespaces) or a `seccomp` profile that permits `clone(CLONE_NEWUSER)` — both of which conflict with `cap_drop: ALL` and the locked-down compose profile.[^7] Rather than weakening the container security posture to satisfy Chromium's internal sandbox, Speedwave provides an equivalent isolation layer at a higher level:
+
+- **macOS:** Lima VM[^8] (ADR-002) provides a separate kernel. The Playwright container runs inside the Lima VM, which runs inside the macOS hypervisor.
+- **Windows:** WSL2 with a Hyper-V boundary[^9] (ADR-004) provides equivalent kernel separation.
+- **Linux:** rootless user namespaces (ADR-026) confine the entire container runtime; the container itself still drops all capabilities.
+
+The three-layer stack (hypervisor → container runtime → `cap_drop: ALL` + `no-new-privileges`) provides stronger isolation than Chromium's in-process sandbox alone would. Passing `--no-sandbox` delegates that role to the outer layers, which is the same approach taken by all major container-based browser testing platforms.[^10]
+
+**`chromium_headless_shell` instead of full Chromium.** The Microsoft Playwright base image ships two Chromium builds: the full browser (used for headed/GUI automation) and `chromium_headless_shell` (a stripped-down build for headless-only workloads).[^11] Regular Chromium bootstraps its own crashpad process and IPC broker, which requires `CAP_SYS_ADMIN` and a running dbus socket — neither of which is available under `cap_drop: ALL` with `no-new-privileges`. The headless shell omits the GPU stack, audio, dbus, and the crashpad broker, so it starts cleanly without any elevated capability.[^12] The web platform APIs exposed to MCP tools are identical; only the out-of-process infrastructure differs.
+
+**`shm_size: 2g`.** Chromium uses POSIX shared memory (`/dev/shm`) for inter-process communication between the browser process and renderer processes.[^13] The Docker/containerd default for `/dev/shm` is 64 MiB, which is sufficient for single-tab CLI workloads but too small for multi-page Playwright sessions — the browser crashes at page load time with `ENOMEM`. Setting `shm_size: 2g` in the compose profile allocates a RAM-backed shared-memory region large enough for concurrent page rendering without requiring a writable volume.[^14]
+
+**`tmpfs /tmp:noexec,nosuid,size=1g`.** Playwright uses `/tmp` for Chromium user-data caches and, when configured with `--output-dir /tmp/playwright-mcp-output`, for screenshot compositing. The `read_only: true` root filesystem prevents writes to any other path. The `size=1g` limit is intentionally larger than other workers (which use `size=64m`) to accommodate page screenshots that are returned inline as base64 rather than written to `/workspace`.
+
+**No `/workspace` mount in v1.** Screenshots and extracted content are returned to the hub as base64-encoded data within the MCP tool response. This eliminates the need for a writable project-directory mount, reducing the blast radius of a compromised browser session to the current conversation rather than the full project directory. If a concrete use case arises that requires file-level output (e.g., saving a PDF to the project), a `/workspace:rw` mount can be added in a future version following the same pattern as other workers.
+
+**`--allowed-hosts mcp-hub`.** The `playwright-mcp` server's `--allowed-hosts` flag restricts which hostnames may make HTTP requests to its Streamable HTTP endpoint.[^15] Setting it to `mcp-hub` ensures that only the hub — not other containers on the compose network, and not any host-side process — can invoke Playwright tools. This prevents a compromised plugin container from pivoting to the browser service.
+
+### 3 — Heartbeat `sed` patch as deliberate tech debt
+
+`@playwright/mcp` version 0.0.70 enables a Streamable HTTP heartbeat by default: the server sends a ping frame every 3 seconds, and kills the session after 5 seconds if no acknowledgement arrives.[^16] Speedwave's MCP Hub connects to each worker over a standard HTTP request-response cycle; it does not maintain a persistent bidirectional SSE channel between tool calls. The heartbeat ping has nowhere to land, so the server closes the connection mid-response, truncating the tool output to zero bytes.
+
+The fix is a `sed` one-liner applied at image build time that flips the heartbeat flag from `true` to `false` in the compiled JavaScript of `playwright-core`.[^17] A `grep -q` guard on the next `RUN` layer verifies that the patched string is present; if a version bump renames or restructures the function, the guard fails the build with a clear message rather than shipping a silently broken image:
+
+```
+FATAL: heartbeat patch did not apply — verify path for @playwright/mcp <version>
+```
+
+This is acknowledged as deliberate tech debt. The correct long-term fix is an upstream `--no-heartbeat` CLI flag in `@playwright/mcp`. When that flag is available, the `sed` block in the Containerfile must be replaced with the flag in the `CMD` array, and the version pin updated accordingly. The build-time guard ensures the patch does not survive undetected across a version bump.
+
+## Consequences
+
+### Positive
+
+- **Zero-configuration browser automation.** Users enable the Playwright toggle and Claude immediately has browser access — no token entry, no setup wizard, no credentials to manage.
+- **Single shared Chromium instance.** All plugins that consume browser automation reuse the same container, avoiding duplicated image layers and concurrent Chromium startups.
+- **No credential surface.** A compromised Playwright container leaks nothing about user accounts, API keys, or project data — there are no credentials to exfiltrate.
+- **`CREDENTIAL_LESS_SERVICES` tripwire.** The test allowlist prevents future services from accidentally omitting auth fields and shipping unauthenticated.
+- **Ephemeral browser state.** Container restart wipes `/tmp` (the user-data dir), giving a fresh Chromium profile on every Speedwave session start.
+
+### Negative
+
+- **`sed` patch fragility.** The heartbeat patch is pinned to `@playwright/mcp 0.0.70`'s internal JavaScript structure. Any version bump requires verifying the patch still applies and the guard still fires. The build-time check catches this at image build, not at runtime.
+- **No persistent screenshot files.** Outputs return as base64, which is suitable for small screenshots but impractical for large PDFs or multi-page captures. Adding `/workspace:rw` in a future version will address this.
+- **`shm_size` is static.** The 2 GiB shared-memory reservation is consumed whether the browser opens one tab or twenty. Future work could make this configurable per-project, but YAGNI applies until a concrete memory-pressure report exists.
+
+## Verification
+
+- `test_every_service_has_auth_fields` — asserts `playwright` has an empty `auth_fields` and that every other service in `TOGGLEABLE_MCP_SERVICES` has at least one field.
+- `test_every_service_has_credential_files` — asserts `playwright` has an empty `credential_files` and that every other service has at least one file.
+- `test_is_service_configured_returns_true_for_credential_less_service` — calls `is_service_configured_with_home` for `playwright` with an empty temp dir and asserts `true` (no token directory required).
+- `test_playwright_has_no_tokens_mount` — renders a compose with Playwright enabled and asserts no `volumes:` entry under `mcp-playwright` references the tokens path.
+- `test_playwright_has_shm_size` — renders a compose with Playwright enabled and asserts `shm_size: 2g`.
+- `test_playwright_has_tmp_size_1g` — renders a compose with Playwright enabled and asserts the `tmpfs` entry for `/tmp` uses `size=1g`.
+
+## References
+
+[^1]: `@playwright/mcp` — Microsoft's official MCP server for Playwright browser automation: https://github.com/microsoft/playwright-mcp
+
+[^2]: `containers/compose.template.yml`, `mcp-playwright` service definition — no `volumes:` credentials stanza: https://github.com/speednet-software/speedwave/blob/dev/containers/compose.template.yml
+
+[^3]: `desktop/src-tauri/src/integrations_cmd.rs`, `is_service_configured` — short-circuits to `true` when `auth_fields` is empty: https://github.com/speednet-software/speedwave/blob/dev/desktop/src-tauri/src/integrations_cmd.rs
+
+[^4]: `desktop/src/src/app/integrations/service-card/service-card.component.ts`, `hasConfigurableFields` getter: https://github.com/speednet-software/speedwave/blob/dev/desktop/src/src/app/integrations/service-card/service-card.component.ts
+
+[^5]: `crates/speedwave-runtime/src/consts.rs`, `CREDENTIAL_LESS_SERVICES` constant and associated tests: https://github.com/speednet-software/speedwave/blob/dev/crates/speedwave-runtime/src/consts.rs
+
+[^6]: Chromium sandbox architecture — uses Linux namespaces and `seccomp-bpf` for renderer isolation: https://chromium.googlesource.com/chromium/src/+/main/docs/linux/sandboxing.md
+
+[^7]: Docker/containerd and Chromium sandbox — `SYS_ADMIN` or `clone(CLONE_NEWUSER)` required for the Chromium namespace sandbox inside a container: https://chromium.googlesource.com/chromium/src/+/main/docs/linux/sandboxing.md#the-sandbox-in-detail
+
+[^8]: ADR-002 — Lima as VM Manager on macOS, establishing the hypervisor isolation layer: https://github.com/speednet-software/speedwave/blob/dev/docs/adr/ADR-002-lima-as-vm-manager-on-macos.md
+
+[^9]: ADR-004 — WSL2 + nerdctl on Windows, establishing the Hyper-V isolation layer: https://github.com/speednet-software/speedwave/blob/dev/docs/adr/ADR-004-wsl2-and-nerdctl-on-windows.md
+
+[^10]: Google Cloud Run Jobs with Chromium — `--no-sandbox` is the documented approach for containerised Chromium when the container itself provides isolation: https://cloud.google.com/run/docs/configuring/services/memory-limits
+
+[^11]: Microsoft Playwright Docker image contents — ships both full Chromium and `chromium_headless_shell`: https://playwright.dev/docs/docker
+
+[^12]: Playwright headless shell vs full Chromium — the shell build omits crashpad, dbus, GPU, and audio stack: https://playwright.dev/docs/browsers#chromium
+
+[^13]: Chromium shared-memory IPC — uses `/dev/shm` (POSIX shared memory) for inter-process communication: https://www.chromium.org/developers/design-documents/inter-process-communication/
+
+[^14]: Docker `shm_size` compose reference — sets the size of `/dev/shm` for a service: https://docs.docker.com/compose/compose-file/05-services/#shm_size
+
+[^15]: `@playwright/mcp` `--allowed-hosts` flag — restricts which hostnames may connect to the Streamable HTTP endpoint: https://github.com/microsoft/playwright-mcp#configuration
+
+[^16]: MCP Streamable HTTP transport heartbeat — the spec defines an optional ping/pong keep-alive on SSE connections; `@playwright/mcp` enables it by default in 0.0.70: https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http
+
+[^17]: `mcp-servers/playwright/Containerfile` — the `sed` patch and `grep -q` guard at build time: https://github.com/speednet-software/speedwave/blob/dev/mcp-servers/playwright/Containerfile

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -45,6 +45,7 @@ This directory contains all Architecture Decision Records (ADRs) for Speedwave. 
 | [ADR-036](ADR-036-self-declaring-worker-policy.md)                     | Self-Declaring Worker Policy via `_meta`                | Accepted              |
 | [ADR-037](ADR-037-code-signing-and-bundled-binary-signing.md)          | Code Signing and Bundled Binary Signing                 | Accepted              |
 | [ADR-038](ADR-038-single-internal-worker-port.md)                      | Single Internal Worker Port                             | Accepted              |
+| [ADR-039](ADR-039-playwright-shared-browser-service.md)                | Playwright Shared Browser Service                       | Accepted              |
 
 ## Creating a New ADR
 

--- a/docs/architecture/containers.md
+++ b/docs/architecture/containers.md
@@ -34,7 +34,7 @@ Container memory limits are defined in `containers/compose.template.yml`. The Cl
 
 - **Claude container:** adaptive (`${CLAUDE_MEMORY}` — see scaling below)
 - **MCP Hub:** 512 MiB (fixed)
-- **MCP workers:** 128 MiB each (fixed)
+- **MCP workers:** 128 MiB each (fixed), except `mcp-playwright` which uses 2048 MiB (`cpus: 2.0`) due to Chromium requirements
 
 **Minimum requirement:** 8 GiB RAM. Speedwave warns at startup if the host has less than 8 GiB.
 

--- a/docs/guides/integrations.md
+++ b/docs/guides/integrations.md
@@ -4,13 +4,14 @@ Speedwave connects Claude Code with external services through MCP (Model Context
 
 ## Available Integrations
 
-| Integration | Service        | Container                            | Token Path                                  |
-| ----------- | -------------- | ------------------------------------ | ------------------------------------------- |
-| Slack       | Messaging      | `speedwave_<project>_mcp_slack`      | `~/.speedwave/tokens/<project>/slack/`      |
-| SharePoint  | Documents      | `speedwave_<project>_mcp_sharepoint` | `~/.speedwave/tokens/<project>/sharepoint/` |
-| GitLab      | Code hosting   | `speedwave_<project>_mcp_gitlab`     | `~/.speedwave/tokens/<project>/gitlab/`     |
-| Redmine     | Issue tracking | `speedwave_<project>_mcp_redmine`    | `~/.speedwave/tokens/<project>/redmine/`    |
-| OS          | Host services  | mcp-os (host process)                | N/A (runs on host)                          |
+| Integration | Service            | Container                            | Token Path                                  |
+| ----------- | ------------------ | ------------------------------------ | ------------------------------------------- |
+| Slack       | Messaging          | `speedwave_<project>_mcp_slack`      | `~/.speedwave/tokens/<project>/slack/`      |
+| SharePoint  | Documents          | `speedwave_<project>_mcp_sharepoint` | `~/.speedwave/tokens/<project>/sharepoint/` |
+| GitLab      | Code hosting       | `speedwave_<project>_mcp_gitlab`     | `~/.speedwave/tokens/<project>/gitlab/`     |
+| Redmine     | Issue tracking     | `speedwave_<project>_mcp_redmine`    | `~/.speedwave/tokens/<project>/redmine/`    |
+| Playwright  | Browser automation | `speedwave_<project>_mcp_playwright` | N/A (no credentials)                        |
+| OS          | Host services      | mcp-os (host process)                | N/A (runs on host)                          |
 
 OS sub-integrations (Reminders, Calendar, Mail, Notes) run via mcp-os on the host — they access native APIs directly (EventKit on macOS, CalDAV/zbus on Linux, WinRT/MAPI on Windows).
 
@@ -84,6 +85,7 @@ Each MCP integration requires specific credentials to function. Fields marked as
 | SharePoint  | `client_id`, `tenant_id`, `site_id`, `base_path` + OAuth tokens | —                                                    |
 | GitLab      | `token`, `host_url`                                             | —                                                    |
 | Redmine     | `api_key`, `host_url`                                           | `project_id` (scope operations to a default project) |
+| Playwright  | _(none — no credentials required)_                              | —                                                    |
 
 ### Redmine Configuration Wizard
 
@@ -98,6 +100,39 @@ The wizard shows up to 100 projects. For Redmine instances with more projects, f
 Existing configurations with `project_name` in `config.json` continue to work — the MCP server reads it if present and auto-fetches it from the API when absent. Manual `config.json` editing remains supported for power users.
 
 **Troubleshooting:** Corporate environments with custom certificate authorities or HTTP proxies may see TLS or connection errors during credential validation. This is a known limitation shared with SharePoint OAuth — the Desktop app uses bundled CA roots (`rustls-tls`), not the OS certificate store, and does not auto-detect system proxy settings.
+
+### Playwright — Browser Automation
+
+Playwright runs a headless Chromium inside a hardened container and exposes it through Microsoft's official [`@playwright/mcp`](https://github.com/microsoft/playwright-mcp) server. It is a **shared service**: both Claude directly and any plugin can use the same browser — Chromium is not duplicated per plugin.
+
+#### When to use Playwright vs `WebFetch`
+
+- `WebFetch` is built into Claude and suits **static HTML** — a GET + HTML-to-markdown conversion. Use it for docs, READMEs, blog posts, anything server-rendered.
+- Playwright runs a real browser and suits **dynamic pages** — JavaScript-rendered SPAs, pages behind a login flow, pages that require waiting for XHR-driven content, or any task that needs screenshots, accessibility snapshots, DOM interaction, or computed styles.
+
+Prefer `WebFetch` when it works; drop to Playwright only when it does not. A Chromium context is an order of magnitude more expensive than a `WebFetch` call.
+
+#### Security profile
+
+Playwright is unique among the built-in integrations in three ways:
+
+- **No credentials.** It accesses only public URLs; there is no `/tokens` mount and no credential file. Enabling the integration requires no configuration.
+- **No `/workspace` mount.** Screenshots, PDFs, and page dumps are returned to Claude as base64 payloads rather than written to the project. This keeps a compromised Chromium from exfiltrating repo contents.
+- **Higher resource limits.** `shm_size: 2g` (Chromium IPC needs it), `tmpfs /tmp: 1g` (Chromium caches heavily), `cpus: 2.0`, `memory: 2048m` — noticeably larger than the 128 MiB budget given to HTTP-only workers.
+
+Container hardening is otherwise identical to every other MCP worker: `cap_drop: ALL`, `no-new-privileges:true`, `read_only: true` root filesystem, `noexec,nosuid` on `/tmp`. Chromium runs with `--no-sandbox` because the Lima/WSL2 VM + container capability-drop layer replaces its in-process sandbox (see [ADR-004](../adr/ADR-004-wsl2-and-nerdctl-on-windows.md)). Each container restart wipes `/tmp` (tmpfs-backed), giving the same ephemeral-profile guarantee as `--isolated` — no cookies, no storage state persist between invocations.
+
+#### Tool surface
+
+`@playwright/mcp` exposes roughly 70 tools grouped into:
+
+- **Navigation** — `browser_navigate`, `browser_navigate_back`, `browser_tabs`.
+- **Extraction** — `browser_snapshot` (accessibility tree, token-efficient), `browser_take_screenshot`, `browser_pdf_save`, `browser_evaluate`, `browser_network_requests`, `browser_console_messages`.
+- **Interaction** — `browser_click`, `browser_type`, `browser_fill_form`, `browser_select_option`, `browser_press_key`, `browser_hover`, `browser_drag`.
+- **Assertions and codegen** — `browser_verify_element_visible`, `browser_verify_text_visible`, `browser_generate_locator`, `browser_pick_locator`.
+- **Tracing** — `browser_start_tracing`, `browser_start_video`, `browser_stop_tracing` (gated behind `--caps devtools` when explicitly enabled).
+
+Refer to the [upstream README](https://github.com/microsoft/playwright-mcp) for the full list and parameter schemas.
 
 ## MCP Hub Architecture
 

--- a/mcp-servers/hub/src/handlers.test.ts
+++ b/mcp-servers/hub/src/handlers.test.ts
@@ -926,6 +926,104 @@ describe('createCodeExecutorHandlers', () => {
     });
   });
 
+  describe('MCP content array passthrough', () => {
+    it('should pass through multi-item content array (text + image)', async () => {
+      const mcpContent = [
+        { type: 'text', text: 'Screenshot taken' },
+        { type: 'image', data: 'iVBORw0KGgo=', mimeType: 'image/png' },
+      ];
+
+      vi.mocked(executorModule.executeCode).mockResolvedValue(createMockExecuteResult(mcpContent));
+
+      const handlers = createCodeExecutorHandlers(mockConfig);
+      const result = await handlers.handleExecuteCode({ code: 'return screenshot' });
+
+      expect(result.content).toEqual(mcpContent);
+      expect(result.content).toHaveLength(2);
+      expect(result.content[0].type).toBe('text');
+      expect(result.content[1].type).toBe('image');
+    });
+
+    it('should pass through single image content item', async () => {
+      const mcpContent = [{ type: 'image', data: 'base64data', mimeType: 'image/jpeg' }];
+
+      vi.mocked(executorModule.executeCode).mockResolvedValue(createMockExecuteResult(mcpContent));
+
+      const handlers = createCodeExecutorHandlers(mockConfig);
+      const result = await handlers.handleExecuteCode({ code: 'return img' });
+
+      expect(result.content).toEqual(mcpContent);
+    });
+
+    it('should pass through resource content items', async () => {
+      const mcpContent = [{ type: 'resource', text: 'resource data' }];
+
+      vi.mocked(executorModule.executeCode).mockResolvedValue(createMockExecuteResult(mcpContent));
+
+      const handlers = createCodeExecutorHandlers(mockConfig);
+      const result = await handlers.handleExecuteCode({ code: 'return res' });
+
+      expect(result.content).toEqual(mcpContent);
+    });
+
+    it('should NOT pass through arrays of non-MCP objects', async () => {
+      const regularArray = [
+        { id: 1, name: 'issue' },
+        { id: 2, name: 'bug' },
+      ];
+
+      vi.mocked(executorModule.executeCode).mockResolvedValue(
+        createMockExecuteResult(regularArray)
+      );
+
+      const handlers = createCodeExecutorHandlers(mockConfig);
+      const result = await handlers.handleExecuteCode({ code: 'return issues' });
+
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0].type).toBe('text');
+      expect(result.content[0].text).toBe(JSON.stringify(regularArray));
+    });
+
+    it('should NOT pass through empty arrays', async () => {
+      vi.mocked(executorModule.executeCode).mockResolvedValue(createMockExecuteResult([]));
+
+      const handlers = createCodeExecutorHandlers(mockConfig);
+      const result = await handlers.handleExecuteCode({ code: 'return []' });
+
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0].type).toBe('text');
+      expect(result.content[0].text).toBe('[]');
+    });
+
+    it('should NOT pass through arrays with unknown type values', async () => {
+      const unknownTypes = [{ type: 'custom', data: 'something' }];
+
+      vi.mocked(executorModule.executeCode).mockResolvedValue(
+        createMockExecuteResult(unknownTypes)
+      );
+
+      const handlers = createCodeExecutorHandlers(mockConfig);
+      const result = await handlers.handleExecuteCode({ code: 'return data' });
+
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0].type).toBe('text');
+      expect(result.content[0].text).toBe(JSON.stringify(unknownTypes));
+    });
+
+    it('should pass through text-only content arrays unchanged', async () => {
+      const textOnlyContent = [{ type: 'text', text: 'just text' }];
+
+      vi.mocked(executorModule.executeCode).mockResolvedValue(
+        createMockExecuteResult(textOnlyContent)
+      );
+
+      const handlers = createCodeExecutorHandlers(mockConfig);
+      const result = await handlers.handleExecuteCode({ code: 'return data' });
+
+      expect(result.content).toEqual(textOnlyContent);
+    });
+  });
+
   describe('timeout validation edge cases', () => {
     it.each([NaN, Infinity, -Infinity])(
       'should reject %s timeout with error',

--- a/mcp-servers/hub/src/handlers.ts
+++ b/mcp-servers/hub/src/handlers.ts
@@ -26,6 +26,37 @@ interface HandlerConfig {
 const toJsonText = (data: unknown): string =>
   typeof data === 'string' ? data : JSON.stringify(data ?? null);
 
+type McpContentType = 'text' | 'image' | 'audio' | 'resource' | 'resource_link';
+
+interface McpContentItem {
+  type: McpContentType;
+  text?: string;
+  data?: string;
+  mimeType?: string;
+}
+
+const MCP_CONTENT_TYPES: Set<McpContentType> = new Set([
+  'text',
+  'image',
+  'audio',
+  'resource',
+  'resource_link',
+]);
+
+function isMcpContentArray(data: unknown): data is McpContentItem[] {
+  if (!Array.isArray(data) || data.length === 0) return false;
+  return data.every((item) => {
+    if (typeof item !== 'object' || item === null || !('type' in item)) return false;
+    const typed = item as McpContentItem;
+    if (!MCP_CONTENT_TYPES.has(typed.type)) return false;
+    if (typed.type === 'text') return typeof typed.text === 'string';
+    if (typed.type === 'image' || typed.type === 'audio') {
+      return typeof typed.data === 'string' && typeof typed.mimeType === 'string';
+    }
+    return true;
+  });
+}
+
 /**
  * Validate and normalize timeout parameter
  * @param paramValue - The timeout_ms value from request params
@@ -163,6 +194,9 @@ export function createCodeExecutorHandlers(config: HandlerConfig) {
         };
       }
 
+      if (isMcpContentArray(result.data)) {
+        return { content: result.data };
+      }
       return {
         content: [{ type: 'text', text: toJsonText(result.data) }],
       };

--- a/mcp-servers/hub/src/http-bridge.test.ts
+++ b/mcp-servers/hub/src/http-bridge.test.ts
@@ -16,6 +16,7 @@ import {
   STARTUP_RETRY_DELAYS_MS,
   parseResponse,
   buildWorkerHeaders,
+  _clearWorkerSessionCacheForTesting,
 } from './http-bridge.js';
 import { LATEST_PROTOCOL_VERSION } from '@speedwave/mcp-shared';
 import {
@@ -858,10 +859,8 @@ describe('http-bridge', () => {
         }),
       });
 
-      // Now throws error instead of silently returning text as wrong type
-      await expect(callWorker('slack', 'send_channel', {})).rejects.toThrow(
-        'Worker slack returned invalid response format. Expected JSON but received: plain text response'
-      );
+      const result = await callWorker('slack', 'send_channel', {});
+      expect(result).toBe('plain text response');
     });
 
     it('should handle empty content array', async () => {
@@ -894,8 +893,10 @@ describe('http-bridge', () => {
         }),
       });
 
+      // Content item with type 'text' but no text field: textItems filter
+      // excludes it (text === undefined), producing an empty joined string.
       const result = await callWorker('slack', 'test', {});
-      expect(result).toEqual({ content: [{ type: 'text' }] });
+      expect(result).toBe('');
     });
 
     it('should handle unknown service', async () => {
@@ -972,7 +973,7 @@ describe('http-bridge', () => {
       await expect(callWorker('gitlab', 'test', {})).rejects.toThrow('Network failure');
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         expect.stringContaining('[http-bridge]'),
-        'Network failure'
+        expect.stringContaining('Network failure')
       );
 
       consoleErrorSpy.mockRestore();
@@ -1046,6 +1047,299 @@ describe('http-bridge', () => {
       expect(calledHeaders['Accept']).toBe('application/json, text/event-stream');
       expect(calledHeaders['MCP-Protocol-Version']).toBe(LATEST_PROTOCOL_VERSION);
       expect(calledHeaders).not.toHaveProperty('Authorization');
+    });
+  });
+
+  describe('callWorker - MCP session handling', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      _clearWorkerSessionCacheForTesting();
+      fetchMock = vi.fn();
+      global.fetch = fetchMock as unknown as typeof fetch;
+    });
+
+    afterEach(() => {
+      _clearWorkerSessionCacheForTesting();
+      vi.restoreAllMocks();
+    });
+
+    it('re-initialises session on 400 "not initialized" and retries', async () => {
+      let callCount = 0;
+      fetchMock.mockImplementation((_url: string, options: { body: string }) => {
+        callCount++;
+        const body = JSON.parse(options.body ?? '{}');
+
+        // 1st call: tools/call → 400 not initialized
+        if (callCount === 1) {
+          return Promise.resolve({
+            ok: false,
+            status: 400,
+            headers: new Headers({ 'content-type': 'text/plain' }),
+            text: async () => 'Bad Request: Server not initialized',
+          });
+        }
+        // 2nd call: initialize → success with session id
+        if (callCount === 2 && body.method === 'initialize') {
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            headers: new Headers({
+              'content-type': 'application/json',
+              'Mcp-Session-Id': 'sess-123',
+            }),
+            json: async () => ({
+              jsonrpc: '2.0',
+              id: body.id,
+              result: {
+                protocolVersion: '2025-11-25',
+                capabilities: {},
+                serverInfo: { name: 'test', version: '1' },
+              },
+            }),
+            text: async () =>
+              JSON.stringify({
+                jsonrpc: '2.0',
+                id: body.id,
+                result: {
+                  protocolVersion: '2025-11-25',
+                  capabilities: {},
+                  serverInfo: { name: 'test', version: '1' },
+                },
+              }),
+          });
+        }
+        // 3rd call: notifications/initialized → 202
+        if (callCount === 3 && body.method === 'notifications/initialized') {
+          return Promise.resolve({
+            ok: true,
+            status: 202,
+            headers: new Headers(),
+            text: async () => '',
+          });
+        }
+        // 4th call: retry tools/call with session → success
+        if (callCount === 4) {
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            headers: new Headers({ 'content-type': 'application/json' }),
+            json: async () => ({
+              jsonrpc: '2.0',
+              id: body.id,
+              result: { content: [{ type: 'text', text: '{"navigated":true}' }] },
+            }),
+          });
+        }
+        return Promise.reject(new Error(`Unexpected call #${callCount}`));
+      });
+
+      const result = await callWorker('gitlab', 'browser_navigate', { url: 'https://example.com' });
+      expect(result).toEqual({ navigated: true });
+      expect(callCount).toBe(4);
+
+      // Verify session header was sent on retry
+      const retryHeaders = fetchMock.mock.calls[3][1].headers;
+      expect(retryHeaders['Mcp-Session-Id']).toBe('sess-123');
+    });
+
+    it('uses cached session on subsequent calls', async () => {
+      // Pre-populate session cache by doing a full init flow
+      let callCount = 0;
+      fetchMock.mockImplementation((_url: string, options: { body: string }) => {
+        callCount++;
+        const body = JSON.parse(options.body ?? '{}');
+
+        // 1st call: tools/call → 400
+        if (callCount === 1) {
+          return Promise.resolve({
+            ok: false,
+            status: 400,
+            headers: new Headers(),
+            text: async () => 'Server not initialized',
+          });
+        }
+        // 2nd: initialize
+        if (callCount === 2) {
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            headers: new Headers({
+              'content-type': 'application/json',
+              'Mcp-Session-Id': 'cached-sess',
+            }),
+            json: async () => ({
+              jsonrpc: '2.0',
+              id: body.id,
+              result: {
+                protocolVersion: '2025-11-25',
+                capabilities: {},
+                serverInfo: { name: 'test', version: '1' },
+              },
+            }),
+            text: async () => '{}',
+          });
+        }
+        // 3rd: notification
+        if (callCount === 3) {
+          return Promise.resolve({
+            ok: true,
+            status: 202,
+            headers: new Headers(),
+            text: async () => '',
+          });
+        }
+        // 4th+: tools/call with cached session — success
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          json: async () => ({
+            jsonrpc: '2.0',
+            id: body.id,
+            result: { content: [{ type: 'text', text: '{"ok":true}' }] },
+          }),
+        });
+      });
+
+      // First call triggers init
+      await callWorker('gitlab', 'test_tool', {});
+      expect(callCount).toBe(4);
+
+      // Second call should use cached session — only 1 fetch (tools/call directly)
+      await callWorker('gitlab', 'test_tool', {});
+      expect(callCount).toBe(5);
+      const secondCallHeaders = fetchMock.mock.calls[4][1].headers;
+      expect(secondCallHeaders['Mcp-Session-Id']).toBe('cached-sess');
+    });
+
+    it('invalidates session on 404 and re-initialises', async () => {
+      let callCount = 0;
+      fetchMock.mockImplementation((_url: string, options: { body: string }) => {
+        callCount++;
+        const body = JSON.parse(options.body ?? '{}');
+
+        // 1st: tools/call → 404 (expired session)
+        if (callCount === 1) {
+          return Promise.resolve({
+            ok: false,
+            status: 404,
+            headers: new Headers(),
+            text: async () => 'Not Found',
+          });
+        }
+        // 2nd: initialize
+        if (callCount === 2) {
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            headers: new Headers({
+              'content-type': 'application/json',
+              'Mcp-Session-Id': 'new-sess',
+            }),
+            json: async () => ({
+              jsonrpc: '2.0',
+              id: body.id,
+              result: {
+                protocolVersion: '2025-11-25',
+                capabilities: {},
+                serverInfo: { name: 'test', version: '1' },
+              },
+            }),
+            text: async () => '{}',
+          });
+        }
+        // 3rd: notification
+        if (callCount === 3) {
+          return Promise.resolve({
+            ok: true,
+            status: 202,
+            headers: new Headers(),
+            text: async () => '',
+          });
+        }
+        // 4th: retry tools/call
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          json: async () => ({
+            jsonrpc: '2.0',
+            id: body.id,
+            result: { content: [{ type: 'text', text: '{"recovered":true}' }] },
+          }),
+        });
+      });
+
+      const result = await callWorker('gitlab', 'test_tool', {});
+      expect(result).toEqual({ recovered: true });
+    });
+  });
+
+  describe('callWorker - multi-content responses', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      fetchMock = vi.fn();
+      global.fetch = fetchMock as unknown as typeof fetch;
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('returns full content array when response includes non-text items', async () => {
+      const multiContent = [
+        { type: 'text', text: 'Screenshot taken' },
+        { type: 'image', data: 'iVBORw0KGgo=', mimeType: 'image/png' },
+      ];
+      fetchMock.mockResolvedValue({
+        ok: true,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({
+          jsonrpc: '2.0',
+          id: '123',
+          result: { content: multiContent },
+        }),
+      });
+
+      const result = await callWorker('gitlab', 'browser_screenshot', {});
+      expect(result).toEqual(multiContent);
+    });
+
+    it('returns parsed JSON for single text-only content', async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({
+          jsonrpc: '2.0',
+          id: '123',
+          result: { content: [{ type: 'text', text: '{"branches":["main"]}' }] },
+        }),
+      });
+
+      const result = await callWorker('gitlab', 'list_branches', {});
+      expect(result).toEqual({ branches: ['main'] });
+    });
+
+    it('joins multiple text items before JSON parsing', async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({
+          jsonrpc: '2.0',
+          id: '123',
+          result: {
+            content: [
+              { type: 'text', text: 'Line 1' },
+              { type: 'text', text: 'Line 2' },
+            ],
+          },
+        }),
+      });
+
+      const result = await callWorker('gitlab', 'test_tool', {});
+      expect(result).toBe('Line 1\nLine 2');
     });
   });
 
@@ -1646,6 +1940,86 @@ describe('http-bridge', () => {
       const result = await isWorkerAvailable('gitlab');
       expect(result).toBe(true);
       expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('initialises session when ping returns "not initialized" (Attempt 2)', async () => {
+      let callCount = 0;
+      fetchMock.mockImplementation((_url: string, options: { body?: string }) => {
+        callCount++;
+        const body = options.body ? JSON.parse(options.body) : {};
+
+        // 1st call: ping → "not initialized" error
+        if (callCount === 1 && body.method === 'ping') {
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            headers: new Headers({ 'content-type': 'application/json' }),
+            json: async () => ({
+              jsonrpc: '2.0',
+              id: body.id,
+              error: { code: -32600, message: 'Server not initialized' },
+            }),
+          });
+        }
+        // 2nd call: initialize → success
+        if (callCount === 2 && body.method === 'initialize') {
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            headers: new Headers({
+              'content-type': 'application/json',
+              'Mcp-Session-Id': 'health-sess',
+            }),
+            json: async () => ({
+              jsonrpc: '2.0',
+              id: body.id,
+              result: {
+                protocolVersion: '2025-11-25',
+                capabilities: {},
+                serverInfo: { name: 'test', version: '1' },
+              },
+            }),
+            text: async () =>
+              JSON.stringify({
+                jsonrpc: '2.0',
+                id: body.id,
+                result: {
+                  protocolVersion: '2025-11-25',
+                  capabilities: {},
+                  serverInfo: { name: 'test', version: '1' },
+                },
+              }),
+          });
+        }
+        // 3rd call: notifications/initialized → 202
+        if (callCount === 3 && body.method === 'notifications/initialized') {
+          return Promise.resolve({
+            ok: true,
+            status: 202,
+            headers: new Headers(),
+            text: async () => '',
+          });
+        }
+        // 4th call: ping with session → success
+        if (callCount === 4 && body.method === 'ping') {
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            headers: new Headers({ 'content-type': 'application/json' }),
+            json: async () => ({
+              jsonrpc: '2.0',
+              id: body.id,
+              result: {},
+            }),
+          });
+        }
+        return Promise.reject(new Error(`Unexpected call #${callCount}: ${body.method}`));
+      });
+
+      clearWorkerCache();
+      const available = await isWorkerAvailable('gitlab');
+      expect(available).toBe(true);
+      expect(callCount).toBe(4);
     });
   });
 });

--- a/mcp-servers/hub/src/http-bridge.ts
+++ b/mcp-servers/hub/src/http-bridge.ts
@@ -84,8 +84,20 @@ export interface JSONRPCResponse {
   id: string | number;
   /** Result object containing MCP response */
   result?: {
-    /** Array of content items */
-    content: Array<{ type: string; text?: string }>;
+    /**
+     * Array of content items. MCP spec 2025-11-25 §Tool Result defines
+     * several `type` values: `"text"`, `"image"` (base64 + mimeType),
+     * `"audio"`, `"resource_link"`, and `"resource"`. Our hub keeps the
+     * shape open so third-party servers (e.g. `@playwright/mcp` returns
+     * a text summary followed by a base64 PNG in the same array) don't
+     * lose structured output.
+     */
+    content: Array<{
+      type: string;
+      text?: string;
+      data?: string;
+      mimeType?: string;
+    }>;
     /** Set by errorResult() when worker returns an error */
     isError?: boolean;
   };
@@ -145,7 +157,14 @@ export async function parseResponse(response: Response): Promise<JSONRPCResponse
         }
       }
     }
-    throw new Error('No JSON-RPC response in SSE stream');
+    // Fail hard with the full body so we can see what the worker actually
+    // sent. This happens in practice when third-party MCP servers emit
+    // progress frames (`event: progress`, `event: ping`, ...) before the
+    // final `data:` line and the stream gets cut off mid-flight.
+    const bodyDump = text.length > 4000 ? text.slice(0, 4000) + '...[truncated]' : text;
+    throw new Error(
+      `No JSON-RPC response in SSE stream (status ${response.status}, ${text.length} bytes). Body:\n${bodyDump}`
+    );
   }
   try {
     return (await response.json()) as JSONRPCResponse;
@@ -199,40 +218,166 @@ function classifyHealthError(error: unknown): string {
 }
 
 /**
+ * Attempt an `initialize` handshake against a worker.
+ *
+ * Strict MCP servers (e.g. `@playwright/mcp`) reject every request with
+ * `Bad Request: Server not initialized` until `initialize` completes AND the
+ * returned `Mcp-Session-Id` header is sent on every subsequent request.
+ * In-house workers are more permissive and answer `ping` without any of
+ * this.
+ *
+ * This helper is called both by `checkWorkerHealth` (startup health path)
+ * and by `ensureWorkerSession` (per-call session management) when
+ * initialization is required.
+ *
+ * Returns the `Mcp-Session-Id` assigned by the worker (or an empty string if
+ * the worker does not use sessions) on success, and `null` on failure.
+ * @param url - Worker base URL (same URL the ping POST is issued against)
+ * @param authToken - Optional bearer token
+ */
+async function performMcpInitialize(url: string, authToken?: string): Promise<string | null> {
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: buildWorkerHeaders(authToken),
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: randomUUID(),
+        method: 'initialize',
+        params: {
+          protocolVersion: LATEST_PROTOCOL_VERSION,
+          capabilities: {},
+          clientInfo: { name: 'speedwave-hub', version: '1.0.0' },
+        },
+      }),
+      signal: AbortSignal.timeout(TIMEOUTS.HEALTH_CHECK_MS),
+      redirect: 'error',
+    });
+    // MCP spec 2025-11-25 §Session Management:
+    //   "A server … MAY assign a session ID at initialization time, by
+    //    including it in an `MCP-Session-Id` header on the HTTP response
+    //    containing the InitializeResult."
+    // HTTP headers are case-insensitive per RFC 7230, so `Mcp-Session-Id`
+    // reads the same header the server wrote, but we keep the canonical
+    // capitalisation when echoing it back on subsequent requests to make
+    // trace logs line up with the spec.
+    const sessionId = response.headers.get('Mcp-Session-Id') ?? '';
+    const result = await parseResponse(response);
+    if (result.error) return null;
+
+    // MCP spec 2025-11-25 §Lifecycle + §Streamable HTTP:
+    //   After InitializeResult the client MUST send
+    //   `notifications/initialized`. Strict servers (e.g. `@playwright/mcp`)
+    //   refuse every subsequent request with 400 "Server not initialized"
+    //   until this notification has been POSTed and ACK'd with 202 Accepted.
+    // Critically, this must complete BEFORE we return — the caller
+    // immediately issues `tools/call` on the session we just built, and any
+    // race with the notification makes the tool call fail.
+    const notifHeaders = buildWorkerHeaders(authToken);
+    if (sessionId) notifHeaders['Mcp-Session-Id'] = sessionId;
+    const notifResponse = await fetch(url, {
+      method: 'POST',
+      headers: notifHeaders,
+      body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }),
+      signal: AbortSignal.timeout(TIMEOUTS.HEALTH_CHECK_MS),
+      redirect: 'error',
+    });
+    // Spec says notifications return 202 Accepted; permissive servers may
+    // return 200. Anything in the 2xx range is fine. Drain the body so the
+    // underlying socket can be reused for the next request.
+    await notifResponse.text().catch(() => undefined);
+    if (!notifResponse.ok) {
+      console.error(
+        `${ts()} [http-bridge] notifications/initialized rejected with ${notifResponse.status} — session is unusable`
+      );
+      return null;
+    }
+
+    return sessionId;
+  } catch (error) {
+    const errorType = classifyHealthError(error);
+    console.warn(
+      `${ts()} [http-bridge] initialize handshake failed for ${url} [${errorType}]: ${error instanceof Error ? error.message : String(error)}`
+    );
+    return null;
+  }
+}
+
+/**
  * Single health-check using MCP `ping` method with `/health` endpoint fallback.
- * First tries a proper MCP JSON-RPC ping request (required per MCP spec).
- * If that fails, falls back to the legacy /health HTTP endpoint for
- * backward compatibility with older workers.
- * Returns true when the worker responds successfully via either method.
+ *
+ * Flow:
+ *   1. Plain MCP `ping` — fast path for our in-house workers that respond to
+ *      `ping` on a fresh connection.
+ *   2. `initialize` handshake followed by `ping` — required by strict MCP
+ *      servers like `@playwright/mcp` that refuse every request with
+ *      `Bad Request: Server not initialized` until the session is
+ *      initialised. This is the spec-compliant flow and the only way to
+ *      talk to most third-party MCP servers.
+ *   3. Legacy `/health` GET — backwards compatibility with any remaining
+ *      worker that predates MCP-over-HTTP.
+ *
+ * Returns `true` when any of the three attempts succeeds.
  * @param service - Service name to check
  */
 async function checkWorkerHealth(service: string): Promise<boolean> {
   const url = getWorkerUrl(service);
   if (!url) return false;
 
-  // Attempt 1: MCP ping via JSON-RPC POST (required per MCP spec)
-  try {
-    const response = await fetch(url, {
-      method: 'POST',
-      headers: buildWorkerHeaders(),
-      body: JSON.stringify({
-        jsonrpc: '2.0',
-        id: randomUUID(),
-        method: 'ping',
-      }),
-      signal: AbortSignal.timeout(TIMEOUTS.HEALTH_CHECK_MS),
-      redirect: 'error',
-    });
-    const result = await parseResponse(response);
-    if (!result.error) return true;
-  } catch (error) {
-    const errorType = classifyHealthError(error);
-    console.warn(
-      `${ts()} [http-bridge] MCP ping failed for ${service} [${errorType}]: ${error instanceof Error ? error.message : String(error)}`
-    );
+  const authToken = getAuthToken(service);
+
+  const postPing = async (
+    sessionId?: string
+  ): Promise<{ ok: boolean; notInitialised: boolean }> => {
+    try {
+      const headers = buildWorkerHeaders(authToken);
+      if (sessionId) {
+        headers['Mcp-Session-Id'] = sessionId;
+      }
+      const response = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: randomUUID(),
+          method: 'ping',
+        }),
+        signal: AbortSignal.timeout(TIMEOUTS.HEALTH_CHECK_MS),
+        redirect: 'error',
+      });
+      const result = await parseResponse(response);
+      if (!result.error) return { ok: true, notInitialised: false };
+      return {
+        ok: false,
+        notInitialised: result.error.message.toLowerCase().includes('not initialized'),
+      };
+    } catch (error) {
+      const errorType = classifyHealthError(error);
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(
+        `${ts()} [http-bridge] MCP ping failed for ${service} [${errorType}]: ${message}`
+      );
+      return { ok: false, notInitialised: message.toLowerCase().includes('not initialized') };
+    }
+  };
+
+  // Attempt 1: plain ping (fast path for permissive workers).
+  const first = await postPing();
+  if (first.ok) return true;
+
+  // Attempt 2: if the server told us it needed initialisation, do it and
+  // retry the ping on the same session. Strict MCP servers assign a
+  // session ID via the Mcp-Session-Id response header on initialize and
+  // reject subsequent requests that do not echo it back.
+  if (first.notInitialised) {
+    const sessionId = await performMcpInitialize(url, authToken);
+    if (sessionId !== null) {
+      const second = await postPing(sessionId);
+      if (second.ok) return true;
+    }
   }
 
-  // Attempt 2: Legacy /health endpoint (backward compatibility)
+  // Attempt 3: legacy /health endpoint (backwards compatibility).
   try {
     const response = await fetch(`${url}/health`, {
       signal: AbortSignal.timeout(TIMEOUTS.HEALTH_CHECK_MS),
@@ -437,6 +582,65 @@ export function parseServiceError(error: unknown, serviceName: string): string {
 //═══════════════════════════════════════════════════════════════════════════════
 
 /**
+ * Per-service cache of `Mcp-Session-Id` values issued by workers.
+ *
+ * Strict MCP servers (`@playwright/mcp`) reject every JSON-RPC request with
+ * `Bad Request: Server not initialized` unless the caller both completed
+ * `initialize` and echoes back the `Mcp-Session-Id` header the worker set in
+ * the initialize response. We remember that header per service and replay it
+ * on subsequent `tools/call` requests. An empty string means the worker
+ * issued no session header (stateless worker) — we still store it so we
+ * don't re-initialize on every call.
+ *
+ * On a `400 Bad Request` with "not initialized" (worker restarted, session
+ * expired) the entry is invalidated and `ensureWorkerSession` re-runs
+ * `initialize`.
+ */
+const workerSessionCache: Map<string, string> = new Map();
+
+/**
+ * Ensures a worker has been initialised for the current hub process and
+ * returns the `Mcp-Session-Id` to echo on subsequent requests (empty string
+ * if the worker is stateless). Caches per service; subsequent callers hit
+ * the cache.
+ * @param service - Service name
+ * @param url - Worker base URL
+ * @param authToken - Optional bearer token
+ */
+async function ensureWorkerSession(
+  service: string,
+  url: string,
+  authToken?: string
+): Promise<string> {
+  const cached = workerSessionCache.get(service);
+  if (cached !== undefined) return cached;
+
+  const sessionId = await performMcpInitialize(url, authToken);
+  if (sessionId === null) {
+    throw new Error(`Worker ${service}: initialize handshake failed`);
+  }
+  workerSessionCache.set(service, sessionId);
+  return sessionId;
+}
+
+/**
+ * Drop a cached session — used on `not initialized` 400 responses and on
+ * explicit transport errors so the next call re-runs `initialize`.
+ * @param service - Service name whose session to invalidate
+ */
+function invalidateWorkerSession(service: string): void {
+  workerSessionCache.delete(service);
+}
+
+/**
+ * Clear the per-service MCP session cache.
+ * Named with `_` prefix to signal it is a test hook — call only from test files.
+ */
+export function _clearWorkerSessionCacheForTesting(): void {
+  workerSessionCache.clear();
+}
+
+/**
  * Call a worker tool via HTTP bridge
  * @param service Service name (slack, sharepoint, redmine, gitlab)
  * @param toolName Tool name to call
@@ -457,19 +661,23 @@ export async function callWorker<T = unknown>(
     throw new Error(`Unknown service: ${service}`);
   }
 
-  const requestId = randomUUID();
   const timeout = options?.timeoutMs ?? TIMEOUTS.WORKER_REQUEST_MS;
+  const authToken = getAuthToken(service);
 
-  try {
-    const authToken = getAuthToken(service);
+  // Helper: performs the actual tools/call request with an optional cached
+  // session id. Separate so we can retry once after session invalidation
+  // without duplicating the request body / error handling.
+  const attemptCall = async (sessionId: string | undefined): Promise<Response> => {
     const headers = buildWorkerHeaders(authToken);
-
-    const response = await fetch(url, {
+    if (sessionId) {
+      headers['Mcp-Session-Id'] = sessionId;
+    }
+    return fetch(url, {
       method: 'POST',
       headers,
       body: JSON.stringify({
         jsonrpc: '2.0',
-        id: requestId,
+        id: randomUUID(),
         method: 'tools/call',
         params: {
           name: toolName,
@@ -479,6 +687,43 @@ export async function callWorker<T = unknown>(
       signal: AbortSignal.timeout(timeout),
       redirect: 'error',
     });
+  };
+
+  try {
+    // Fast path: try the call with whatever session is cached (or none, for
+    // permissive workers that never required `initialize`). This keeps the
+    // round-trip count at 1 for the common case — only strict MCP servers
+    // (`@playwright/mcp`) that reject with 400 "not initialized" pay the
+    // cost of an extra initialize handshake.
+    const cachedSid = workerSessionCache.get(service);
+    let response = await attemptCall(cachedSid);
+
+    // Strict MCP servers signal session trouble in two ways:
+    //   * 400 "Server not initialized" — no session on this request at all.
+    //   * 404 Not Found               — the Mcp-Session-Id we just sent has
+    //                                    expired or refers to a worker
+    //                                    instance that has since restarted.
+    // Both cases are recoverable by invalidating the cached session and
+    // running `initialize` (+ `notifications/initialized`) again before
+    // retrying the call exactly once.
+    if (response.status === 400 || response.status === 404) {
+      const body = await response.text();
+      const bodyLower = body.toLowerCase();
+      const looksLikeSessionIssue =
+        bodyLower.includes('not initialized') ||
+        (response.status === 404 &&
+          (bodyLower.includes('session') || bodyLower.includes('not found')));
+      if (looksLikeSessionIssue) {
+        console.warn(
+          `${ts()} [http-bridge] ${service}: ${response.status} on tools/call (${body.slice(0, 200)}) — re-initialising session`
+        );
+        invalidateWorkerSession(service);
+        const sessionId = await ensureWorkerSession(service, url, authToken);
+        response = await attemptCall(sessionId);
+      } else {
+        throw new Error(`Worker ${service} returned ${response.status}: ${body.slice(0, 200)}`);
+      }
+    }
 
     if (!response.ok) {
       throw new Error(`Worker ${service} returned ${response.status}: ${response.statusText}`);
@@ -490,30 +735,45 @@ export async function callWorker<T = unknown>(
       throw new Error(`Worker ${service} error: ${result.error.message}`);
     }
 
-    // Extract text content from MCP response
+    // Extract content from MCP response.
     const content = result.result?.content;
-    if (content && content.length > 0 && content[0].text) {
-      const text = content[0].text;
-
+    if (content && content.length > 0) {
       // Check if worker returned an error (e.g., notConfiguredMessage('Redmine'))
-      // errorResult() sets isError: true and wraps message in "Error: " prefix
+      // errorResult() sets isError: true and wraps message in "Error: " prefix.
       if (result.result?.isError) {
-        throw new Error(text);
+        const firstText = content.find((c) => c.type === 'text')?.text ?? 'Unknown error';
+        throw new Error(firstText);
       }
 
-      // Try to parse as JSON (normal response)
+      // Multi-item responses are spec-compliant (MCP 2025-11-25 §Tool Result:
+      // "can contain multiple content items of different types"). A strict
+      // server like `@playwright/mcp` returns a text summary followed by a
+      // base64 `image` item on `browser_take_screenshot`. Pass the whole
+      // array through so the executor / caller can forward every item — the
+      // image is useless without its sibling text describing the screenshot,
+      // and vice versa.
+      const textItems = content.filter((c) => c.type === 'text' && c.text !== undefined);
+      const hasNonTextItems = content.some((c) => c.type !== 'text');
+      if (hasNonTextItems) {
+        return content as T;
+      }
+
+      // Single text item — legacy shape used by all in-house workers.
+      // MCP spec 2025-11-25 §Tool Result → Text Content defines the content
+      // item as `{ "type": "text", "text": "Tool result text" }` — any
+      // string is valid, no JSON requirement. Our workers happen to wrap
+      // JSON because their bridge API returns structured data. Try JSON
+      // first so existing workers keep their typed shape; fall back to
+      // the raw string when parsing fails. Multiple text items are joined
+      // with newlines before the JSON attempt.
+      const text = textItems.map((c) => c.text).join('\n');
       try {
         return JSON.parse(text) as T;
-      } catch (parseError) {
-        const preview = text.length > 100 ? text.substring(0, 100) + '...' : text;
-        console.error(
-          `${ts()} [http-bridge] Worker ${service} returned invalid JSON:`,
-          `Preview: "${preview}"`,
-          `Parse error: ${parseError instanceof Error ? parseError.message : parseError}`
+      } catch {
+        console.warn(
+          `${ts()} [http-bridge] ${service}.${toolName}: non-JSON text response (${text.length} bytes) — passing through as string`
         );
-        throw new Error(
-          `Worker ${service} returned invalid response format. Expected JSON but received: ${preview}`
-        );
+        return text as T;
       }
     }
 
@@ -525,7 +785,7 @@ export async function callWorker<T = unknown>(
 
     console.error(
       `${ts()} [http-bridge] callWorker(${service}, ${toolName}) failed:`,
-      error instanceof Error ? error.message : error
+      error instanceof Error ? (error.stack ?? error.message) : JSON.stringify(error)
     );
     throw error;
   }

--- a/mcp-servers/hub/src/hub-types.ts
+++ b/mcp-servers/hub/src/hub-types.ts
@@ -118,8 +118,20 @@ export type TimeoutClass = 'standard' | 'long';
  * Tool file metadata (for progressive disclosure)
  */
 export interface ToolMetadata {
-  /** Tool name */
+  /** Tool name as exposed by the hub (camelCase, used by JS bridge API). */
   name: string;
+  /**
+   * Tool name as exposed by the worker itself (often snake_case, especially
+   * for third-party MCP servers that follow the MCP spec literally, e.g.
+   * `@playwright/mcp`'s `browser_navigate`). Hub uses this verbatim when
+   * issuing `tools/call` so the worker recognises the method; the hub-side
+   * `name` above is only the JS bridge alias.
+   *
+   * Optional for backward compatibility with tests that build metadata
+   * without going through `mergeToolWithMeta`; when absent, callers fall
+   * back to `name`.
+   */
+  workerToolName?: string;
   /** Tool description */
   description: string;
   /** Search keywords */

--- a/mcp-servers/hub/src/tool-discovery.ts
+++ b/mcp-servers/hub/src/tool-discovery.ts
@@ -194,6 +194,13 @@ export function mergeToolWithMeta(tool: Tool, service: string, methodName: strin
   const rawOsCategory = typeof meta.osCategory === 'string' ? meta.osCategory : undefined;
   return {
     name: methodName,
+    // Preserve the worker's original tool name (often snake_case for strict
+    // MCP servers like `@playwright/mcp` which expose `browser_navigate`
+    // rather than the camelCase `browserNavigate` used in our JS bridge
+    // API). Without this the hub discovers the tool, rewrites the name to
+    // camelCase, and then fails `tools/call` because the worker has never
+    // heard of `browserNavigate`.
+    workerToolName: tool.name,
     description: tool.description,
     keywords: tool.keywords ?? [],
     inputSchema: tool.inputSchema,

--- a/mcp-servers/hub/src/tool-registry.test.ts
+++ b/mcp-servers/hub/src/tool-registry.test.ts
@@ -23,6 +23,7 @@ import {
   stopBackgroundRefresh,
   initializeRegistry,
   refreshServiceTools,
+  _setDiscoveryRetryDelaysForTesting,
 } from './tool-registry.js';
 import { TIMEOUTS } from '@speedwave/mcp-shared';
 import type { ToolMetadata } from './hub-types.js';
@@ -40,6 +41,10 @@ describe('tool-registry', () => {
   beforeEach(() => {
     _resetRegistryForTesting();
     populateRegistryWithMockTools();
+    // Skip the up-to-7 s production backoff (1+2+4 s delays) so tests don't wait
+    // every time discovery returns zero tools. The retry logic itself is
+    // covered by a dedicated test in this file.
+    _setDiscoveryRetryDelaysForTesting([0, 0, 0]);
   });
 
   afterEach(() => {
@@ -578,6 +583,39 @@ describe('tool-registry', () => {
 
       expect(TOOL_REGISTRY['redmine']['createItem']).toBeDefined();
       expect(TOOL_REGISTRY['redmine']['listItems']).toBeUndefined();
+    });
+  });
+
+  describe('discoverWithStartupRetry', () => {
+    it('retries discovery when first attempt returns zero tools', async () => {
+      const { discoverAndMergeService } = await import('./tool-discovery.js');
+      const mockDiscover = vi.mocked(discoverAndMergeService);
+
+      _resetRegistryForTesting();
+      mockDiscover.mockClear();
+      _setDiscoveryRetryDelaysForTesting([0, 0, 0]);
+      resetServiceCaches();
+      process.env.ENABLED_SERVICES = 'gitlab';
+      process.env.WORKER_GITLAB_URL = 'http://mcp-gitlab:3000';
+
+      const toolsOnSecondAttempt: Record<string, ToolMetadata> = {
+        listBranches: {
+          name: 'listBranches',
+          workerToolName: 'list_branches',
+          description: 'List branches',
+          keywords: ['git'],
+          inputSchema: { type: 'object', properties: {} },
+          example: '',
+          service: 'gitlab',
+        } as ToolMetadata,
+      };
+
+      mockDiscover.mockResolvedValueOnce({}).mockResolvedValueOnce(toolsOnSecondAttempt);
+
+      await initializeRegistry();
+
+      expect(mockDiscover).toHaveBeenCalledTimes(2);
+      expect(Object.keys(TOOL_REGISTRY['gitlab'] ?? {}).length).toBe(1);
     });
   });
 });

--- a/mcp-servers/hub/src/tool-registry.ts
+++ b/mcp-servers/hub/src/tool-registry.ts
@@ -16,6 +16,7 @@ import { ToolMetadata, TimeoutClass } from './hub-types.js';
 import { getAllServiceNames } from './service-list.js';
 import { discoverAndMergeService } from './tool-discovery.js';
 import { ts, TIMEOUTS } from '@speedwave/mcp-shared';
+import { STARTUP_RETRY_DELAYS_MS } from './http-bridge.js';
 
 /**
  * Escape special regex characters in a string to prevent regex injection.
@@ -72,13 +73,75 @@ export let SERVICE_NAMES: readonly string[] = [];
 //═══════════════════════════════════════════════════════════════════════════════
 
 /**
+ * Retry backoff for initial tool discovery. Matches `STARTUP_RETRY_DELAYS_MS`
+ * in http-bridge.ts so a slow-starting worker (e.g. mcp-playwright needs a
+ * few seconds to bring Chromium up) has the same window to become reachable
+ * for discovery as it has for health checks. Without this, discovery ran
+ * exactly once at hub boot — if the worker was not listening yet, the
+ * service ended up with an empty registry until the next background refresh
+ * (every 5 minutes).
+ *
+ * Tests can override with `[0, 0, 0]` via `_setDiscoveryRetryDelaysForTesting`
+ * so the suite doesn't pay the 7 s real wall-clock of the production schedule.
+ */
+let discoveryRetryDelays: readonly number[] = STARTUP_RETRY_DELAYS_MS;
+
+/**
+ * Test-only hook: swap the discovery retry schedule so unit tests don't sleep
+ * for up to 7 s. Keep the production value intact otherwise.
+ * @param delaysMs - Array of delays in ms; `[]` disables retries entirely.
+ * @internal
+ */
+export function _setDiscoveryRetryDelaysForTesting(delaysMs: readonly number[]): void {
+  discoveryRetryDelays = delaysMs;
+}
+
+/**
+ * Discover tools for a single service with retry + backoff.
+ * Only retries when discovery returned zero tools — a non-empty registry
+ * is considered authoritative even if it is smaller than expected.
+ * @param service - Service name to discover
+ */
+async function discoverWithStartupRetry(service: string): Promise<Record<string, ToolMetadata>> {
+  const attempts = discoveryRetryDelays.length + 1;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    try {
+      const tools = await discoverAndMergeService(service);
+      if (Object.keys(tools).length > 0) return tools;
+    } catch (error) {
+      console.warn(
+        `${ts()} [tool-registry] ${service}: discovery attempt ${attempt + 1} failed — ` +
+          (error instanceof Error ? error.message : String(error))
+      );
+    }
+
+    const delay = discoveryRetryDelays[attempt];
+    if (delay === undefined) break;
+    console.log(
+      `${ts()} [tool-registry] ${service}: retrying discovery in ${delay / 1000}s (${attempt + 1}/${discoveryRetryDelays.length})...`
+    );
+    await new Promise((resolve) => setTimeout(resolve, delay));
+  }
+  console.warn(
+    `${ts()} [tool-registry] ${service}: registry empty after ${discoveryRetryDelays.length + 1} attempts — will populate on next background refresh`
+  );
+  return {};
+}
+
+/**
  * Initialize the registry from workers.
  * Called once at startup before initializeBridges().
  *
  * For each service:
  * 1. Try to discover tools from worker (JSON-RPC tools/list)
- * 2. Merge tool data including _meta fields
- * 3. If worker unavailable, service gets empty registry entry
+ * 2. Retry with backoff if the first attempt returns zero tools — a
+ *    slow-starting worker (e.g. `mcp-playwright` spinning up Chromium)
+ *    may not be ready when the hub boots, and without the retry the
+ *    service's registry stays empty until the next background refresh
+ *    five minutes later.
+ * 3. Merge tool data including `_meta` fields.
+ * 4. If the worker is still unavailable after retries, the service gets
+ *    an empty registry entry; background refresh will populate it later.
  */
 export async function initializeRegistry(): Promise<void> {
   if (_initialized) return;
@@ -97,17 +160,9 @@ export async function initializeRegistry(): Promise<void> {
       continue;
     }
 
-    try {
-      const tools = await discoverAndMergeService(service);
-      _registry[service] = tools;
-      console.log(`${ts()} [tool-registry] ${service}: ${Object.keys(tools).length} tools loaded`);
-    } catch (error) {
-      console.warn(
-        `${ts()} [tool-registry] ${service}: discovery failed, empty registry`,
-        error instanceof Error ? error.message : error
-      );
-      _registry[service] = {};
-    }
+    const tools = await discoverWithStartupRetry(service);
+    _registry[service] = tools;
+    console.log(`${ts()} [tool-registry] ${service}: ${Object.keys(tools).length} tools loaded`);
   }
 
   // Start background refresh (every 5 minutes)
@@ -408,12 +463,19 @@ export function buildServiceBridge(
 
   for (const methodName of Object.keys(tools)) {
     const metadata = tools[methodName];
+    // The JS bridge surface uses `methodName` (camelCase, e.g. `browserNavigate`)
+    // but the actual `tools/call` request must carry the worker's own tool
+    // name (often snake_case, e.g. `browser_navigate` for `@playwright/mcp`).
+    // Fall back to `methodName` for legacy metadata that was built without
+    // `workerToolName` — covers all in-house workers whose tool names
+    // already match the camelCase convention.
+    const workerToolName = metadata.workerToolName ?? methodName;
     bridge[methodName] = (params?: Record<string, unknown>) => {
       const perToolTimeout = metadata.timeoutMs;
       const remainingTimeout = getTimeoutMs?.();
       const timeoutMs = perToolTimeout ?? remainingTimeout;
       const options = timeoutMs ? { timeoutMs } : undefined;
-      return callWorker(service, methodName, params || {}, options);
+      return callWorker(service, workerToolName, params || {}, options);
     };
   }
 

--- a/mcp-servers/playwright/Containerfile
+++ b/mcp-servers/playwright/Containerfile
@@ -1,0 +1,111 @@
+# Speedwave MCP Playwright Worker
+#
+# Shared browser automation service — wraps Microsoft's official @playwright/mcp
+# package in a Speedwave-hardened container. Consumed by the `figma`,
+# `accessibility-audit`, `visual-regression`, and `site-analyzer` plugins (and
+# directly from Claude).
+#
+# Security profile:
+# - No /tokens mount (Playwright has no credentials).
+# - No /workspace mount in v1 (outputs returned as base64 to reduce attack
+#   surface). Will be revisited if a concrete use case requires it.
+# - --no-sandbox is safe: Lima/WSL2 VM + container cap_drop:ALL replace
+#   Chromium's sandbox, per ADR-004.
+# - --user-data-dir redirects Chromium's profile to tmpfs; container restart
+#   wipes /tmp, giving the same ephemeral-profile guarantee as --isolated.
+# - shm_size=2g set in compose (Chromium IPC needs more than the 64 MB default
+#   or it crashes on startup with ENOMEM).
+
+# Pinned digest for reproducible builds.
+# Tag: v1.59.1-jammy — tracks Playwright core 1.59.1.
+# Refresh the digest with:
+#   curl -sI -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
+#     https://mcr.microsoft.com/v2/playwright/manifests/v1.59.1-jammy | grep -i digest
+FROM mcr.microsoft.com/playwright:v1.59.1-jammy@sha256:8a0360d39d1973be506dd59002904a774f6d697d4946c94063b3fd006461c8ff
+
+# @playwright/mcp is Microsoft's official MCP server for Playwright.
+# Version is pinned; bump deliberately as part of a regular dependency-update cadence.
+ARG PLAYWRIGHT_MCP_VERSION=0.0.70
+
+# Install the MCP server globally. The image already ships Chromium + OS deps
+# (libnss, fonts, etc.) matching the Playwright core version installed here.
+RUN npm install -g "@playwright/mcp@${PLAYWRIGHT_MCP_VERSION}" \
+    && npm cache clean --force
+
+# Disable the Streamable-HTTP heartbeat (ping every 3 s, 5 s kill timeout).
+# playwright-mcp's heartbeat assumes a persistent bidirectional SSE channel
+# that the Hub does not maintain — the ping has nowhere to land, so after
+# 5 s the server calls close() and the in-flight tools/call response is
+# truncated to 0 bytes. The sed flips the only `true` (Streamable HTTP) to
+# `false`; the SSE transport on line 106 already passes `false`.
+# Pinned to @playwright/mcp 0.0.70 — re-verify on version bumps.
+RUN sed -i 's/mcpServer\.connect(serverBackendFactory, transport, true)/mcpServer.connect(serverBackendFactory, transport, false)/' \
+       /usr/lib/node_modules/@playwright/mcp/node_modules/playwright-core/lib/tools/utils/mcp/http.js \
+    && grep -q 'mcpServer.connect(serverBackendFactory, transport, false)' \
+       /usr/lib/node_modules/@playwright/mcp/node_modules/playwright-core/lib/tools/utils/mcp/http.js \
+    || (echo "FATAL: heartbeat patch did not apply — verify path for @playwright/mcp ${PLAYWRIGHT_MCP_VERSION}" && exit 1)
+
+# Non-root user pre-created by the base image (UID 1000).
+USER pwuser
+
+WORKDIR /home/pwuser
+
+ENV PORT=3000 \
+    NODE_ENV=production
+
+EXPOSE 3000
+
+# Invoke the installed binary directly — do NOT use `npx` here. Under the
+# hardened compose profile (`read_only: true`) any attempt by npm/npx to
+# create `~/.npm` (cache/logs) fails with ENOENT and the container exits
+# with code 1. The global npm install above placed `playwright-mcp` in
+# /usr/bin/, so we call it unambiguously with an absolute path.
+#
+# --host 0.0.0.0:        reachable by mcp-hub on the compose network.
+# --port 3000:           conforms to ADR-038 (PORT_WORKER).
+# --browser chromium:    use the Chromium build preinstalled in the Microsoft
+#                        Playwright base image (/ms-playwright/chromium-*).
+#                        Without this flag playwright-mcp defaults to the
+#                        `chrome` channel (Google Chrome stable), which is
+#                        NOT bundled in the base image — we'd need a second
+#                        `npx playwright install chrome` step and a writable
+#                        home directory for the browser cache, which the
+#                        hardened compose profile (read_only rootfs) makes
+#                        impossible.
+# --allowed-hosts mcp-hub: restrict to hub hostname. Other containers on the
+#                        compose network cannot call Playwright directly.
+# --headless:            no display server inside the container.
+# --no-sandbox:          required because the container drops all capabilities;
+#                        the VM + container hardening layer takes over
+#                        Chromium's in-process sandboxing role. See ADR-004.
+# Path to the preinstalled Chrome Headless Shell. Regular Chromium requires
+# CAP_SYS_ADMIN / dbus to bootstrap its own crashpad + IPC plumbing, which
+# would force us to drop `cap_drop: ALL` from the compose profile. The
+# headless shell is a stripped-down Chromium build that needs none of that
+# and runs cleanly under our hardened profile (no capabilities, no-new-
+# privileges, read-only rootfs). Same browser engine, same web platform
+# APIs — just no GPU/dbus/audio stack.
+#
+# Version number (`1217`) is pinned via the base image tag above; when you
+# bump `v1.59.1-jammy` keep this path's version in sync or the launch
+# will fail with ENOENT.
+
+# --user-data-dir / --output-dir:
+#   playwright-mcp defaults to $HOME/.playwright-mcp and $HOME/.playwright-mcp-output
+#   for its cache and file outputs. With `read_only: true` on the root
+#   filesystem these mkdirs fail with ENOENT, so we redirect both to /tmp
+#   (backed by a compose tmpfs, so the data is still ephemeral). Note that
+#   `--user-data-dir` is mutually exclusive with `--isolated` — playwright-mcp
+#   crashes on startup if both are set. We go with the user-data-dir path
+#   because restarting the container already wipes /tmp, which gives us the
+#   same "fresh profile on restart" guarantee isolated mode advertises.
+CMD ["/usr/bin/playwright-mcp", \
+     "--host", "0.0.0.0", \
+     "--port", "3000", \
+     "--browser", "chromium", \
+     "--executable-path", "/ms-playwright/chromium_headless_shell-1217/chrome-linux/headless_shell", \
+     "--user-data-dir", "/tmp/playwright-mcp-userdata", \
+     "--output-dir", "/tmp/playwright-mcp-output", \
+     "--allowed-hosts", "mcp-hub", \
+     "--headless", \
+     "--no-sandbox"]

--- a/mcp-servers/playwright/Containerfile
+++ b/mcp-servers/playwright/Containerfile
@@ -1,4 +1,4 @@
-# Speedwave MCP Playwright Worker
+# Speedwave MCP Playwright Worker — see ADR-039 in docs/adr/
 #
 # Shared browser automation service — wraps Microsoft's official @playwright/mcp
 # package in a Speedwave-hardened container. Consumed by the `figma`,

--- a/mcp-servers/playwright/package-lock.json
+++ b/mcp-servers/playwright/package-lock.json
@@ -1,0 +1,75 @@
+{
+  "name": "@speedwave/mcp-playwright",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@speedwave/mcp-playwright",
+      "version": "0.1.0",
+      "dependencies": {
+        "@playwright/mcp": "0.0.70"
+      }
+    },
+    "node_modules/@playwright/mcp": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/@playwright/mcp/-/mcp-0.0.70.tgz",
+      "integrity": "sha512-Kl0a6l9VL8rvT1oBou3hS5yArjwWV9UlwAkq+0skfK1YVg8XfmmNaAmwZhMeNx/ZhGiWXfCllo6rD/jvZz+WuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0-alpha-1774999321000",
+        "playwright-core": "1.60.0-alpha-1774999321000"
+      },
+      "bin": {
+        "playwright-mcp": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0-alpha-1774999321000",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0-alpha-1774999321000.tgz",
+      "integrity": "sha512-Bd5DkzYKG+2g1jLO6NeTXmGLbBYSFffJIOsR4l4hUBkJvzvGGdLZ7jZb2tOtb0WIoWXQKdQj3Ap6WthV4DBS8w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0-alpha-1774999321000"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0-alpha-1774999321000",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0-alpha-1774999321000.tgz",
+      "integrity": "sha512-ams3Zo4VXxeOg5ZTTh16GkE8g48Bmxo/9pg9gXl9SVKlVohCU7Jaog7XntY8yFuzENA6dJc1Fz7Z/NNTm9nGEw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/mcp-servers/playwright/package.json
+++ b/mcp-servers/playwright/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@speedwave/mcp-playwright",
+  "version": "0.1.0",
+  "description": "Speedwave MCP Playwright worker — packages Microsoft's @playwright/mcp as a hardened shared browser-automation service",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "echo 'mcp-playwright has no build step; see Containerfile'",
+    "test": "echo 'mcp-playwright is tested via compose integration tests in speedwave-runtime'"
+  },
+  "dependencies": {
+    "@playwright/mcp": "0.0.70"
+  }
+}

--- a/scripts/bundle-build-context.ps1
+++ b/scripts/bundle-build-context.ps1
@@ -20,7 +20,8 @@ New-Item -ItemType Directory -Path "$dest\build-context\mcp-servers" -Force | Ou
 Copy-Item mcp-servers\tsconfig.base.json "$dest\build-context\mcp-servers\"
 
 # os is intentionally excluded — it runs on the host and is bundled separately as mcp-os/
-$services = @('shared','hub','slack','sharepoint','redmine','gitlab')
+# playwright has no own src/ — the image installs @playwright/mcp from npm at build time.
+$services = @('shared','hub','slack','sharepoint','redmine','gitlab','playwright')
 
 foreach ($svc in $services) {
     $svcDest = "$dest\build-context\mcp-servers\$svc"
@@ -29,7 +30,10 @@ foreach ($svc in $services) {
     if (Test-Path "mcp-servers\$svc\package-lock.json") {
         Copy-Item "mcp-servers\$svc\package-lock.json" "$svcDest\"
     }
-    Copy-Item -Recurse "mcp-servers\$svc\src" "$svcDest\src"
+    # Some services (e.g. playwright) wrap an upstream npm package and have no src/.
+    if (Test-Path "mcp-servers\$svc\src") {
+        Copy-Item -Recurse "mcp-servers\$svc\src" "$svcDest\src"
+    }
     if (Test-Path "mcp-servers\$svc\tsconfig.json") {
         Copy-Item "mcp-servers\$svc\tsconfig.json" "$svcDest\"
     }

--- a/scripts/bundle-build-context.sh
+++ b/scripts/bundle-build-context.sh
@@ -28,7 +28,8 @@ mkdir -p "$DEST/build-context/mcp-servers"
 cp "$REPO_ROOT/mcp-servers/tsconfig.base.json" "$DEST/build-context/mcp-servers/"
 
 # os is intentionally excluded — it runs on the host and is bundled separately as mcp-os/
-MCP_SERVICES="shared hub slack sharepoint redmine gitlab"
+# playwright has no own src/ — the image installs @playwright/mcp from npm at build time.
+MCP_SERVICES="shared hub slack sharepoint redmine gitlab playwright"
 
 for svc in $MCP_SERVICES; do
   svc_src="$REPO_ROOT/mcp-servers/$svc"
@@ -36,7 +37,8 @@ for svc in $MCP_SERVICES; do
   mkdir -p "$svc_dest"
   cp "$svc_src/package.json" "$svc_dest/"
   [ -f "$svc_src/package-lock.json" ] && cp "$svc_src/package-lock.json" "$svc_dest/"
-  cp -r "$svc_src/src" "$svc_dest/"
+  # Some services (e.g. playwright) have no own src/ — they wrap an upstream npm package.
+  [ -d "$svc_src/src" ] && cp -r "$svc_src/src" "$svc_dest/"
   [ -f "$svc_src/tsconfig.json" ] && cp "$svc_src/tsconfig.json" "$svc_dest/"
   for f in Dockerfile Containerfile; do
     [ -f "$svc_src/$f" ] && cp "$svc_src/$f" "$svc_dest/"


### PR DESCRIPTION
## Summary

- Add `mcp-playwright` as a new built-in MCP service wrapping Microsoft's `@playwright/mcp` in a hardened container
- Wire through the full stack: compose template, Rust config/consts/build, hub session management, multi-content passthrough, and desktop UI
- Hub MCP session lifecycle: `initialize` + `notifications/initialized` + `Mcp-Session-Id` caching for strict MCP servers
- Startup discovery retry with backoff for slow-starting workers (Chromium boot)
- `workerToolName` preservation for snake_case tool names from third-party MCP servers
- `isMcpContentArray` guard for image/text content passthrough (screenshots)
- Credential-less service support in desktop UI (`hasConfigurableFields` getter)
- Security: `--allowed-hosts mcp-hub` (not `*`), no `/tokens` mount, no `/workspace` mount, base image pinned by SHA256

## Test plan

- [x] MCP hub tests pass (509 tests) — session handling, content passthrough, discovery retry
- [x] MCP type-check passes (all workspaces)
- [x] Rust tests pass (866 tests) — compose rendering, config, consts
- [x] Pre-push hooks pass (lint, format, all test suites)
- [ ] Manual: enable Playwright in Desktop UI, navigate to a URL, take a screenshot
- [ ] Manual: verify screenshot returns as inline base64 image in Claude chat
- [ ] Manual: verify credential-less service card renders without configure form