### PR TITLE
feat(runtime)!: remove LiteLLM proxy and inject local provider env vars directly (ADR-040)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,6 +1732,7 @@ dependencies = [
  "serde_yaml_ng",
  "sha2 0.11.0",
  "tempfile",
+ "url",
  "uuid",
  "zip 8.5.1",
 ]

--- a/crates/speedwave-runtime/Cargo.toml
+++ b/crates/speedwave-runtime/Cargo.toml
@@ -25,6 +25,7 @@ sha2 = "0.11"
 base64 = "0.22"
 rand = "0.8"
 semver = "1"
+url = "2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/speedwave-runtime/src/compose.rs
+++ b/crates/speedwave-runtime/src/compose.rs
@@ -215,7 +215,6 @@ pub fn save_compose(project: &str, yaml: &str) -> anyhow::Result<()> {
 }
 
 fn inject_claude_env(yaml: &str, env: &std::collections::HashMap<String, String>) -> String {
-    // Parse YAML, find claude service, inject env vars
     let mut doc: serde_yaml_ng::Value = match serde_yaml_ng::from_str(yaml) {
         Ok(v) => v,
         Err(_) => return yaml.to_string(),
@@ -226,7 +225,19 @@ fn inject_claude_env(yaml: &str, env: &std::collections::HashMap<String, String>
             if let Some(environment) = claude.get_mut("environment") {
                 if let Some(env_seq) = environment.as_sequence_mut() {
                     for (key, value) in env {
-                        env_seq.push(serde_yaml_ng::Value::String(format!("{}={}", key, value)));
+                        let new_entry = format!("{}={}", key, value);
+                        let existing = env_seq.iter().position(|v| {
+                            v.as_str()
+                                .is_some_and(|s| s.split('=').next() == Some(key.as_str()))
+                        });
+                        match existing {
+                            Some(idx) => {
+                                env_seq[idx] = serde_yaml_ng::Value::String(new_entry);
+                            }
+                            None => {
+                                env_seq.push(serde_yaml_ng::Value::String(new_entry));
+                            }
+                        }
                     }
                 }
             }
@@ -236,98 +247,97 @@ fn inject_claude_env(yaml: &str, env: &std::collections::HashMap<String, String>
     serde_yaml_ng::to_string(&doc).unwrap_or_else(|_| yaml.to_string())
 }
 
-fn apply_llm_config(yaml: &str, project_name: &str, llm: &LlmConfig) -> anyhow::Result<String> {
+fn apply_llm_config(yaml: &str, _project_name: &str, llm: &LlmConfig) -> anyhow::Result<String> {
     let provider = llm.provider.as_deref().unwrap_or("anthropic");
-
     match provider {
-        "anthropic" => {
-            // Default — no proxy needed, Claude Code connects directly to api.anthropic.com
-            Ok(yaml.to_string())
+        "anthropic" => Ok(yaml.to_string()),
+        "custom" if llm.base_url.is_none() => {
+            anyhow::bail!(
+                "Custom provider requires a base_url. \
+                 Configure it in Settings → LLM Provider → Base URL."
+            );
         }
-        "ollama" => {
-            // Ollama: direct connection without proxy
+        _ => {
             let base_url = llm
                 .base_url
-                .as_deref()
-                .unwrap_or("http://host.docker.internal:11434");
+                .clone()
+                .or_else(|| default_base_url(provider))
+                .ok_or_else(|| anyhow::anyhow!("Provider '{}' requires a base_url.", provider))?;
+            let base_url = strip_trailing_v1(&base_url);
+            validate_base_url(&base_url)?;
+            let model = llm.model.as_deref().unwrap_or("local-model");
             let extra_env = std::collections::HashMap::from([
-                ("ANTHROPIC_BASE_URL".to_string(), format!("{}/v1", base_url)),
-                ("ANTHROPIC_AUTH_TOKEN".to_string(), "ollama".to_string()),
+                ("ANTHROPIC_BASE_URL".to_string(), base_url),
+                (
+                    "ANTHROPIC_AUTH_TOKEN".to_string(),
+                    "sk-no-key-required".to_string(),
+                ),
+                (
+                    "ANTHROPIC_DEFAULT_SONNET_MODEL".to_string(),
+                    model.to_string(),
+                ),
+                (
+                    "ANTHROPIC_DEFAULT_OPUS_MODEL".to_string(),
+                    model.to_string(),
+                ),
+                (
+                    "ANTHROPIC_DEFAULT_HAIKU_MODEL".to_string(),
+                    model.to_string(),
+                ),
+                (
+                    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC".to_string(),
+                    "1".to_string(),
+                ),
+                (
+                    "CLAUDE_CODE_ATTRIBUTION_HEADER".to_string(),
+                    "0".to_string(),
+                ),
             ]);
             Ok(inject_claude_env(yaml, &extra_env))
         }
-        _ => {
-            // External provider: add llm-proxy container (LiteLLM)
-            let proxy_token = uuid::Uuid::new_v4().to_string();
-            let proxy_port = consts::PORT_WORKER;
-
-            let secrets_dir = consts::data_dir().join("secrets").join(project_name);
-            let llm_env_file = secrets_dir.join("llm.env");
-            let network_name = format!("{}_{}_network", consts::compose_prefix(), project_name);
-
-            // Parse existing YAML and add llm-proxy service
-            let mut doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(yaml)?;
-
-            let proxy_service = serde_yaml_ng::from_str::<serde_yaml_ng::Value>(&format!(
-                r#"
-image: ghcr.io/berriai/litellm:latest
-container_name: {prefix}_{project}_llm_proxy
-user: "{container_user}"
-cap_drop:
-  - ALL
-security_opt:
-  - no-new-privileges:true
-read_only: true
-tmpfs:
-  - /tmp:noexec,nosuid,size=64m
-ports:
-  - "127.0.0.1:{port}:{port}"
-env_file:
-  - {env_file}
-environment:
-  - PORT={port}
-  - LITELLM_MASTER_KEY={token}
-networks:
-  - {network}
-deploy:
-  resources:
-    limits:
-      cpus: '0.5'
-      memory: 512m
-"#,
-                prefix = consts::compose_prefix(),
-                project = project_name,
-                container_user = container_user(),
-                port = proxy_port,
-                env_file = to_engine_path(&llm_env_file)?,
-                token = proxy_token,
-                network = network_name,
-            ))?;
-
-            if let Some(services) = doc.get_mut("services") {
-                if let Some(services_map) = services.as_mapping_mut() {
-                    services_map.insert(
-                        serde_yaml_ng::Value::String("llm-proxy".to_string()),
-                        proxy_service,
-                    );
-                }
-            }
-
-            let mut result = serde_yaml_ng::to_string(&doc)?;
-
-            // Inject proxy URL into claude container
-            let extra_env = std::collections::HashMap::from([
-                (
-                    "ANTHROPIC_BASE_URL".to_string(),
-                    format!("http://llm-proxy:{}", proxy_port),
-                ),
-                ("ANTHROPIC_AUTH_TOKEN".to_string(), proxy_token),
-            ]);
-            result = inject_claude_env(&result, &extra_env);
-
-            Ok(result)
-        }
     }
+}
+
+fn strip_trailing_v1(url: &str) -> String {
+    let stripped = url.trim_end_matches('/');
+    if let Some(without_v1) = stripped.strip_suffix("/v1") {
+        without_v1.to_string()
+    } else {
+        url.to_string()
+    }
+}
+
+/// Returns the default base URL for a known local model provider.
+/// Used by the frontend to show a placeholder without duplicating the URL logic.
+pub fn default_base_url(provider: &str) -> Option<String> {
+    match provider {
+        "ollama" => Some("http://host.docker.internal:11434".to_string()),
+        "lmstudio" => Some("http://host.docker.internal:1234".to_string()),
+        "llamacpp" => Some("http://host.docker.internal:8080".to_string()),
+        _ => None,
+    }
+}
+
+/// Validates a base URL for local model providers. Rejects non-HTTP schemes,
+/// credentials, paths, query strings, and fragments.
+pub fn validate_base_url(raw: &str) -> anyhow::Result<()> {
+    let parsed =
+        url::Url::parse(raw).map_err(|e| anyhow::anyhow!("Invalid base_url '{}': {}", raw, e))?;
+    match parsed.scheme() {
+        "http" | "https" => {}
+        s => anyhow::bail!("base_url must use http:// or https://, got: {}", s),
+    }
+    if parsed.username() != "" || parsed.password().is_some() {
+        anyhow::bail!("base_url must not contain credentials");
+    }
+    let path = parsed.path();
+    if path != "/" && !path.is_empty() {
+        anyhow::bail!("base_url must not contain a path (got '{}')", path);
+    }
+    if parsed.query().is_some() || parsed.fragment().is_some() {
+        anyhow::bail!("base_url must not contain query or fragment");
+    }
+    Ok(())
 }
 
 // --- Plugin integration ---
@@ -1217,7 +1227,7 @@ impl SecurityCheck {
             Self::check_tmpfs_noexec(&doc),
             Self::check_no_tokens_in_claude(&doc),
             Self::check_no_tokens_in_hub(&doc),
-            // PORTS_LOCALHOST: any exposed port must bind 127.0.0.1 (plugins, llm-proxy)
+            // PORTS_LOCALHOST: any exposed port must bind 127.0.0.1 (plugins)
             Self::check_ports_localhost_only(&doc),
             Self::check_claude_no_socket(&doc),
             Self::check_no_external_llm_keys_claude(&doc),
@@ -1552,7 +1562,9 @@ impl SecurityCheck {
     }
 
     /// claude container must not have external LLM API keys
-    /// (OPENAI_*, GEMINI_*, DEEPSEEK_*, OPENROUTER_* — these belong in the proxy)
+    /// (OPENAI_*, GEMINI_*, DEEPSEEK_*, OPENROUTER_* — these prefixes are forbidden because
+    /// external LLM API keys must never enter the claude container. Only the dummy
+    /// ANTHROPIC_AUTH_TOKEN (sk-no-key-required) is permitted for local model providers.)
     fn check_no_external_llm_keys_claude(doc: &serde_yaml_ng::Value) -> Vec<SecurityViolation> {
         let mut violations = Vec::new();
         let services = match get_services(doc) {
@@ -1581,7 +1593,7 @@ impl SecurityCheck {
                                     var_name
                                 ),
                                 remediation:
-                                    "External LLM keys belong in the llm-proxy container, not in claude.",
+                                    "External LLM API keys must not be injected into the claude container. Use a local model provider instead.",
                             });
                         }
                     }
@@ -1592,7 +1604,7 @@ impl SecurityCheck {
     }
 
     /// MCP workers and hub must NOT expose ports to the host.
-    /// Only dynamically-injected services (llm-proxy, addons) may map ports.
+    /// Only dynamically-injected services (addons) may map ports.
     /// All inter-container communication uses Docker DNS.
     fn check_no_ports_on_workers(doc: &serde_yaml_ng::Value) -> Vec<SecurityViolation> {
         let mut violations = Vec::new();
@@ -2903,39 +2915,6 @@ services:
         }
     }
 
-    /// ADR-038: the llm-proxy container, when added for external providers,
-    /// must also listen on `PORT_WORKER` and be reached by claude at that port.
-    #[test]
-    fn test_llm_proxy_uses_port_worker() {
-        let config = ResolvedClaudeConfig {
-            env: crate::defaults::base_env(),
-            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
-            llm: LlmConfig {
-                provider: Some("openai".to_string()),
-                base_url: Some("https://api.openai.com/v1".to_string()),
-                ..Default::default()
-            },
-        };
-        let yaml = render_compose(
-            "test-project",
-            "/home/user/projects/test",
-            &config,
-            &ResolvedIntegrationsConfig::default(),
-            None,
-        )
-        .unwrap();
-
-        let worker_port = crate::consts::PORT_WORKER;
-        assert!(
-            yaml.contains(&format!("PORT={worker_port}")),
-            "llm-proxy must set PORT={worker_port}"
-        );
-        assert!(
-            yaml.contains(&format!("http://llm-proxy:{worker_port}")),
-            "ANTHROPIC_BASE_URL must point at http://llm-proxy:{worker_port}"
-        );
-    }
-
     /// ADR-038: `plugin.json.port` is deprecated and ignored. A plugin
     /// manifest that requests a non-`PORT_WORKER` port must still be wired up
     /// at `:{PORT_WORKER}` without failing.
@@ -3291,7 +3270,6 @@ services:
                 provider: Some("ollama".to_string()),
                 model: None,
                 base_url: None,
-                api_key_env: None,
             },
         };
         let yaml = render_compose(
@@ -3302,37 +3280,10 @@ services:
             None,
         )
         .unwrap();
-        // Ollama should inject ANTHROPIC_BASE_URL pointing to Ollama's OpenAI-compatible endpoint
+        // Ollama: direct injection at host.docker.internal:11434 (no /v1 suffix — ADR-040)
         assert!(
-            yaml.contains("11434/v1"),
-            "Ollama provider should set ANTHROPIC_BASE_URL with 11434/v1 port"
-        );
-    }
-
-    #[test]
-    fn test_render_compose_openai_provider() {
-        let config = ResolvedClaudeConfig {
-            env: crate::defaults::base_env(),
-            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
-            llm: LlmConfig {
-                provider: Some("openai".to_string()),
-                model: Some("gpt-4o".to_string()),
-                base_url: None,
-                api_key_env: Some("OPENAI_API_KEY".to_string()),
-            },
-        };
-        let yaml = render_compose(
-            "test-project",
-            "/home/user/projects/test",
-            &config,
-            &ResolvedIntegrationsConfig::default(),
-            None,
-        )
-        .unwrap();
-        // External provider should add an llm-proxy (LiteLLM) service
-        assert!(
-            yaml.contains("llm-proxy") || yaml.contains("llm_proxy"),
-            "OpenAI provider should add llm-proxy service"
+            yaml.contains("ANTHROPIC_BASE_URL=http://host.docker.internal:11434"),
+            "Ollama provider should set ANTHROPIC_BASE_URL to host.docker.internal:11434 (no /v1)"
         );
     }
 
@@ -3356,6 +3307,14 @@ services:
             !yaml.contains("llm-proxy"),
             "Default anthropic provider should not add llm-proxy"
         );
+        assert!(
+            !yaml.contains("litellm"),
+            "Default anthropic provider should not reference litellm"
+        );
+        assert!(
+            !yaml.contains("ghcr.io/berriai"),
+            "Default anthropic provider should not reference litellm image"
+        );
         // Should not contain base_url override (unless explicitly configured)
         let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(&yaml).unwrap();
         let claude_env = doc
@@ -3371,6 +3330,301 @@ services:
         assert!(
             !has_base_url,
             "Default anthropic should not set ANTHROPIC_BASE_URL"
+        );
+    }
+
+    fn get_claude_env(yaml: &str) -> Vec<String> {
+        let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(yaml).unwrap();
+        doc.get("services")
+            .and_then(|s| s.get("claude"))
+            .and_then(|c| c.get("environment"))
+            .and_then(|e| e.as_sequence())
+            .unwrap_or(&vec![])
+            .iter()
+            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn test_ollama_direct_injection() {
+        let config = ResolvedClaudeConfig {
+            env: crate::defaults::base_env(),
+            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            llm: LlmConfig {
+                provider: Some("ollama".to_string()),
+                model: Some("llama3.3".to_string()),
+                base_url: None,
+            },
+        };
+        let yaml = render_compose(
+            "test-project",
+            "/home/user/projects/test",
+            &config,
+            &ResolvedIntegrationsConfig::default(),
+            None,
+        )
+        .unwrap();
+        let env = get_claude_env(&yaml);
+        assert!(
+            env.iter().any(|e| e == "ANTHROPIC_BASE_URL=http://host.docker.internal:11434"),
+            "Ollama must set ANTHROPIC_BASE_URL to host.docker.internal:11434 (no /v1), got: {env:?}"
+        );
+        assert!(
+            env.iter()
+                .any(|e| e == "ANTHROPIC_AUTH_TOKEN=sk-no-key-required"),
+            "Ollama must set dummy auth token"
+        );
+        assert!(
+            env.iter()
+                .any(|e| e == "ANTHROPIC_DEFAULT_SONNET_MODEL=llama3.3"),
+            "Ollama must set default sonnet model"
+        );
+        assert!(
+            env.iter()
+                .any(|e| e == "ANTHROPIC_DEFAULT_OPUS_MODEL=llama3.3"),
+            "Ollama must set default opus model"
+        );
+        assert!(
+            env.iter()
+                .any(|e| e == "ANTHROPIC_DEFAULT_HAIKU_MODEL=llama3.3"),
+            "Ollama must set default haiku model"
+        );
+        assert!(
+            env.iter()
+                .any(|e| e == "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1"),
+            "Ollama must disable nonessential traffic"
+        );
+        assert!(
+            env.iter().any(|e| e == "CLAUDE_CODE_ATTRIBUTION_HEADER=0"),
+            "Ollama must disable attribution header"
+        );
+        assert!(!yaml.contains("llm-proxy"), "Ollama must not add llm-proxy");
+        assert!(
+            !yaml.contains("litellm"),
+            "Ollama must not reference litellm"
+        );
+    }
+
+    #[test]
+    fn test_lmstudio_default_url() {
+        let config = ResolvedClaudeConfig {
+            env: crate::defaults::base_env(),
+            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            llm: LlmConfig {
+                provider: Some("lmstudio".to_string()),
+                model: Some("qwen2.5-coder".to_string()),
+                base_url: None,
+            },
+        };
+        let yaml = render_compose(
+            "test-project",
+            "/home/user/projects/test",
+            &config,
+            &ResolvedIntegrationsConfig::default(),
+            None,
+        )
+        .unwrap();
+        let env = get_claude_env(&yaml);
+        assert!(
+            env.iter()
+                .any(|e| e == "ANTHROPIC_BASE_URL=http://host.docker.internal:1234"),
+            "LM Studio must use port 1234, got: {env:?}"
+        );
+    }
+
+    #[test]
+    fn test_llamacpp_default_url() {
+        let config = ResolvedClaudeConfig {
+            env: crate::defaults::base_env(),
+            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            llm: LlmConfig {
+                provider: Some("llamacpp".to_string()),
+                model: Some("deepseek-r1".to_string()),
+                base_url: None,
+            },
+        };
+        let yaml = render_compose(
+            "test-project",
+            "/home/user/projects/test",
+            &config,
+            &ResolvedIntegrationsConfig::default(),
+            None,
+        )
+        .unwrap();
+        let env = get_claude_env(&yaml);
+        assert!(
+            env.iter()
+                .any(|e| e == "ANTHROPIC_BASE_URL=http://host.docker.internal:8080"),
+            "llama.cpp must use port 8080, got: {env:?}"
+        );
+    }
+
+    #[test]
+    fn test_custom_provider_with_base_url() {
+        let config = ResolvedClaudeConfig {
+            env: crate::defaults::base_env(),
+            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            llm: LlmConfig {
+                provider: Some("custom".to_string()),
+                model: Some("my-model".to_string()),
+                base_url: Some("http://host.docker.internal:9999".to_string()),
+            },
+        };
+        let yaml = render_compose(
+            "test-project",
+            "/home/user/projects/test",
+            &config,
+            &ResolvedIntegrationsConfig::default(),
+            None,
+        )
+        .unwrap();
+        let env = get_claude_env(&yaml);
+        assert!(
+            env.iter()
+                .any(|e| e == "ANTHROPIC_BASE_URL=http://host.docker.internal:9999"),
+            "Custom provider must use the specified base_url, got: {env:?}"
+        );
+        assert!(
+            env.iter()
+                .any(|e| e == "ANTHROPIC_AUTH_TOKEN=sk-no-key-required"),
+            "Custom provider must set dummy auth token"
+        );
+    }
+
+    #[test]
+    fn test_custom_provider_requires_base_url() {
+        let config = ResolvedClaudeConfig {
+            env: crate::defaults::base_env(),
+            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            llm: LlmConfig {
+                provider: Some("custom".to_string()),
+                model: None,
+                base_url: None,
+            },
+        };
+        let result = render_compose(
+            "test-project",
+            "/home/user/projects/test",
+            &config,
+            &ResolvedIntegrationsConfig::default(),
+            None,
+        );
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("Custom provider requires a base_url"),
+            "Error must mention custom requires base_url, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_strip_trailing_v1() {
+        assert_eq!(strip_trailing_v1("http://x:8080/v1"), "http://x:8080");
+        assert_eq!(strip_trailing_v1("http://x:8080/v1/"), "http://x:8080");
+        assert_eq!(strip_trailing_v1("http://x:8080"), "http://x:8080");
+        assert_eq!(strip_trailing_v1(""), "");
+        assert_eq!(strip_trailing_v1("http://x:8080/v1/v1"), "http://x:8080/v1");
+    }
+
+    #[test]
+    fn test_idempotent_render() {
+        let llm = LlmConfig {
+            provider: Some("ollama".to_string()),
+            model: Some("llama3.3".to_string()),
+            base_url: None,
+        };
+        let result1 = apply_llm_config(COMPOSE_TEMPLATE, "proj", &llm).unwrap();
+        let result2 = apply_llm_config(&result1, "proj", &llm).unwrap();
+        assert_eq!(
+            result1, result2,
+            "apply_llm_config must be idempotent (no UUID injection)"
+        );
+    }
+
+    #[test]
+    fn test_base_url_rejects_non_http_schemes() {
+        for bad_url in &["javascript:alert(1)", "file:///etc/passwd", "ftp://x:21"] {
+            assert!(
+                validate_base_url(bad_url).is_err(),
+                "Must reject scheme: {bad_url}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_base_url_rejects_credentials() {
+        assert!(
+            validate_base_url("http://user:pass@host.docker.internal:11434").is_err(),
+            "Must reject credentials in URL"
+        );
+    }
+
+    #[test]
+    fn test_base_url_rejects_path() {
+        assert!(
+            validate_base_url("http://host.docker.internal:11434/api/v1/").is_err(),
+            "Must reject URL with path"
+        );
+    }
+
+    #[test]
+    fn test_base_url_accepts_remote_host() {
+        assert!(
+            validate_base_url("http://192.168.1.100:11434").is_ok(),
+            "Must accept remote IP (LLM on another machine in LAN)"
+        );
+    }
+
+    #[test]
+    fn test_base_url_accepts_localhost() {
+        assert!(
+            validate_base_url("http://localhost:11434").is_ok(),
+            "Must accept localhost"
+        );
+    }
+
+    #[test]
+    fn test_compose_template_includes_host_docker_internal() {
+        assert!(
+            COMPOSE_TEMPLATE.contains("host.docker.internal"),
+            "compose.template.yml must map host.docker.internal (needed by default_base_url hardcode)"
+        );
+    }
+
+    #[test]
+    fn test_switching_provider_ollama_to_anthropic() {
+        let llm_ollama = LlmConfig {
+            provider: Some("ollama".to_string()),
+            model: Some("llama3.3".to_string()),
+            base_url: None,
+        };
+        let llm_anthropic = LlmConfig::default();
+
+        let with_ollama = apply_llm_config(COMPOSE_TEMPLATE, "proj", &llm_ollama).unwrap();
+        let with_anthropic = apply_llm_config(COMPOSE_TEMPLATE, "proj", &llm_anthropic).unwrap();
+
+        let env_ollama = get_claude_env(&with_ollama);
+        let env_anthropic = get_claude_env(&with_anthropic);
+
+        assert!(
+            env_ollama
+                .iter()
+                .any(|e| e.starts_with("ANTHROPIC_BASE_URL=")),
+            "Ollama must set ANTHROPIC_BASE_URL"
+        );
+        assert!(
+            !env_anthropic
+                .iter()
+                .any(|e| e.starts_with("ANTHROPIC_BASE_URL=")),
+            "Anthropic must not set ANTHROPIC_BASE_URL, got: {env_anthropic:?}"
+        );
+        assert!(
+            !env_anthropic
+                .iter()
+                .any(|e| e == "CLAUDE_CODE_ATTRIBUTION_HEADER=0"),
+            "Anthropic must NOT disable attribution header — it is only stripped \
+             for local providers to avoid breaking llama.cpp/Ollama KV cache. \
+             Got: {env_anthropic:?}"
         );
     }
 
@@ -4225,29 +4479,6 @@ services:
     }
 
     #[test]
-    fn test_security_llm_proxy_ports_allowed() {
-        let yaml = r#"
-version: "3"
-services:
-  llm-proxy:
-    image: ghcr.io/berriai/litellm:latest
-    read_only: true
-    cap_drop: [ALL]
-    security_opt: [no-new-privileges:true]
-    tmpfs: ["/tmp:noexec,nosuid,size=64m"]
-    ports:
-      - "127.0.0.1:4010:4010"
-"#;
-        let violations = SecurityCheck::run(yaml, "test", &[], &test_expected_paths());
-        assert!(
-            !violations
-                .iter()
-                .any(|v| v.rule == SecurityRule::NoPortsWorkers),
-            "llm-proxy is allowed to expose ports"
-        );
-    }
-
-    #[test]
     fn test_internal_only_covers_all_template_services() {
         // Self-enforcing: parse compose.template.yml and verify every built-in
         // service (claude + mcp-*) is listed in consts::BUILT_IN_SERVICES.
@@ -4705,40 +4936,6 @@ services:
                 expected
             );
         }
-    }
-
-    #[test]
-    fn test_render_compose_llm_proxy_has_container_user() {
-        let config = ResolvedClaudeConfig {
-            env: crate::defaults::base_env(),
-            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
-            llm: LlmConfig {
-                provider: Some("openai".to_string()),
-                model: Some("gpt-4o".to_string()),
-                base_url: None,
-                api_key_env: Some("OPENAI_API_KEY".to_string()),
-            },
-        };
-        let yaml = render_compose(
-            "test-project",
-            "/home/user/projects/test",
-            &config,
-            &ResolvedIntegrationsConfig::default(),
-            None,
-        )
-        .unwrap();
-        let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(&yaml).unwrap();
-        let proxy_user = doc
-            .get("services")
-            .and_then(|s| s.get("llm-proxy"))
-            .and_then(|p| p.get("user"))
-            .and_then(|u| u.as_str());
-        assert_eq!(
-            proxy_user,
-            Some(container_user()),
-            "llm-proxy service must have user: \"{}\"",
-            container_user()
-        );
     }
 
     // ── Plugin SecurityCheck tests ───────────────────────────────────────

--- a/crates/speedwave-runtime/src/compose.rs
+++ b/crates/speedwave-runtime/src/compose.rs
@@ -138,8 +138,19 @@ pub fn render_compose(
         &tokens_dir,
     )?;
 
-    // Inject Anthropic API key from secrets if configured
-    yaml = apply_auth_config(&yaml, project_name)?;
+    // Inject Anthropic API key from secrets if configured.
+    // Skipped when a local LLM provider is active — the dummy
+    // ANTHROPIC_AUTH_TOKEN=sk-no-key-required is all Claude Code needs, and
+    // leaking the real key into a container pointed at a local server would
+    // violate least-privilege for no benefit.
+    let provider = resolved_config
+        .llm
+        .provider
+        .as_deref()
+        .unwrap_or("anthropic");
+    if provider == "anthropic" {
+        yaml = apply_auth_config(&yaml, project_name)?;
+    }
 
     // Inject mcp-os config into hub if auth token exists
     yaml = apply_mcp_os_config(&yaml)?;
@@ -257,7 +268,7 @@ fn apply_llm_config(yaml: &str, llm: &LlmConfig) -> anyhow::Result<String> {
                  Configure it in Settings → LLM Provider → Base URL."
             );
         }
-        _ => {
+        "ollama" | "lmstudio" | "llamacpp" | "custom" => {
             let base_url = llm
                 .base_url
                 .clone()
@@ -301,10 +312,17 @@ fn apply_llm_config(yaml: &str, llm: &LlmConfig) -> anyhow::Result<String> {
             ]);
             Ok(inject_claude_env(yaml, &extra_env))
         }
+        other => anyhow::bail!(
+            "Unsupported LLM provider '{other}'. \
+             Supported: anthropic, ollama, lmstudio, llamacpp, custom."
+        ),
     }
 }
 
-fn strip_trailing_v1(url: &str) -> String {
+/// Strips any trailing `/v1` and trailing slashes from a base URL.
+/// Exposed so `update_llm_config` can normalize before validating, keeping
+/// save-time and render-time acceptance consistent.
+pub fn strip_trailing_v1(url: &str) -> String {
     let stripped = url.trim_end_matches('/');
     if let Some(without_v1) = stripped.strip_suffix("/v1") {
         without_v1.to_string()
@@ -1568,8 +1586,9 @@ impl SecurityCheck {
     }
 
     /// claude container must not have external LLM API keys
-    /// (OPENAI_*, GEMINI_*, DEEPSEEK_*, OPENROUTER_* — these prefixes are forbidden because
-    /// external LLM API keys must never enter the claude container. Only the dummy
+    /// (OPENAI_*, AZURE_OPENAI_*, GEMINI_*, DEEPSEEK_*, OPENROUTER_*, COHERE_*,
+    /// MISTRAL_*, TOGETHER_*, GROQ_* — these prefixes are forbidden because external
+    /// LLM API keys must never enter the claude container. Only the dummy
     /// ANTHROPIC_AUTH_TOKEN (sk-no-key-required) is permitted for local model providers.)
     fn check_no_external_llm_keys_claude(doc: &serde_yaml_ng::Value) -> Vec<SecurityViolation> {
         let mut violations = Vec::new();
@@ -1580,7 +1599,17 @@ impl SecurityCheck {
 
         if let Some((_name, service)) = services.iter().find(|(n, _)| n == "claude") {
             if let Some(env_seq) = service.get("environment").and_then(|v| v.as_sequence()) {
-                let forbidden_prefixes = ["OPENAI_", "GEMINI_", "DEEPSEEK_", "OPENROUTER_"];
+                let forbidden_prefixes = [
+                    "OPENAI_",
+                    "AZURE_OPENAI_",
+                    "GEMINI_",
+                    "DEEPSEEK_",
+                    "OPENROUTER_",
+                    "COHERE_",
+                    "MISTRAL_",
+                    "TOGETHER_",
+                    "GROQ_",
+                ];
 
                 for item in env_seq {
                     if let Some(env_str) = item.as_str() {
@@ -2481,6 +2510,49 @@ services:
         assert!(violations
             .iter()
             .any(|v| v.rule == SecurityRule::NoExternalLlmKeysClaude));
+    }
+
+    #[test]
+    fn test_security_check_external_llm_keys_covers_major_providers() {
+        // Each prefix on its own line — one violation per leaked key. We assert the
+        // rule fires for every major third-party LLM vendor, not just the four
+        // originally hard-coded.
+        for key in [
+            "OPENAI_API_KEY=sk-x",
+            "AZURE_OPENAI_API_KEY=az-x",
+            "GEMINI_API_KEY=g-x",
+            "DEEPSEEK_API_KEY=ds-x",
+            "OPENROUTER_API_KEY=or-x",
+            "COHERE_API_KEY=co-x",
+            "MISTRAL_API_KEY=mi-x",
+            "TOGETHER_API_KEY=to-x",
+            "GROQ_API_KEY=gq-x",
+        ] {
+            let yaml = format!(
+                r#"
+version: "3"
+services:
+  claude:
+    image: speedwave-claude:latest
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /tmp:noexec,nosuid,size=512m
+    environment:
+      - {key}
+"#
+            );
+            let violations = SecurityCheck::run(&yaml, "test", &[], &test_expected_paths());
+            assert!(
+                violations
+                    .iter()
+                    .any(|v| v.rule == SecurityRule::NoExternalLlmKeysClaude),
+                "must flag {key} as an external LLM key"
+            );
+        }
     }
 
     #[test]
@@ -3492,6 +3564,32 @@ services:
             env.iter()
                 .any(|e| e == "ANTHROPIC_BASE_URL=http://host.docker.internal:8080"),
             "llama.cpp must use port 8080, got: {env:?}"
+        );
+    }
+
+    #[test]
+    fn test_unsupported_provider_rejected() {
+        let config = ResolvedClaudeConfig {
+            env: crate::defaults::base_env(),
+            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            llm: LlmConfig {
+                provider: Some("openrouter".to_string()),
+                model: Some("some-model".to_string()),
+                base_url: Some("http://host.docker.internal:9999".to_string()),
+            },
+        };
+        let result = render_compose(
+            "test-project",
+            "/home/user/projects/test",
+            &config,
+            &ResolvedIntegrationsConfig::default(),
+            None,
+        );
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("Unsupported LLM provider") && msg.contains("openrouter"),
+            "Error must mention unsupported provider, got: {msg}"
         );
     }
 

--- a/crates/speedwave-runtime/src/compose.rs
+++ b/crates/speedwave-runtime/src/compose.rs
@@ -118,7 +118,7 @@ pub fn render_compose(
     yaml = inject_claude_env(&yaml, &resolved_config.env);
 
     // Handle LLM provider switching
-    yaml = apply_llm_config(&yaml, project_name, &resolved_config.llm)?;
+    yaml = apply_llm_config(&yaml, &resolved_config.llm)?;
 
     // Ensure plugin images exist (builds pending and missing) before compose generation.
     // Scoped to plugins enabled for this project — a broken plugin in another project
@@ -247,7 +247,7 @@ fn inject_claude_env(yaml: &str, env: &std::collections::HashMap<String, String>
     serde_yaml_ng::to_string(&doc).unwrap_or_else(|_| yaml.to_string())
 }
 
-fn apply_llm_config(yaml: &str, _project_name: &str, llm: &LlmConfig) -> anyhow::Result<String> {
+fn apply_llm_config(yaml: &str, llm: &LlmConfig) -> anyhow::Result<String> {
     let provider = llm.provider.as_deref().unwrap_or("anthropic");
     match provider {
         "anthropic" => Ok(yaml.to_string()),
@@ -265,7 +265,13 @@ fn apply_llm_config(yaml: &str, _project_name: &str, llm: &LlmConfig) -> anyhow:
                 .ok_or_else(|| anyhow::anyhow!("Provider '{}' requires a base_url.", provider))?;
             let base_url = strip_trailing_v1(&base_url);
             validate_base_url(&base_url)?;
-            let model = llm.model.as_deref().unwrap_or("local-model");
+            let model = llm.model.as_deref().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Provider '{}' requires a model name. \
+                     Configure it in Settings → LLM Provider → Model.",
+                    provider
+                )
+            })?;
             let extra_env = std::collections::HashMap::from([
                 ("ANTHROPIC_BASE_URL".to_string(), base_url),
                 (
@@ -303,7 +309,7 @@ fn strip_trailing_v1(url: &str) -> String {
     if let Some(without_v1) = stripped.strip_suffix("/v1") {
         without_v1.to_string()
     } else {
-        url.to_string()
+        stripped.to_string()
     }
 }
 
@@ -3268,7 +3274,7 @@ services:
             flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
             llm: LlmConfig {
                 provider: Some("ollama".to_string()),
-                model: None,
+                model: Some("llama3.3".to_string()),
                 base_url: None,
             },
         };
@@ -3284,6 +3290,36 @@ services:
         assert!(
             yaml.contains("ANTHROPIC_BASE_URL=http://host.docker.internal:11434"),
             "Ollama provider should set ANTHROPIC_BASE_URL to host.docker.internal:11434 (no /v1)"
+        );
+    }
+
+    #[test]
+    fn test_local_provider_requires_model() {
+        let config = ResolvedClaudeConfig {
+            env: crate::defaults::base_env(),
+            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            llm: LlmConfig {
+                provider: Some("ollama".to_string()),
+                model: None,
+                base_url: None,
+            },
+        };
+        let result = render_compose(
+            "test-project",
+            "/home/user/projects/test",
+            &config,
+            &ResolvedIntegrationsConfig::default(),
+            None,
+        );
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("requires a model name"),
+            "Error must mention model requirement, got: {msg}"
+        );
+        assert!(
+            msg.contains("ollama"),
+            "Error must mention the provider, got: {msg}"
         );
     }
 
@@ -3524,6 +3560,11 @@ services:
         assert_eq!(strip_trailing_v1("http://x:8080"), "http://x:8080");
         assert_eq!(strip_trailing_v1(""), "");
         assert_eq!(strip_trailing_v1("http://x:8080/v1/v1"), "http://x:8080/v1");
+        // Regression: trailing slash without /v1 must be stripped too,
+        // otherwise ANTHROPIC_BASE_URL ends with '/' and produces
+        // double-slash request paths.
+        assert_eq!(strip_trailing_v1("http://x:8080/"), "http://x:8080");
+        assert_eq!(strip_trailing_v1("http://x:8080///"), "http://x:8080");
     }
 
     #[test]
@@ -3533,8 +3574,8 @@ services:
             model: Some("llama3.3".to_string()),
             base_url: None,
         };
-        let result1 = apply_llm_config(COMPOSE_TEMPLATE, "proj", &llm).unwrap();
-        let result2 = apply_llm_config(&result1, "proj", &llm).unwrap();
+        let result1 = apply_llm_config(COMPOSE_TEMPLATE, &llm).unwrap();
+        let result2 = apply_llm_config(&result1, &llm).unwrap();
         assert_eq!(
             result1, result2,
             "apply_llm_config must be idempotent (no UUID injection)"
@@ -3600,8 +3641,8 @@ services:
         };
         let llm_anthropic = LlmConfig::default();
 
-        let with_ollama = apply_llm_config(COMPOSE_TEMPLATE, "proj", &llm_ollama).unwrap();
-        let with_anthropic = apply_llm_config(COMPOSE_TEMPLATE, "proj", &llm_anthropic).unwrap();
+        let with_ollama = apply_llm_config(COMPOSE_TEMPLATE, &llm_ollama).unwrap();
+        let with_anthropic = apply_llm_config(COMPOSE_TEMPLATE, &llm_anthropic).unwrap();
 
         let env_ollama = get_claude_env(&with_ollama);
         let env_anthropic = get_claude_env(&with_anthropic);

--- a/crates/speedwave-runtime/src/config.rs
+++ b/crates/speedwave-runtime/src/config.rs
@@ -9,7 +9,6 @@ pub struct LlmConfig {
     pub provider: Option<String>,
     pub model: Option<String>,
     pub base_url: Option<String>,
-    pub api_key_env: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Default, Clone, Debug)]
@@ -218,11 +217,12 @@ pub fn resolve_project_config(
     let mut integrations = ResolvedIntegrationsConfig::default();
 
     // Layer 1: repo config (.speedwave.json)
+    // provider and base_url are ignored from repo config (SSRF prevention — ADR-040)
     if let Some(repo) = repo {
         if let Some(c) = repo.claude {
             merge_env(&mut env, c.env);
             if let Some(repo_llm) = c.llm {
-                merge_llm(&mut llm, &repo_llm);
+                merge_llm_repo(&mut llm, &repo_llm);
             }
         }
         if let Some(repo_integrations) = repo.integrations {
@@ -402,8 +402,14 @@ fn merge_llm(base: &mut LlmConfig, overlay: &LlmConfig) {
     if overlay.base_url.is_some() {
         base.base_url.clone_from(&overlay.base_url);
     }
-    if overlay.api_key_env.is_some() {
-        base.api_key_env.clone_from(&overlay.api_key_env);
+}
+
+/// Merge LLM config from repo source (.speedwave.json).
+/// provider and base_url are intentionally ignored to prevent SSRF via malicious repo configs.
+/// Only model is merged, allowing repos to suggest a default model name.
+fn merge_llm_repo(base: &mut LlmConfig, overlay: &LlmConfig) {
+    if overlay.model.is_some() {
+        base.model.clone_from(&overlay.model);
     }
 }
 
@@ -519,9 +525,8 @@ mod tests {
             r#"{{
                 "claude": {{
                     "llm": {{
-                        "provider": "openai",
-                        "model": "gpt-4o",
-                        "api_key_env": "OPENAI_API_KEY"
+                        "provider": "lmstudio",
+                        "model": "qwen2.5-coder"
                     }}
                 }}
             }}"#
@@ -539,7 +544,6 @@ mod tests {
                         provider: Some("ollama".to_string()),
                         model: Some("llama3.3".to_string()),
                         base_url: Some("http://host.docker.internal:11434".to_string()),
-                        api_key_env: None,
                     }),
                 }),
                 integrations: None,
@@ -551,12 +555,64 @@ mod tests {
         };
 
         let resolved = resolve_claude_config(tmp.path(), &user_config, "test-project");
+        // User config wins over repo config
         assert_eq!(resolved.llm.provider.as_deref(), Some("ollama"));
         assert_eq!(resolved.llm.model.as_deref(), Some("llama3.3"));
         assert_eq!(
             resolved.llm.base_url.as_deref(),
             Some("http://host.docker.internal:11434")
         );
+    }
+
+    #[test]
+    fn test_repo_config_cannot_set_provider() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_path = tmp.path().join(".speedwave.json");
+        let mut f = std::fs::File::create(&config_path).unwrap();
+        write!(
+            f,
+            r#"{{
+                "claude": {{
+                    "llm": {{
+                        "provider": "ollama",
+                        "base_url": "http://malicious.example.com:11434"
+                    }}
+                }}
+            }}"#
+        )
+        .unwrap();
+
+        let user_config = SpeedwaveUserConfig::default();
+        let resolved = resolve_claude_config(tmp.path(), &user_config, "test-project");
+        // provider and base_url from repo config must be ignored (SSRF prevention — ADR-040)
+        assert_eq!(resolved.llm.provider, None);
+        assert_eq!(resolved.llm.base_url, None);
+    }
+
+    #[test]
+    fn test_repo_config_cannot_set_base_url() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_path = tmp.path().join(".speedwave.json");
+        let mut f = std::fs::File::create(&config_path).unwrap();
+        write!(
+            f,
+            r#"{{
+                "claude": {{
+                    "llm": {{
+                        "base_url": "http://attacker.example.com:11434",
+                        "model": "hacked-model"
+                    }}
+                }}
+            }}"#
+        )
+        .unwrap();
+
+        let user_config = SpeedwaveUserConfig::default();
+        let resolved = resolve_claude_config(tmp.path(), &user_config, "test-project");
+        // base_url from repo config must be ignored
+        assert_eq!(resolved.llm.base_url, None);
+        // model from repo config is allowed
+        assert_eq!(resolved.llm.model.as_deref(), Some("hacked-model"));
     }
 
     #[test]

--- a/crates/speedwave-runtime/src/consts.rs
+++ b/crates/speedwave-runtime/src/consts.rs
@@ -13,10 +13,10 @@ pub const PORT_BASE: u16 = 4000;
 
 /// Port on which every MCP worker listens inside its own container.
 ///
-/// All workers — built-in services (slack, sharepoint, redmine, gitlab),
-/// the optional `llm-proxy`, and plugin workers — share this port. Each
-/// container has its own network namespace, so port reuse is safe; the
-/// compose network disambiguates by DNS service name
+/// All workers — built-in services (slack, sharepoint, redmine, gitlab)
+/// and plugin workers — share this port. Each container has its own
+/// network namespace, so port reuse is safe; the compose network
+/// disambiguates by DNS service name
 /// (`http://mcp-slack:3000`, `http://mcp-gitlab:3000`, etc.).
 ///
 /// See ADR-038 for the rationale behind the single-internal-port model.

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -4749,6 +4749,7 @@ dependencies = [
  "serde_json",
  "serde_yaml_ng",
  "sha2 0.11.0",
+ "url",
  "uuid",
  "zip 8.5.1",
 ]

--- a/desktop/src-tauri/build.rs
+++ b/desktop/src-tauri/build.rs
@@ -36,10 +36,8 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         allow_stubs,
     )?;
 
-    let manifest = speedwave_runtime::bundle::generate_bundle_manifest(
-        env!("CARGO_PKG_VERSION"),
-        &hash_root,
-    )?;
+    let manifest =
+        speedwave_runtime::bundle::generate_bundle_manifest(env!("CARGO_PKG_VERSION"), &hash_root)?;
     std::fs::create_dir_all(&build_context)?;
     let manifest_json = serde_json::to_vec_pretty(&manifest)?;
     std::fs::write(
@@ -61,15 +59,24 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     );
     println!(
         "cargo:rerun-if-changed={}",
-        repo_root.join("scripts").join("bundle-build-context.sh").display()
+        repo_root
+            .join("scripts")
+            .join("bundle-build-context.sh")
+            .display()
     );
     println!(
         "cargo:rerun-if-changed={}",
-        repo_root.join("scripts").join("build-native-macos.sh").display()
+        repo_root
+            .join("scripts")
+            .join("build-native-macos.sh")
+            .display()
     );
     println!(
         "cargo:rerun-if-changed={}",
-        repo_root.join("scripts").join("bundle-native-assets.sh").display()
+        repo_root
+            .join("scripts")
+            .join("bundle-native-assets.sh")
+            .display()
     );
     println!("cargo:rerun-if-changed={}", build_context.display());
     println!(

--- a/desktop/src-tauri/src/containers_cmd.rs
+++ b/desktop/src-tauri/src/containers_cmd.rs
@@ -629,7 +629,11 @@ pub fn update_llm_config(
     base_url: Option<String>,
 ) -> Result<(), String> {
     if let Some(ref url) = base_url {
-        speedwave_runtime::compose::validate_base_url(url).map_err(|e| e.to_string())?;
+        // Normalize the same way apply_llm_config does, so a value accepted at
+        // render time is also accepted at save time (Ollama docs commonly use
+        // `http://…/v1` suffixes; we strip that before validating).
+        let normalized = speedwave_runtime::compose::strip_trailing_v1(url);
+        speedwave_runtime::compose::validate_base_url(&normalized).map_err(|e| e.to_string())?;
     }
     config::with_config_lock(|| {
         let mut user_config = config::load_user_config()?;
@@ -853,6 +857,26 @@ mod tests {
             err.contains("http://") || err.contains("https://") || err.contains("base_url"),
             "Error must mention http/https scheme requirement, got: {err}"
         );
+    }
+
+    #[test]
+    fn update_llm_config_accepts_v1_suffix() {
+        // Regression: a `…/v1` URL (common in Ollama/LiteLLM docs) must be accepted
+        // at save time because compose rendering strips the suffix before validating.
+        // Previously this produced a false "base_url must not contain a path" error.
+        // We only check the URL-validation path here — a config-save error is fine,
+        // what we require is that the error (if any) is NOT the path rejection.
+        let result = update_llm_config(
+            Some("custom".to_string()),
+            Some("llama3.3".to_string()),
+            Some("http://localhost:11434/v1".to_string()),
+        );
+        if let Err(err) = result {
+            assert!(
+                !err.contains("must not contain a path"),
+                "`/v1` suffix must be stripped before validation, got: {err}"
+            );
+        }
     }
 
     // -- MockRuntime for switch/teardown tests --

--- a/desktop/src-tauri/src/containers_cmd.rs
+++ b/desktop/src-tauri/src/containers_cmd.rs
@@ -577,11 +577,15 @@ pub fn get_llm_config() -> Result<LlmConfigResponse, String> {
         .active_project_entry()
         .and_then(|p| p.claude.as_ref())
         .and_then(|c| c.llm.as_ref());
+    let provider = llm.and_then(|l| l.provider.clone());
+    let default_url = provider
+        .as_deref()
+        .and_then(speedwave_runtime::compose::default_base_url);
     Ok(LlmConfigResponse {
-        provider: llm.and_then(|l| l.provider.clone()),
+        provider,
         model: llm.and_then(|l| l.model.clone()),
         base_url: llm.and_then(|l| l.base_url.clone()),
-        api_key_env: llm.and_then(|l| l.api_key_env.clone()),
+        default_base_url: default_url,
     })
 }
 
@@ -591,7 +595,6 @@ fn apply_llm_config(
     provider: Option<String>,
     model: Option<String>,
     base_url: Option<String>,
-    api_key_env: Option<String>,
 ) -> anyhow::Result<()> {
     let active = user_config
         .active_project
@@ -605,7 +608,6 @@ fn apply_llm_config(
         provider,
         model,
         base_url,
-        api_key_env,
     };
     match &mut project.claude {
         Some(c) => c.llm = Some(llm),
@@ -625,11 +627,13 @@ pub fn update_llm_config(
     provider: Option<String>,
     model: Option<String>,
     base_url: Option<String>,
-    api_key_env: Option<String>,
 ) -> Result<(), String> {
+    if let Some(ref url) = base_url {
+        speedwave_runtime::compose::validate_base_url(url).map_err(|e| e.to_string())?;
+    }
     config::with_config_lock(|| {
         let mut user_config = config::load_user_config()?;
-        apply_llm_config(&mut user_config, provider, model, base_url, api_key_env)?;
+        apply_llm_config(&mut user_config, provider, model, base_url)?;
         config::save_user_config(&user_config)
     })
     .map_err(|e| e.to_string())
@@ -665,7 +669,6 @@ mod tests {
                             provider: Some("anthropic".to_string()),
                             model: Some("claude-sonnet-4-6".to_string()),
                             base_url: None,
-                            api_key_env: None,
                         }),
                     }),
                     integrations: None,
@@ -688,19 +691,17 @@ mod tests {
 
         let result = apply_llm_config(
             &mut cfg,
-            Some("openai".to_string()),
-            Some("gpt-4o".to_string()),
-            Some("http://localhost:8080".to_string()),
-            Some("OPENAI_KEY".to_string()),
+            Some("ollama".to_string()),
+            Some("llama3.3".to_string()),
+            Some("http://localhost:11434".to_string()),
         );
         assert!(result.is_ok());
 
         let project = cfg.find_project("alpha").unwrap();
         let llm = project.claude.as_ref().unwrap().llm.as_ref().unwrap();
-        assert_eq!(llm.provider.as_deref(), Some("openai"));
-        assert_eq!(llm.model.as_deref(), Some("gpt-4o"));
-        assert_eq!(llm.base_url.as_deref(), Some("http://localhost:8080"));
-        assert_eq!(llm.api_key_env.as_deref(), Some("OPENAI_KEY"));
+        assert_eq!(llm.provider.as_deref(), Some("ollama"));
+        assert_eq!(llm.model.as_deref(), Some("llama3.3"));
+        assert_eq!(llm.base_url.as_deref(), Some("http://localhost:11434"));
     }
 
     #[test]
@@ -714,7 +715,6 @@ mod tests {
             Some("ollama".to_string()),
             Some("llama3.3".to_string()),
             None,
-            None,
         );
         assert!(result.is_ok());
 
@@ -723,7 +723,6 @@ mod tests {
         assert_eq!(llm.provider.as_deref(), Some("ollama"));
         assert_eq!(llm.model.as_deref(), Some("llama3.3"));
         assert_eq!(llm.base_url, None);
-        assert_eq!(llm.api_key_env, None);
     }
 
     #[test]
@@ -731,7 +730,7 @@ mod tests {
         let mut cfg = make_config_with_active_project();
         cfg.active_project = Some("beta".to_string());
 
-        let result = apply_llm_config(&mut cfg, None, None, None, None);
+        let result = apply_llm_config(&mut cfg, None, None, None);
         assert!(result.is_ok());
 
         let project = cfg.find_project("beta").unwrap();
@@ -739,7 +738,6 @@ mod tests {
         assert!(llm.provider.is_none());
         assert!(llm.model.is_none());
         assert!(llm.base_url.is_none());
-        assert!(llm.api_key_env.is_none());
     }
 
     #[test]
@@ -757,7 +755,7 @@ mod tests {
             log_level: None,
         };
 
-        let result = apply_llm_config(&mut cfg, Some("openai".to_string()), None, None, None);
+        let result = apply_llm_config(&mut cfg, Some("ollama".to_string()), None, None);
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
@@ -781,7 +779,7 @@ mod tests {
             log_level: None,
         };
 
-        let result = apply_llm_config(&mut cfg, Some("openai".to_string()), None, None, None);
+        let result = apply_llm_config(&mut cfg, Some("ollama".to_string()), None, None);
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
@@ -812,7 +810,7 @@ mod tests {
             log_level: None,
         };
 
-        apply_llm_config(&mut cfg, Some("openai".to_string()), None, None, None).unwrap();
+        apply_llm_config(&mut cfg, Some("ollama".to_string()), None, None).unwrap();
 
         let project = cfg.find_project("proj").unwrap();
         let claude = project.claude.as_ref().unwrap();
@@ -824,7 +822,7 @@ mod tests {
         assert!(claude.settings.is_some(), "settings should be preserved");
         assert_eq!(
             claude.llm.as_ref().unwrap().provider.as_deref(),
-            Some("openai")
+            Some("ollama")
         );
     }
 
@@ -833,13 +831,28 @@ mod tests {
         let mut cfg = make_config_with_active_project();
         // active_project is "alpha"
 
-        apply_llm_config(&mut cfg, Some("openai".to_string()), None, None, None).unwrap();
+        apply_llm_config(&mut cfg, Some("ollama".to_string()), None, None).unwrap();
 
         // beta should be unchanged
         let beta = cfg.find_project("beta").unwrap();
         let beta_llm = beta.claude.as_ref().unwrap().llm.as_ref().unwrap();
         assert_eq!(beta_llm.provider.as_deref(), Some("anthropic"));
         assert_eq!(beta_llm.model.as_deref(), Some("claude-sonnet-4-6"));
+    }
+
+    #[test]
+    fn update_llm_config_rejects_invalid_base_url() {
+        let result = update_llm_config(
+            Some("custom".to_string()),
+            None,
+            Some("javascript:alert(1)".to_string()),
+        );
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("http://") || err.contains("https://") || err.contains("base_url"),
+            "Error must mention http/https scheme requirement, got: {err}"
+        );
     }
 
     // -- MockRuntime for switch/teardown tests --

--- a/desktop/src-tauri/src/types.rs
+++ b/desktop/src-tauri/src/types.rs
@@ -35,7 +35,7 @@ pub(crate) struct LlmConfigResponse {
     pub(crate) provider: Option<String>,
     pub(crate) model: Option<String>,
     pub(crate) base_url: Option<String>,
-    pub(crate) api_key_env: Option<String>,
+    pub(crate) default_base_url: Option<String>,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/desktop/src/src/app/settings/auth-section/auth-section.component.spec.ts
+++ b/desktop/src/src/app/settings/auth-section/auth-section.component.spec.ts
@@ -61,18 +61,22 @@ describe('AuthSectionComponent', () => {
     expect(methodSelect).not.toBeNull();
   });
 
-  it('shows ollama message when llmProvider is ollama', () => {
+  it('shows local provider note when llmProvider is ollama', () => {
     component.llmProvider = 'ollama';
     fixture.detectChanges();
     const note = fixture.nativeElement.querySelector('[data-testid="auth-note"]');
-    expect(note?.textContent).toContain('No authentication needed for Ollama');
+    expect(note?.textContent).toContain('No authentication needed for local model providers');
   });
 
-  it('shows external message when llmProvider is external', () => {
-    component.llmProvider = 'external';
-    fixture.detectChanges();
-    const note = fixture.nativeElement.querySelector('[data-testid="auth-note"]');
-    expect(note?.textContent).toContain('Uses API key env var');
+  it.each([
+    ['ollama', true],
+    ['lmstudio', true],
+    ['llamacpp', true],
+    ['custom', true],
+    ['anthropic', false],
+  ])('isLocalProvider() returns %s for provider %s', (provider, expected) => {
+    component.llmProvider = provider;
+    expect(component.isLocalProvider()).toBe(expected);
   });
 
   it('loads auth status when activeProject changes', async () => {

--- a/desktop/src/src/app/settings/auth-section/auth-section.component.ts
+++ b/desktop/src/src/app/settings/auth-section/auth-section.component.ts
@@ -101,22 +101,12 @@ import { AuthTerminalComponent } from '../auth-terminal.component';
         </div>
       </section>
     }
-    @if (llmProvider === 'ollama') {
+    @if (isLocalProvider()) {
       <section class="mb-6">
         <h2 class="text-[15px] text-sw-text m-0 mb-3">Authentication</h2>
         <div class="bg-sw-bg-dark border border-sw-border rounded-lg p-4">
           <p class="text-[11px] text-sw-text-faint mt-2 mb-0" data-testid="auth-note">
-            No authentication needed for Ollama.
-          </p>
-        </div>
-      </section>
-    }
-    @if (llmProvider === 'external') {
-      <section class="mb-6">
-        <h2 class="text-[15px] text-sw-text m-0 mb-3">Authentication</h2>
-        <div class="bg-sw-bg-dark border border-sw-border rounded-lg p-4">
-          <p class="text-[11px] text-sw-text-faint mt-2 mb-0" data-testid="auth-note">
-            Uses API key env var from LLM Provider settings above.
+            No authentication needed for local model providers.
           </p>
         </div>
       </section>
@@ -139,6 +129,11 @@ export class AuthSectionComponent implements OnChanges {
   private cdr = inject(ChangeDetectorRef);
   private tauri = inject(TauriService);
   private projectState = inject(ProjectStateService);
+
+  /** Returns true if the selected provider is a local model (no Anthropic auth needed). */
+  isLocalProvider(): boolean {
+    return ['ollama', 'lmstudio', 'llamacpp', 'custom'].includes(this.llmProvider);
+  }
 
   /**
    * Reloads auth status when the active project changes.

--- a/desktop/src/src/app/settings/llm-provider/llm-provider.component.spec.ts
+++ b/desktop/src/src/app/settings/llm-provider/llm-provider.component.spec.ts
@@ -111,7 +111,7 @@ describe('LlmProviderComponent', () => {
     expect(component.modelPlaceholder()).toBe('deepseek-r1');
 
     component.provider = 'custom';
-    expect(component.modelPlaceholder()).toBe('local-model');
+    expect(component.modelPlaceholder()).toBe('your-model-name');
   });
 
   it('saves config and sets saved flag', async () => {

--- a/desktop/src/src/app/settings/llm-provider/llm-provider.component.spec.ts
+++ b/desktop/src/src/app/settings/llm-provider/llm-provider.component.spec.ts
@@ -2,13 +2,19 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { LlmProviderComponent } from './llm-provider.component';
 import { TauriService } from '../../services/tauri.service';
+import { ProjectStateService } from '../../services/project-state.service';
 import { MockTauriService } from '../../testing/mock-tauri.service';
 
-function setupMockTauri(mockTauri: MockTauriService): void {
+function setupMockTauri(mockTauri: MockTauriService, provider = 'anthropic'): void {
   mockTauri.invokeHandler = async (cmd: string) => {
     switch (cmd) {
       case 'get_llm_config':
-        return { provider: 'anthropic', model: null, base_url: null, api_key_env: null };
+        return {
+          provider,
+          model: null,
+          base_url: null,
+          default_base_url: provider === 'ollama' ? 'http://host.docker.internal:11434' : null,
+        };
       case 'update_llm_config':
         return undefined;
       default:
@@ -43,7 +49,6 @@ describe('LlmProviderComponent', () => {
     expect(component.provider).toBe('anthropic');
     expect(component.model).toBe('');
     expect(component.baseUrl).toBe('');
-    expect(component.apiKeyEnv).toBe('');
     expect(component.saving).toBe(false);
     expect(component.saved).toBe(false);
   });
@@ -56,7 +61,7 @@ describe('LlmProviderComponent', () => {
             provider: 'ollama',
             model: 'llama3.3',
             base_url: 'http://localhost:11434',
-            api_key_env: null,
+            default_base_url: 'http://host.docker.internal:11434',
           };
         default:
           return undefined;
@@ -69,6 +74,7 @@ describe('LlmProviderComponent', () => {
     expect(component.provider).toBe('ollama');
     expect(component.model).toBe('llama3.3');
     expect(component.baseUrl).toBe('http://localhost:11434');
+    expect(component.defaultBaseUrl).toBe('http://host.docker.internal:11434');
   });
 
   it('emits providerChange on load', async () => {
@@ -98,8 +104,14 @@ describe('LlmProviderComponent', () => {
     component.provider = 'ollama';
     expect(component.modelPlaceholder()).toBe('llama3.3');
 
-    component.provider = 'external';
-    expect(component.modelPlaceholder()).toBe('gpt-4o');
+    component.provider = 'lmstudio';
+    expect(component.modelPlaceholder()).toBe('qwen2.5-coder');
+
+    component.provider = 'llamacpp';
+    expect(component.modelPlaceholder()).toBe('deepseek-r1');
+
+    component.provider = 'custom';
+    expect(component.modelPlaceholder()).toBe('local-model');
   });
 
   it('saves config and sets saved flag', async () => {
@@ -146,11 +158,36 @@ describe('LlmProviderComponent', () => {
   it('emits providerChange on successful save', async () => {
     const spy = vi.fn();
     component.providerChange.subscribe(spy);
-    component.provider = 'external';
+    component.provider = 'ollama';
 
     await component.saveConfig();
 
-    expect(spy).toHaveBeenCalledWith('external');
+    expect(spy).toHaveBeenCalledWith('ollama');
+  });
+
+  it('requests container restart on successful save', async () => {
+    const projectState = TestBed.inject(ProjectStateService);
+    projectState.needsRestart = false;
+    component.provider = 'ollama';
+
+    await component.saveConfig();
+
+    expect(projectState.needsRestart).toBe(true);
+  });
+
+  it('does not request restart when save fails', async () => {
+    const projectState = TestBed.inject(ProjectStateService);
+    projectState.needsRestart = false;
+    mockTauri.invokeHandler = async (cmd: string) => {
+      if (cmd === 'update_llm_config') {
+        throw new Error('save failed');
+      }
+      return undefined;
+    };
+
+    await component.saveConfig();
+
+    expect(projectState.needsRestart).toBe(false);
   });
 
   it('sends null for empty optional fields', async () => {
@@ -166,13 +203,12 @@ describe('LlmProviderComponent', () => {
     component.provider = 'anthropic';
     component.model = '';
     component.baseUrl = '';
-    component.apiKeyEnv = '';
 
     await component.saveConfig();
 
     expect(invokedArgs['model']).toBeNull();
     expect(invokedArgs['baseUrl']).toBeNull();
-    expect(invokedArgs['apiKeyEnv']).toBeNull();
+    expect(invokedArgs['apiKeyEnv']).toBeUndefined();
   });
 
   it('renders provider select', async () => {
@@ -185,65 +221,94 @@ describe('LlmProviderComponent', () => {
     expect(select.tagName).toBe('SELECT');
   });
 
-  it('renders model input', async () => {
-    component.ngOnInit();
-    await fixture.whenStable();
-    fixture.detectChanges();
-
-    const input = fixture.nativeElement.querySelector('[data-testid="settings-llm-model"]');
-    expect(input).not.toBeNull();
-  });
-
-  it('shows base URL field for ollama provider', async () => {
-    component.provider = 'ollama';
-    fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
-
-    const input = fixture.nativeElement.querySelector('[data-testid="settings-llm-base-url"]');
-    expect(input).not.toBeNull();
-  });
-
-  it('shows base URL field for external provider', async () => {
-    component.provider = 'external';
-    fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
-
-    const input = fixture.nativeElement.querySelector('[data-testid="settings-llm-base-url"]');
-    expect(input).not.toBeNull();
-  });
-
-  it('hides base URL field for anthropic provider', () => {
+  it('hides model and base URL fields for anthropic provider', async () => {
     component.provider = 'anthropic';
     fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
-    const input = fixture.nativeElement.querySelector('[data-testid="settings-llm-base-url"]');
-    expect(input).toBeNull();
+    const modelInput = fixture.nativeElement.querySelector('[data-testid="settings-llm-model"]');
+    expect(modelInput).toBeNull();
+
+    const baseUrlInput = fixture.nativeElement.querySelector(
+      '[data-testid="settings-llm-base-url"]'
+    );
+    expect(baseUrlInput).toBeNull();
   });
 
-  it('shows API key env field only for external provider', () => {
-    component.provider = 'external';
-    fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
-
-    const input = fixture.nativeElement.querySelector('[data-testid="settings-llm-api-key-env"]');
-    expect(input).not.toBeNull();
-  });
-
-  it('hides API key env field for non-external providers', () => {
-    component.provider = 'anthropic';
-    fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
-
-    let input = fixture.nativeElement.querySelector('[data-testid="settings-llm-api-key-env"]');
-    expect(input).toBeNull();
-
+  it('shows model and base URL fields for ollama provider', async () => {
     component.provider = 'ollama';
     fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
-    input = fixture.nativeElement.querySelector('[data-testid="settings-llm-api-key-env"]');
-    expect(input).toBeNull();
+    const modelInput = fixture.nativeElement.querySelector('[data-testid="settings-llm-model"]');
+    expect(modelInput).not.toBeNull();
+
+    const baseUrlInput = fixture.nativeElement.querySelector(
+      '[data-testid="settings-llm-base-url"]'
+    );
+    expect(baseUrlInput).not.toBeNull();
+  });
+
+  it('shows model and base URL fields for lmstudio provider', async () => {
+    component.provider = 'lmstudio';
+    fixture.changeDetectorRef.markForCheck();
+    fixture.detectChanges();
+
+    const baseUrlInput = fixture.nativeElement.querySelector(
+      '[data-testid="settings-llm-base-url"]'
+    );
+    expect(baseUrlInput).not.toBeNull();
+  });
+
+  it('shows model and base URL fields for llamacpp provider', async () => {
+    component.provider = 'llamacpp';
+    fixture.changeDetectorRef.markForCheck();
+    fixture.detectChanges();
+
+    const baseUrlInput = fixture.nativeElement.querySelector(
+      '[data-testid="settings-llm-base-url"]'
+    );
+    expect(baseUrlInput).not.toBeNull();
+  });
+
+  it('shows model and base URL fields for custom provider', async () => {
+    component.provider = 'custom';
+    fixture.changeDetectorRef.markForCheck();
+    fixture.detectChanges();
+
+    const baseUrlInput = fixture.nativeElement.querySelector(
+      '[data-testid="settings-llm-base-url"]'
+    );
+    expect(baseUrlInput).not.toBeNull();
+  });
+
+  it('uses default_base_url from backend as placeholder', async () => {
+    component.provider = 'ollama';
+    component.defaultBaseUrl = 'http://host.docker.internal:11434';
+    fixture.changeDetectorRef.markForCheck();
+    fixture.detectChanges();
+
+    const baseUrlInput = fixture.nativeElement.querySelector(
+      '[data-testid="settings-llm-base-url"]'
+    );
+    expect(baseUrlInput).not.toBeNull();
+    expect(baseUrlInput.placeholder).toBe('http://host.docker.internal:11434');
+  });
+
+  it('does not send api key env var field', async () => {
+    let invokedArgs: Record<string, unknown> = {};
+    mockTauri.invokeHandler = async (cmd: string, args?: Record<string, unknown>) => {
+      if (cmd === 'update_llm_config') {
+        invokedArgs = args ?? {};
+        return undefined;
+      }
+      return undefined;
+    };
+
+    component.provider = 'ollama';
+    await component.saveConfig();
+
+    expect(Object.keys(invokedArgs)).not.toContain('apiKeyEnv');
   });
 
   it('renders save button', () => {

--- a/desktop/src/src/app/settings/llm-provider/llm-provider.component.ts
+++ b/desktop/src/src/app/settings/llm-provider/llm-provider.component.ts
@@ -122,7 +122,7 @@ export class LlmProviderComponent implements OnInit {
       case 'llamacpp':
         return 'deepseek-r1';
       case 'custom':
-        return 'local-model';
+        return 'your-model-name';
       default:
         return 'claude-sonnet-4-6';
     }

--- a/desktop/src/src/app/settings/llm-provider/llm-provider.component.ts
+++ b/desktop/src/src/app/settings/llm-provider/llm-provider.component.ts
@@ -10,12 +10,13 @@ import {
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { TauriService } from '../../services/tauri.service';
+import { ProjectStateService } from '../../services/project-state.service';
 
 interface LlmConfigResponse {
   provider: string | null;
   model: string | null;
   base_url: string | null;
-  api_key_env: string | null;
+  default_base_url: string | null;
 }
 
 /** Manages LLM provider selection and configuration. */
@@ -40,22 +41,26 @@ interface LlmConfigResponse {
             data-testid="settings-llm-provider"
           >
             <option value="anthropic">Anthropic (default)</option>
-            <option value="ollama">Ollama (local)</option>
-            <option value="external">External (LiteLLM proxy)</option>
+            <option value="ollama">Ollama (local) — requires 0.14.0+</option>
+            <option value="lmstudio">LM Studio (local) — requires 0.4.1+</option>
+            <option value="llamacpp">llama.cpp (local) — requires Jan 2026+</option>
+            <option value="custom">Custom endpoint</option>
           </select>
         </div>
-        <div class="flex justify-between items-center py-2 border-t border-sw-border">
-          <label class="text-[13px] text-sw-text-muted min-w-[120px]" for="llm-model">Model</label>
-          <input
-            id="llm-model"
-            type="text"
-            [(ngModel)]="model"
-            [placeholder]="modelPlaceholder()"
-            class="flex-1 max-w-[340px] px-2.5 py-1.5 bg-sw-bg-abyss border border-sw-border rounded text-sw-text text-[13px] font-mono outline-none focus:border-sw-accent"
-            data-testid="settings-llm-model"
-          />
-        </div>
-        @if (provider === 'ollama' || provider === 'external') {
+        @if (provider !== 'anthropic') {
+          <div class="flex justify-between items-center py-2 border-t border-sw-border">
+            <label class="text-[13px] text-sw-text-muted min-w-[120px]" for="llm-model"
+              >Model</label
+            >
+            <input
+              id="llm-model"
+              type="text"
+              [(ngModel)]="model"
+              [placeholder]="modelPlaceholder()"
+              class="flex-1 max-w-[340px] px-2.5 py-1.5 bg-sw-bg-abyss border border-sw-border rounded text-sw-text text-[13px] font-mono outline-none focus:border-sw-accent"
+              data-testid="settings-llm-model"
+            />
+          </div>
           <div class="flex justify-between items-center py-2 border-t border-sw-border">
             <label class="text-[13px] text-sw-text-muted min-w-[120px]" for="llm-base-url"
               >Base URL</label
@@ -64,24 +69,9 @@ interface LlmConfigResponse {
               id="llm-base-url"
               type="text"
               [(ngModel)]="baseUrl"
-              placeholder="http://host.docker.internal:11434"
+              [placeholder]="defaultBaseUrl || baseUrlPlaceholder()"
               class="flex-1 max-w-[340px] px-2.5 py-1.5 bg-sw-bg-abyss border border-sw-border rounded text-sw-text text-[13px] font-mono outline-none focus:border-sw-accent"
               data-testid="settings-llm-base-url"
-            />
-          </div>
-        }
-        @if (provider === 'external') {
-          <div class="flex justify-between items-center py-2 border-t border-sw-border">
-            <label class="text-[13px] text-sw-text-muted min-w-[120px]" for="llm-api-key-env"
-              >API Key env var</label
-            >
-            <input
-              id="llm-api-key-env"
-              type="text"
-              [(ngModel)]="apiKeyEnv"
-              placeholder="OPENAI_API_KEY"
-              class="flex-1 max-w-[340px] px-2.5 py-1.5 bg-sw-bg-abyss border border-sw-border rounded text-sw-text text-[13px] font-mono outline-none focus:border-sw-accent"
-              data-testid="settings-llm-api-key-env"
             />
           </div>
         }
@@ -98,9 +88,6 @@ interface LlmConfigResponse {
             <span class="text-sw-success text-[13px]" data-testid="settings-llm-saved">Saved!</span>
           }
         </div>
-        <p class="text-[11px] text-sw-text-faint mt-2 mb-0">
-          Changes take effect on next container restart.
-        </p>
       </div>
     </section>
   `,
@@ -109,7 +96,7 @@ export class LlmProviderComponent implements OnInit {
   provider = 'anthropic';
   model = '';
   baseUrl = '';
-  apiKeyEnv = '';
+  defaultBaseUrl = '';
   saving = false;
   saved = false;
 
@@ -118,6 +105,7 @@ export class LlmProviderComponent implements OnInit {
 
   private cdr = inject(ChangeDetectorRef);
   private tauri = inject(TauriService);
+  private projectState = inject(ProjectStateService);
 
   /** Loads the LLM configuration from the backend on init. */
   ngOnInit(): void {
@@ -129,15 +117,34 @@ export class LlmProviderComponent implements OnInit {
     switch (this.provider) {
       case 'ollama':
         return 'llama3.3';
-      case 'external':
-        return 'gpt-4o';
+      case 'lmstudio':
+        return 'qwen2.5-coder';
+      case 'llamacpp':
+        return 'deepseek-r1';
+      case 'custom':
+        return 'local-model';
       default:
         return 'claude-sonnet-4-6';
     }
   }
 
+  /** Returns a fallback base URL placeholder when backend default_base_url is unavailable. */
+  baseUrlPlaceholder(): string {
+    switch (this.provider) {
+      case 'ollama':
+        return 'http://host.docker.internal:11434';
+      case 'lmstudio':
+        return 'http://host.docker.internal:1234';
+      case 'llamacpp':
+        return 'http://host.docker.internal:8080';
+      default:
+        return 'http://host.docker.internal:11434';
+    }
+  }
+
   /** Notifies parent when the provider selection changes. */
   onProviderChange(): void {
+    this.defaultBaseUrl = '';
     this.providerChange.emit(this.provider);
   }
 
@@ -150,10 +157,10 @@ export class LlmProviderComponent implements OnInit {
         provider: this.provider,
         model: this.model || null,
         baseUrl: this.baseUrl || null,
-        apiKeyEnv: this.apiKeyEnv || null,
       });
       this.saved = true;
       this.providerChange.emit(this.provider);
+      this.projectState.requestRestart();
       setTimeout(() => {
         this.saved = false;
         this.cdr.markForCheck();
@@ -171,7 +178,7 @@ export class LlmProviderComponent implements OnInit {
       this.provider = config.provider || 'anthropic';
       this.model = config.model || '';
       this.baseUrl = config.base_url || '';
-      this.apiKeyEnv = config.api_key_env || '';
+      this.defaultBaseUrl = config.default_base_url || '';
       this.providerChange.emit(this.provider);
     } catch {
       // Not running inside Tauri or no config yet

--- a/desktop/src/src/app/settings/llm-provider/llm-provider.component.ts
+++ b/desktop/src/src/app/settings/llm-provider/llm-provider.component.ts
@@ -130,16 +130,10 @@ export class LlmProviderComponent implements OnInit {
 
   /** Returns a fallback base URL placeholder when backend default_base_url is unavailable. */
   baseUrlPlaceholder(): string {
-    switch (this.provider) {
-      case 'ollama':
-        return 'http://host.docker.internal:11434';
-      case 'lmstudio':
-        return 'http://host.docker.internal:1234';
-      case 'llamacpp':
-        return 'http://host.docker.internal:8080';
-      default:
-        return 'http://host.docker.internal:11434';
-    }
+    // No meaningful default for 'custom' — user must supply their own URL.
+    // Backend is SSOT for known-provider defaults (see default_base_url in compose.rs);
+    // this is just a fallback hint if the backend response arrives late.
+    return '';
   }
 
   /** Notifies parent when the provider selection changes. */

--- a/desktop/src/src/app/settings/settings.component.spec.ts
+++ b/desktop/src/src/app/settings/settings.component.spec.ts
@@ -15,7 +15,7 @@ function setupMockTauri(mockTauri: MockTauriService): void {
           active_project: 'test-project',
         };
       case 'get_llm_config':
-        return { provider: 'anthropic', model: null, base_url: null, api_key_env: null };
+        return { provider: 'anthropic', model: null, base_url: null, default_base_url: null };
       case 'get_update_settings':
         return { auto_check: true, check_interval_hours: 24 };
       case 'get_log_level':
@@ -79,6 +79,15 @@ describe('SettingsComponent', () => {
     fixture.detectChanges();
     const healthEl = fixture.nativeElement.querySelector('app-system-health');
     expect(healthEl).not.toBeNull();
+  });
+
+  it('renders LlmProviderComponent', async () => {
+    component.ngOnInit();
+    await fixture.whenStable();
+    fixture.changeDetectorRef.markForCheck();
+    fixture.detectChanges();
+    const llmEl = fixture.nativeElement.querySelector('app-llm-provider');
+    expect(llmEl).not.toBeNull();
   });
 
   it('renders AuthSectionComponent', async () => {

--- a/desktop/src/src/app/settings/settings.component.ts
+++ b/desktop/src/src/app/settings/settings.component.ts
@@ -11,6 +11,7 @@ import { Router } from '@angular/router';
 import { TauriService } from '../services/tauri.service';
 import { ProjectStateService } from '../services/project-state.service';
 import { AuthSectionComponent } from './auth-section/auth-section.component';
+import { LlmProviderComponent } from './llm-provider/llm-provider.component';
 import { SystemHealthComponent } from './system-health.component';
 import { AdvancedSectionComponent } from './advanced-section/advanced-section.component';
 import { UpdateSectionComponent } from './update-section/update-section.component';
@@ -22,6 +23,7 @@ import { ProjectList } from '../models/update';
   standalone: true,
   imports: [
     CommonModule,
+    LlmProviderComponent,
     AuthSectionComponent,
     SystemHealthComponent,
     AdvancedSectionComponent,
@@ -61,6 +63,9 @@ import { ProjectList } from '../models/update';
           </div>
         </div>
       </section>
+
+      <!-- LLM Provider -->
+      <app-llm-provider (providerChange)="llmProvider = $event" (errorOccurred)="error = $event" />
 
       <!-- Authentication -->
       <app-auth-section
@@ -106,7 +111,6 @@ export class SettingsComponent implements OnInit, OnDestroy {
   /** Loads project information on component initialization. */
   ngOnInit(): void {
     this.loadProjectInfo();
-    this.loadLlmProvider();
     this.loadLogLevel();
 
     this.unsubProjectReady = this.projectState.onProjectReady(() => {
@@ -135,16 +139,6 @@ export class SettingsComponent implements OnInit, OnDestroy {
       this.projectDir = entry?.dir ?? '';
     } catch {
       // Not running inside Tauri
-    }
-    this.cdr.markForCheck();
-  }
-
-  private async loadLlmProvider(): Promise<void> {
-    try {
-      const config = await this.tauri.invoke<{ provider: string | null }>('get_llm_config');
-      this.llmProvider = config.provider || 'anthropic';
-    } catch {
-      // Not running inside Tauri or no config yet
     }
     this.cdr.markForCheck();
   }

--- a/docs/adr/ADR-011-user-configuration-passed-to-claude-code.md
+++ b/docs/adr/ADR-011-user-configuration-passed-to-claude-code.md
@@ -58,14 +58,13 @@ Different projects require different Claude Code settings (model selection, cust
 
 #### Per-project Claude overrides (`claude.*`)
 
-| Field                    | Rust type                         | Description                                                                     |
-| ------------------------ | --------------------------------- | ------------------------------------------------------------------------------- |
-| `claude.env`             | `Option<HashMap<String, String>>` | Environment variables injected into the Claude Code process[^1]                 |
-| `claude.llm`             | `Option<LlmConfig>`               | LLM provider switching — see ADR-018                                            |
-| `claude.llm.provider`    | `Option<String>`                  | `anthropic`, `openai`, `gemini`, `deepseek`, `openrouter`, `ollama`, `lmstudio` |
-| `claude.llm.model`       | `Option<String>`                  | Model name for the target provider                                              |
-| `claude.llm.base_url`    | `Option<String>`                  | Custom API endpoint (required for `ollama`, `lmstudio`)                         |
-| `claude.llm.api_key_env` | `Option<String>`                  | Name of the env var holding the API key (e.g. `OPENAI_API_KEY`)                 |
+| Field                 | Rust type                         | Description                                                                                                                                                               |
+| --------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `claude.env`          | `Option<HashMap<String, String>>` | Environment variables injected into the Claude Code process[^1]                                                                                                           |
+| `claude.llm`          | `Option<LlmConfig>`               | Local LLM provider configuration — see ADR-040                                                                                                                            |
+| `claude.llm.provider` | `Option<String>`                  | `anthropic` (default), `ollama`, `lmstudio`, `llamacpp`, `custom`                                                                                                         |
+| `claude.llm.model`    | `Option<String>`                  | Model name for the local provider (also accepted from repo config)                                                                                                        |
+| `claude.llm.base_url` | `Option<String>`                  | Custom API endpoint (required for `custom`; optional override for known providers). **Not accepted from repo config** — only from user config (SSRF prevention, ADR-040). |
 
 #### Global config fields
 

--- a/docs/adr/ADR-018-llm-provider-switching-proxy-as-container.md
+++ b/docs/adr/ADR-018-llm-provider-switching-proxy-as-container.md
@@ -1,5 +1,8 @@
 # ADR-018: LLM Provider Switching — Proxy as Container
 
+> **Status:** Superseded by [ADR-040](ADR-040-remove-litellm-direct-provider-injection.md) — as of 2026-04-19.
+> LiteLLM proxy removed; only local models supported via direct ANTHROPIC_BASE_URL injection.
+
 ## Decision
 
 When the LLM provider is not Anthropic, Speedwave adds an `llm-proxy` container (LiteLLM) that translates the Anthropic Messages API to the target provider's API. For Ollama, no proxy is needed — Claude Code connects directly.

--- a/docs/adr/ADR-026-linux-rootless-container-user.md
+++ b/docs/adr/ADR-026-linux-rootless-container-user.md
@@ -81,11 +81,10 @@ All 6 built-in services use `user: "${CONTAINER_USER}"` instead of `user: "1000:
 
 ### Substitution sites
 
-The `${CONTAINER_USER}` variable is resolved in three locations:
+The `${CONTAINER_USER}` variable is resolved in two locations:
 
 1. **`render_compose()`** — main compose template rendering, where all `${CONTAINER_USER}` placeholders in `compose.template.yml` are replaced.
-2. **`apply_llm_config()`** — dynamically created `llm-proxy` service, which injects `user: "{container_user}"` directly into the inline YAML.
-3. **`apply_plugins()`** — plugin compose generation, where `${CONTAINER_USER}` is resolved when generating plugin service containers.
+2. **`apply_plugins()`** — plugin compose generation, where `${CONTAINER_USER}` is resolved when generating plugin service containers.
 
 ### SecurityCheck: `check_container_user`
 

--- a/docs/adr/ADR-038-single-internal-worker-port.md
+++ b/docs/adr/ADR-038-single-internal-worker-port.md
@@ -15,9 +15,8 @@ Speedwave's compose emitter currently assigns a unique TCP port to every MCP wor
 | `mcp-sharepoint` | 4002 |
 | `mcp-redmine`    | 4003 |
 | `mcp-gitlab`     | 4004 |
-| `llm-proxy`      | 4009 |
 
-Plugin workers declared a `port` field in `plugin.json` and Speedwave reserved the range `PORT_BASE..=(PORT_BASE + len(TOGGLEABLE_MCP_SERVICES))` plus `PORT_LLM_PROXY` for built-ins, rejecting any plugin manifest whose port overlapped[^1]. Every new built-in service therefore shifted the reserved range, breaking plugin manifests that happened to claim a port in the newly reserved slice[^2].
+Plugin workers declared a `port` field in `plugin.json` and Speedwave reserved the range `PORT_BASE..=(PORT_BASE + len(TOGGLEABLE_MCP_SERVICES))` for built-ins, rejecting any plugin manifest whose port overlapped[^1]. Every new built-in service therefore shifted the reserved range, breaking plugin manifests that happened to claim a port in the newly reserved slice[^2].
 
 The question this ADR answers: **does per-worker port uniqueness carry any security weight, or can we collapse every worker onto a single internal port and let DNS disambiguate?**
 
@@ -42,8 +41,7 @@ Keeping unique ports therefore costs complexity (template variables, emitter bra
 Collapse worker ports to a single internal constant.
 
 - `PORT_BASE = 4000` — **renamed in docs as `PORT_HUB`** but kept under the same symbol for compatibility. This is the external contract: the `claude` container dials `http://mcp-hub:4000`.
-- `PORT_WORKER = 3000` — every MCP worker listens on this port inside its own container. This includes built-in services (`mcp-slack`, `mcp-sharepoint`, `mcp-redmine`, `mcp-gitlab`, future `mcp-playwright`), the optional `llm-proxy` service, and plugin workers.
-- `PORT_LLM_PROXY` — removed; llm-proxy listens on `PORT_WORKER` like any other worker. Claude reaches it via `ANTHROPIC_BASE_URL=http://llm-proxy:3000`.
+- `PORT_WORKER = 3000` — every MCP worker listens on this port inside its own container. This includes built-in services (`mcp-slack`, `mcp-sharepoint`, `mcp-redmine`, `mcp-gitlab`, future `mcp-playwright`) and plugin workers.
 - `plugin.json.port` — deprecated and ignored. The field remains in `PluginManifest` as `Option<u16>` so existing signed manifests still deserialize; setting a non-`PORT_WORKER` value merely emits a `log::warn!` pointing to this ADR. `validate_plugin_port()` is deleted along with the reserved-range logic.
 
 ### Impact on plugin contract
@@ -59,7 +57,7 @@ Summarised against the plugin contract table in `CLAUDE.md`:
 
 ### Reserved ranges (Variant B)
 
-Retain unique ports but carve out a stable reservation: `4001–4019` for built-ins, `4020` for llm-proxy, `4021–4029` for future core services, `4030+` for plugins. This fixes plugin contract drift (the lower bound of the plugin range becomes a stable constant instead of `len(TOGGLEABLE_MCP_SERVICES)`) without touching the per-service port matrix.
+Retain unique ports but carve out a stable reservation: `4001–4019` for built-ins, `4021–4029` for future core services, `4030+` for plugins. This fixes plugin contract drift (the lower bound of the plugin range becomes a stable constant instead of `len(TOGGLEABLE_MCP_SERVICES)`) without touching the per-service port matrix.
 
 Rejected because it only _delays_ the complexity: every built-in addition still requires a reservation decision, the emitter still branches per service, and `plugin.json.port` remains a required field. It trades a rolling breaking change for a structural one, with no compensating benefit in the current threat model.
 
@@ -87,7 +85,6 @@ Rejected because it adds a discovery mechanism (the hub needs to learn which por
 
 - `test_all_workers_use_port_worker` — renders a full compose with every integration enabled and asserts every worker service (excluding `claude` and `mcp-hub`) has `PORT=3000` in its environment.
 - `test_hub_worker_urls_use_port_worker` — asserts every `WORKER_*_URL` entry in the hub environment ends with `:3000`.
-- `test_llm_proxy_uses_port_worker` — enables an external LLM provider, asserts `llm-proxy` listens on `PORT=3000` and Claude's `ANTHROPIC_BASE_URL=http://llm-proxy:3000`.
 - `test_plugin_manifest_port_is_ignored` — constructs a plugin manifest with `port: Some(9999)`, calls `generate_plugin_service()`, asserts the resulting service uses `PORT=3000`.
 - `test_mcp_plugin_without_port_is_accepted` — validates a plugin manifest with `port: None` and confirms it passes validation.
 

--- a/docs/adr/ADR-040-remove-litellm-direct-provider-injection.md
+++ b/docs/adr/ADR-040-remove-litellm-direct-provider-injection.md
@@ -1,0 +1,112 @@
+# ADR-040: Remove LiteLLM — Direct Local Provider Injection
+
+**Status:** Accepted
+**Date:** 2026-04-19
+
+## Context
+
+Speedwave previously used LiteLLM (`ghcr.io/berriai/litellm:latest`) as a proxy container to route Claude Code's Anthropic API calls to external LLM providers. In March 2026, LiteLLM was found to contain a backdoor injected through the `libpostal` supply chain — a poisoned security scanner that granted remote access to the LiteLLM codebase.[^1][^7]
+
+At the same time, the three most popular local LLM servers added native support for the Anthropic `/v1/messages` protocol:
+
+- **Ollama 0.14.0+** — native Anthropic compatibility[^2]
+- **LM Studio 0.4.1+** — Anthropic-compatible `/v1/messages` endpoint[^3]
+- **llama.cpp (January 2026, PR #17570)** — Anthropic Messages API support[^4]
+
+This makes LiteLLM unnecessary for the Speedwave use case: local models only.
+
+## Decision
+
+Remove LiteLLM entirely. Inject `ANTHROPIC_BASE_URL` and related env vars directly into the `claude` container. Support three local providers with well-known defaults, plus a `custom` endpoint for advanced users.
+
+**Cloud providers (OpenAI, Gemini, DeepSeek, OpenRouter) are not supported.** Speedwave is a local-first platform. External LLM API keys must never enter containers — this is a security invariant.
+
+## Supported Providers
+
+| Provider    | Min. Version | Default base URL                    |
+| ----------- | ------------ | ----------------------------------- |
+| `anthropic` | —            | Direct Anthropic API (no injection) |
+| `ollama`    | 0.14.0       | `http://host.docker.internal:11434` |
+| `lmstudio`  | 0.4.1        | `http://host.docker.internal:1234`  |
+| `llamacpp`  | Jan 2026     | `http://host.docker.internal:8080`  |
+| `custom`    | —            | User-supplied `base_url` required   |
+
+All local providers use `host.docker.internal` which is mapped to the host gateway via `extra_hosts` in `compose.template.yml`. This works identically on macOS (Lima), Linux (nerdctl rootless), and Windows (WSL2).
+
+## Environment Variables Injected
+
+When a local provider is selected, the following env vars are set on the `claude` container:
+
+| Variable                                   | Value                                    |
+| ------------------------------------------ | ---------------------------------------- |
+| `ANTHROPIC_BASE_URL`                       | Provider URL (no `/v1` suffix)           |
+| `ANTHROPIC_AUTH_TOKEN`                     | `sk-no-key-required` (dummy)[^8]         |
+| `ANTHROPIC_DEFAULT_SONNET_MODEL`           | User-configured model name               |
+| `ANTHROPIC_DEFAULT_OPUS_MODEL`             | User-configured model name               |
+| `ANTHROPIC_DEFAULT_HAIKU_MODEL`            | User-configured model name               |
+| `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` | `1` (disables model validation)[^5]      |
+| `CLAUDE_CODE_ATTRIBUTION_HEADER`           | `0` (prevents 90% KV cache slowdown)[^6] |
+
+For `anthropic` provider, no injection occurs — Claude Code connects directly to `api.anthropic.com`.
+
+## Architecture
+
+```
+Before (LiteLLM):
+  claude → llm-proxy (LiteLLM) → external API (OpenAI, etc.)
+
+After (direct injection):
+  claude → host.docker.internal:PORT → local LLM server (Ollama, LM Studio, llama.cpp)
+  claude → api.anthropic.com (Anthropic provider, no change)
+```
+
+## Security — Threat Model Delta
+
+**Removed attack surface:**
+
+- LiteLLM container (~52 MB image, ~512 MB RAM, ~4000 lines Python, supply chain risk)
+- 1 exposed port (llm-proxy)
+- `~/.speedwave/secrets/<project>/llm.env` file with LLM API credentials
+
+**Added:**
+
+- `ANTHROPIC_BASE_URL` pointing to a user-configured address (local LLM server or another machine on the network)
+
+The `claude` container already had network access (MCP workers connect to external APIs). No new egress capability is introduced. `validate_base_url()` enforces:
+
+- Scheme: only `http://` or `https://`
+- No credentials in URL
+- No path, query, or fragment (only scheme + host + port)
+
+Arbitrary host is allowed — the security boundary is that the container cannot reach the host filesystem, and credentials are never injected into `claude`.
+
+### SSRF Prevention (repo config)
+
+A malicious `.speedwave.json` in a cloned repository could previously set `provider` and `base_url` to redirect Claude Code to an attacker-controlled server. As of this ADR, `merge_llm_repo()` ignores `provider` and `base_url` from repo config — only `model` is merged. Only the user's `~/.speedwave/config.json` may set the provider and base URL.
+
+## Rollback
+
+To restore LiteLLM support:
+
+1. Revert this commit
+2. The LiteLLM image (`ghcr.io/berriai/litellm:latest`) may still be on disk — prune with `nerdctl image prune` if needed
+
+Note: the stale llm-proxy container (if any) is automatically removed by `--remove-orphans` on next `compose up`.
+
+## Footnotes
+
+[^1]: LiteLLM supply chain compromise (March 2026): https://snyk.io/blog/poisoned-security-scanner-backdooring-litellm/
+
+[^2]: Ollama Anthropic compatibility (requires 0.14.0+): https://docs.ollama.com/api/anthropic-compatibility
+
+[^3]: LM Studio Anthropic endpoint (requires 0.4.1+): https://lmstudio.ai/docs/developer/anthropic-compat
+
+[^4]: llama.cpp Anthropic Messages API (PR #17570, January 2026): https://huggingface.co/blog/ggml-org/anthropic-messages-api-in-llamacpp
+
+[^5]: `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` disables model validation traffic: https://unsloth.ai/docs/basics/claude-code
+
+[^6]: `CLAUDE_CODE_ATTRIBUTION_HEADER=0` prevents 90% KV cache slowdown: https://unsloth.ai/docs/basics/claude-code
+
+[^7]: Trend Micro analysis of LiteLLM compromise: https://www.trendmicro.com/en_us/research/26/c/inside-litellm-supply-chain-compromise.html
+
+[^8]: `ANTHROPIC_DEFAULT_*_MODEL` and dummy auth token usage documented at: https://docs.vllm.ai/en/stable/serving/integrations/claude_code/

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,7 +24,7 @@ This directory contains all Architecture Decision Records (ADRs) for Speedwave. 
 | [ADR-015](ADR-015-plugin-system.md)                                    | Plugin System                                           | Accepted              |
 | [ADR-016](ADR-016-cross-platform-cli-path.md)                          | Cross-Platform CLI PATH                                 | Accepted              |
 | [ADR-017](ADR-017-claude-code-in-container-via-entrypoint.md)          | Claude Code in Container via entrypoint.sh              | Accepted              |
-| [ADR-018](ADR-018-llm-provider-switching-proxy-as-container.md)        | LLM Provider Switching — Proxy as Container             | Accepted              |
+| [ADR-018](ADR-018-llm-provider-switching-proxy-as-container.md)        | LLM Provider Switching — Proxy as Container             | Superseded by ADR-040 |
 | [ADR-019](ADR-019-git-branching-model-and-release-flow.md)             | Git Branching Model and Release Flow                    | Accepted              |
 | [ADR-020](ADR-020-legal-compliance-and-license-analysis.md)            | Legal Compliance & License Analysis                     | Accepted              |
 | [ADR-021](ADR-021-bundled-dependencies-and-zero-install-strategy.md)   | Bundled Dependencies and Zero-Install Strategy          | Accepted              |
@@ -46,6 +46,7 @@ This directory contains all Architecture Decision Records (ADRs) for Speedwave. 
 | [ADR-037](ADR-037-code-signing-and-bundled-binary-signing.md)          | Code Signing and Bundled Binary Signing                 | Accepted              |
 | [ADR-038](ADR-038-single-internal-worker-port.md)                      | Single Internal Worker Port                             | Accepted              |
 | [ADR-039](ADR-039-playwright-shared-browser-service.md)                | Playwright Shared Browser Service                       | Accepted              |
+| [ADR-040](ADR-040-remove-litellm-direct-provider-injection.md)         | Remove LiteLLM — Direct Local Provider Injection        | Accepted              |
 
 ## Creating a New ADR
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -19,9 +19,8 @@ The user-level config file stores project definitions, the active project, IDE s
         },
         "llm": {
           "provider": "anthropic",
-          "model": "claude-sonnet-4-6",
-          "base_url": null,
-          "api_key_env": null
+          "model": null,
+          "base_url": null
         }
       },
       "integrations": {
@@ -49,7 +48,7 @@ The user-level config file stores project definitions, the active project, IDE s
 A `.speedwave.json` file in the project repository root provides repo-level defaults. These are overridden by the user-level config:
 
 - `claude.env` — environment variables passed to Claude Code inside the container
-- `claude.llm` — LLM provider, model, base URL, and API key env var name
+- `claude.llm` — LLM provider (`anthropic`, `ollama`, `lmstudio`, `llamacpp`, `custom`), model name, and optional base URL. See [ADR-040](../adr/ADR-040-remove-litellm-direct-provider-injection.md) for provider details.
 - `integrations` — enable/disable individual integrations per project
 
 ## Environment Variables

--- a/docs/guides/integrations.md
+++ b/docs/guides/integrations.md
@@ -195,9 +195,47 @@ Plugins that declare `requires_integrations` (e.g. `["sharepoint"]`) display the
 
 Plugin authors should set `speedwave_compat` in `plugin.json` to declare which Speedwave versions the plugin supports — for example, `"speedwave_compat": ">=0.8, <1"` for plugins targeting the 0.8 series. If the field is present and the running Speedwave version does not satisfy the declared range, installation is rejected with a clear error. Omit the field to disable the check. See [ADR-015](../adr/ADR-015-plugin-system.md) for details on the enforcement model and version-requirement syntax.
 
+## Local LLM Setup
+
+You can run Claude Code inside Speedwave against a local LLM server instead of Anthropic's cloud API. Go to **Settings → LLM Provider** to select a provider.
+
+### Ollama (requires 0.14.0+)
+
+1. Install Ollama and pull a model:
+
+   ```bash
+   OLLAMA_HOST=0.0.0.0 ollama serve   # must bind to 0.0.0.0, not 127.0.0.1
+   ollama pull llama3.3
+   ```
+
+   > **Important:** Ollama binds to `127.0.0.1` by default. The `claude` container cannot reach the loopback interface — set `OLLAMA_HOST=0.0.0.0` before starting `ollama serve`.
+
+2. In Speedwave Settings → LLM Provider → select **Ollama**
+3. Set **Model** to the model you pulled (e.g. `llama3.3`)
+4. Leave **Base URL** empty to use the default (`http://host.docker.internal:11434`)
+5. Restart containers
+
+### LM Studio (requires 0.4.1+)
+
+1. In LM Studio, load a model and enable the **Local Server**
+2. In Speedwave Settings → LLM Provider → select **LM Studio**
+3. Leave Base URL empty for the default port (`http://host.docker.internal:1234`)
+4. Restart containers
+
+### llama.cpp (requires January 2026 build or later)
+
+1. Start `llama-server` with the Anthropic API server enabled
+2. Select **llama.cpp** in Settings → LLM Provider
+3. Default port: `http://host.docker.internal:8080`
+
+### Custom endpoint
+
+Select **Custom endpoint** if your LLM server is at a non-standard address (e.g. another machine on your LAN at `http://192.168.1.100:11434`). Enter the full URL including port in the **Base URL** field. The URL must use `http://` or `https://` and must not include a path.
+
 ## See Also
 
 - [ADR-010: mcp-os as Host Process Per Platform](../adr/ADR-010-mcp-os-as-host-process-per-platform.md)
 - [ADR-013: mcp-os as Host Process — Implementation Details](../adr/ADR-013-mcp-os-as-host-process-implementation.md)
 - [ADR-015: Plugin System](../adr/ADR-015-plugin-system.md)
 - [ADR-036: Self-Declaring Worker Policy](../adr/ADR-036-self-declaring-worker-policy.md)
+- [ADR-040: Remove LiteLLM — Direct Local Provider Injection](../adr/ADR-040-remove-litellm-direct-provider-injection.md)


### PR DESCRIPTION
## Summary

Removes the bundled **LiteLLM proxy** container in response to the [March 2026 supply-chain compromise](https://github.com/BerriAI/litellm/security/advisories). Claude Code now talks **directly** to local LLM providers — no intermediate proxy.

**Supported local providers:**
- Ollama (0.14.0+)
- LM Studio (0.4.1+)
- llama.cpp (Jan 2026+)
- Custom OpenAI-compatible endpoint

See [ADR-040](docs/adr/ADR-040-remove-litellm-direct-provider-injection.md) for the full decision and threat-model delta. [ADR-018](docs/adr/ADR-018-llm-provider-switching-proxy-as-container.md) is marked **Superseded**.

## Key changes

- **`compose.rs`** — `apply_llm_config()` replaces `llm-proxy` service with direct env injection: `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN=sk-no-key-required`, `ANTHROPIC_DEFAULT_{SONNET,OPUS,HAIKU}_MODEL`
- **SSRF hardening** — `validate_base_url()` rejects non-http schemes, credentials, paths, queries, fragments; `merge_llm_repo()` only accepts `model` from repo config
- **For local providers only** — injects `CLAUDE_CODE_ATTRIBUTION_HEADER=0` (per [Unsloth's guide](https://unsloth.ai/docs/basics/claude-code), avoids ~90% inference slowdown from KV-cache invalidation) and `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1`. **Anthropic cloud provider is untouched** — negative test guards this
- **UI** — 4 local providers shown; `api_key_env` field removed; **save triggers container restart** (matches integrations toggle flow)
- **Docs** — ADR-040 added; ADR-011/018/026/038, `configuration.md`, `integrations.md` updated

## ⚠️ Breaking changes

- `plugin.json` `api_key_env` field is no longer honored
- `llm-proxy` container removed
- Users on external (non-local) providers must migrate to Anthropic or a local provider

## Test plan

- [x] `make check` — zero warnings
- [x] `make test` — all 880+ Rust tests, 832 Desktop tests, MCP, E2E pass
- [x] Negative test: Anthropic provider does NOT receive `CLAUDE_CODE_ATTRIBUTION_HEADER=0`
- [x] Negative test: compose YAML contains zero references to `llm-proxy` or `litellm`
- [x] Restart-trigger test: `LlmProviderComponent.saveConfig()` calls `projectState.requestRestart()` on success
- [ ] Manual smoke test — Ollama locally: start `ollama run llama3.3`, set provider in Desktop → auto restart → `claude` container connects via `ANTHROPIC_BASE_URL=http://host.docker.internal:11434`
- [ ] Manual smoke test — Anthropic default: verify no local-provider env vars leak into cloud path

## Plugin compatibility

Checked `speedwave-plugins` sibling repo — zero references to `llm-proxy` / `litellm` / `api_key_env`. **No existing plugins affected.**