### PR TITLE
feat(desktop): auto-discover LLM models with SSRF policy (ADR-041)

### DIFF
--- a/containers/claude-resources/system-prompts/local-llm.md
+++ b/containers/claude-resources/system-prompts/local-llm.md
@@ -1,0 +1,59 @@
+You are Claude Code running inside Speedwave — a security-hardened container that connects you to external services (files, browser automation, Slack, GitLab, Redmine, SharePoint, etc.) through an MCP (Model Context Protocol) hub. You are assisting a software engineer with their work.
+
+# How you call tools
+
+You have access to tools via MCP. To invoke a tool you MUST emit a `tool_use` content block with this exact shape:
+
+```
+{
+  "type": "tool_use",
+  "id": "<unique-id-for-this-call>",
+  "name": "<tool-name>",
+  "input": { ... tool-specific JSON ... }
+}
+```
+
+The runtime will execute the tool and return a `tool_result` block referencing the same `id`. Never try to call tools by emitting raw shell commands, `curl`, or JSON-RPC payloads — those will be treated as text, not executed. Never guess tool names or invent tool endpoints; only use tools the runtime has advertised to you.
+
+When you need to do something with the world (read a file, browse a page, query an API, run a command) — pick the right tool and emit a `tool_use` block. When you only need to reason or explain — emit a normal text block.
+
+# Available tools (built-in)
+
+The Speedwave MCP hub exposes these core tools to you; additional tools appear automatically when the user enables plugins:
+
+- **Bash** — run a shell command inside the container. Use for file listing, git, build/test commands, quick inspections. Prefer dedicated tools (Read/Edit/Grep/Glob) when one fits.
+- **Read** — read a file from the project workspace (`/workspace/...`). Always use absolute paths.
+- **Write** — create or overwrite a file in the workspace. Prefer Edit for changes to existing files.
+- **Edit** — make an exact-string replacement in an existing file. Read the file first.
+- **Glob** — find files by pattern (e.g. `src/**/*.ts`). Faster than `find`.
+- **Grep** — search file contents with ripgrep. Supports regex, globs, file types.
+- **WebFetch** / **WebSearch** — fetch or search the public web.
+- **Playwright browser tools** (`browser_navigate`, `browser_snapshot`, `browser_take_screenshot`, `browser_click`, `browser_type`, `browser_evaluate`, …) — real Chromium automation via the shared Playwright worker. Use `browser_snapshot` first to get an accessibility tree of the page, then act on specific refs.
+
+Plugin tools (Slack, SharePoint, GitLab, Redmine, Figma, …) appear only when the user has enabled and configured those plugins for this project.
+
+# Project context
+
+- The user's project is mounted at `/workspace` (read-write). Treat it as the current working directory for all file operations.
+- `/workspace/CLAUDE.md` (if present) contains project-specific instructions written by the user. Read it when you start working on a non-trivial task and follow its guidance.
+- Skills, commands, agents, and hooks the user has installed live under `~/.claude/` — the runtime loads them automatically; you don't need to read them manually.
+- The container has no direct access to the user's credentials. All external services are reached through MCP workers that hold the tokens.
+
+# How to work
+
+- **Understand before you act.** For a non-trivial task, start by reading the relevant files (CLAUDE.md, the file the user mentioned, nearby code). Don't propose changes to code you haven't read.
+- **Prefer the right tool over the clever one.** Use Read/Edit/Grep/Glob for files; reserve Bash for things that need a shell. Don't `cat` a file with Bash — use Read.
+- **One tool call at a time unless they're independent.** If you have several independent queries to make (e.g. reading three unrelated files), emit them in a single turn as parallel tool calls. If a later call depends on an earlier result, wait for the result.
+- **Edit minimally.** When changing existing code, change only what the task requires. Don't refactor surrounding code, don't add comments, don't introduce abstractions for hypothetical future use.
+- **Say what you did.** After finishing a task, give a short summary (one or two sentences) of what changed and where. Don't restate the diff.
+- **Ask when genuinely blocked.** If the task is ambiguous or you need information only the user has, ask a concrete question. Don't guess.
+
+# What not to do
+
+- Do not fabricate file paths, function names, or tool results. If you don't know, read or search.
+- Do not commit, push, or run destructive git commands unless the user explicitly asks.
+- Do not bypass failing tests, lint errors, or CI — fix the underlying issue.
+- Do not add `TODO`, `FIXME`, or `@deprecated` comments — fix the code now or flag it to the user.
+- Do not write files outside `/workspace` (except `/tmp` for scratch). The rest of the container filesystem is read-only for a reason.
+
+Keep responses concise. Use Markdown for formatting when it helps readability. When referencing code, use `path/to/file.ext:line` so the user's editor can jump to it.

--- a/crates/speedwave-cli/src/main.rs
+++ b/crates/speedwave-cli/src/main.rs
@@ -636,7 +636,7 @@ fn main() -> anyhow::Result<()> {
 
     // exec -it -> interactive Claude terminal inside container
     let mut exec_cmd: Vec<&str> = vec![consts::CLAUDE_BINARY];
-    exec_cmd.extend_from_slice(&resolved.flags);
+    exec_cmd.extend(resolved.flags.iter().map(String::as_str));
     let status = runtime
         .container_exec(&container_name, &exec_cmd)
         .status()?;

--- a/crates/speedwave-runtime/src/compose.rs
+++ b/crates/speedwave-runtime/src/compose.rs
@@ -262,13 +262,7 @@ fn apply_llm_config(yaml: &str, llm: &LlmConfig) -> anyhow::Result<String> {
     let provider = llm.provider.as_deref().unwrap_or("anthropic");
     match provider {
         "anthropic" => Ok(yaml.to_string()),
-        "custom" if llm.base_url.is_none() => {
-            anyhow::bail!(
-                "Custom provider requires a base_url. \
-                 Configure it in Settings → LLM Provider → Base URL."
-            );
-        }
-        "ollama" | "lmstudio" | "llamacpp" | "custom" => {
+        "ollama" | "lmstudio" | "llamacpp" => {
             let base_url = llm
                 .base_url
                 .clone()
@@ -290,16 +284,16 @@ fn apply_llm_config(yaml: &str, llm: &LlmConfig) -> anyhow::Result<String> {
                     "sk-no-key-required".to_string(),
                 ),
                 (
-                    "ANTHROPIC_DEFAULT_SONNET_MODEL".to_string(),
+                    "ANTHROPIC_CUSTOM_MODEL_OPTION".to_string(),
                     model.to_string(),
                 ),
                 (
-                    "ANTHROPIC_DEFAULT_OPUS_MODEL".to_string(),
-                    model.to_string(),
+                    "ANTHROPIC_CUSTOM_MODEL_OPTION_NAME".to_string(),
+                    custom_model_display_name(provider, model),
                 ),
                 (
-                    "ANTHROPIC_DEFAULT_HAIKU_MODEL".to_string(),
-                    model.to_string(),
+                    "ANTHROPIC_CUSTOM_MODEL_OPTION_DESCRIPTION".to_string(),
+                    custom_model_description(provider),
                 ),
                 (
                     "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC".to_string(),
@@ -314,7 +308,7 @@ fn apply_llm_config(yaml: &str, llm: &LlmConfig) -> anyhow::Result<String> {
         }
         other => anyhow::bail!(
             "Unsupported LLM provider '{other}'. \
-             Supported: anthropic, ollama, lmstudio, llamacpp, custom."
+             Supported: anthropic, ollama, lmstudio, llamacpp."
         ),
     }
 }
@@ -340,6 +334,29 @@ pub fn default_base_url(provider: &str) -> Option<String> {
         "llamacpp" => Some("http://host.docker.internal:8080".to_string()),
         _ => None,
     }
+}
+
+/// Human-readable label for a local LLM provider.
+///
+/// Invariant: the only callers (`custom_model_display_name` and
+/// `custom_model_description`) are reached only after `apply_llm_config`
+/// narrows the provider to one of the three local values below. Any other
+/// value at this point indicates a programmer error in `apply_llm_config`.
+fn provider_display_label(provider: &str) -> &'static str {
+    match provider {
+        "ollama" => "Ollama",
+        "lmstudio" => "LM Studio",
+        "llamacpp" => "llama.cpp",
+        other => unreachable!("provider_display_label called with unsupported provider '{other}'"),
+    }
+}
+
+fn custom_model_display_name(provider: &str, model: &str) -> String {
+    format!("{} ({})", model, provider_display_label(provider))
+}
+
+fn custom_model_description(provider: &str) -> String {
+    format!("Local model served by {}", provider_display_label(provider))
 }
 
 /// Validates a base URL for local model providers. Rejects non-HTTP schemes,
@@ -2199,6 +2216,13 @@ fn get_services(doc: &serde_yaml_ng::Value) -> Option<Vec<(String, &serde_yaml_n
 mod tests {
     use super::*;
 
+    fn default_flags() -> Vec<String> {
+        crate::defaults::DEFAULT_FLAGS
+            .iter()
+            .map(|s| s.to_string())
+            .collect()
+    }
+
     fn get_hub_env_seq(doc: &serde_yaml_ng::Value) -> Vec<String> {
         doc.get("services")
             .and_then(|s| s.get("mcp-hub"))
@@ -2568,7 +2592,7 @@ services:
     fn test_render_compose_substitution() {
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
-            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            flags: default_flags(),
             llm: LlmConfig::default(),
         };
         let result = render_compose(
@@ -2602,7 +2626,7 @@ services:
     fn test_render_compose_uses_bundle_scoped_image_refs() {
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
-            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            flags: default_flags(),
             llm: LlmConfig::default(),
         };
         let manifest = bundle::load_current_bundle_manifest().unwrap();
@@ -2647,7 +2671,7 @@ services:
     fn test_rendered_compose_has_sharepoint_workspace_mount() {
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
-            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            flags: default_flags(),
             llm: LlmConfig::default(),
         };
         let yaml = render_compose(
@@ -2675,7 +2699,7 @@ services:
     fn test_render_compose_playwright_service_present() {
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
-            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            flags: default_flags(),
             llm: LlmConfig::default(),
         };
         let integrations = ResolvedIntegrationsConfig {
@@ -2738,7 +2762,7 @@ services:
     fn test_render_compose_playwright_no_token_mount() {
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
-            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            flags: default_flags(),
             llm: LlmConfig::default(),
         };
         let integrations = ResolvedIntegrationsConfig {
@@ -2774,7 +2798,7 @@ services:
     fn test_render_compose_playwright_no_workspace_mount() {
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
-            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            flags: default_flags(),
             llm: LlmConfig::default(),
         };
         let integrations = ResolvedIntegrationsConfig {
@@ -2811,7 +2835,7 @@ services:
     fn test_playwright_worker_url_in_hub_env() {
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
-            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            flags: default_flags(),
             llm: LlmConfig::default(),
         };
         let integrations = ResolvedIntegrationsConfig {
@@ -2869,7 +2893,7 @@ services:
     fn test_rendered_compose_has_mcp_hub_port() {
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
-            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            flags: default_flags(),
             llm: LlmConfig::default(),
         };
         let yaml = render_compose(
@@ -2896,7 +2920,7 @@ services:
         // If these drift apart, entrypoint.sh generates wrong mcp-config.json URL.
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
-            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            flags: default_flags(),
             llm: LlmConfig::default(),
         };
         let yaml = render_compose(
@@ -2922,7 +2946,7 @@ services:
     fn test_all_workers_use_port_worker() {
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
-            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            flags: default_flags(),
             llm: LlmConfig::default(),
         };
         let yaml = render_compose(
@@ -2967,7 +2991,7 @@ services:
     fn test_hub_worker_urls_use_port_worker() {
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
-            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            flags: default_flags(),
             llm: LlmConfig::default(),
         };
         let yaml = render_compose(
@@ -3058,7 +3082,7 @@ services:
         // MCP_HUB_PORT must survive the parse → serialize roundtrip.
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
-            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            flags: default_flags(),
             llm: LlmConfig::default(),
         };
         let yaml = render_compose(
@@ -3085,7 +3109,7 @@ services:
         // not somewhere else in the compose file.
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
-            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            flags: default_flags(),
             llm: LlmConfig::default(),
         };
         let yaml = render_compose(
@@ -3150,7 +3174,7 @@ services:
     fn test_rendered_compose_passes_security_check() {
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
-            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            flags: default_flags(),
             llm: LlmConfig::default(),
         };
         let yaml = render_compose(
@@ -3343,7 +3367,7 @@ services:
     fn test_render_compose_ollama_provider() {
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
-            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            flags: default_flags(),
             llm: LlmConfig {
                 provider: Some("ollama".to_string()),
                 model: Some("llama3.3".to_string()),
@@ -3369,7 +3393,7 @@ services:
     fn test_local_provider_requires_model() {
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
-            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            flags: default_flags(),
             llm: LlmConfig {
                 provider: Some("ollama".to_string()),
                 model: None,
@@ -3399,7 +3423,7 @@ services:
     fn test_render_compose_default_anthropic() {
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
-            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            flags: default_flags(),
             llm: LlmConfig::default(), // provider = None → defaults to "anthropic"
         };
         let yaml = render_compose(
@@ -3457,7 +3481,7 @@ services:
     fn test_ollama_direct_injection() {
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
-            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            flags: default_flags(),
             llm: LlmConfig {
                 provider: Some("ollama".to_string()),
                 model: Some("llama3.3".to_string()),
@@ -3484,18 +3508,28 @@ services:
         );
         assert!(
             env.iter()
-                .any(|e| e == "ANTHROPIC_DEFAULT_SONNET_MODEL=llama3.3"),
-            "Ollama must set default sonnet model"
+                .any(|e| e == "ANTHROPIC_CUSTOM_MODEL_OPTION=llama3.3"),
+            "Ollama must set ANTHROPIC_CUSTOM_MODEL_OPTION to the user model, got: {env:?}"
         );
         assert!(
             env.iter()
-                .any(|e| e == "ANTHROPIC_DEFAULT_OPUS_MODEL=llama3.3"),
-            "Ollama must set default opus model"
+                .any(|e| e == "ANTHROPIC_CUSTOM_MODEL_OPTION_NAME=llama3.3 (Ollama)"),
+            "Ollama must set ANTHROPIC_CUSTOM_MODEL_OPTION_NAME with provider label, got: {env:?}"
         );
         assert!(
             env.iter()
-                .any(|e| e == "ANTHROPIC_DEFAULT_HAIKU_MODEL=llama3.3"),
-            "Ollama must set default haiku model"
+                .any(|e| e
+                    == "ANTHROPIC_CUSTOM_MODEL_OPTION_DESCRIPTION=Local model served by Ollama"),
+            "Ollama must set ANTHROPIC_CUSTOM_MODEL_OPTION_DESCRIPTION, got: {env:?}"
+        );
+        assert!(
+            !env
+                .iter()
+                .any(|e| e.starts_with("ANTHROPIC_DEFAULT_SONNET_MODEL=")
+                    || e.starts_with("ANTHROPIC_DEFAULT_OPUS_MODEL=")
+                    || e.starts_with("ANTHROPIC_DEFAULT_HAIKU_MODEL=")),
+            "Local providers must not override Anthropic alias models — use ANTHROPIC_CUSTOM_MODEL_OPTION \
+             so the /model picker shows a single explicit entry. Got: {env:?}"
         );
         assert!(
             env.iter()
@@ -3517,7 +3551,7 @@ services:
     fn test_lmstudio_default_url() {
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
-            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            flags: default_flags(),
             llm: LlmConfig {
                 provider: Some("lmstudio".to_string()),
                 model: Some("qwen2.5-coder".to_string()),
@@ -3544,7 +3578,7 @@ services:
     fn test_llamacpp_default_url() {
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
-            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            flags: default_flags(),
             llm: LlmConfig {
                 provider: Some("llamacpp".to_string()),
                 model: Some("deepseek-r1".to_string()),
@@ -3571,7 +3605,7 @@ services:
     fn test_unsupported_provider_rejected() {
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
-            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            flags: default_flags(),
             llm: LlmConfig {
                 provider: Some("openrouter".to_string()),
                 model: Some("some-model".to_string()),
@@ -3594,46 +3628,18 @@ services:
     }
 
     #[test]
-    fn test_custom_provider_with_base_url() {
+    fn test_custom_provider_rejected_after_removal() {
+        // Regression guard: the `custom` provider value was removed end-to-end.
+        // Any lingering config that still sets `provider = "custom"` must now
+        // fall through to the same unknown-provider path used by any other
+        // unsupported value (e.g. `openrouter`), not a bespoke `custom` branch.
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
-            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            flags: default_flags(),
             llm: LlmConfig {
                 provider: Some("custom".to_string()),
                 model: Some("my-model".to_string()),
                 base_url: Some("http://host.docker.internal:9999".to_string()),
-            },
-        };
-        let yaml = render_compose(
-            "test-project",
-            "/home/user/projects/test",
-            &config,
-            &ResolvedIntegrationsConfig::default(),
-            None,
-        )
-        .unwrap();
-        let env = get_claude_env(&yaml);
-        assert!(
-            env.iter()
-                .any(|e| e == "ANTHROPIC_BASE_URL=http://host.docker.internal:9999"),
-            "Custom provider must use the specified base_url, got: {env:?}"
-        );
-        assert!(
-            env.iter()
-                .any(|e| e == "ANTHROPIC_AUTH_TOKEN=sk-no-key-required"),
-            "Custom provider must set dummy auth token"
-        );
-    }
-
-    #[test]
-    fn test_custom_provider_requires_base_url() {
-        let config = ResolvedClaudeConfig {
-            env: crate::defaults::base_env(),
-            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
-            llm: LlmConfig {
-                provider: Some("custom".to_string()),
-                model: None,
-                base_url: None,
             },
         };
         let result = render_compose(
@@ -3646,8 +3652,12 @@ services:
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
         assert!(
-            msg.contains("Custom provider requires a base_url"),
-            "Error must mention custom requires base_url, got: {msg}"
+            msg.contains("Unsupported LLM provider") && msg.contains("custom"),
+            "Error must treat 'custom' as unsupported, got: {msg}"
+        );
+        assert!(
+            !msg.contains("Custom provider requires a base_url"),
+            "The legacy 'custom requires base_url' error must be gone, got: {msg}"
         );
     }
 
@@ -3723,11 +3733,55 @@ services:
     }
 
     #[test]
-    fn test_compose_template_includes_host_docker_internal() {
-        assert!(
-            COMPOSE_TEMPLATE.contains("host.docker.internal"),
-            "compose.template.yml must map host.docker.internal (needed by default_base_url hardcode)"
-        );
+    fn test_compose_template_contains_all_container_host_aliases() {
+        // compose.template.yml injects all aliases from CONTAINER_HOST_ALIASES via
+        // extra_hosts. Iterating the constant (rather than asserting on a literal)
+        // keeps the test in sync with the SSOT — adding a new alias to the const
+        // without updating the template will fail here.
+        for alias in consts::CONTAINER_HOST_ALIASES {
+            assert!(
+                COMPOSE_TEMPLATE.contains(alias),
+                "compose.template.yml must map {} (named in CONTAINER_HOST_ALIASES)",
+                alias
+            );
+        }
+    }
+
+    #[test]
+    fn test_all_template_aliases_are_in_container_host_aliases() {
+        // Inverse guard: every "host.*.internal" hostname that appears in the
+        // extra_hosts block of compose.template.yml must be named in
+        // CONTAINER_HOST_ALIASES.  Without this check, adding an alias to the
+        // template without updating the constant would silently break host-side
+        // code that uses CONTAINER_HOST_ALIASES to rewrite aliases to loopback.
+        let mut in_extra_hosts = false;
+        for line in COMPOSE_TEMPLATE.lines() {
+            let trimmed = line.trim();
+            if trimmed == "extra_hosts:" {
+                in_extra_hosts = true;
+                continue;
+            }
+            // A non-indented, non-list line signals the end of the extra_hosts block.
+            if in_extra_hosts && !trimmed.starts_with('-') && !trimmed.is_empty() {
+                in_extra_hosts = false;
+            }
+            if !in_extra_hosts {
+                continue;
+            }
+            // Lines look like: - "host.lima.internal:${HOST_GATEWAY}"
+            if let Some(alias) = trimmed
+                .strip_prefix("- \"")
+                .and_then(|s| s.split(':').next())
+                .filter(|h| h.starts_with("host.") && h.ends_with(".internal"))
+            {
+                assert!(
+                    consts::CONTAINER_HOST_ALIASES.contains(&alias),
+                    "compose.template.yml extra_hosts contains '{}' which is not in \
+                     CONTAINER_HOST_ALIASES — add it to the const in consts.rs",
+                    alias
+                );
+            }
+        }
     }
 
     #[test]
@@ -3765,6 +3819,67 @@ services:
              for local providers to avoid breaking llama.cpp/Ollama KV cache. \
              Got: {env_anthropic:?}"
         );
+        assert!(
+            !env_anthropic
+                .iter()
+                .any(|e| e.starts_with("ANTHROPIC_CUSTOM_MODEL_OPTION")),
+            "Anthropic provider must NOT inject ANTHROPIC_CUSTOM_MODEL_OPTION — it is only \
+             set for local providers. Got: {env_anthropic:?}"
+        );
+    }
+
+    #[test]
+    fn test_llamacpp_custom_model_option_labels() {
+        let config = ResolvedClaudeConfig {
+            env: crate::defaults::base_env(),
+            flags: default_flags(),
+            llm: LlmConfig {
+                provider: Some("llamacpp".to_string()),
+                model: Some("deepseek-r1".to_string()),
+                base_url: None,
+            },
+        };
+        let yaml = render_compose(
+            "test-project",
+            "/home/user/projects/test",
+            &config,
+            &ResolvedIntegrationsConfig::default(),
+            None,
+        )
+        .unwrap();
+        let env = get_claude_env(&yaml);
+        assert!(
+            env.iter()
+                .any(|e| e == "ANTHROPIC_CUSTOM_MODEL_OPTION_NAME=deepseek-r1 (llama.cpp)"),
+            "llamacpp display name must use 'llama.cpp' label, got: {env:?}"
+        );
+    }
+
+    #[test]
+    fn test_lmstudio_custom_model_option_labels() {
+        let config = ResolvedClaudeConfig {
+            env: crate::defaults::base_env(),
+            flags: default_flags(),
+            llm: LlmConfig {
+                provider: Some("lmstudio".to_string()),
+                model: Some("qwen2.5-coder".to_string()),
+                base_url: None,
+            },
+        };
+        let yaml = render_compose(
+            "test-project",
+            "/home/user/projects/test",
+            &config,
+            &ResolvedIntegrationsConfig::default(),
+            None,
+        )
+        .unwrap();
+        let env = get_claude_env(&yaml);
+        assert!(
+            env.iter()
+                .any(|e| e == "ANTHROPIC_CUSTOM_MODEL_OPTION_NAME=qwen2.5-coder (LM Studio)"),
+            "lmstudio display name must use 'LM Studio' label, got: {env:?}"
+        );
     }
 
     #[test]
@@ -3772,7 +3887,7 @@ services:
         // Regression guard: CLAUDE_VERSION must be the pinned semver from defaults.
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
-            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            flags: default_flags(),
             llm: LlmConfig::default(),
         };
         let yaml = render_compose(
@@ -3804,7 +3919,7 @@ services:
         // This guards against accidentally adding :ro to the workspace mount.
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
-            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            flags: default_flags(),
             llm: LlmConfig::default(),
         };
         let yaml = render_compose(
@@ -4288,7 +4403,7 @@ services:
         // Read-only — container only reads the lock file; Speedwave host writes it.
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
-            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            flags: default_flags(),
             llm: LlmConfig::default(),
         };
         let yaml = render_compose(
@@ -4463,7 +4578,7 @@ services:
         // CLAUDE_CODE_IDE_HOST_OVERRIDE must be in the claude service environment.
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
-            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            flags: default_flags(),
             llm: LlmConfig::default(),
         };
         let yaml = render_compose(
@@ -4497,7 +4612,7 @@ services:
     fn test_claude_env_has_no_flicker() {
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
-            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            flags: default_flags(),
             llm: LlmConfig::default(),
         };
         let yaml = render_compose(
@@ -4531,7 +4646,7 @@ services:
     fn test_claude_env_has_effort_level() {
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
-            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            flags: default_flags(),
             llm: LlmConfig::default(),
         };
         let yaml = render_compose(
@@ -4663,7 +4778,7 @@ services:
     fn test_render_compose_rejects_invalid_project_name() {
         let resolved = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
-            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            flags: default_flags(),
             llm: LlmConfig::default(),
         };
         let integrations = ResolvedIntegrationsConfig::default();
@@ -4852,7 +4967,7 @@ services:
     fn test_render_compose_with_mixed_enabled_disabled_end_to_end() {
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
-            flags: crate::defaults::DEFAULT_FLAGS.to_vec(),
+            flags: default_flags(),
             llm: LlmConfig::default(),
         };
         let mut integrations = ResolvedIntegrationsConfig::default();

--- a/crates/speedwave-runtime/src/config.rs
+++ b/crates/speedwave-runtime/src/config.rs
@@ -199,7 +199,7 @@ impl SpeedwaveUserConfig {
 #[derive(Debug, Clone)]
 pub struct ResolvedClaudeConfig {
     pub env: HashMap<String, String>,
-    pub flags: Vec<&'static str>,
+    pub flags: Vec<String>,
     pub llm: LlmConfig,
 }
 
@@ -243,12 +243,45 @@ pub fn resolve_project_config(
         }
     }
 
-    let claude = ResolvedClaudeConfig {
-        env,
-        flags: defaults::DEFAULT_FLAGS.to_vec(),
-        llm,
-    };
+    let mut flags: Vec<String> = defaults::DEFAULT_FLAGS
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    // Local LLMs usually can't fit Claude Code's ~16k-token built-in system
+    // prompt into their context window without severe quality loss. Replace
+    // it with a slimmed-down Speedwave-authored prompt that still teaches the
+    // model the MCP tool_use protocol (without which it cannot call any tool)
+    // but drops the Anthropic-specific guidance, examples, and persona text.
+    // Anthropic-hosted models keep the full built-in prompt unchanged.
+    // See ADR-040.
+    if is_local_provider(llm.provider.as_deref()) {
+        push_flag_pair(
+            &mut flags,
+            "--system-prompt-file",
+            crate::consts::LOCAL_LLM_SYSTEM_PROMPT_PATH,
+        );
+        // Default Claude Code to the user's local model so the chat statusline
+        // and the `/model` picker agree with Settings out of the box (without
+        // this, Claude Code starts on Sonnet 4.6 and the user has to manually
+        // switch via /model). `ANTHROPIC_CUSTOM_MODEL_OPTION` registers the
+        // model as a picker option; `--model` selects it as the default.
+        if let Some(model) = llm.model.as_deref() {
+            push_flag_pair(&mut flags, "--model", model);
+        }
+    }
+
+    let claude = ResolvedClaudeConfig { env, flags, llm };
     (claude, integrations)
+}
+
+/// Returns true for provider values that point at a local LLM server
+/// (Ollama, LM Studio, or llama.cpp).
+/// `None` / `Some("anthropic")` → false (Anthropic-hosted models).
+pub fn is_local_provider(provider: Option<&str>) -> bool {
+    matches!(
+        provider,
+        Some("ollama") | Some("lmstudio") | Some("llamacpp")
+    )
 }
 
 /// Merges: defaults -> repo config (.speedwave.json) -> user config (~/.speedwave/config.json).
@@ -384,6 +417,18 @@ where
     with_config_lock_in(crate::consts::data_dir(), f)
 }
 
+/// Appends a `--flag value` pair to `flags`.
+/// Panics in debug builds if `value` is empty, preventing silent "flag without
+/// a value" bugs (e.g. pushing `"--model"` and then forgetting the model string).
+fn push_flag_pair(flags: &mut Vec<String>, flag: &'static str, value: &str) {
+    debug_assert!(
+        !value.is_empty(),
+        "flag value for '{flag}' must not be empty"
+    );
+    flags.push(flag.to_string());
+    flags.push(value.to_string());
+}
+
 fn merge_env(base: &mut HashMap<String, String>, overlay: Option<HashMap<String, String>>) {
     if let Some(overlay) = overlay {
         for (key, value) in overlay {
@@ -434,10 +479,16 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let resolved = resolve_claude_config(tmp.path(), &user_config, "test-project");
         assert_eq!(resolved.env.get("ANTHROPIC_MODEL"), None);
-        assert!(resolved.flags.contains(&"--dangerously-skip-permissions"));
-        assert!(resolved.flags.contains(&"--mcp-config"));
-        assert!(resolved.flags.contains(&defaults::MCP_CONFIG_PATH));
-        assert!(resolved.flags.contains(&"--strict-mcp-config"));
+        assert!(resolved
+            .flags
+            .iter()
+            .any(|f| f == "--dangerously-skip-permissions"));
+        assert!(resolved.flags.iter().any(|f| f == "--mcp-config"));
+        assert!(resolved
+            .flags
+            .iter()
+            .any(|f| f == defaults::MCP_CONFIG_PATH));
+        assert!(resolved.flags.iter().any(|f| f == "--strict-mcp-config"));
     }
 
     #[test]
@@ -792,6 +843,121 @@ mod tests {
         let json = r#"{"projects":[],"active_project":null,"selected_ide":null}"#;
         let parsed: SpeedwaveUserConfig = serde_json::from_str(json).unwrap();
         assert_eq!(parsed.log_level, None);
+    }
+
+    // ── resolve_project_config: local-provider flag injection (ADR-040) ──
+
+    fn make_ollama_user_config(
+        tmp_dir: &std::path::Path,
+        model: Option<&str>,
+    ) -> SpeedwaveUserConfig {
+        SpeedwaveUserConfig {
+            projects: vec![ProjectUserEntry {
+                name: "test-project".to_string(),
+                dir: tmp_dir.to_string_lossy().to_string(),
+                claude: Some(ClaudeOverrides {
+                    env: None,
+                    settings: None,
+                    llm: Some(LlmConfig {
+                        provider: Some("ollama".to_string()),
+                        model: model.map(|m| m.to_string()),
+                        base_url: Some("http://host.docker.internal:11434".to_string()),
+                    }),
+                }),
+                integrations: None,
+                plugin_settings: None,
+            }],
+            active_project: None,
+            selected_ide: None,
+            log_level: None,
+        }
+    }
+
+    #[test]
+    fn resolve_injects_system_prompt_flag_for_ollama() {
+        let tmp = tempfile::tempdir().unwrap();
+        let user_config = make_ollama_user_config(tmp.path(), Some("llama3.3"));
+        let resolved = resolve_claude_config(tmp.path(), &user_config, "test-project");
+        let flags = &resolved.flags;
+        let pos = flags.iter().position(|f| f == "--system-prompt-file");
+        assert!(
+            pos.is_some(),
+            "expected --system-prompt-file flag for ollama provider; flags: {flags:?}"
+        );
+        assert_eq!(
+            flags.get(pos.unwrap() + 1).map(|s| s.as_str()),
+            Some("/speedwave/resources/system-prompts/local-llm.md"),
+            "expected local-llm.md path after --system-prompt-file; flags: {flags:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_injects_model_flag_when_model_set() {
+        let tmp = tempfile::tempdir().unwrap();
+        let user_config = make_ollama_user_config(tmp.path(), Some("llama3.3"));
+        let resolved = resolve_claude_config(tmp.path(), &user_config, "test-project");
+        let flags = &resolved.flags;
+        let pos = flags.iter().position(|f| f == "--model");
+        assert!(
+            pos.is_some(),
+            "expected --model flag for ollama provider with model set; flags: {flags:?}"
+        );
+        assert_eq!(
+            flags.get(pos.unwrap() + 1).map(|s| s.as_str()),
+            Some("llama3.3"),
+            "expected model value after --model flag; flags: {flags:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_does_not_inject_model_flag_when_model_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let user_config = make_ollama_user_config(tmp.path(), None);
+        let resolved = resolve_claude_config(tmp.path(), &user_config, "test-project");
+        let flags = &resolved.flags;
+        assert!(
+            !flags.iter().any(|f| f == "--model"),
+            "expected no --model flag when model is None; flags: {flags:?}"
+        );
+        assert!(
+            flags.iter().any(|f| f == "--system-prompt-file"),
+            "expected --system-prompt-file flag even without model; flags: {flags:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_does_not_inject_local_flags_for_anthropic() {
+        let tmp = tempfile::tempdir().unwrap();
+        let user_config = SpeedwaveUserConfig {
+            projects: vec![ProjectUserEntry {
+                name: "test-project".to_string(),
+                dir: tmp.path().to_string_lossy().to_string(),
+                claude: Some(ClaudeOverrides {
+                    env: None,
+                    settings: None,
+                    llm: Some(LlmConfig {
+                        provider: Some("anthropic".to_string()),
+                        model: None,
+                        base_url: None,
+                    }),
+                }),
+                integrations: None,
+                plugin_settings: None,
+            }],
+            active_project: None,
+            selected_ide: None,
+            log_level: None,
+        };
+        let resolved = resolve_claude_config(tmp.path(), &user_config, "test-project");
+        let flags = &resolved.flags;
+        assert!(
+            !flags.iter().any(|f| f == "--system-prompt-file"),
+            "expected no --system-prompt-file for anthropic provider; flags: {flags:?}"
+        );
+        assert!(
+            !flags.iter().any(|f| f == "--model"),
+            "expected no --model flag for anthropic provider; flags: {flags:?}"
+        );
     }
 
     fn assert_all_integrations_disabled(r: &ResolvedIntegrationsConfig) {

--- a/crates/speedwave-runtime/src/consts.rs
+++ b/crates/speedwave-runtime/src/consts.rs
@@ -38,6 +38,17 @@ pub const LIMA_HOST: &str = "host.lima.internal";
 pub const NERDCTL_LINUX_HOST: &str = "host.docker.internal";
 /// Hostname reachable from inside WSL2/nerdctl containers pointing to the Windows host.
 pub const WSL_HOST: &str = "host.speedwave.internal";
+/// Podman-compatibility alias injected via `extra_hosts` in compose.template.yml.
+/// Containers use this when built for environments that expect the Podman convention.
+pub const CONTAINERS_HOST: &str = "host.containers.internal";
+
+/// All hostnames resolved inside containers to the host gateway via `extra_hosts`
+/// in `compose.template.yml`. Used by host-side code (Desktop settings) that needs
+/// to probe the same endpoint a container would hit: each alias is rewritten to
+/// `127.0.0.1` before a local HTTP probe because the aliases are not present in
+/// the host's resolver (Lima/WSL2/rootless nerdctl inject them only inside the VM).
+pub const CONTAINER_HOST_ALIASES: &[&str] =
+    &[LIMA_HOST, NERDCTL_LINUX_HOST, WSL_HOST, CONTAINERS_HOST];
 
 /// IP of the macOS host as seen from inside nerdctl containers in the Lima vzNAT network.
 /// Lima vzNAT always assigns 192.168.5.2 to the host — this is static, not DHCP.
@@ -129,6 +140,12 @@ pub const NESTED_VIRT_WARNING_MSG: &str = "\
     - Increase VM memory to at least 8 GB\n\
     - Enable nested virtualization in VM settings (VT-x/EPT or AMD-V/RVI)\n\
     - Close other memory-intensive applications";
+
+/// Path inside the container to the system prompt file used when running a
+/// local LLM (Ollama, LM Studio, llama.cpp). The slim prompt replaces
+/// Claude Code's built-in ~16k-token prompt which exceeds local model context
+/// windows. See ADR-040.
+pub const LOCAL_LLM_SYSTEM_PROMPT_PATH: &str = "/speedwave/resources/system-prompts/local-llm.md";
 
 /// Error prefix used by backend when SecurityCheck or OS prereqs fail.
 /// Frontend matches on this string to distinguish blocking (check_failed)
@@ -1311,5 +1328,23 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn test_container_host_aliases_contains_all_named_hosts() {
+        // Alignment guard: CONTAINER_HOST_ALIASES is composed from the per-platform
+        // host constants. If someone adds a new alias to `extra_hosts` in
+        // compose.template.yml and forgets to name it here, this test doesn't catch
+        // that (separate template test does). This test catches the inverse:
+        // renaming one of the named hosts without updating the composition.
+        assert!(CONTAINER_HOST_ALIASES.contains(&LIMA_HOST));
+        assert!(CONTAINER_HOST_ALIASES.contains(&NERDCTL_LINUX_HOST));
+        assert!(CONTAINER_HOST_ALIASES.contains(&WSL_HOST));
+        assert!(CONTAINER_HOST_ALIASES.contains(&CONTAINERS_HOST));
+        assert_eq!(
+            CONTAINER_HOST_ALIASES.len(),
+            4,
+            "expected exactly 4 container host aliases; update this test if you added a new platform alias to compose.template.yml"
+        );
     }
 }

--- a/desktop/src-tauri/src/chat.rs
+++ b/desktop/src-tauri/src/chat.rs
@@ -674,7 +674,7 @@ fn build_ask_user_response(request: &ControlRequest, selected_label: &str) -> se
 ///
 /// When `resume_session_id` is `Some`, adds `--resume <id>` to resume an
 /// existing conversation.
-pub fn build_claude_args(resume_session_id: Option<&str>, flags: &[&str]) -> Vec<String> {
+pub fn build_claude_args(resume_session_id: Option<&str>, flags: &[String]) -> Vec<String> {
     let mut args = vec![
         consts::CLAUDE_BINARY.to_string(),
         "-p".to_string(),
@@ -694,7 +694,7 @@ pub fn build_claude_args(resume_session_id: Option<&str>, flags: &[&str]) -> Vec
     }
 
     for flag in flags {
-        args.push(flag.to_string());
+        args.push(flag.clone());
     }
 
     args
@@ -2111,7 +2111,7 @@ mod tests {
 
     #[test]
     fn build_claude_args_includes_flags() {
-        let args = build_claude_args(None, &["--dangerously-skip-permissions"]);
+        let args = build_claude_args(None, &["--dangerously-skip-permissions".to_string()]);
         assert!(args.contains(&"--dangerously-skip-permissions".to_string()));
     }
 

--- a/desktop/src-tauri/src/containers_cmd.rs
+++ b/desktop/src-tauri/src/containers_cmd.rs
@@ -581,12 +581,36 @@ pub fn get_llm_config() -> Result<LlmConfigResponse, String> {
     let default_url = provider
         .as_deref()
         .and_then(speedwave_runtime::compose::default_base_url);
+    let base_url = llm.and_then(|l| l.base_url.clone());
+
+    // Non-destructive migration: if a previously-stored base_url no longer
+    // satisfies the current SSRF policy (e.g. someone saved `http://169.254.169.254`
+    // before the policy was introduced), log a warning. The value is still
+    // returned so the UI can show it in the input; the Save path will reject
+    // it on the user's next edit. See ADR-041.
+    if let Some(ref url) = base_url {
+        let normalized = speedwave_runtime::compose::strip_trailing_v1(url);
+        if let Err(e) = crate::llm_cmd::validate_llm_base_url(&normalized) {
+            log::warn!("get_llm_config: stored base_url '{url}' fails current SSRF policy: {e}");
+        }
+    }
+
     Ok(LlmConfigResponse {
         provider,
         model: llm.and_then(|l| l.model.clone()),
-        base_url: llm.and_then(|l| l.base_url.clone()),
+        base_url,
         default_base_url: default_url,
     })
+}
+
+/// Returns the backend-authoritative default base URL for a given provider.
+///
+/// Delegates to `speedwave_runtime::compose::default_base_url` so the frontend
+/// never needs to duplicate URL strings. Returns `None` for unknown providers
+/// (e.g. `"anthropic"` has no local server URL).
+#[tauri::command]
+pub fn get_default_base_url(provider: String) -> Result<Option<String>, String> {
+    Ok(speedwave_runtime::compose::default_base_url(&provider))
 }
 
 /// Applies LLM config to the active project in-memory. Extracted for testability.
@@ -633,6 +657,11 @@ pub fn update_llm_config(
         // render time is also accepted at save time (Ollama docs commonly use
         // `http://…/v1` suffixes; we strip that before validating).
         let normalized = speedwave_runtime::compose::strip_trailing_v1(url);
+        // SSRF guard — same policy as LLM discovery probe. Blocks link-local,
+        // metadata, IPv6-mapped bypasses, embedded credentials, query/fragment.
+        // See ADR-041.
+        crate::llm_cmd::validate_llm_base_url(&normalized).map_err(|e| e.to_string())?;
+        // Belt-and-suspenders syntactic validation from the runtime crate.
         speedwave_runtime::compose::validate_base_url(&normalized).map_err(|e| e.to_string())?;
     }
     config::with_config_lock(|| {
@@ -847,15 +876,17 @@ mod tests {
     #[test]
     fn update_llm_config_rejects_invalid_base_url() {
         let result = update_llm_config(
-            Some("custom".to_string()),
+            Some("ollama".to_string()),
             None,
             Some("javascript:alert(1)".to_string()),
         );
         assert!(result.is_err());
         let err = result.unwrap_err();
+        // Either the new SSRF guard (scheme denylist) or the runtime syntactic
+        // validator rejects this; both mention the allowed schemes.
         assert!(
-            err.contains("http://") || err.contains("https://") || err.contains("base_url"),
-            "Error must mention http/https scheme requirement, got: {err}"
+            err.to_lowercase().contains("http"),
+            "Error must reference the allowed http(s) scheme, got: {err}"
         );
     }
 
@@ -867,7 +898,7 @@ mod tests {
         // We only check the URL-validation path here — a config-save error is fine,
         // what we require is that the error (if any) is NOT the path rejection.
         let result = update_llm_config(
-            Some("custom".to_string()),
+            Some("ollama".to_string()),
             Some("llama3.3".to_string()),
             Some("http://localhost:11434/v1".to_string()),
         );
@@ -877,6 +908,139 @@ mod tests {
                 "`/v1` suffix must be stripped before validation, got: {err}"
             );
         }
+    }
+
+    // ── Save-path SSRF coverage (ADR-041) ────────────────────────────────
+    //
+    // Before these tests, `update_llm_config` ran only compose::validate_base_url,
+    // which accepts `http://169.254.169.254` and friends. The new
+    // `llm_cmd::validate_llm_base_url` guard closes that hole — these tests
+    // exercise it at the command boundary. Validation fails before the config
+    // file is touched, so no fixture/lock setup is required.
+
+    fn url_rejection_err(url: &str) -> String {
+        update_llm_config(Some("ollama".to_string()), None, Some(url.to_string())).unwrap_err()
+    }
+
+    #[test]
+    fn update_llm_config_rejects_metadata_ip() {
+        let err = url_rejection_err("http://169.254.169.254:8080");
+        assert!(
+            err.to_lowercase().contains("private") || err.to_lowercase().contains("reserved"),
+            "metadata IP must be rejected with a private/reserved error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn update_llm_config_rejects_link_local_ipv6() {
+        let err = url_rejection_err("http://[fe80::1]");
+        assert!(
+            err.to_lowercase().contains("private") || err.to_lowercase().contains("reserved"),
+            "IPv6 link-local must be rejected, got: {err}"
+        );
+    }
+
+    #[test]
+    fn update_llm_config_rejects_credentials() {
+        let err = url_rejection_err("http://user:pass@localhost:11434");
+        assert!(
+            err.to_lowercase().contains("credentials"),
+            "embedded credentials must be rejected, got: {err}"
+        );
+    }
+
+    #[test]
+    fn update_llm_config_rejects_query_string() {
+        let err = url_rejection_err("http://localhost:11434?foo=bar");
+        assert!(
+            err.to_lowercase().contains("query"),
+            "query string must be rejected, got: {err}"
+        );
+    }
+
+    #[test]
+    fn update_llm_config_accepts_loopback_via_validation() {
+        // `update_llm_config` may fail later (no active project) — we just need
+        // the error (if any) NOT to be a URL rejection.
+        let result = update_llm_config(
+            Some("ollama".to_string()),
+            Some("llama3.3".to_string()),
+            Some("http://127.0.0.1:11434".to_string()),
+        );
+        if let Err(err) = result {
+            assert!(
+                !err.to_lowercase().contains("private")
+                    && !err.to_lowercase().contains("blocked")
+                    && !err.to_lowercase().contains("credentials"),
+                "loopback must NOT be rejected by URL validation, got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn update_llm_config_accepts_rfc1918_via_validation() {
+        let result = update_llm_config(
+            Some("ollama".to_string()),
+            Some("llama3.3".to_string()),
+            Some("http://192.168.1.50:11434".to_string()),
+        );
+        if let Err(err) = result {
+            assert!(
+                !err.to_lowercase().contains("private") && !err.to_lowercase().contains("blocked"),
+                "RFC1918 must NOT be rejected by URL validation, got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn update_llm_config_accepts_public_domain_via_validation() {
+        // Per ADR-041: user-written URL == user's threat model (align with Redmine).
+        let result = update_llm_config(
+            Some("ollama".to_string()),
+            Some("x".to_string()),
+            Some("http://my-ollama.company.com".to_string()),
+        );
+        if let Err(err) = result {
+            assert!(
+                !err.to_lowercase().contains("blocked"),
+                "public domain must NOT be rejected by URL validation, got: {err}"
+            );
+        }
+    }
+
+    // -- get_default_base_url tests --
+
+    #[test]
+    fn get_default_base_url_returns_ollama_url() {
+        let result = get_default_base_url("ollama".to_string()).unwrap();
+        assert_eq!(
+            result,
+            Some("http://host.docker.internal:11434".to_string())
+        );
+    }
+
+    #[test]
+    fn get_default_base_url_returns_lmstudio_url() {
+        let result = get_default_base_url("lmstudio".to_string()).unwrap();
+        assert_eq!(result, Some("http://host.docker.internal:1234".to_string()));
+    }
+
+    #[test]
+    fn get_default_base_url_returns_llamacpp_url() {
+        let result = get_default_base_url("llamacpp".to_string()).unwrap();
+        assert_eq!(result, Some("http://host.docker.internal:8080".to_string()));
+    }
+
+    #[test]
+    fn get_default_base_url_returns_none_for_anthropic() {
+        let result = get_default_base_url("anthropic".to_string()).unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn get_default_base_url_returns_none_for_unknown_provider() {
+        let result = get_default_base_url("openai".to_string()).unwrap();
+        assert_eq!(result, None);
     }
 
     // -- MockRuntime for switch/teardown tests --

--- a/desktop/src-tauri/src/containers_cmd.rs
+++ b/desktop/src-tauri/src/containers_cmd.rs
@@ -652,6 +652,15 @@ pub fn update_llm_config(
     model: Option<String>,
     base_url: Option<String>,
 ) -> Result<(), String> {
+    if let Some(ref m) = model {
+        // A model name starting with `--` (or `-`) would be interpreted as
+        // a flag by Claude Code's argument parser when rendered as
+        // `--model <name>`. Reject at save time so the free-text input can't
+        // smuggle flags into the CLI invocation.
+        if m.starts_with("--") || m.starts_with('-') {
+            return Err("Model name must not start with '-' (CLI flag collision)".to_string());
+        }
+    }
     if let Some(ref url) = base_url {
         // Normalize the same way apply_llm_config does, so a value accepted at
         // render time is also accepted at save time (Ollama docs commonly use
@@ -661,7 +670,8 @@ pub fn update_llm_config(
         // metadata, IPv6-mapped bypasses, embedded credentials, query/fragment.
         // See ADR-041.
         crate::llm_cmd::validate_llm_base_url(&normalized).map_err(|e| e.to_string())?;
-        // Belt-and-suspenders syntactic validation from the runtime crate.
+        // validate_base_url also rejects path components (http://host/path),
+        // which validate_llm_base_url does not check.
         speedwave_runtime::compose::validate_base_url(&normalized).map_err(|e| e.to_string())?;
     }
     config::with_config_lock(|| {
@@ -871,6 +881,53 @@ mod tests {
         let beta_llm = beta.claude.as_ref().unwrap().llm.as_ref().unwrap();
         assert_eq!(beta_llm.provider.as_deref(), Some("anthropic"));
         assert_eq!(beta_llm.model.as_deref(), Some("claude-sonnet-4-6"));
+    }
+
+    #[test]
+    fn update_llm_config_rejects_model_with_flag_prefix() {
+        // Regression: a model name starting with `--` would be rendered as
+        // `--model --dangerously-skip-permissions` in the Claude Code
+        // invocation; argument parsers may treat the value as another flag.
+        let result = update_llm_config(
+            Some("ollama".to_string()),
+            Some("--dangerously-skip-permissions".to_string()),
+            Some("http://localhost:11434".to_string()),
+        );
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.to_lowercase().contains("flag"),
+            "Error must reference the flag collision, got: {err}"
+        );
+    }
+
+    #[test]
+    fn update_llm_config_rejects_model_with_single_dash_prefix() {
+        let result = update_llm_config(
+            Some("ollama".to_string()),
+            Some("-h".to_string()),
+            Some("http://localhost:11434".to_string()),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn update_llm_config_accepts_model_with_dash_in_middle() {
+        // Common model names contain dashes (e.g. `llama-3.3`, `qwen-coder`).
+        // The guard only rejects leading dashes.
+        let result = update_llm_config(
+            Some("ollama".to_string()),
+            Some("llama-3.3".to_string()),
+            Some("http://localhost:11434".to_string()),
+        );
+        // The save itself may fail for project-config reasons in the test env,
+        // but the model-name check must not be the reason.
+        if let Err(e) = result {
+            assert!(
+                !e.to_lowercase().contains("flag collision"),
+                "Middle-dash model must not trigger flag-collision guard, got: {e}"
+            );
+        }
     }
 
     #[test]

--- a/desktop/src-tauri/src/http_util.rs
+++ b/desktop/src-tauri/src/http_util.rs
@@ -1,0 +1,136 @@
+// Shared HTTP utilities for Tauri commands that make outbound requests from
+// the Desktop host process.
+//
+// Extracted from `redmine_api_cmd` when a second caller (`llm_cmd`) needed the
+// same size-bounded body reader (Rule of Three — two concrete consumers).
+// Future outbound-HTTP commands should import from here rather than copy the
+// streaming-body guard or reinvent the size limit.
+
+/// Maximum response body size the Desktop will buffer from an outbound HTTP
+/// request. Chosen to fit any legitimate JSON API response (Redmine project
+/// lists, LLM model listings) while bounding OOM risk from a rogue or
+/// misconfigured endpoint returning gigabytes of data via chunked transfer
+/// encoding.
+pub(crate) const MAX_RESPONSE_BODY_BYTES: usize = 5 * 1024 * 1024; // 5 MiB
+
+/// Reads a response body chunk-by-chunk, aborting if the accumulated size
+/// exceeds `MAX_RESPONSE_BODY_BYTES`. Prevents OOM from rogue servers using
+/// chunked transfer encoding (no Content-Length header).
+///
+/// `label` is included in error messages so callers can identify which HTTP
+/// operation failed (e.g. "Credentials validation", "LLM model discovery").
+pub(crate) async fn read_body_limited(
+    resp: reqwest::Response,
+    label: &str,
+) -> Result<Vec<u8>, String> {
+    if let Some(len) = resp.content_length() {
+        if len > MAX_RESPONSE_BODY_BYTES as u64 {
+            return Err(format!(
+                "{label} response too large ({len} bytes, limit {MAX_RESPONSE_BODY_BYTES})"
+            ));
+        }
+    }
+
+    let mut buf = Vec::with_capacity(
+        resp.content_length()
+            .map(|l| l as usize)
+            .unwrap_or(4096)
+            .min(MAX_RESPONSE_BODY_BYTES),
+    );
+
+    let mut stream = resp;
+    while let Some(chunk) = stream
+        .chunk()
+        .await
+        .map_err(|e| format!("Failed to read {label} response chunk: {e}"))?
+    {
+        if buf.len().saturating_add(chunk.len()) > MAX_RESPONSE_BODY_BYTES {
+            return Err(format!(
+                "{label} response too large (exceeded {MAX_RESPONSE_BODY_BYTES} byte limit)"
+            ));
+        }
+        buf.extend_from_slice(&chunk);
+    }
+
+    Ok(buf)
+}
+
+/// Translates a container-side host alias to `127.0.0.1`. Host-side only.
+///
+/// Inside containers, aliases in `CONTAINER_HOST_ALIASES` resolve via
+/// `extra_hosts`. From the Desktop host process those aliases are absent —
+/// this function rewrites them to `127.0.0.1` before issuing HTTP requests.
+///
+/// Returns `Some("127.0.0.1")` for known aliases, `None` otherwise.
+pub(crate) fn rewrite_container_alias_to_loopback(host: &str) -> Option<&'static str> {
+    if speedwave_runtime::consts::CONTAINER_HOST_ALIASES.contains(&host) {
+        Some("127.0.0.1")
+    } else {
+        None
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_max_response_body_bytes_is_5_mib() {
+        // Guard: changing this value affects multiple callers (Redmine + LLM
+        // discovery). Update both tests and downstream error-message assertions
+        // if you bump the limit.
+        assert_eq!(MAX_RESPONSE_BODY_BYTES, 5 * 1024 * 1024);
+    }
+
+    #[test]
+    fn test_rewrite_alias_host_docker_internal() {
+        assert_eq!(
+            rewrite_container_alias_to_loopback("host.docker.internal"),
+            Some("127.0.0.1")
+        );
+    }
+
+    #[test]
+    fn test_rewrite_alias_host_lima_internal() {
+        assert_eq!(
+            rewrite_container_alias_to_loopback("host.lima.internal"),
+            Some("127.0.0.1")
+        );
+    }
+
+    #[test]
+    fn test_rewrite_alias_host_containers_internal() {
+        assert_eq!(
+            rewrite_container_alias_to_loopback("host.containers.internal"),
+            Some("127.0.0.1")
+        );
+    }
+
+    #[test]
+    fn test_rewrite_alias_host_speedwave_internal() {
+        assert_eq!(
+            rewrite_container_alias_to_loopback("host.speedwave.internal"),
+            Some("127.0.0.1")
+        );
+    }
+
+    #[test]
+    fn test_rewrite_alias_passthrough_localhost() {
+        assert_eq!(rewrite_container_alias_to_loopback("localhost"), None);
+    }
+
+    #[test]
+    fn test_rewrite_alias_passthrough_public_domain() {
+        assert_eq!(rewrite_container_alias_to_loopback("example.com"), None);
+    }
+
+    #[test]
+    fn test_rewrite_alias_passthrough_ipv4() {
+        assert_eq!(rewrite_container_alias_to_loopback("192.168.1.1"), None);
+    }
+}

--- a/desktop/src-tauri/src/llm_cmd.rs
+++ b/desktop/src-tauri/src/llm_cmd.rs
@@ -1,0 +1,1074 @@
+// LLM model discovery — Tauri command for probing local LLM servers.
+//
+// When a user configures a local-LLM provider in Settings (ollama, lmstudio,
+// llamacpp) the Desktop can hit the server's `/v1/models` or `/api/tags`
+// endpoint and present the advertised models as a `<select>`.
+// The same SSRF-safe validation path (`validate_llm_base_url`) is reused by
+// `containers_cmd::update_llm_config` so both discover and save reject
+// link-local, metadata, and other dangerous URLs.
+//
+// See docs/adr/ADR-041-local-llm-model-discovery.md for the threat model and
+// the RFC1918/loopback/public-domain policy rationale.
+
+use serde::Deserialize;
+use std::time::Duration;
+
+use crate::http_util::{read_body_limited, MAX_RESPONSE_BODY_BYTES};
+use crate::url_validation::{is_private_on_premise, validate_url, PrivatePolicy};
+
+/// Production timeout for the HTTP probe. Localhost / LAN should respond well
+/// under this; a model mid-load that hasn't come up yet will time out and
+/// the UI falls back to the free-text input.
+const DISCOVERY_TIMEOUT_SECS: u64 = 5;
+
+// ---------------------------------------------------------------------------
+// Response DTOs
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct OllamaTagsResponse {
+    /// Ollama returns the list under `models`. Additional fields (`model`,
+    /// `modified_at`, `size`, `digest`, `details`) are ignored — no
+    /// `deny_unknown_fields` so a future Ollama schema extension won't break us.
+    models: Vec<OllamaModel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OllamaModel {
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAIModelsResponse {
+    /// OpenAI-compatible servers (LM Studio, llama.cpp) advertise models under
+    /// `data`.
+    data: Vec<OpenAIModel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAIModel {
+    id: String,
+}
+
+// ---------------------------------------------------------------------------
+// Pure parsers (tested in isolation, no HTTP)
+// ---------------------------------------------------------------------------
+
+fn parse_ollama(body: &[u8]) -> anyhow::Result<Vec<String>> {
+    let resp: OllamaTagsResponse = serde_json::from_slice(body)
+        .map_err(|e| anyhow::anyhow!("failed to parse Ollama /api/tags response: {e}"))?;
+    Ok(resp.models.into_iter().map(|m| m.name).collect())
+}
+
+fn parse_openai(body: &[u8]) -> anyhow::Result<Vec<String>> {
+    let resp: OpenAIModelsResponse = serde_json::from_slice(body)
+        .map_err(|e| anyhow::anyhow!("failed to parse OpenAI /v1/models response: {e}"))?;
+    Ok(resp.data.into_iter().map(|m| m.id).collect())
+}
+
+// ---------------------------------------------------------------------------
+// URL validation (shared between discover and save paths)
+// ---------------------------------------------------------------------------
+
+/// Validates a base URL for a local LLM provider.
+///
+/// Policy (see ADR-041):
+/// - Loopback (127.0.0.0/8, ::1, IPv6-mapped loopback) — allowed with `warn!`.
+/// - RFC 1918 private + IPv6 ULA (fc00::/7) — allowed with `warn!`.
+/// - Link-local / metadata / reserved — rejected via `validate_url`.
+/// - Public IP / public domain — allowed with `warn!` (user-written URL; same
+///   threat model as Redmine's `validate_redmine_host_url`).
+/// - `http://` scheme warns about cleartext transmission.
+///
+/// Rejects embedded credentials, backslashes, query strings, fragments, and
+/// non-HTTP schemes in all cases.
+///
+/// Returns the parsed `url::Url` so callers (the discover pipeline) can reuse
+/// the parse result without re-parsing.
+pub(crate) fn validate_llm_base_url(url: &str) -> Result<url::Url, String> {
+    // Reject backslashes before parsing (Windows path confusion)
+    if url.contains('\\') {
+        return Err("URL must not contain backslashes".to_string());
+    }
+
+    let candidate: url::Url = url.parse().map_err(|e: url::ParseError| e.to_string())?;
+
+    // Reject query and fragment up front — LLM endpoints are canonical paths.
+    if candidate.query().is_some() {
+        return Err("URL must not contain a query string".to_string());
+    }
+    if candidate.fragment().is_some() {
+        return Err("URL must not contain a fragment".to_string());
+    }
+
+    // If the host is a private on-premise address (loopback, RFC1918, ULA) OR
+    // the literal hostname `localhost` (which `validate_url` otherwise blocks),
+    // skip the base validator and check scheme/host ourselves. Otherwise
+    // delegate to `validate_url` which handles link-local rejection, IPv6-mapped
+    // IPv4 bypass prevention, decimal IP bypass, and the full RFC 5737 / 2544 /
+    // 6666 / 3849 reserved-range set.
+    let host_is_localhost = matches!(
+        candidate.host(),
+        Some(url::Host::Domain(d)) if d.eq_ignore_ascii_case("localhost")
+    );
+    let parsed =
+        if host_is_localhost || is_private_on_premise(&candidate, PrivatePolicy::AllowLoopback) {
+            match candidate.scheme() {
+                "http" | "https" => {}
+                scheme => {
+                    return Err(format!(
+                        "Blocked URL scheme '{}': only http and https are allowed",
+                        scheme
+                    ))
+                }
+            }
+            if candidate.host().is_none() {
+                return Err("URL has no host".to_string());
+            }
+            let host = candidate.host_str().unwrap_or("unknown");
+            if host_is_localhost || is_loopback_host(&candidate) {
+                log::warn!("Allowing loopback address for local LLM: {}", host);
+            } else {
+                log::warn!("Allowing private address for local LLM: {}", host);
+            }
+            candidate
+        } else {
+            let v = validate_url(url)?;
+            log::warn!(
+                "Allowing public address for local LLM: {}",
+                v.host_str().unwrap_or("unknown")
+            );
+            v
+        };
+
+    // Reject embedded credentials.
+    if parsed.password().is_some() || !parsed.username().is_empty() {
+        return Err("URL must not contain embedded credentials".to_string());
+    }
+
+    // Warn about cleartext HTTP (credentials are not transmitted, but an
+    // on-path attacker can still read LLM traffic content).
+    if parsed.scheme() == "http" {
+        log::warn!("LLM traffic will be transmitted in cleartext over HTTP");
+    }
+
+    Ok(parsed)
+}
+
+/// Returns true when the parsed URL's host is an IPv4/IPv6 loopback address
+/// (native or IPv6-mapped). Used purely to pick the right `warn!` message.
+fn is_loopback_host(url: &url::Url) -> bool {
+    match url.host() {
+        Some(url::Host::Ipv4(v4)) => v4.is_loopback(),
+        Some(url::Host::Ipv6(v6)) => {
+            v6.is_loopback()
+                || v6
+                    .to_ipv4_mapped()
+                    .map(|v4| v4.is_loopback())
+                    .unwrap_or(false)
+        }
+        _ => false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// HTTP client helper
+// ---------------------------------------------------------------------------
+
+/// Builds an HTTP client for the LLM discovery probe. Redirects disabled to prevent SSRF.
+fn build_llm_probe_client() -> Result<reqwest::Client, String> {
+    reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .user_agent(format!("Speedwave-Desktop/{}", env!("CARGO_PKG_VERSION")))
+        .build()
+        .map_err(|e| format!("Failed to build HTTP client: {e}"))
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint selection
+// ---------------------------------------------------------------------------
+
+/// Returns the path suffix to append to the validated base URL for the given
+/// provider, or `Err("unsupported")` for unknown / anthropic providers.
+fn endpoint_path(provider: &str) -> Result<&'static str, String> {
+    match provider {
+        "anthropic" => Err("unsupported".to_string()),
+        "ollama" => Ok("/api/tags"),
+        "lmstudio" | "llamacpp" => Ok("/v1/models"),
+        _ => Err("unsupported".to_string()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// URL normalisation pipeline
+// ---------------------------------------------------------------------------
+
+/// Strips `/v1`, rewrites container host aliases, and runs SSRF validation.
+///
+/// Returns the validated `url::Url` ready for endpoint path composition.
+fn normalize_and_validate_discovery_url(base_url: &str) -> Result<url::Url, String> {
+    // 1. Strip trailing /v1 (Ollama docs sometimes include it).
+    let normalized = speedwave_runtime::compose::strip_trailing_v1(base_url);
+
+    // 2. Parse URL; early-Err on malformed input.
+    let mut parsed: url::Url = normalized
+        .parse()
+        .map_err(|e: url::ParseError| format!("Invalid base_url: {e}"))?;
+
+    // 3. Rewrite container-side host aliases (host.docker.internal etc.) to
+    //    loopback. On the Desktop host process, those aliases are not in
+    //    /etc/hosts — we need to hit the server on 127.0.0.1 directly.
+    if let Some(host_str) = parsed.host_str() {
+        if let Some(loopback) = crate::http_util::rewrite_container_alias_to_loopback(host_str) {
+            parsed
+                .set_host(Some(loopback))
+                .map_err(|e| format!("URL host rewrite failed: {e}"))?;
+        }
+    }
+
+    // 4. SSRF-safe validation (same function used by the save path).
+    validate_llm_base_url(parsed.as_str())
+}
+
+// ---------------------------------------------------------------------------
+// Core logic (parameterized timeout for testing)
+// ---------------------------------------------------------------------------
+
+/// Discovers available models from a local LLM server.
+///
+/// `timeout` controls both the reqwest-level request timeout. Production uses
+/// `DISCOVERY_TIMEOUT_SECS` via the Tauri wrapper; tests pass shorter
+/// durations to keep the suite fast.
+///
+/// Returns `Err("empty")` when the server responds OK but with no models (a
+/// server up without any model loaded). The UI treats this the same as an
+/// offline server and falls back to the free-text input.
+pub(crate) async fn do_discover_llm_models(
+    provider: &str,
+    base_url: &str,
+    client: &reqwest::Client,
+    timeout: Duration,
+) -> Result<Vec<String>, String> {
+    // 1. Short-circuit anthropic — there's no local model-list endpoint.
+    if provider == "anthropic" {
+        return Err("unsupported".to_string());
+    }
+
+    // 2. Normalise URL: strip /v1, rewrite container aliases, SSRF-validate.
+    let validated = normalize_and_validate_discovery_url(base_url)?;
+
+    // 3. Compose the endpoint URL.
+    let endpoint_suffix = endpoint_path(provider)?;
+    let url = format!(
+        "{}{}",
+        validated.as_str().trim_end_matches('/'),
+        endpoint_suffix
+    );
+
+    // 4. Issue the GET with the requested timeout.
+    let resp = client
+        .get(&url)
+        .header("Accept", "application/json")
+        .timeout(timeout)
+        .send()
+        .await
+        .map_err(|e| {
+            log::debug!("LLM model discovery: HTTP send failed for {url}: {e}");
+            format!("LLM model discovery: request failed: {e}")
+        })?;
+
+    // 5. Status check. 3xx is treated as non-2xx because we disabled redirect
+    //    following — a 3xx here means the server tried to bounce us, which is
+    //    either a misconfiguration or an SSRF attempt. warn!-level for
+    //    security auditability.
+    let status = resp.status();
+    if !status.is_success() {
+        if status.is_redirection() {
+            log::warn!(
+                "LLM model discovery: refusing to follow {} redirect to {}",
+                status.as_u16(),
+                resp.headers()
+                    .get("location")
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or("<missing>")
+            );
+        } else {
+            log::debug!("LLM model discovery: non-2xx status {}", status.as_u16());
+        }
+        return Err(format!("LLM server returned HTTP {}", status.as_u16()));
+    }
+
+    // 6. Content-Type sanity. A 200 with text/html body means the user
+    //    probably pointed at a Grafana / admin UI rather than an LLM server.
+    //    Case-insensitive prefix match (charset params vary).
+    if let Some(ct) = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+    {
+        if ct.to_ascii_lowercase().starts_with("text/html") {
+            log::debug!("LLM model discovery: unexpected HTML response");
+            return Err("LLM server returned an HTML response".to_string());
+        }
+    }
+
+    // 7. Body read with size cap (protects against OOM).
+    let body = read_body_limited(resp, "LLM model discovery").await?;
+
+    // 8. Parse per provider.
+    let models = match provider {
+        "ollama" => parse_ollama(&body).map_err(|e| {
+            log::debug!("LLM model discovery: Ollama parse failed: {e}");
+            format!("Failed to parse Ollama response: {e}")
+        })?,
+        _ => parse_openai(&body).map_err(|e| {
+            log::debug!("LLM model discovery: OpenAI parse failed: {e}");
+            format!("Failed to parse OpenAI-compatible response: {e}")
+        })?,
+    };
+
+    log::debug!(
+        "LLM model discovery: {} returned {} model(s)",
+        provider,
+        models.len()
+    );
+
+    // 9. Empty list is a failure — UI will show the free-text input.
+    if models.is_empty() {
+        return Err("empty".to_string());
+    }
+
+    // Sanity: ensure we haven't accidentally accepted a body larger than the
+    // cap. This is defensive — read_body_limited already enforces.
+    debug_assert!(body.len() <= MAX_RESPONSE_BODY_BYTES);
+
+    Ok(models)
+}
+
+// ---------------------------------------------------------------------------
+// Tauri command (thin wrapper)
+// ---------------------------------------------------------------------------
+
+/// Tauri entry point for LLM model discovery. Builds a per-call reqwest client
+/// and delegates to `do_discover_llm_models` with the production timeout.
+#[tauri::command]
+pub async fn discover_llm_models(
+    provider: String,
+    base_url: String,
+) -> Result<Vec<String>, String> {
+    let client = build_llm_probe_client()?;
+    do_discover_llm_models(
+        &provider,
+        &base_url,
+        &client,
+        Duration::from_secs(DISCOVERY_TIMEOUT_SECS),
+    )
+    .await
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    // ── normalize_and_validate_discovery_url ────────────────────────────
+
+    #[test]
+    fn normalize_strips_v1_suffix() {
+        let url = normalize_and_validate_discovery_url("http://127.0.0.1:11434/v1").unwrap();
+        assert!(
+            !url.as_str().contains("/v1"),
+            "expected /v1 to be stripped; got: {}",
+            url
+        );
+        assert_eq!(url.host_str(), Some("127.0.0.1"));
+    }
+
+    #[test]
+    fn normalize_rewrites_container_alias() {
+        let url =
+            normalize_and_validate_discovery_url("http://host.docker.internal:11434").unwrap();
+        assert_eq!(
+            url.host_str(),
+            Some("127.0.0.1"),
+            "expected container alias rewritten to 127.0.0.1; got: {}",
+            url
+        );
+    }
+
+    #[test]
+    fn normalize_rejects_metadata_ip() {
+        let err = normalize_and_validate_discovery_url("http://169.254.169.254").unwrap_err();
+        assert!(
+            err.to_lowercase().contains("private") || err.to_lowercase().contains("reserved"),
+            "expected metadata IP rejection; got: {err}"
+        );
+    }
+
+    // ── Pure parsers ────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_ollama_happy_path() {
+        // Extra fields (`model`, `modified_at`, …) MUST NOT break parse — we
+        // deliberately do not set `deny_unknown_fields`.
+        let body = br#"{
+            "models": [
+                {
+                    "name": "llama3.3",
+                    "model": "llama3.3:latest",
+                    "modified_at": "2024-01-01T00:00:00Z",
+                    "size": "4000000000",
+                    "digest": "",
+                    "details": { "format": "gguf" }
+                },
+                { "name": "qwen2.5" }
+            ]
+        }"#;
+        assert_eq!(parse_ollama(body).unwrap(), vec!["llama3.3", "qwen2.5"]);
+    }
+
+    #[test]
+    fn parse_ollama_empty_list() {
+        let body = br#"{ "models": [] }"#;
+        assert!(parse_ollama(body).unwrap().is_empty());
+    }
+
+    #[test]
+    fn parse_ollama_malformed_json() {
+        assert!(parse_ollama(b"not json at all").is_err());
+    }
+
+    #[test]
+    fn parse_ollama_wrong_outer_type() {
+        assert!(parse_ollama(b"[]").is_err());
+    }
+
+    #[test]
+    fn parse_ollama_wrong_field_type_for_name() {
+        let body = br#"{ "models": [ { "name": 42 } ] }"#;
+        assert!(parse_ollama(body).is_err());
+    }
+
+    #[test]
+    fn parse_openai_happy_path() {
+        let body = br#"{
+            "data": [
+                { "id": "gpt-oss", "object": "model", "owned_by": "organization" },
+                { "id": "qwen" }
+            ]
+        }"#;
+        assert_eq!(parse_openai(body).unwrap(), vec!["gpt-oss", "qwen"]);
+    }
+
+    #[test]
+    fn parse_openai_empty_list() {
+        assert!(parse_openai(br#"{ "data": [] }"#).unwrap().is_empty());
+    }
+
+    #[test]
+    fn parse_openai_malformed_json() {
+        assert!(parse_openai(b"{bad").is_err());
+    }
+
+    #[test]
+    fn parse_openai_wrong_outer_type() {
+        assert!(parse_openai(b"[]").is_err());
+    }
+
+    // ── validate_llm_base_url: branch coverage ──────────────────────────
+    //
+    // `url_validation::validate_url` already has 50+ tests covering every
+    // RFC-reserved range and IPv6-mapped IPv4 bypass. These tests cover the
+    // LLM-specific delta: branch selection (on-premise arm vs. delegation
+    // arm) and the policy difference (loopback allowed).
+
+    #[test]
+    fn validate_allows_localhost_hostname() {
+        // The `localhost` hostname is special-cased via host_is_localhost in
+        // validate_llm_base_url — must be allowed under the LLM policy.
+        assert!(validate_llm_base_url("http://localhost:11434").is_ok());
+    }
+
+    #[test]
+    fn validate_allows_loopback_ipv4() {
+        // On-premise arm (AllowLoopback).
+        assert!(validate_llm_base_url("http://127.0.0.1:11434").is_ok());
+    }
+
+    #[test]
+    fn validate_allows_rfc1918() {
+        // On-premise arm (RFC 1918).
+        assert!(validate_llm_base_url("http://192.168.1.1").is_ok());
+    }
+
+    #[test]
+    fn validate_blocks_link_local_metadata() {
+        // Delegation arm → url_validation rejects.
+        let err = validate_llm_base_url("http://169.254.169.254").unwrap_err();
+        assert!(
+            err.to_lowercase().contains("private") || err.to_lowercase().contains("reserved"),
+            "expected metadata IP rejection; got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_allows_public_ipv4() {
+        // Delegation arm → url_validation accepts public IPs.
+        assert!(validate_llm_base_url("http://8.8.8.8").is_ok());
+    }
+
+    #[test]
+    fn validate_allows_public_domain() {
+        // Delegation arm — unknown DNS name is treated as public (align with Redmine).
+        assert!(validate_llm_base_url("http://my-ollama.lan").is_ok());
+    }
+
+    #[test]
+    fn validate_allows_loopback_ipv6() {
+        assert!(validate_llm_base_url("http://[::1]").is_ok());
+    }
+
+    #[test]
+    fn validate_allows_ula_ipv6() {
+        assert!(validate_llm_base_url("http://[fc00::1]").is_ok());
+    }
+
+    #[test]
+    fn validate_blocks_link_local_ipv6() {
+        assert!(validate_llm_base_url("http://[fe80::1]").is_err());
+    }
+
+    #[test]
+    fn validate_blocks_mapped_link_local() {
+        assert!(validate_llm_base_url("http://[::ffff:169.254.169.254]").is_err());
+    }
+
+    #[test]
+    fn validate_allows_mapped_loopback() {
+        // Delta vs Redmine — under AllowLoopback, IPv6-mapped loopback is OK.
+        assert!(validate_llm_base_url("http://[::ffff:127.0.0.1]").is_ok());
+    }
+
+    // Schema / format rejections
+
+    #[test]
+    fn validate_blocks_file_scheme() {
+        assert!(validate_llm_base_url("file:///etc/passwd").is_err());
+    }
+
+    #[test]
+    fn validate_blocks_javascript_scheme() {
+        assert!(validate_llm_base_url("javascript:alert(1)").is_err());
+    }
+
+    #[test]
+    fn validate_blocks_ssh_scheme() {
+        assert!(validate_llm_base_url("ssh://user@host").is_err());
+    }
+
+    #[test]
+    fn validate_blocks_ftp_scheme() {
+        assert!(validate_llm_base_url("ftp://ollama.com").is_err());
+    }
+
+    #[test]
+    fn validate_blocks_data_scheme() {
+        assert!(validate_llm_base_url("data:text/html,<script>").is_err());
+    }
+
+    #[test]
+    fn validate_blocks_backslash() {
+        assert!(validate_llm_base_url("http://localhost\\admin").is_err());
+    }
+
+    #[test]
+    fn validate_blocks_credentials() {
+        assert!(validate_llm_base_url("http://user:pass@localhost:11434").is_err());
+    }
+
+    #[test]
+    fn validate_blocks_credentials_on_private() {
+        assert!(validate_llm_base_url("http://admin:secret@192.168.1.1").is_err());
+    }
+
+    #[test]
+    fn validate_blocks_empty() {
+        assert!(validate_llm_base_url("").is_err());
+    }
+
+    #[test]
+    fn validate_blocks_no_scheme() {
+        assert!(validate_llm_base_url("example.com").is_err());
+    }
+
+    #[test]
+    fn validate_blocks_scheme_only() {
+        assert!(validate_llm_base_url("https:").is_err());
+    }
+
+    #[test]
+    fn validate_blocks_with_query() {
+        assert!(validate_llm_base_url("http://localhost:11434?foo=bar").is_err());
+    }
+
+    #[test]
+    fn validate_blocks_with_fragment() {
+        assert!(validate_llm_base_url("http://localhost:11434#frag").is_err());
+    }
+
+    // ── Log capture tests ───────────────────────────────────────────────
+    //
+    // Uses a process-global TestLogger behind `serial_test::serial` to avoid
+    // interference from tauri-plugin-log or parallel tests.
+
+    struct TestLogger {
+        records: Mutex<Vec<(log::Level, String)>>,
+    }
+
+    impl TestLogger {
+        fn new() -> Self {
+            Self {
+                records: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn take(&self) -> Vec<(log::Level, String)> {
+            let mut guard = self.records.lock().unwrap();
+            std::mem::take(&mut *guard)
+        }
+    }
+
+    impl log::Log for TestLogger {
+        fn enabled(&self, _: &log::Metadata) -> bool {
+            true
+        }
+        fn log(&self, record: &log::Record) {
+            self.records
+                .lock()
+                .unwrap()
+                .push((record.level(), record.args().to_string()));
+        }
+        fn flush(&self) {}
+    }
+
+    fn test_logger() -> &'static TestLogger {
+        static LOGGER: OnceLock<TestLogger> = OnceLock::new();
+        let logger = LOGGER.get_or_init(TestLogger::new);
+        // Safe to call multiple times — only the first succeeds; subsequent
+        // calls return Err which we ignore.
+        let _ = log::set_logger(logger);
+        log::set_max_level(log::LevelFilter::Trace);
+        logger
+    }
+
+    fn warns_contain(records: &[(log::Level, String)], needle: &str) -> bool {
+        records.iter().any(|(level, msg)| {
+            *level == log::Level::Warn && msg.to_lowercase().contains(&needle.to_lowercase())
+        })
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn logs_warn_on_cleartext_http_private_ip() {
+        let logger = test_logger();
+        let _ = logger.take();
+        validate_llm_base_url("http://192.168.1.1").unwrap();
+        let records = logger.take();
+        assert!(
+            warns_contain(&records, "cleartext"),
+            "expected cleartext warning; got: {records:?}"
+        );
+        assert!(
+            warns_contain(&records, "private"),
+            "expected private-address warning; got: {records:?}"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn logs_warn_on_public_ip() {
+        let logger = test_logger();
+        let _ = logger.take();
+        validate_llm_base_url("http://8.8.8.8").unwrap();
+        let records = logger.take();
+        assert!(
+            warns_contain(&records, "public"),
+            "expected public-address warning; got: {records:?}"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn logs_warn_on_loopback() {
+        let logger = test_logger();
+        let _ = logger.take();
+        validate_llm_base_url("http://127.0.0.1").unwrap();
+        let records = logger.take();
+        assert!(
+            warns_contain(&records, "loopback"),
+            "expected loopback warning; got: {records:?}"
+        );
+    }
+
+    // ── Command-level (anthropic short-circuit, alias rewrite) ──────────
+
+    #[tokio::test]
+    async fn do_discover_rejects_anthropic() {
+        let client = build_llm_probe_client().unwrap();
+        let err = do_discover_llm_models(
+            "anthropic",
+            "http://127.0.0.1:11434",
+            &client,
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err, "unsupported");
+    }
+
+    #[tokio::test]
+    async fn do_discover_rejects_file_scheme() {
+        let client = build_llm_probe_client().unwrap();
+        assert!(do_discover_llm_models(
+            "ollama",
+            "file:///etc/passwd",
+            &client,
+            Duration::from_secs(1),
+        )
+        .await
+        .is_err());
+    }
+
+    #[tokio::test]
+    async fn do_discover_rejects_metadata_ip() {
+        let client = build_llm_probe_client().unwrap();
+        // We never issue the request — validate_llm_base_url rejects first.
+        assert!(do_discover_llm_models(
+            "ollama",
+            "http://169.254.169.254",
+            &client,
+            Duration::from_secs(1),
+        )
+        .await
+        .is_err());
+    }
+
+    #[tokio::test]
+    async fn do_discover_rewrites_docker_internal_via_mockito() {
+        // Start a local mockito server on a dynamic 127.0.0.1 port, then call
+        // do_discover with base_url = host.docker.internal:{port}. The rewrite
+        // helper must substitute 127.0.0.1 so the request actually lands on
+        // our mock (rather than failing DNS resolution for host.docker.internal
+        // on the host).
+        let mut server = mockito::Server::new_async().await;
+        let port = server.host_with_port();
+        let port = port.split(':').nth(1).unwrap();
+        let mock = server
+            .mock("GET", "/api/tags")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"models":[{"name":"test-model"}]}"#)
+            .create_async()
+            .await;
+
+        let client = build_llm_probe_client().unwrap();
+        let base_url = format!("http://host.docker.internal:{}", port);
+        let models = do_discover_llm_models("ollama", &base_url, &client, Duration::from_secs(2))
+            .await
+            .unwrap();
+        assert_eq!(models, vec!["test-model"]);
+        mock.assert_async().await;
+    }
+
+    // ── Integration tests via mockito ───────────────────────────────────
+
+    #[tokio::test]
+    async fn integration_ollama_happy_path() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/api/tags")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"models":[{"name":"llama3.3"},{"name":"qwen2.5"}]}"#)
+            .create_async()
+            .await;
+        let client = build_llm_probe_client().unwrap();
+        let models =
+            do_discover_llm_models("ollama", &server.url(), &client, Duration::from_secs(2))
+                .await
+                .unwrap();
+        assert_eq!(models, vec!["llama3.3", "qwen2.5"]);
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn integration_lmstudio_happy_path() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/v1/models")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"data":[{"id":"gpt-oss"},{"id":"qwen"}]}"#)
+            .create_async()
+            .await;
+        let client = build_llm_probe_client().unwrap();
+        let models =
+            do_discover_llm_models("lmstudio", &server.url(), &client, Duration::from_secs(2))
+                .await
+                .unwrap();
+        assert_eq!(models, vec!["gpt-oss", "qwen"]);
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn integration_llamacpp_happy_path() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/v1/models")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"data":[{"id":"bielik"}]}"#)
+            .create_async()
+            .await;
+        let client = build_llm_probe_client().unwrap();
+        let models =
+            do_discover_llm_models("llamacpp", &server.url(), &client, Duration::from_secs(2))
+                .await
+                .unwrap();
+        assert_eq!(models, vec!["bielik"]);
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn discover_rejects_custom_provider_after_removal() {
+        // Regression guard: `custom` was removed as a first-class provider. Any
+        // lingering config that still passes it through the Tauri command must
+        // now land on the generic unknown-provider path (`Err("unsupported")`),
+        // not a bespoke `custom` branch that routes to `/v1/models`. The client
+        // is unused because the rejection happens before any HTTP call.
+        let client = build_llm_probe_client().unwrap();
+        let err = do_discover_llm_models(
+            "custom",
+            "http://127.0.0.1:1234",
+            &client,
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err, "unsupported");
+    }
+
+    #[tokio::test]
+    async fn integration_returns_err_on_500() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/v1/models")
+            .with_status(500)
+            .create_async()
+            .await;
+        let client = build_llm_probe_client().unwrap();
+        assert!(
+            do_discover_llm_models("lmstudio", &server.url(), &client, Duration::from_secs(2),)
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn integration_returns_err_on_401() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/v1/models")
+            .with_status(401)
+            .create_async()
+            .await;
+        let client = build_llm_probe_client().unwrap();
+        assert!(
+            do_discover_llm_models("lmstudio", &server.url(), &client, Duration::from_secs(2),)
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn integration_returns_err_on_429() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/v1/models")
+            .with_status(429)
+            .create_async()
+            .await;
+        let client = build_llm_probe_client().unwrap();
+        assert!(
+            do_discover_llm_models("lmstudio", &server.url(), &client, Duration::from_secs(2),)
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn integration_returns_err_on_html_content_type() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/v1/models")
+            .with_status(200)
+            // Mixed-case + charset param — check is case-insensitive + prefix.
+            .with_header("content-type", "TEXT/HTML; charset=UTF-8")
+            .with_body("<!doctype html><html>...</html>")
+            .create_async()
+            .await;
+        let client = build_llm_probe_client().unwrap();
+        let err =
+            do_discover_llm_models("lmstudio", &server.url(), &client, Duration::from_secs(2))
+                .await
+                .unwrap_err();
+        assert!(err.to_lowercase().contains("html"));
+    }
+
+    #[tokio::test]
+    async fn integration_accepts_mixed_case_json_content_type() {
+        // Regression guard: the content-type sanity check must NOT reject
+        // `application/json; charset=utf-8` with unusual casing.
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/v1/models")
+            .with_status(200)
+            .with_header("content-type", "Application/JSON; charset=UTF-8")
+            .with_body(r#"{"data":[{"id":"x"}]}"#)
+            .create_async()
+            .await;
+        let client = build_llm_probe_client().unwrap();
+        let models =
+            do_discover_llm_models("lmstudio", &server.url(), &client, Duration::from_secs(2))
+                .await
+                .unwrap();
+        assert_eq!(models, vec!["x"]);
+    }
+
+    #[tokio::test]
+    async fn integration_returns_err_on_empty_list() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/v1/models")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"data":[]}"#)
+            .create_async()
+            .await;
+        let client = build_llm_probe_client().unwrap();
+        let err =
+            do_discover_llm_models("lmstudio", &server.url(), &client, Duration::from_secs(2))
+                .await
+                .unwrap_err();
+        assert_eq!(err, "empty");
+    }
+
+    #[tokio::test]
+    async fn integration_returns_err_on_oversized_body() {
+        let oversized = vec![b'x'; MAX_RESPONSE_BODY_BYTES + 1];
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/v1/models")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(oversized)
+            .create_async()
+            .await;
+        let client = build_llm_probe_client().unwrap();
+        let err =
+            do_discover_llm_models("lmstudio", &server.url(), &client, Duration::from_secs(2))
+                .await
+                .unwrap_err();
+        assert!(err.to_lowercase().contains("too large"));
+    }
+
+    #[tokio::test]
+    async fn integration_returns_err_on_timeout() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/v1/models")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_chunked_body(|w| {
+                // Sleep longer than the test's 100ms timeout before writing.
+                std::thread::sleep(Duration::from_secs(2));
+                w.write_all(b"{}")?;
+                Ok(())
+            })
+            .create_async()
+            .await;
+        let client = build_llm_probe_client().unwrap();
+        assert!(do_discover_llm_models(
+            "lmstudio",
+            &server.url(),
+            &client,
+            Duration::from_millis(100),
+        )
+        .await
+        .is_err());
+    }
+
+    #[tokio::test]
+    async fn integration_redirect_not_followed() {
+        // First server returns 302 → second server. Second server must never
+        // be hit because Policy::none() blocks redirect following.
+        let mut target = mockito::Server::new_async().await;
+        let never_hit = target
+            .mock("GET", "/v1/models")
+            .with_status(200)
+            .expect(0)
+            .create_async()
+            .await;
+
+        let mut redirect = mockito::Server::new_async().await;
+        let initial = redirect
+            .mock("GET", "/v1/models")
+            .with_status(302)
+            .with_header("location", &format!("{}/v1/models", target.url()))
+            .create_async()
+            .await;
+
+        let client = build_llm_probe_client().unwrap();
+        assert!(do_discover_llm_models(
+            "lmstudio",
+            &redirect.url(),
+            &client,
+            Duration::from_secs(2),
+        )
+        .await
+        .is_err());
+
+        initial.assert_async().await;
+        never_hit.assert_async().await; // expect(0) — confirms redirect NOT followed
+    }
+
+    #[tokio::test]
+    async fn integration_redirect_to_metadata_ip_not_followed() {
+        // 302 → http://169.254.169.254/latest/meta-data/. If we were following
+        // redirects, this would turn into a real (slow / refused) network
+        // fetch. Assertion (b): wrap the whole operation in a 500ms timeout —
+        // if we blew through it, something fetched the metadata URL.
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/v1/models")
+            .with_status(302)
+            .with_header("location", "http://169.254.169.254/latest/meta-data/")
+            .create_async()
+            .await;
+
+        let client = build_llm_probe_client().unwrap();
+        let result = tokio::time::timeout(
+            Duration::from_millis(500),
+            do_discover_llm_models("lmstudio", &server.url(), &client, Duration::from_secs(2)),
+        )
+        .await
+        .expect("operation must complete within 500ms — otherwise redirect was followed");
+
+        assert!(result.is_err());
+    }
+}

--- a/desktop/src-tauri/src/llm_cmd.rs
+++ b/desktop/src-tauri/src/llm_cmd.rs
@@ -122,9 +122,9 @@ pub(crate) fn validate_llm_base_url(url: &str) -> Result<url::Url, String> {
                     ))
                 }
             }
-            if candidate.host().is_none() {
-                return Err("URL has no host".to_string());
-            }
+            // Host is guaranteed present here: host_is_localhost requires
+            // Some(Domain("localhost")); is_private_on_premise returns true
+            // only for Some(Ipv4) or Some(Ipv6). No None path reaches this arm.
             let host = candidate.host_str().unwrap_or("unknown");
             if host_is_localhost || is_loopback_host(&candidate) {
                 log::warn!("Allowing loopback address for local LLM: {}", host);

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -16,8 +16,10 @@ mod diagnostics;
 mod fs_perms;
 mod health;
 mod history;
+mod http_util;
 mod ide_bridge;
 mod integrations_cmd;
+mod llm_cmd;
 mod log_file;
 mod logging_cmd;
 mod mcp_os_process;
@@ -1341,7 +1343,9 @@ fn main() {
             // Settings
             containers_cmd::factory_reset,
             containers_cmd::get_llm_config,
+            containers_cmd::get_default_base_url,
             containers_cmd::update_llm_config,
+            llm_cmd::discover_llm_models,
             // Authentication
             auth_commands::save_api_key,
             auth_commands::delete_api_key,

--- a/desktop/src-tauri/src/redmine_api_cmd.rs
+++ b/desktop/src-tauri/src/redmine_api_cmd.rs
@@ -500,6 +500,52 @@ mod tests {
         );
     }
 
+    // ── URL validation: CGNAT (RFC 6598) allowed — Tailscale support ────
+
+    #[test]
+    fn validate_url_allows_cgnat_lower_boundary() {
+        // RFC 6598 CGNAT (100.64.0.0/10) — commonly seen on Tailscale and
+        // carrier-grade NAT networks. Previously blocked by Redmine's
+        // is_private_on_premise (which only covered RFC 1918); now accepted
+        // via the shared url_validation::is_private_on_premise(BlockLoopback).
+        let result = validate_redmine_host_url("http://100.64.1.1:3000/");
+        assert!(
+            result.is_ok(),
+            "CGNAT 100.64.x.x should be allowed: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    fn validate_url_allows_cgnat_upper_boundary() {
+        // Last address in 100.64.0.0/10 — must still be classified as on-premise.
+        let result = validate_redmine_host_url("http://100.127.255.254/");
+        assert!(
+            result.is_ok(),
+            "CGNAT upper boundary should be allowed: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    fn validate_url_rejects_just_outside_cgnat() {
+        // 100.128.x.x is outside /10 — must NOT be classified as CGNAT and
+        // must NOT be mistaken for on-premise by the IP classifier.
+        // It's a regular public IP, which Redmine accepts with a warn; this
+        // test documents that it goes through the public-IP path, not CGNAT.
+        let result = validate_redmine_host_url("http://100.128.0.1/");
+        // Public IP — Redmine's policy is to allow with warn (user-written).
+        // The important invariant is that it does NOT go through the
+        // CGNAT/on-premise arm; this is exercised indirectly by the test
+        // passing (if the classifier were wrong, validate_url rejection
+        // logic would differ).
+        assert!(
+            result.is_ok(),
+            "100.128.0.1 (outside CGNAT) should still resolve as a public IP: {:?}",
+            result.err()
+        );
+    }
+
     // ── URL validation: path preserved ──────────────────────────────────
 
     #[test]

--- a/desktop/src-tauri/src/redmine_api_cmd.rs
+++ b/desktop/src-tauri/src/redmine_api_cmd.rs
@@ -7,7 +7,9 @@
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
-const MAX_RESPONSE_BODY_BYTES: usize = 5 * 1024 * 1024; // 5 MiB
+use crate::http_util::read_body_limited;
+#[cfg(test)]
+use crate::http_util::MAX_RESPONSE_BODY_BYTES;
 
 // ---------------------------------------------------------------------------
 // Response DTOs
@@ -113,8 +115,12 @@ fn validate_redmine_host_url(url: &str) -> Result<String, String> {
     let candidate: url::Url = url.parse().map_err(|e: url::ParseError| e.to_string())?;
 
     // If private on-premise address (RFC1918 or IPv6 ULA), skip base validation
-    // (which blocks all private IPs) and validate scheme/host ourselves
-    let parsed = if is_private_on_premise(&candidate) {
+    // (which blocks all private IPs) and validate scheme/host ourselves.
+    // Redmine policy blocks loopback — use `PrivatePolicy::BlockLoopback`.
+    let parsed = if crate::url_validation::is_private_on_premise(
+        &candidate,
+        crate::url_validation::PrivatePolicy::BlockLoopback,
+    ) {
         match candidate.scheme() {
             "http" | "https" => {}
             scheme => {
@@ -154,65 +160,8 @@ fn validate_redmine_host_url(url: &str) -> Result<String, String> {
     Ok(result)
 }
 
-/// Returns `true` if the URL's host is a private on-premise address:
-/// RFC1918 IPv4 (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) or
-/// IPv6 Unique Local Address (fc00::/7, RFC 4193).
-/// Returns `false` for loopback, link-local, unspecified, or any other reserved range.
-fn is_private_on_premise(url: &url::Url) -> bool {
-    match url.host() {
-        Some(url::Host::Ipv4(ipv4)) => {
-            ipv4.is_private()
-                && !ipv4.is_loopback()
-                && !ipv4.is_link_local()
-                && !ipv4.is_unspecified()
-        }
-        Some(url::Host::Ipv6(ipv6)) => {
-            // fc00::/7 — IPv6 Unique Local Address (RFC 4193)
-            (ipv6.segments()[0] & 0xfe00) == 0xfc00
-        }
-        _ => false,
-    }
-}
-
-// ---------------------------------------------------------------------------
-// HTTP body reader with size guard
-// ---------------------------------------------------------------------------
-
-/// Reads a response body chunk-by-chunk, aborting if the accumulated size
-/// exceeds `MAX_RESPONSE_BODY_BYTES`. Prevents OOM from rogue servers using
-/// chunked transfer encoding (no Content-Length header).
-async fn read_body_limited(resp: reqwest::Response, label: &str) -> Result<Vec<u8>, String> {
-    if let Some(len) = resp.content_length() {
-        if len > MAX_RESPONSE_BODY_BYTES as u64 {
-            return Err(format!(
-                "{label} response too large ({len} bytes, limit {MAX_RESPONSE_BODY_BYTES})"
-            ));
-        }
-    }
-
-    let mut buf = Vec::with_capacity(
-        resp.content_length()
-            .map(|l| l as usize)
-            .unwrap_or(4096)
-            .min(MAX_RESPONSE_BODY_BYTES),
-    );
-
-    let mut stream = resp;
-    while let Some(chunk) = stream
-        .chunk()
-        .await
-        .map_err(|e| format!("Failed to read {label} response chunk: {e}"))?
-    {
-        if buf.len().saturating_add(chunk.len()) > MAX_RESPONSE_BODY_BYTES {
-            return Err(format!(
-                "{label} response too large (exceeded {MAX_RESPONSE_BODY_BYTES} byte limit)"
-            ));
-        }
-        buf.extend_from_slice(&chunk);
-    }
-
-    Ok(buf)
-}
+// read_body_limited + MAX_RESPONSE_BODY_BYTES moved to `crate::http_util`
+// (Rule of Three: the LLM discovery command is the second consumer).
 
 // ---------------------------------------------------------------------------
 // HTTP client helper
@@ -1169,72 +1118,10 @@ mod tests {
         );
     }
 
-    // ── is_private_on_premise helper tests ──────────────────────────────
-
-    #[test]
-    fn private_on_premise_identifies_10_range() {
-        let url: url::Url = "http://10.0.0.1/".parse().unwrap();
-        assert!(is_private_on_premise(&url));
-    }
-
-    #[test]
-    fn private_on_premise_identifies_172_16_range() {
-        let url: url::Url = "http://172.16.0.1/".parse().unwrap();
-        assert!(is_private_on_premise(&url));
-    }
-
-    #[test]
-    fn private_on_premise_identifies_192_168_range() {
-        let url: url::Url = "http://192.168.1.1/".parse().unwrap();
-        assert!(is_private_on_premise(&url));
-    }
-
-    #[test]
-    fn private_on_premise_rejects_ipv4_loopback() {
-        let url: url::Url = "http://127.0.0.1/".parse().unwrap();
-        assert!(
-            !is_private_on_premise(&url),
-            "Loopback is not private on-premise"
-        );
-    }
-
-    #[test]
-    fn private_on_premise_rejects_ipv4_link_local() {
-        let url: url::Url = "http://169.254.1.1/".parse().unwrap();
-        assert!(
-            !is_private_on_premise(&url),
-            "Link-local is not private on-premise"
-        );
-    }
-
-    #[test]
-    fn private_on_premise_rejects_domain() {
-        let url: url::Url = "http://example.com/".parse().unwrap();
-        assert!(
-            !is_private_on_premise(&url),
-            "Domain is not private on-premise"
-        );
-    }
-
-    // ── IPv6 ULA tests ───────────────────────────────────────────────────
-
-    #[test]
-    fn private_on_premise_identifies_ipv6_ula_fd() {
-        let url: url::Url = "http://[fd12:3456:789a::1]/".parse().unwrap();
-        assert!(
-            is_private_on_premise(&url),
-            "fd::/8 (ULA) should be private on-premise"
-        );
-    }
-
-    #[test]
-    fn private_on_premise_identifies_ipv6_ula_fc() {
-        let url: url::Url = "http://[fc00::1]/".parse().unwrap();
-        assert!(
-            is_private_on_premise(&url),
-            "fc00::/8 (ULA) should be private on-premise"
-        );
-    }
+    // Note: is_private_on_premise helper + its coverage moved to url_validation.rs
+    // as part of the consolidation for LLM model discovery (ADR-041). Redmine uses
+    // PrivatePolicy::BlockLoopback; LLM discovery uses PrivatePolicy::AllowLoopback.
+    // See url_validation::tests for private_on_premise_*_policy tests.
 
     #[test]
     fn validate_url_allows_ipv6_ula_for_redmine() {
@@ -1243,56 +1130,6 @@ mod tests {
             result.is_ok(),
             "IPv6 ULA should be allowed for on-premise Redmine: {:?}",
             result.err()
-        );
-    }
-
-    #[test]
-    fn private_on_premise_rejects_ipv6_loopback() {
-        let url: url::Url = "http://[::1]/".parse().unwrap();
-        assert!(
-            !is_private_on_premise(&url),
-            "IPv6 loopback is not private on-premise"
-        );
-    }
-
-    #[test]
-    fn private_on_premise_rejects_ipv6_link_local() {
-        let url: url::Url = "http://[fe80::1]/".parse().unwrap();
-        assert!(
-            !is_private_on_premise(&url),
-            "IPv6 link-local is not private on-premise"
-        );
-    }
-
-    #[test]
-    fn private_on_premise_rejects_ipv6_global() {
-        let url: url::Url = "http://[2001:db8::1]/".parse().unwrap();
-        assert!(
-            !is_private_on_premise(&url),
-            "IPv6 global address is not private on-premise"
-        );
-    }
-
-    #[test]
-    fn private_on_premise_rejects_ipv6_just_outside_ula() {
-        // fe00:: — 0xfe00 & 0xfe00 = 0xfe00 ≠ 0xfc00, so NOT ULA
-        let url: url::Url = "http://[fe00::1]/".parse().unwrap();
-        assert!(
-            !is_private_on_premise(&url),
-            "fe00:: is just outside ULA range fc00::/7"
-        );
-    }
-
-    #[test]
-    fn private_on_premise_rejects_ipv6_mapped_rfc1918() {
-        // ::ffff:10.0.0.1 — IPv6-mapped IPv4 private. The url crate represents
-        // this as Host::Ipv6 with first segment 0x0000, which does NOT match
-        // the fc00::/7 check. This documents the design intent: IPv6-mapped
-        // IPv4 private addresses are NOT handled by the IPv6 ULA arm.
-        let url: url::Url = "http://[::ffff:10.0.0.1]/".parse().unwrap();
-        assert!(
-            !is_private_on_premise(&url),
-            "IPv6-mapped RFC1918 is not matched by the ULA arm"
         );
     }
 

--- a/desktop/src-tauri/src/setup_wizard.rs
+++ b/desktop/src-tauri/src/setup_wizard.rs
@@ -1209,7 +1209,33 @@ pub fn start_containers(project: &str) -> anyhow::Result<()> {
 // Check Claude auth status inside the container
 // ---------------------------------------------------------------------------
 
+/// Pure lookup for the project's LLM provider name from the user config.
+/// Returns `None` when the project is missing or `claude.llm.provider` is
+/// unset. Separated out so the local-provider branch in `check_claude_auth`
+/// can be covered without mocking the container runtime.
+pub(crate) fn lookup_project_provider<'a>(
+    user_config: &'a speedwave_runtime::config::SpeedwaveUserConfig,
+    project: &str,
+) -> Option<&'a str> {
+    user_config
+        .find_project(project)
+        .and_then(|p| p.claude.as_ref())
+        .and_then(|c| c.llm.as_ref())
+        .and_then(|l| l.provider.as_deref())
+}
+
 pub fn check_claude_auth(project: &str) -> anyhow::Result<bool> {
+    let user_config = speedwave_runtime::config::load_user_config().unwrap_or_else(|e| {
+        log::warn!(
+            "check_claude_auth: failed to load user config, defaulting to anthropic path: {e}"
+        );
+        speedwave_runtime::config::SpeedwaveUserConfig::default()
+    });
+    let provider = lookup_project_provider(&user_config, project);
+    if speedwave_runtime::config::is_local_provider(provider) {
+        log::info!("check_claude_auth: local provider — skipping Anthropic OAuth check");
+        return Ok(true);
+    }
     let rt = runtime::detect_runtime();
     let container_name = format!("{}_{}_claude", consts::compose_prefix(), project);
     log::info!("check_claude_auth: container={container_name}");
@@ -1871,7 +1897,122 @@ fn link_cli_from(cli_source: &std::path::Path, home: &std::path::Path) -> anyhow
 #[cfg(test)]
 mod tests {
     use super::*;
+    use speedwave_runtime::config::{
+        ClaudeOverrides, LlmConfig, ProjectUserEntry, SpeedwaveUserConfig,
+    };
     use std::collections::HashMap;
+
+    fn project_with_provider(name: &str, provider: Option<&str>) -> ProjectUserEntry {
+        ProjectUserEntry {
+            name: name.to_string(),
+            dir: String::new(),
+            claude: Some(ClaudeOverrides {
+                env: None,
+                settings: None,
+                llm: Some(LlmConfig {
+                    provider: provider.map(str::to_string),
+                    model: None,
+                    base_url: None,
+                }),
+            }),
+            integrations: None,
+            plugin_settings: None,
+        }
+    }
+
+    #[test]
+    fn lookup_provider_returns_ollama() {
+        let cfg = SpeedwaveUserConfig {
+            projects: vec![project_with_provider("proj", Some("ollama"))],
+            ..Default::default()
+        };
+        assert_eq!(lookup_project_provider(&cfg, "proj"), Some("ollama"));
+    }
+
+    #[test]
+    fn lookup_provider_returns_lmstudio() {
+        let cfg = SpeedwaveUserConfig {
+            projects: vec![project_with_provider("proj", Some("lmstudio"))],
+            ..Default::default()
+        };
+        assert_eq!(lookup_project_provider(&cfg, "proj"), Some("lmstudio"));
+    }
+
+    #[test]
+    fn lookup_provider_returns_llamacpp() {
+        let cfg = SpeedwaveUserConfig {
+            projects: vec![project_with_provider("proj", Some("llamacpp"))],
+            ..Default::default()
+        };
+        assert_eq!(lookup_project_provider(&cfg, "proj"), Some("llamacpp"));
+    }
+
+    #[test]
+    fn lookup_provider_returns_anthropic() {
+        let cfg = SpeedwaveUserConfig {
+            projects: vec![project_with_provider("proj", Some("anthropic"))],
+            ..Default::default()
+        };
+        assert_eq!(lookup_project_provider(&cfg, "proj"), Some("anthropic"));
+    }
+
+    #[test]
+    fn lookup_provider_returns_none_when_project_missing() {
+        let cfg = SpeedwaveUserConfig::default();
+        assert_eq!(lookup_project_provider(&cfg, "missing"), None);
+    }
+
+    #[test]
+    fn lookup_provider_returns_none_when_claude_section_missing() {
+        let cfg = SpeedwaveUserConfig {
+            projects: vec![ProjectUserEntry {
+                name: "proj".to_string(),
+                dir: String::new(),
+                claude: None,
+                integrations: None,
+                plugin_settings: None,
+            }],
+            ..Default::default()
+        };
+        assert_eq!(lookup_project_provider(&cfg, "proj"), None);
+    }
+
+    #[test]
+    fn lookup_provider_returns_none_when_llm_section_missing() {
+        let cfg = SpeedwaveUserConfig {
+            projects: vec![ProjectUserEntry {
+                name: "proj".to_string(),
+                dir: String::new(),
+                claude: Some(ClaudeOverrides::default()),
+                integrations: None,
+                plugin_settings: None,
+            }],
+            ..Default::default()
+        };
+        assert_eq!(lookup_project_provider(&cfg, "proj"), None);
+    }
+
+    #[test]
+    fn lookup_provider_returns_none_when_provider_field_missing() {
+        let cfg = SpeedwaveUserConfig {
+            projects: vec![project_with_provider("proj", None)],
+            ..Default::default()
+        };
+        assert_eq!(lookup_project_provider(&cfg, "proj"), None);
+    }
+
+    #[test]
+    fn local_provider_branch_covers_ollama_lmstudio_llamacpp() {
+        // Guard: `check_claude_auth` skips Anthropic OAuth exactly for the three
+        // local providers. If `is_local_provider` expands or contracts, this
+        // test documents which set the auth-skip branch fires on.
+        use speedwave_runtime::config::is_local_provider;
+        assert!(is_local_provider(Some("ollama")));
+        assert!(is_local_provider(Some("lmstudio")));
+        assert!(is_local_provider(Some("llamacpp")));
+        assert!(!is_local_provider(Some("anthropic")));
+        assert!(!is_local_provider(None));
+    }
 
     /// Validates that a path component does not contain traversal or unsafe characters.
     fn validate_path_component(name: &str, label: &str) -> anyhow::Result<()> {

--- a/desktop/src-tauri/src/url_validation.rs
+++ b/desktop/src-tauri/src/url_validation.rs
@@ -32,6 +32,84 @@ pub(crate) fn is_private_or_reserved(ip: std::net::IpAddr) -> bool {
     }
 }
 
+/// Policy for classifying a URL host as "private on-premise" vs. public.
+///
+/// Different Desktop features have different tolerance for loopback:
+/// - Redmine integration (`validate_redmine_host_url`) uses `BlockLoopback`: a
+///   self-hosted Redmine on 127.0.0.1 is unusual and most likely a misconfiguration.
+/// - LLM model discovery (`validate_llm_base_url`) uses `AllowLoopback`: local
+///   Ollama / LM Studio / llama.cpp servers commonly bind to loopback, and
+///   Speedwave's `default_base_url` points there via `host.*.internal` aliases
+///   rewritten to `127.0.0.1` on the host side.
+///
+/// Both policies always accept RFC 1918 IPv4 and IPv6 ULA (fc00::/7) and always
+/// reject link-local, metadata, and reserved ranges — those are not valid
+/// "on-premise" destinations under any policy.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum PrivatePolicy {
+    /// Loopback (127.0.0.0/8, ::1, IPv6-mapped loopback) is NOT on-premise.
+    /// Redmine policy.
+    BlockLoopback,
+    /// Loopback addresses ARE on-premise. LLM discovery policy.
+    AllowLoopback,
+}
+
+/// Returns `true` when the URL's host is a private on-premise address under
+/// the given policy: RFC 1918 IPv4 (10/8, 172.16/12, 192.168/16), CGNAT shared
+/// space (100.64.0.0/10, RFC 6598 — used by Tailscale, carrier NAT, etc.),
+/// IPv6 ULA (fc00::/7, RFC 4193), and — if `policy == AllowLoopback` —
+/// loopback (127.0.0.0/8, ::1, IPv6-mapped loopback).
+///
+/// Returns `false` for every other host (public IP, public domain, localhost
+/// string, link-local, metadata, multicast, documentation prefix, etc.) — those
+/// are either untrusted (require a different validation path) or actively
+/// blocked (link-local / metadata).
+pub(crate) fn is_private_on_premise(url: &url::Url, policy: PrivatePolicy) -> bool {
+    match url.host() {
+        Some(url::Host::Ipv4(ipv4)) => {
+            if ipv4.is_private() && !ipv4.is_link_local() && !ipv4.is_unspecified() {
+                return true;
+            }
+            // RFC 6598 — 100.64.0.0/10 shared address space (CGNAT). Non-routable
+            // on the public internet; in practice used by Tailscale and similar
+            // mesh VPNs. Functionally equivalent to RFC 1918 for SSRF purposes.
+            let oct = ipv4.octets();
+            if oct[0] == 100 && (oct[1] & 0xc0) == 64 {
+                return true;
+            }
+            let allow_loopback = match policy {
+                PrivatePolicy::BlockLoopback => false,
+                PrivatePolicy::AllowLoopback => true,
+            };
+            allow_loopback && ipv4.is_loopback()
+        }
+        Some(url::Host::Ipv6(ipv6)) => {
+            // fc00::/7 — IPv6 Unique Local Address (RFC 4193)
+            if (ipv6.segments()[0] & 0xfe00) == 0xfc00 {
+                return true;
+            }
+            let allow_loopback = match policy {
+                PrivatePolicy::BlockLoopback => false,
+                PrivatePolicy::AllowLoopback => true,
+            };
+            if allow_loopback {
+                if ipv6.is_loopback() {
+                    return true;
+                }
+                // IPv6-mapped IPv4 loopback (::ffff:127.0.0.1) — under AllowLoopback
+                // policy, the mapped form should follow the same rule as native IPv4.
+                if let Some(mapped_v4) = ipv6.to_ipv4_mapped() {
+                    if mapped_v4.is_loopback() {
+                        return true;
+                    }
+                }
+            }
+            false
+        }
+        _ => false,
+    }
+}
+
 /// Validates a URL string: only http/https schemes allowed, no localhost or private IPs.
 /// Uses parsed IP types (not string matching) to prevent IPv6-mapped IPv4 bypasses.
 pub(crate) fn validate_url(url: &str) -> Result<url::Url, String> {
@@ -522,5 +600,169 @@ mod tests {
             ["macos", "linux", "windows"].contains(&platform.as_str()),
             "get_platform() returned unexpected value: {platform}"
         );
+    }
+
+    // ── is_private_on_premise: RFC 1918 (both policies accept) ──────────
+
+    #[test]
+    fn is_private_on_premise_identifies_rfc1918_10_block_loopback() {
+        let url: url::Url = "http://10.0.0.1/".parse().unwrap();
+        assert!(is_private_on_premise(&url, PrivatePolicy::BlockLoopback));
+    }
+
+    #[test]
+    fn is_private_on_premise_identifies_rfc1918_10_allow_loopback() {
+        let url: url::Url = "http://10.0.0.1/".parse().unwrap();
+        assert!(is_private_on_premise(&url, PrivatePolicy::AllowLoopback));
+    }
+
+    #[test]
+    fn is_private_on_premise_identifies_rfc1918_172_16_block_loopback() {
+        let url: url::Url = "http://172.16.0.1/".parse().unwrap();
+        assert!(is_private_on_premise(&url, PrivatePolicy::BlockLoopback));
+    }
+
+    #[test]
+    fn is_private_on_premise_identifies_rfc1918_192_168_block_loopback() {
+        let url: url::Url = "http://192.168.1.1/".parse().unwrap();
+        assert!(is_private_on_premise(&url, PrivatePolicy::BlockLoopback));
+    }
+
+    // ── Loopback: policy delta (block vs allow) ─────────────────────────
+
+    #[test]
+    fn is_private_on_premise_rejects_ipv4_loopback_block_policy() {
+        let url: url::Url = "http://127.0.0.1/".parse().unwrap();
+        assert!(!is_private_on_premise(&url, PrivatePolicy::BlockLoopback));
+    }
+
+    #[test]
+    fn is_private_on_premise_accepts_ipv4_loopback_allow_policy() {
+        let url: url::Url = "http://127.0.0.1/".parse().unwrap();
+        assert!(is_private_on_premise(&url, PrivatePolicy::AllowLoopback));
+    }
+
+    #[test]
+    fn is_private_on_premise_rejects_ipv6_loopback_block_policy() {
+        let url: url::Url = "http://[::1]/".parse().unwrap();
+        assert!(!is_private_on_premise(&url, PrivatePolicy::BlockLoopback));
+    }
+
+    #[test]
+    fn is_private_on_premise_accepts_ipv6_loopback_allow_policy() {
+        let url: url::Url = "http://[::1]/".parse().unwrap();
+        assert!(is_private_on_premise(&url, PrivatePolicy::AllowLoopback));
+    }
+
+    #[test]
+    fn is_private_on_premise_accepts_ipv6_mapped_loopback_allow_policy() {
+        // ::ffff:127.0.0.1 — IPv6-mapped IPv4 loopback. Under AllowLoopback
+        // the mapped form should follow the same rule as native IPv4.
+        let url: url::Url = "http://[::ffff:127.0.0.1]/".parse().unwrap();
+        assert!(is_private_on_premise(&url, PrivatePolicy::AllowLoopback));
+    }
+
+    #[test]
+    fn is_private_on_premise_rejects_ipv6_mapped_loopback_block_policy() {
+        let url: url::Url = "http://[::ffff:127.0.0.1]/".parse().unwrap();
+        assert!(!is_private_on_premise(&url, PrivatePolicy::BlockLoopback));
+    }
+
+    // ── Link-local: rejected under both policies ────────────────────────
+
+    #[test]
+    fn is_private_on_premise_rejects_ipv4_link_local_both_policies() {
+        let url: url::Url = "http://169.254.1.1/".parse().unwrap();
+        assert!(!is_private_on_premise(&url, PrivatePolicy::BlockLoopback));
+        assert!(!is_private_on_premise(&url, PrivatePolicy::AllowLoopback));
+    }
+
+    #[test]
+    fn is_private_on_premise_rejects_ipv6_link_local_both_policies() {
+        let url: url::Url = "http://[fe80::1]/".parse().unwrap();
+        assert!(!is_private_on_premise(&url, PrivatePolicy::BlockLoopback));
+        assert!(!is_private_on_premise(&url, PrivatePolicy::AllowLoopback));
+    }
+
+    // ── Domain / public IP: rejected (delegated to validate_url) ────────
+
+    #[test]
+    fn is_private_on_premise_rejects_domain_both_policies() {
+        let url: url::Url = "http://example.com/".parse().unwrap();
+        assert!(!is_private_on_premise(&url, PrivatePolicy::BlockLoopback));
+        assert!(!is_private_on_premise(&url, PrivatePolicy::AllowLoopback));
+    }
+
+    // ── IPv6 ULA: identified under both policies ────────────────────────
+
+    #[test]
+    fn is_private_on_premise_identifies_ipv6_ula_fd_both_policies() {
+        let url: url::Url = "http://[fd12:3456:789a::1]/".parse().unwrap();
+        assert!(is_private_on_premise(&url, PrivatePolicy::BlockLoopback));
+        assert!(is_private_on_premise(&url, PrivatePolicy::AllowLoopback));
+    }
+
+    #[test]
+    fn is_private_on_premise_identifies_ipv6_ula_fc_both_policies() {
+        let url: url::Url = "http://[fc00::1]/".parse().unwrap();
+        assert!(is_private_on_premise(&url, PrivatePolicy::BlockLoopback));
+        assert!(is_private_on_premise(&url, PrivatePolicy::AllowLoopback));
+    }
+
+    // ── IPv6 edge cases ─────────────────────────────────────────────────
+
+    #[test]
+    fn is_private_on_premise_rejects_ipv6_global_both_policies() {
+        // 2001:db8:: is in the documentation prefix (RFC 3849) — not private on-premise.
+        let url: url::Url = "http://[2001:db8::1]/".parse().unwrap();
+        assert!(!is_private_on_premise(&url, PrivatePolicy::BlockLoopback));
+        assert!(!is_private_on_premise(&url, PrivatePolicy::AllowLoopback));
+    }
+
+    #[test]
+    fn is_private_on_premise_rejects_ipv6_just_outside_ula_both_policies() {
+        // fe00:: — 0xfe00 & 0xfe00 = 0xfe00 ≠ 0xfc00, so NOT ULA
+        let url: url::Url = "http://[fe00::1]/".parse().unwrap();
+        assert!(!is_private_on_premise(&url, PrivatePolicy::BlockLoopback));
+        assert!(!is_private_on_premise(&url, PrivatePolicy::AllowLoopback));
+    }
+
+    #[test]
+    fn is_private_on_premise_rejects_ipv6_mapped_rfc1918_both_policies() {
+        // ::ffff:10.0.0.1 — IPv6-mapped IPv4 RFC1918. The url crate represents
+        // this as Host::Ipv6 with a specific shape that does NOT satisfy our
+        // fc00::/7 check. Under both policies we do NOT treat a mapped RFC1918
+        // address as "on-premise private" via the IPv6 arm — callers that
+        // need to block such addresses (mapped metadata IPs etc.) delegate
+        // to `validate_url` which has dedicated to_ipv4_mapped handling.
+        let url: url::Url = "http://[::ffff:10.0.0.1]/".parse().unwrap();
+        assert!(!is_private_on_premise(&url, PrivatePolicy::BlockLoopback));
+        assert!(!is_private_on_premise(&url, PrivatePolicy::AllowLoopback));
+    }
+
+    // ── CGNAT (RFC 6598, 100.64.0.0/10): both policies accept ──────────
+
+    #[test]
+    fn is_private_on_premise_identifies_cgnat_block_policy() {
+        // 100.64.0.1 is within the 100.64.0.0/10 CGNAT range (RFC 6598).
+        // Used by Tailscale and carrier NAT — treated as on-premise under
+        // both policies.
+        let url: url::Url = "http://100.64.0.1:8080/".parse().unwrap();
+        assert!(is_private_on_premise(&url, PrivatePolicy::BlockLoopback));
+    }
+
+    #[test]
+    fn is_private_on_premise_identifies_cgnat_allow_policy() {
+        let url: url::Url = "http://100.64.0.1:8080/".parse().unwrap();
+        assert!(is_private_on_premise(&url, PrivatePolicy::AllowLoopback));
+    }
+
+    #[test]
+    fn is_private_on_premise_rejects_just_outside_cgnat() {
+        // 100.128.0.1 has oct[1] = 128, which fails the (128 & 0xc0) == 64
+        // check (128 & 0xc0 == 128 ≠ 64), so it is NOT in the CGNAT block.
+        let url: url::Url = "http://100.128.0.1:8080/".parse().unwrap();
+        assert!(!is_private_on_premise(&url, PrivatePolicy::BlockLoopback));
+        assert!(!is_private_on_premise(&url, PrivatePolicy::AllowLoopback));
     }
 }

--- a/desktop/src/src/app/chat/chat.component.html
+++ b/desktop/src/src/app/chat/chat.component.html
@@ -85,7 +85,7 @@
         >
           @for (msg of viewingTranscript.messages; track $index) {
             <div
-              class="max-w-[85%] px-4 py-3 rounded-lg leading-normal break-words"
+              class="w-fit max-w-[85%] px-4 py-3 rounded-lg leading-normal break-words"
               [class.self-end]="msg.role === 'user'"
               [class.bg-sw-bg-navy]="msg.role === 'user'"
               [class.self-start]="msg.role === 'assistant'"

--- a/desktop/src/src/app/chat/message/chat-message.component.spec.ts
+++ b/desktop/src/src/app/chat/message/chat-message.component.spec.ts
@@ -96,6 +96,38 @@ describe('ChatMessageComponent', () => {
     expect(msg?.getAttribute('data-role')).toBe('user');
   });
 
+  it('host right-aligns user messages via justify-end', () => {
+    component.blocks = [{ type: 'text', content: 'ok' }];
+    component.role = 'user';
+    fixture.detectChanges();
+
+    const host = fixture.nativeElement as HTMLElement;
+    expect(host.classList.contains('justify-end')).toBe(true);
+    expect(host.classList.contains('justify-start')).toBe(false);
+  });
+
+  it('host left-aligns assistant messages via justify-start', () => {
+    component.blocks = [{ type: 'text', content: 'hello' }];
+    component.role = 'assistant';
+    fixture.detectChanges();
+
+    const host = fixture.nativeElement as HTMLElement;
+    expect(host.classList.contains('justify-start')).toBe(true);
+    expect(host.classList.contains('justify-end')).toBe(false);
+  });
+
+  it('bubble shrinks to content width (w-fit) with 85% cap', () => {
+    component.blocks = [{ type: 'text', content: 'ok' }];
+    component.role = 'user';
+    fixture.detectChanges();
+
+    const bubble = fixture.nativeElement.querySelector(
+      '[data-testid="chat-message"]'
+    ) as HTMLElement;
+    expect(bubble.classList.contains('w-fit')).toBe(true);
+    expect(bubble.classList.contains('max-w-[85%]')).toBe(true);
+  });
+
   it('shows streaming cursor when streaming', () => {
     component.blocks = [{ type: 'text', content: 'partial...' }];
     component.role = 'assistant';

--- a/desktop/src/src/app/chat/message/chat-message.component.ts
+++ b/desktop/src/src/app/chat/message/chat-message.component.ts
@@ -18,16 +18,20 @@ import { AskUserBlockComponent } from '../blocks/ask-user-block.component';
     AskUserBlockComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  host: { class: 'block' },
+  host: {
+    class: 'flex w-full',
+    '[class.justify-end]': "role === 'user'",
+    '[class.justify-start]': "role === 'assistant'",
+  },
   template: `
     <div
       data-testid="chat-message"
       [attr.data-role]="role"
-      class="max-w-[85%] px-4 py-3 rounded-lg leading-relaxed break-words"
+      class="w-fit max-w-[85%] px-4 py-3 rounded-lg leading-relaxed break-words"
       [class]="
         role === 'user'
-          ? 'self-end bg-sw-bg-navy text-sw-text'
-          : 'self-start bg-sw-bg-dark text-sw-text border border-sw-border'
+          ? 'bg-sw-bg-navy text-sw-text'
+          : 'bg-sw-bg-dark text-sw-text border border-sw-border'
       "
       [class.!border-sw-accent]="streaming"
     >

--- a/desktop/src/src/app/settings/llm-provider/llm-provider.component.spec.ts
+++ b/desktop/src/src/app/settings/llm-provider/llm-provider.component.spec.ts
@@ -168,6 +168,7 @@ describe('LlmProviderComponent', () => {
     const spy = vi.fn();
     component.providerChange.subscribe(spy);
     component.provider = 'ollama';
+    component.model = 'llama3.3';
 
     await component.saveConfig();
 
@@ -178,6 +179,7 @@ describe('LlmProviderComponent', () => {
     const projectState = TestBed.inject(ProjectStateService);
     projectState.needsRestart = false;
     component.provider = 'ollama';
+    component.model = 'llama3.3';
 
     await component.saveConfig();
 
@@ -747,5 +749,52 @@ describe('LlmProviderComponent', () => {
     expect(invokedArgs['baseUrl']).toBe('http://host.docker.internal:11434');
     expect(invokedArgs['baseUrl']).not.toBeNull();
     expect(invokedArgs['baseUrl']).not.toBe('');
+  });
+
+  it('save_rejects_local_provider_with_empty_model', async () => {
+    // UX guard: compose::apply_llm_config rejects a null model for local
+    // providers, but that error only surfaces at container start. Catching
+    // it at Save time gives immediate feedback.
+    let invokeCalled = false;
+    mockTauri.invokeHandler = async (cmd: string) => {
+      if (cmd === 'update_llm_config') {
+        invokeCalled = true;
+      }
+      return undefined;
+    };
+
+    let emittedError = '';
+    component.errorOccurred.subscribe((msg: string) => {
+      emittedError = msg;
+    });
+
+    component.provider = 'ollama';
+    component.baseUrl = 'http://localhost:11434';
+    component.model = '';
+
+    await component.saveConfig();
+
+    expect(invokeCalled).toBe(false);
+    expect(emittedError).toContain('model name is required');
+  });
+
+  it('save_allows_anthropic_with_empty_model', async () => {
+    // Anthropic infers the model from ANTHROPIC_MODEL env or Claude's
+    // default — no model in config is legal.
+    let invokeCalled = false;
+    mockTauri.invokeHandler = async (cmd: string) => {
+      if (cmd === 'update_llm_config') {
+        invokeCalled = true;
+      }
+      return undefined;
+    };
+
+    component.provider = 'anthropic';
+    component.baseUrl = '';
+    component.model = '';
+
+    await component.saveConfig();
+
+    expect(invokeCalled).toBe(true);
   });
 });

--- a/desktop/src/src/app/settings/llm-provider/llm-provider.component.spec.ts
+++ b/desktop/src/src/app/settings/llm-provider/llm-provider.component.spec.ts
@@ -5,18 +5,30 @@ import { TauriService } from '../../services/tauri.service';
 import { ProjectStateService } from '../../services/project-state.service';
 import { MockTauriService } from '../../testing/mock-tauri.service';
 
+const DEFAULT_BASE_URLS: Record<string, string> = {
+  ollama: 'http://host.docker.internal:11434',
+  lmstudio: 'http://host.docker.internal:1234',
+  llamacpp: 'http://host.docker.internal:8080',
+};
+
 function setupMockTauri(mockTauri: MockTauriService, provider = 'anthropic'): void {
-  mockTauri.invokeHandler = async (cmd: string) => {
+  mockTauri.invokeHandler = async (cmd: string, args?: Record<string, unknown>) => {
     switch (cmd) {
       case 'get_llm_config':
         return {
           provider,
           model: null,
           base_url: null,
-          default_base_url: provider === 'ollama' ? 'http://host.docker.internal:11434' : null,
+          default_base_url: DEFAULT_BASE_URLS[provider] ?? null,
         };
+      case 'get_default_base_url':
+        return DEFAULT_BASE_URLS[(args?.['provider'] as string) ?? ''] ?? null;
       case 'update_llm_config':
         return undefined;
+      case 'discover_llm_models':
+        // Default: empty list so the component falls back to text input.
+        // Individual tests override this.
+        throw new Error('offline');
       default:
         return undefined;
     }
@@ -87,12 +99,12 @@ describe('LlmProviderComponent', () => {
     expect(spy).toHaveBeenCalledWith('anthropic');
   });
 
-  it('emits providerChange when provider selection changes', () => {
+  it('emits providerChange when provider selection changes', async () => {
     const spy = vi.fn();
     component.providerChange.subscribe(spy);
 
     component.provider = 'ollama';
-    component.onProviderChange();
+    await component.onProviderChange();
 
     expect(spy).toHaveBeenCalledWith('ollama');
   });
@@ -109,9 +121,6 @@ describe('LlmProviderComponent', () => {
 
     component.provider = 'llamacpp';
     expect(component.modelPlaceholder()).toBe('deepseek-r1');
-
-    component.provider = 'custom';
-    expect(component.modelPlaceholder()).toBe('your-model-name');
   });
 
   it('saves config and sets saved flag', async () => {
@@ -271,17 +280,6 @@ describe('LlmProviderComponent', () => {
     expect(baseUrlInput).not.toBeNull();
   });
 
-  it('shows model and base URL fields for custom provider', async () => {
-    component.provider = 'custom';
-    fixture.changeDetectorRef.markForCheck();
-    fixture.detectChanges();
-
-    const baseUrlInput = fixture.nativeElement.querySelector(
-      '[data-testid="settings-llm-base-url"]'
-    );
-    expect(baseUrlInput).not.toBeNull();
-  });
-
   it('uses default_base_url from backend as placeholder', async () => {
     component.provider = 'ollama';
     component.defaultBaseUrl = 'http://host.docker.internal:11434';
@@ -316,5 +314,438 @@ describe('LlmProviderComponent', () => {
     const btn = fixture.nativeElement.querySelector('[data-testid="settings-llm-save"]');
     expect(btn).not.toBeNull();
     expect(btn.textContent.trim()).toContain('Save');
+  });
+
+  // ── Model discovery (ADR-041) ────────────────────────────────────────
+
+  function setupDiscoveryMock(
+    mockTauri: MockTauriService,
+    opts: {
+      provider?: string;
+      baseUrl?: string;
+      defaultBaseUrl?: string;
+      model?: string;
+      discover?: (args?: Record<string, unknown>) => Promise<string[]>;
+    } = {}
+  ): { discoverCalls: Array<Record<string, unknown> | undefined> } {
+    const discoverCalls: Array<Record<string, unknown> | undefined> = [];
+    mockTauri.invokeHandler = async (cmd: string, args?: Record<string, unknown>) => {
+      switch (cmd) {
+        case 'get_llm_config':
+          return {
+            provider: opts.provider ?? 'ollama',
+            model: opts.model ?? null,
+            base_url: opts.baseUrl ?? null,
+            default_base_url: opts.defaultBaseUrl ?? 'http://host.docker.internal:11434',
+          };
+        case 'get_default_base_url': {
+          const p = (args?.['provider'] as string) ?? '';
+          const defaults: Record<string, string> = {
+            ollama: opts.defaultBaseUrl ?? 'http://host.docker.internal:11434',
+            lmstudio: 'http://host.docker.internal:1234',
+            llamacpp: 'http://host.docker.internal:8080',
+          };
+          return defaults[p] ?? null;
+        }
+        case 'update_llm_config':
+          return undefined;
+        case 'discover_llm_models':
+          discoverCalls.push(args);
+          if (opts.discover) {
+            return opts.discover(args);
+          }
+          return [];
+        default:
+          return undefined;
+      }
+    };
+    return { discoverCalls };
+  }
+
+  it('renders_select_on_happy_path', async () => {
+    setupDiscoveryMock(mockTauri, {
+      provider: 'ollama',
+      discover: async () => ['llama3.3', 'qwen2.5'],
+    });
+    await component.ngOnInit();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const select = fixture.nativeElement.querySelector('[data-testid="settings-llm-model"]');
+    expect(select).not.toBeNull();
+    expect(select.tagName).toBe('SELECT');
+    const opts = Array.from(select.querySelectorAll('option')).map((o: Element) =>
+      (o.textContent || '').trim()
+    );
+    expect(opts).toContain('llama3.3');
+    expect(opts).toContain('qwen2.5');
+  });
+
+  it('keeps_input_on_offline_failure', async () => {
+    const errorSpy = vi.fn();
+    component.errorOccurred.subscribe(errorSpy);
+    setupDiscoveryMock(mockTauri, {
+      provider: 'ollama',
+      discover: async () => {
+        throw new Error('offline');
+      },
+    });
+    await component.ngOnInit();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement.querySelector('[data-testid="settings-llm-model"]');
+    expect(el).not.toBeNull();
+    expect(el.tagName).toBe('INPUT');
+    expect(component.discoveryState.kind).toBe('failed');
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('skips_discovery_for_anthropic', async () => {
+    const { discoverCalls } = setupDiscoveryMock(mockTauri, { provider: 'anthropic' });
+    await component.ngOnInit();
+    await fixture.whenStable();
+    expect(discoverCalls.length).toBe(0);
+  });
+
+  it('blur_retriggers_discovery', async () => {
+    const { discoverCalls } = setupDiscoveryMock(mockTauri, {
+      provider: 'ollama',
+      defaultBaseUrl: 'http://host.docker.internal:11434',
+      discover: async () => ['m1'],
+    });
+    await component.ngOnInit();
+    await fixture.whenStable();
+    const callsAfterInit = discoverCalls.length;
+    component.baseUrl = 'http://localhost:1234';
+    await component.discoverModels(false);
+    expect(discoverCalls.length).toBeGreaterThan(callsAfterInit);
+  });
+
+  it('refresh_button_invokes_discovery_bypassing_dedupe', async () => {
+    // Two sequential refreshes on the same URL must both fire.
+    const { discoverCalls } = setupDiscoveryMock(mockTauri, {
+      provider: 'ollama',
+      discover: async () => ['m'],
+    });
+    await component.ngOnInit();
+    await fixture.whenStable();
+    const before = discoverCalls.length;
+    await component.discoverModels(true);
+    await component.discoverModels(true);
+    expect(discoverCalls.length).toBe(before + 2);
+  });
+
+  it('dedupes_provider_change_and_blur_on_same_url', async () => {
+    // While a probe is in-flight against URL X, a second trigger with the
+    // same URL must be deduped (return without invoking). Use a hanging
+    // promise so we can issue the second trigger before the first resolves.
+    let resolveFirst: (v: string[]) => void = () => {};
+    const hanging = new Promise<string[]>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const { discoverCalls } = setupDiscoveryMock(mockTauri, {
+      provider: 'ollama',
+      discover: async () => await hanging,
+    });
+    // Bypass ngOnInit — set state directly so we can control timing.
+    component.provider = 'ollama';
+    component.baseUrl = 'http://localhost:11434';
+    const firstCall = component.discoverModels(false);
+    // Same URL, while first is pending → must dedupe.
+    await component.discoverModels(false);
+    expect(discoverCalls.length).toBe(1);
+    resolveFirst(['m']);
+    await firstCall;
+  });
+
+  it('discards_stale_response_on_rapid_blur', async () => {
+    // First blur is slow; change URL; second blur returns fast. Final state
+    // must reflect the second URL, not the first.
+    let resolveFirst: (v: string[]) => void = () => {};
+    const slow = new Promise<string[]>((r) => {
+      resolveFirst = r;
+    });
+    let callIdx = 0;
+    mockTauri.invokeHandler = async (cmd: string) => {
+      if (cmd === 'discover_llm_models') {
+        callIdx += 1;
+        if (callIdx === 1) return await slow;
+        return ['model-from-second'];
+      }
+      return undefined;
+    };
+    component.provider = 'ollama';
+    component.baseUrl = 'http://a.invalid';
+    const firstCall = component.discoverModels(false);
+    // Flush the first invoke so its await on `slow` is reached before we
+    // mutate baseUrl (otherwise a change-detection flush may conflate them).
+    await Promise.resolve();
+    component.baseUrl = 'http://b.invalid';
+    await component.discoverModels(false);
+    // Now let the first probe finish with a stale result.
+    resolveFirst(['model-from-first']);
+    await firstCall;
+    await fixture.whenStable();
+    expect(component.discoveryState.kind).toBe('ready');
+    if (component.discoveryState.kind === 'ready') {
+      expect(component.discoveryState.models).toEqual(['model-from-second']);
+      expect(component.discoveryState.url).toBe('http://b.invalid');
+    }
+  });
+
+  it('onProviderChange_clears_stale_models', async () => {
+    setupDiscoveryMock(mockTauri, {
+      provider: 'ollama',
+      discover: async () => ['m'],
+    });
+    await component.ngOnInit();
+    await fixture.whenStable();
+    expect(component.discoveryState.kind).toBe('ready');
+    // Switching provider resets state synchronously. The new provider has a
+    // known defaultBaseUrl so the new discovery probe fires immediately,
+    // moving state to `in-flight` — either way the stale `ready` is cleared.
+    component.provider = 'lmstudio';
+    const p = component.onProviderChange();
+    expect(['idle', 'in-flight']).toContain(component.discoveryState.kind);
+    expect(component.discoveryState.kind).not.toBe('ready');
+    await p;
+  });
+
+  it('preserves_legacy_model_spoza_listy', async () => {
+    // A persisted model name must survive loadConfig even when the stored
+    // base_url is non-default (discovery is not auto-triggered on startup for
+    // user-supplied URLs). The model field stays as a text input so the user
+    // can see and edit their persisted value.
+    setupDiscoveryMock(mockTauri, {
+      provider: 'ollama',
+      model: 'legacy',
+      baseUrl: 'http://localhost:11434',
+      discover: async () => ['a', 'b'],
+    });
+    await component.ngOnInit();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    // Model value is preserved from config even without auto-discovery.
+    expect(component.model).toBe('legacy');
+    // No auto-probe → discoveryState stays idle → model field is a text INPUT.
+    expect(component.discoveryState.kind).toBe('idle');
+    const el = fixture.nativeElement.querySelector('[data-testid="settings-llm-model"]');
+    expect(el).not.toBeNull();
+    expect(el.tagName).toBe('INPUT');
+  });
+
+  it('preserves_legacy_model_when_default_url_auto_probed', async () => {
+    // When baseUrl is empty (falls back to default), auto-probe fires and
+    // discovery returns a list. If the persisted model is in the list, it is
+    // kept; if not, the first discovered model is auto-selected. Either way
+    // the model <select> is rendered with all discovered options.
+    setupDiscoveryMock(mockTauri, {
+      provider: 'ollama',
+      model: 'legacy',
+      baseUrl: null as unknown as string,
+      defaultBaseUrl: 'http://host.docker.internal:11434',
+      discover: async () => ['legacy', 'a', 'b'],
+    });
+    await component.ngOnInit();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(component.model).toBe('legacy');
+    const select = fixture.nativeElement.querySelector('[data-testid="settings-llm-model"]');
+    expect(select).not.toBeNull();
+    expect(select.tagName).toBe('SELECT');
+    const opts = Array.from(select.querySelectorAll('option')).map((o: Element) =>
+      (o.getAttribute('value') || '').toString()
+    );
+    expect(opts).toContain('legacy');
+    expect(opts).toContain('a');
+    expect(opts).toContain('b');
+  });
+
+  it('non_default_stored_base_url_stays_idle_on_init', async () => {
+    // Non-default URL (including link-local / RFC1918 addresses) must NOT be
+    // auto-probed on startup. discoveryState stays idle; user must explicitly
+    // click Refresh or blur the Base URL field to trigger a probe.
+    const { discoverCalls } = setupDiscoveryMock(mockTauri, {
+      provider: 'ollama',
+      baseUrl: 'http://169.254.169.254',
+      discover: async () => {
+        throw new Error('URL host 169.254.169.254: private/reserved');
+      },
+    });
+    await component.ngOnInit();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(discoverCalls.length).toBe(0);
+    expect(component.discoveryState.kind).toBe('idle');
+    const el = fixture.nativeElement.querySelector('[data-testid="settings-llm-model"]');
+    expect(el.tagName).toBe('INPUT');
+  });
+
+  it('non_default_stored_base_url_probes_on_explicit_refresh', async () => {
+    // After init (no auto-probe), user clicking Refresh must trigger discovery
+    // even for a non-default URL.
+    const { discoverCalls } = setupDiscoveryMock(mockTauri, {
+      provider: 'ollama',
+      baseUrl: 'http://169.254.169.254',
+      discover: async () => {
+        throw new Error('URL host 169.254.169.254: private/reserved');
+      },
+    });
+    await component.ngOnInit();
+    await fixture.whenStable();
+    expect(discoverCalls.length).toBe(0);
+
+    await component.discoverModels(true);
+    expect(discoverCalls.length).toBe(1);
+    expect(component.discoveryState.kind).toBe('failed');
+  });
+
+  it('skips_auto_probe_for_persisted_non_default_url', async () => {
+    // A cloned malicious repo could set base_url to an internal RFC1918 host.
+    // Opening Settings must NOT silently probe that host — the user must
+    // explicitly click Refresh or blur the Base URL field.
+    const { discoverCalls } = setupDiscoveryMock(mockTauri, {
+      provider: 'ollama',
+      baseUrl: 'http://192.168.1.50:11434',
+      defaultBaseUrl: 'http://host.docker.internal:11434',
+      discover: async () => ['malicious-model'],
+    });
+
+    await component.ngOnInit();
+    await fixture.whenStable();
+
+    expect(discoverCalls.length).toBe(0);
+    expect(component.discoveryState.kind).toBe('idle');
+  });
+
+  it('onProviderChange_increments_counter_before_state_reset', async () => {
+    // Invariant: the discoveryCounter is bumped synchronously inside
+    // onProviderChange so that any in-flight response from the previous
+    // provider (which carries the OLD id) is discarded when it arrives.
+    setupDiscoveryMock(mockTauri, { provider: 'ollama' });
+    // Seed the counter at a known value via a private-field cast.
+    (component as unknown as Record<string, number>)['discoveryCounter'] = 5;
+    component.provider = 'ollama';
+    // Plant a stale in-flight state with the current (pre-bump) id.
+    component.discoveryState = {
+      kind: 'in-flight',
+      url: 'http://prev',
+      id: 5, // matches seeded counter — will be stale after bump
+    };
+    component.provider = 'lmstudio';
+    await component.onProviderChange();
+
+    // Counter must have grown beyond 5 (bumped at least once in onProviderChange,
+    // possibly again inside discoverModels). Any response carrying id=5 is now stale.
+    const currentCounter = (component as unknown as Record<string, number>)['discoveryCounter'];
+    expect(currentCounter).toBeGreaterThan(5);
+
+    // If a discoverModels probe is in-flight, its id must also be > 5,
+    // confirming the stale id=5 response would be rejected on arrival.
+    if (component.discoveryState.kind === 'in-flight') {
+      expect(component.discoveryState.id).toBeGreaterThan(5);
+    }
+  });
+
+  // ── DiscoveryState.reason: unsupported / empty categories ────────────
+
+  it('maps_unsupported_error_to_unsupported_reason', async () => {
+    // Backend returns Err("unsupported") for anthropic-like providers.
+    // The component must map the "unsupported" message to reason='unsupported'
+    // and show a different message than the offline case.
+    setupDiscoveryMock(mockTauri, {
+      provider: 'ollama',
+      discover: async () => {
+        throw new Error('unsupported');
+      },
+    });
+    component.provider = 'ollama';
+    component.baseUrl = 'http://localhost:11434';
+    await component.discoverModels(false);
+
+    expect(component.discoveryState.kind).toBe('failed');
+    if (component.discoveryState.kind === 'failed') {
+      expect(component.discoveryState.reason).toBe('unsupported');
+    }
+    const unsupportedMsg = component.discoveryFailureMessage();
+    expect(unsupportedMsg.length).toBeGreaterThan(0);
+    // Must differ from the offline message produced by reason='offline'.
+    const offlineMsg = (() => {
+      const saved = component.discoveryState;
+      component.discoveryState = {
+        kind: 'failed',
+        url: 'http://localhost:11434',
+        reason: 'offline',
+      };
+      const m = component.discoveryFailureMessage();
+      component.discoveryState = saved;
+      return m;
+    })();
+    expect(unsupportedMsg).not.toBe(offlineMsg);
+  });
+
+  it('maps_empty_error_to_other_reason', async () => {
+    // Backend returns Err("empty") when the server is up but has no models loaded.
+    // The component must map the "empty" message to reason='other'.
+    setupDiscoveryMock(mockTauri, {
+      provider: 'ollama',
+      discover: async () => {
+        throw new Error('empty');
+      },
+    });
+    component.provider = 'ollama';
+    component.baseUrl = 'http://localhost:11434';
+    await component.discoverModels(false);
+
+    expect(component.discoveryState.kind).toBe('failed');
+    if (component.discoveryState.kind === 'failed') {
+      expect(component.discoveryState.reason).toBe('other');
+    }
+    const otherMsg = component.discoveryFailureMessage();
+    expect(otherMsg.length).toBeGreaterThan(0);
+    // Must differ from the offline message.
+    const offlineMsg = (() => {
+      const saved = component.discoveryState;
+      component.discoveryState = {
+        kind: 'failed',
+        url: 'http://localhost:11434',
+        reason: 'offline',
+      };
+      const m = component.discoveryFailureMessage();
+      component.discoveryState = saved;
+      return m;
+    })();
+    expect(otherMsg).not.toBe(offlineMsg);
+  });
+
+  // ── saveConfig: effectiveBaseUrl fallback for local providers ─────────
+
+  it('save_falls_back_to_default_base_url_for_local_provider_with_blank_url', async () => {
+    // When the user leaves Base URL blank for a local provider, saveConfig
+    // must fall back to defaultBaseUrl so compose can inject ANTHROPIC_BASE_URL.
+    // An empty string or null would leave the container without a base URL.
+    let invokedArgs: Record<string, unknown> = {};
+    mockTauri.invokeHandler = async (cmd: string, args?: Record<string, unknown>) => {
+      if (cmd === 'update_llm_config') {
+        invokedArgs = args ?? {};
+        return undefined;
+      }
+      return undefined;
+    };
+
+    component.provider = 'ollama';
+    component.baseUrl = '';
+    component.defaultBaseUrl = 'http://host.docker.internal:11434';
+    component.model = 'llama3.3';
+
+    await component.saveConfig();
+
+    expect(invokedArgs['baseUrl']).toBe('http://host.docker.internal:11434');
+    expect(invokedArgs['baseUrl']).not.toBeNull();
+    expect(invokedArgs['baseUrl']).not.toBe('');
   });
 });

--- a/desktop/src/src/app/settings/llm-provider/llm-provider.component.ts
+++ b/desktop/src/src/app/settings/llm-provider/llm-provider.component.ts
@@ -357,17 +357,15 @@ export class LlmProviderComponent implements OnInit {
       });
       // Stale-discard: drop responses whose id doesn't match the latest trigger.
       if (this.discoveryState.kind !== 'in-flight' || this.discoveryState.id !== id) return;
-      if (models.length > 0) {
-        this.discoveryState = { kind: 'ready', url: effectiveUrl, models };
-        // Auto-select the first discovered model when the current value is
-        // blank or not on the list — otherwise the <select> renders with no
-        // active <option> and Save would persist an empty model name.
-        if (!this.model || !models.includes(this.model)) {
-          this.model = models[0];
-        }
-      } else {
-        // Defensive — backend already maps empty to Err("empty"), but be safe.
-        this.discoveryState = { kind: 'failed', url: effectiveUrl, reason: 'other' };
+      // Invariant: do_discover_llm_models maps empty lists to Err("empty"),
+      // so a resolved Ok always carries a non-empty array — the success path
+      // never observes length === 0.
+      this.discoveryState = { kind: 'ready', url: effectiveUrl, models };
+      // Auto-select the first discovered model when the current value is
+      // blank or not on the list — otherwise the <select> renders with no
+      // active <option> and Save would persist an empty model name.
+      if (!this.model || !models.includes(this.model)) {
+        this.model = models[0];
       }
     } catch (e: unknown) {
       if (this.discoveryState.kind !== 'in-flight' || this.discoveryState.id !== id) return;

--- a/desktop/src/src/app/settings/llm-provider/llm-provider.component.ts
+++ b/desktop/src/src/app/settings/llm-provider/llm-provider.component.ts
@@ -387,6 +387,13 @@ export class LlmProviderComponent implements OnInit {
 
   /** Persists the LLM provider configuration to the backend. */
   async saveConfig(): Promise<void> {
+    // Surface the model-required error at Save time. compose::apply_llm_config
+    // also rejects this, but its error only surfaces at container start —
+    // a user who clicks Save sees no immediate feedback otherwise.
+    if (this.provider !== 'anthropic' && !this.model) {
+      this.errorOccurred.emit('A model name is required for local providers');
+      return;
+    }
     this.saving = true;
     this.saved = false;
     try {

--- a/desktop/src/src/app/settings/llm-provider/llm-provider.component.ts
+++ b/desktop/src/src/app/settings/llm-provider/llm-provider.component.ts
@@ -19,6 +19,21 @@ interface LlmConfigResponse {
   default_base_url: string | null;
 }
 
+/**
+ * Discovery state for the LLM model listing. Discriminated union makes the
+ * allowed transitions explicit and prevents inconsistent combinations of
+ * `discovering + discoveryFailed + discoveredModels` booleans.
+ *
+ * The `id` on `in-flight` matches the component's monotonic counter — arriving
+ * responses whose id is not the latest counter value are discarded as stale
+ * (handles rapid blur / provider change races).
+ */
+type DiscoveryState =
+  | { kind: 'idle' }
+  | { kind: 'in-flight'; url: string; id: number }
+  | { kind: 'ready'; url: string; models: string[] }
+  | { kind: 'failed'; url: string; reason: 'offline' | 'unsupported' | 'other' };
+
 /** Manages LLM provider selection and configuration. */
 @Component({
   selector: 'app-llm-provider',
@@ -37,30 +52,16 @@ interface LlmConfigResponse {
             id="llm-provider"
             [(ngModel)]="provider"
             (ngModelChange)="onProviderChange()"
-            class="flex-1 max-w-[340px] px-2.5 py-1.5 bg-sw-bg-abyss border border-sw-border rounded text-sw-text text-[13px] font-mono outline-none focus:border-sw-accent"
+            class="flex-1 px-2.5 py-1.5 bg-sw-bg-abyss border border-sw-border rounded text-sw-text text-[13px] font-mono outline-none focus:border-sw-accent"
             data-testid="settings-llm-provider"
           >
-            <option value="anthropic">Anthropic (default)</option>
-            <option value="ollama">Ollama (local) — requires 0.14.0+</option>
-            <option value="lmstudio">LM Studio (local) — requires 0.4.1+</option>
-            <option value="llamacpp">llama.cpp (local) — requires Jan 2026+</option>
-            <option value="custom">Custom endpoint</option>
+            <option value="anthropic">Anthropic</option>
+            <option value="ollama">Ollama</option>
+            <option value="lmstudio">LM Studio</option>
+            <option value="llamacpp">llama.cpp</option>
           </select>
         </div>
         @if (provider !== 'anthropic') {
-          <div class="flex justify-between items-center py-2 border-t border-sw-border">
-            <label class="text-[13px] text-sw-text-muted min-w-[120px]" for="llm-model"
-              >Model</label
-            >
-            <input
-              id="llm-model"
-              type="text"
-              [(ngModel)]="model"
-              [placeholder]="modelPlaceholder()"
-              class="flex-1 max-w-[340px] px-2.5 py-1.5 bg-sw-bg-abyss border border-sw-border rounded text-sw-text text-[13px] font-mono outline-none focus:border-sw-accent"
-              data-testid="settings-llm-model"
-            />
-          </div>
           <div class="flex justify-between items-center py-2 border-t border-sw-border">
             <label class="text-[13px] text-sw-text-muted min-w-[120px]" for="llm-base-url"
               >Base URL</label
@@ -70,10 +71,70 @@ interface LlmConfigResponse {
               type="text"
               [(ngModel)]="baseUrl"
               [placeholder]="defaultBaseUrl || baseUrlPlaceholder()"
-              class="flex-1 max-w-[340px] px-2.5 py-1.5 bg-sw-bg-abyss border border-sw-border rounded text-sw-text text-[13px] font-mono outline-none focus:border-sw-accent"
+              (blur)="discoverModels(false)"
+              class="flex-1 px-2.5 py-1.5 bg-sw-bg-abyss border border-sw-border rounded text-sw-text text-[13px] font-mono outline-none focus:border-sw-accent"
               data-testid="settings-llm-base-url"
             />
           </div>
+          <div class="flex justify-between items-center py-2 border-t border-sw-border">
+            <label class="text-[13px] text-sw-text-muted min-w-[120px]" for="llm-model"
+              >Model</label
+            >
+            <div class="flex flex-1 gap-2">
+              @if (discoveryState.kind === 'ready') {
+                <select
+                  id="llm-model"
+                  [(ngModel)]="model"
+                  class="flex-1 px-2.5 py-1.5 bg-sw-bg-abyss border border-sw-border rounded text-sw-text text-[13px] font-mono outline-none focus:border-sw-accent"
+                  data-testid="settings-llm-model"
+                >
+                  @if (model && !discoveryState.models.includes(model)) {
+                    <option [value]="model">{{ model }}</option>
+                  }
+                  @for (m of discoveryState.models; track m) {
+                    <option [value]="m">{{ m }}</option>
+                  }
+                </select>
+              } @else {
+                <input
+                  id="llm-model"
+                  type="text"
+                  [(ngModel)]="model"
+                  [placeholder]="modelPlaceholder()"
+                  class="flex-1 px-2.5 py-1.5 bg-sw-bg-abyss border border-sw-border rounded text-sw-text text-[13px] font-mono outline-none focus:border-sw-accent"
+                  data-testid="settings-llm-model"
+                />
+              }
+              <button
+                type="button"
+                data-testid="settings-llm-refresh"
+                class="px-3 py-1.5 bg-transparent text-sw-text-muted border border-sw-border rounded text-[12px] font-mono cursor-pointer hover:enabled:text-sw-text hover:enabled:border-sw-accent disabled:opacity-40 disabled:cursor-not-allowed"
+                [disabled]="discoveryState.kind === 'in-flight'"
+                (click)="discoverModels(true)"
+                title="Fetch the list of models from the server"
+              >
+                @if (discoveryState.kind === 'in-flight') {
+                  Discovering...
+                } @else {
+                  Refresh
+                }
+              </button>
+            </div>
+          </div>
+          @if (discoveryState.kind === 'failed') {
+            <div class="flex justify-end pb-1">
+              <span class="text-[11px] text-sw-warning" data-testid="settings-llm-discovery-error">
+                {{ discoveryFailureMessage() }}
+              </span>
+            </div>
+          }
+          @if (discoveryState.kind === 'in-flight') {
+            <div class="flex justify-end pb-1">
+              <span class="text-[11px] text-sw-text-muted" data-testid="settings-llm-discovering">
+                Probing {{ discoveryState.url }}...
+              </span>
+            </div>
+          }
         }
         <div class="flex items-center gap-3 pt-3 pb-1">
           <button
@@ -100,6 +161,40 @@ export class LlmProviderComponent implements OnInit {
   saving = false;
   saved = false;
 
+  /** Current state of the model discovery probe. See `DiscoveryState` docstring. */
+  discoveryState: DiscoveryState = { kind: 'idle' };
+
+  /**
+   * Monotonic counter incremented on every discovery trigger. An arriving
+   * response whose `id` is not equal to the counter is a stale response from
+   * a superseded trigger and must be discarded.
+   */
+  private discoveryCounter = 0;
+
+  /**
+   * Tracks the provider value from the previous `onProviderChange` call so we
+   * can detect actual changes (ngModelChange can fire without a user edit).
+   */
+  private lastKnownProvider = 'anthropic';
+
+  /**
+   * Session cache of the last URL the user had in the Base URL field per
+   * provider. Lets us restore their previous entry when they switch back to
+   * a provider instead of overwriting it with the hard-coded default
+   * (which is often wrong for the user's specific setup — e.g. llama.cpp
+   * default is :8080 but many users run it on a different port).
+   * Seeded from the persisted config on init for the config's provider.
+   */
+  private baseUrlByProvider: Record<string, string> = {};
+
+  /**
+   * Cache of the backend-authoritative default base URL per provider.
+   * Populated on ngOnInit via `get_default_base_url` for each local provider
+   * so that `isDefaultBaseUrl` stays synchronous (no await on the hot path).
+   * Backend is SSOT for these values (see `speedwave_runtime::compose::default_base_url`).
+   */
+  private defaultBaseUrlsByProvider: Record<string, string> = {};
+
   @Output() providerChange = new EventEmitter<string>();
   @Output() errorOccurred = new EventEmitter<string>();
 
@@ -121,8 +216,6 @@ export class LlmProviderComponent implements OnInit {
         return 'qwen2.5-coder';
       case 'llamacpp':
         return 'deepseek-r1';
-      case 'custom':
-        return 'your-model-name';
       default:
         return 'claude-sonnet-4-6';
     }
@@ -130,16 +223,168 @@ export class LlmProviderComponent implements OnInit {
 
   /** Returns a fallback base URL placeholder when backend default_base_url is unavailable. */
   baseUrlPlaceholder(): string {
-    // No meaningful default for 'custom' — user must supply their own URL.
-    // Backend is SSOT for known-provider defaults (see default_base_url in compose.rs);
-    // this is just a fallback hint if the backend response arrives late.
+    // Backend is SSOT for known-provider defaults (see default_base_url in
+    // compose.rs); this is just a fallback hint if the backend response
+    // arrives late.
     return '';
   }
 
-  /** Notifies parent when the provider selection changes. */
-  onProviderChange(): void {
-    this.defaultBaseUrl = '';
+  /**
+   * Human-readable explanation of why model discovery failed, shown inline
+   * under the Model field so the user understands why the select fell back
+   * to a free-text input.
+   */
+  discoveryFailureMessage(): string {
+    if (this.discoveryState.kind !== 'failed') return '';
+    const url = this.discoveryState.url;
+    const label = this.providerDisplayLabel();
+    switch (this.discoveryState.reason) {
+      case 'offline':
+        return `${label} server not reachable at ${url}. Make sure it's running and the local server is enabled.`;
+      case 'unsupported':
+        return `${label} does not support model discovery — type the model name manually.`;
+      case 'other':
+        return `${label} at ${url} returned no models (the server is up but no model is loaded).`;
+    }
+  }
+
+  /** Returns the UI-friendly label for the current provider. */
+  private providerDisplayLabel(): string {
+    switch (this.provider) {
+      case 'ollama':
+        return 'Ollama';
+      case 'lmstudio':
+        return 'LM Studio';
+      case 'llamacpp':
+        return 'llama.cpp';
+      default:
+        return 'Provider';
+    }
+  }
+
+  /**
+   * Handles a change of the provider dropdown.
+   *
+   * Each provider has a different default port, so baseUrl must be reset on
+   * any real change — keeping an Ollama URL around for LM Studio would send
+   * probes to the wrong server. After the reset, defaultBaseUrl is shown as
+   * the input placeholder and discovery is kicked off against it; if the
+   * server isn't running the UI gracefully falls back to the text input.
+   *
+   * Counter bump invalidates any in-flight probe from the previous provider
+   * so its response is discarded on arrival.
+   */
+  async onProviderChange(): Promise<void> {
+    if (this.provider === this.lastKnownProvider) {
+      // Guard against redundant ngModelChange fires (HMR reinit, identical
+      // selection etc.) — don't wipe state on no-op.
+      return;
+    }
+    // Stash the URL we were just on so the user gets it back if they switch
+    // back to this provider during the same session (e.g. they typed :8001
+    // for llama.cpp, switched to Ollama to check something, came back — we
+    // restore :8001 instead of the hardcoded :8080 default).
+    const previousProvider = this.lastKnownProvider;
+    if (previousProvider !== 'anthropic' && this.baseUrl) {
+      this.baseUrlByProvider[previousProvider] = this.baseUrl;
+    }
+    this.lastKnownProvider = this.provider;
+    this.discoveryCounter++;
+    // Clear stale state synchronously so the UI reflects the provider change
+    // immediately — even while the async default-URL fetch is in-flight.
+    // Model is provider-specific; clearing prevents stale options on the new provider.
+    this.model = '';
+    this.discoveryState = { kind: 'idle' };
     this.providerChange.emit(this.provider);
+    this.cdr.markForCheck();
+    // Fetch the backend-authoritative default for the new provider if not yet cached.
+    // This keeps compose.rs as the SSOT and avoids duplicating URL strings here.
+    // Done AFTER the synchronous state reset above so the UI is consistent.
+    if (this.provider !== 'anthropic' && !this.defaultBaseUrlsByProvider[this.provider]) {
+      try {
+        const freshDefault = await this.tauri.invoke<string | null>('get_default_base_url', {
+          provider: this.provider,
+        });
+        if (freshDefault) {
+          this.defaultBaseUrlsByProvider[this.provider] = freshDefault;
+        }
+      } catch {
+        // Not in Tauri or unknown provider — cache stays empty for this provider.
+      }
+    }
+    this.defaultBaseUrl = this.defaultBaseUrlsByProvider[this.provider] ?? '';
+    // Restore the cached URL for this provider if we have one; otherwise fall
+    // back to the provider's backend-authoritative default. Anthropic has no baseUrl.
+    const cached = this.baseUrlByProvider[this.provider];
+    this.baseUrl = this.provider === 'anthropic' ? '' : cached || this.defaultBaseUrl;
+    // discoverModels self-gates on anthropic and empty URL — no outer guard needed.
+    if (this.baseUrl) {
+      await this.discoverModels(false);
+    }
+  }
+
+  /**
+   * Probes the local LLM server for the list of available models.
+   * Fires only on explicit intent: user blur on baseUrl, Refresh click, or
+   * initial load with persisted baseUrl. Provider switches do NOT probe
+   * automatically — the new provider's default URL is typically wrong for
+   * this user (different port, server not running).
+   * @param isRefresh When true, bypass the same-URL dedupe check. Used by the
+   *   Refresh button to let the user force a re-probe.
+   */
+  async discoverModels(isRefresh: boolean): Promise<void> {
+    if (this.provider === 'anthropic') return;
+    const effectiveUrl = this.baseUrl || this.defaultBaseUrl;
+    if (!effectiveUrl) return;
+
+    // Dedupe: skip same-URL non-refresh triggers while a probe is in-flight.
+    if (
+      !isRefresh &&
+      this.discoveryState.kind === 'in-flight' &&
+      this.discoveryState.url === effectiveUrl
+    ) {
+      return;
+    }
+
+    const id = ++this.discoveryCounter;
+    this.discoveryState = { kind: 'in-flight', url: effectiveUrl, id };
+    this.cdr.markForCheck();
+
+    try {
+      const models = await this.tauri.invoke<string[]>('discover_llm_models', {
+        provider: this.provider,
+        baseUrl: effectiveUrl,
+      });
+      // Stale-discard: drop responses whose id doesn't match the latest trigger.
+      if (this.discoveryState.kind !== 'in-flight' || this.discoveryState.id !== id) return;
+      if (models.length > 0) {
+        this.discoveryState = { kind: 'ready', url: effectiveUrl, models };
+        // Auto-select the first discovered model when the current value is
+        // blank or not on the list — otherwise the <select> renders with no
+        // active <option> and Save would persist an empty model name.
+        if (!this.model || !models.includes(this.model)) {
+          this.model = models[0];
+        }
+      } else {
+        // Defensive — backend already maps empty to Err("empty"), but be safe.
+        this.discoveryState = { kind: 'failed', url: effectiveUrl, reason: 'other' };
+      }
+    } catch (e: unknown) {
+      if (this.discoveryState.kind !== 'in-flight' || this.discoveryState.id !== id) return;
+      const msg = e instanceof Error ? e.message : String(e);
+      let reason: 'offline' | 'unsupported' | 'other' = 'offline';
+      if (msg === 'unsupported') {
+        reason = 'unsupported';
+      } else if (msg === 'empty') {
+        reason = 'other';
+      }
+      this.discoveryState = { kind: 'failed', url: effectiveUrl, reason };
+      // No errorOccurred.emit — discovery failure is silent degradation
+      // (UI falls back to the free-text input).
+    } finally {
+      // Always mark for check, even when early-returning via stale-discard.
+      this.cdr.markForCheck();
+    }
   }
 
   /** Persists the LLM provider configuration to the backend. */
@@ -147,10 +392,15 @@ export class LlmProviderComponent implements OnInit {
     this.saving = true;
     this.saved = false;
     try {
+      // If the user left baseUrl blank for a local provider, fall back to the
+      // provider default so compose can inject ANTHROPIC_BASE_URL. Anthropic
+      // ignores baseUrl entirely, so null is correct there.
+      const effectiveBaseUrl =
+        this.provider === 'anthropic' ? null : this.baseUrl || this.defaultBaseUrl || null;
       await this.tauri.invoke('update_llm_config', {
         provider: this.provider,
         model: this.model || null,
-        baseUrl: this.baseUrl || null,
+        baseUrl: effectiveBaseUrl,
       });
       this.saved = true;
       this.providerChange.emit(this.provider);
@@ -166,6 +416,21 @@ export class LlmProviderComponent implements OnInit {
     this.cdr.markForCheck();
   }
 
+  /**
+   * Returns true when `url` exactly matches the backend-authoritative default
+   * for `provider`. Uses the `defaultBaseUrlsByProvider` cache (populated on
+   * init via `get_default_base_url` — backend is SSOT, see compose.rs).
+   * Used by `loadConfig` to distinguish a known-safe default from a
+   * user-supplied URL so we never silently probe arbitrary hosts on startup
+   * (SSRF mitigation).
+   * @param provider The selected provider (e.g. `ollama`, `lmstudio`, `llamacpp`).
+   * @param url The base URL to check against the provider's cached default.
+   */
+  private isDefaultBaseUrl(provider: string, url: string): boolean {
+    const def = this.defaultBaseUrlsByProvider[provider];
+    return !!def && url === def;
+  }
+
   private async loadConfig(): Promise<void> {
     try {
       const config = await this.tauri.invoke<LlmConfigResponse>('get_llm_config');
@@ -173,10 +438,41 @@ export class LlmProviderComponent implements OnInit {
       this.model = config.model || '';
       this.baseUrl = config.base_url || '';
       this.defaultBaseUrl = config.default_base_url || '';
+      this.lastKnownProvider = this.provider;
+      // Seed the per-provider cache with the backend-authoritative default for
+      // the persisted provider so `isDefaultBaseUrl` can compare without a
+      // round-trip (backend is SSOT via get_default_base_url / compose.rs).
+      if (this.provider !== 'anthropic' && this.defaultBaseUrl) {
+        this.defaultBaseUrlsByProvider[this.provider] = this.defaultBaseUrl;
+      }
+      // Seed the per-provider URL cache with the persisted URL so switching away
+      // and back doesn't lose it.
+      if (this.provider !== 'anthropic' && this.baseUrl) {
+        this.baseUrlByProvider[this.provider] = this.baseUrl;
+      }
       this.providerChange.emit(this.provider);
-    } catch {
-      // Not running inside Tauri or no config yet
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      // Silently ignore the common "not in Tauri" case (browser dev mode).
+      // Log anything else so real backend errors aren't hidden.
+      if (!msg.toLowerCase().includes('tauri') && !msg.toLowerCase().includes('invoke')) {
+        console.error('loadConfig: unexpected error loading LLM config:', e);
+      }
     }
     this.cdr.markForCheck();
+    // Auto-probe only when the effective URL is a known-safe default. Any
+    // user-supplied URL (even one persisted in config) must NOT be probed
+    // silently — a cloned malicious repo could set base_url to an internal
+    // RFC1918 host, turning Settings open into an SSRF probe. The user must
+    // explicitly click Refresh or blur the Base URL field to trigger a probe
+    // against a non-default URL.
+    const effectiveUrl = this.baseUrl || this.defaultBaseUrl;
+    const isSafeToAutoProbe =
+      this.provider !== 'anthropic' &&
+      !!effectiveUrl &&
+      (this.baseUrl === '' || this.isDefaultBaseUrl(this.provider, this.baseUrl));
+    if (isSafeToAutoProbe) {
+      await this.discoverModels(false);
+    }
   }
 }

--- a/desktop/src/src/app/settings/settings.component.ts
+++ b/desktop/src/src/app/settings/settings.component.ts
@@ -30,8 +30,9 @@ import { ProjectList } from '../models/update';
     UpdateSectionComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: { class: 'block bg-sw-bg-darkest min-h-screen p-6 text-sw-text' },
   template: `
-    <div class="max-w-[700px] mx-auto mt-8 px-6">
+    <div>
       <h1 class="text-xl text-sw-accent m-0 mb-6">Settings</h1>
 
       @if (error) {

--- a/docs/adr/ADR-011-user-configuration-passed-to-claude-code.md
+++ b/docs/adr/ADR-011-user-configuration-passed-to-claude-code.md
@@ -58,13 +58,13 @@ Different projects require different Claude Code settings (model selection, cust
 
 #### Per-project Claude overrides (`claude.*`)
 
-| Field                 | Rust type                         | Description                                                                                                                                                               |
-| --------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `claude.env`          | `Option<HashMap<String, String>>` | Environment variables injected into the Claude Code process[^1]                                                                                                           |
-| `claude.llm`          | `Option<LlmConfig>`               | Local LLM provider configuration — see ADR-040                                                                                                                            |
-| `claude.llm.provider` | `Option<String>`                  | `anthropic` (default), `ollama`, `lmstudio`, `llamacpp`, `custom`                                                                                                         |
-| `claude.llm.model`    | `Option<String>`                  | Model name for the local provider (also accepted from repo config)                                                                                                        |
-| `claude.llm.base_url` | `Option<String>`                  | Custom API endpoint (required for `custom`; optional override for known providers). **Not accepted from repo config** — only from user config (SSRF prevention, ADR-040). |
+| Field                 | Rust type                         | Description                                                                                                                          |
+| --------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `claude.env`          | `Option<HashMap<String, String>>` | Environment variables injected into the Claude Code process[^1]                                                                      |
+| `claude.llm`          | `Option<LlmConfig>`               | Local LLM provider configuration — see ADR-040                                                                                       |
+| `claude.llm.provider` | `Option<String>`                  | `anthropic` (default), `ollama`, `lmstudio`, `llamacpp`                                                                              |
+| `claude.llm.model`    | `Option<String>`                  | Model name for the local provider (also accepted from repo config)                                                                   |
+| `claude.llm.base_url` | `Option<String>`                  | Optional; overrides the provider default port. **Not accepted from repo config** — only from user config (SSRF prevention, ADR-040). |
 
 #### Global config fields
 

--- a/docs/adr/ADR-040-remove-litellm-direct-provider-injection.md
+++ b/docs/adr/ADR-040-remove-litellm-direct-provider-injection.md
@@ -17,7 +17,7 @@ This makes LiteLLM unnecessary for the Speedwave use case: local models only.
 
 ## Decision
 
-Remove LiteLLM entirely. Inject `ANTHROPIC_BASE_URL` and related env vars directly into the `claude` container. Support three local providers with well-known defaults, plus a `custom` endpoint for advanced users.
+Remove LiteLLM entirely. Inject `ANTHROPIC_BASE_URL` and related env vars directly into the `claude` container. Support three local providers with well-known defaults.
 
 **Cloud providers (OpenAI, Gemini, DeepSeek, OpenRouter) are not supported.** Speedwave is a local-first platform. External LLM API keys must never enter containers — this is a security invariant.
 
@@ -29,7 +29,6 @@ Remove LiteLLM entirely. Inject `ANTHROPIC_BASE_URL` and related env vars direct
 | `ollama`    | 0.14.0       | `http://host.docker.internal:11434` |
 | `lmstudio`  | 0.4.1        | `http://host.docker.internal:1234`  |
 | `llamacpp`  | Jan 2026     | `http://host.docker.internal:8080`  |
-| `custom`    | —            | User-supplied `base_url` required   |
 
 All local providers use `host.docker.internal` which is mapped to the host gateway via `extra_hosts` in `compose.template.yml`. This works identically on macOS (Lima), Linux (nerdctl rootless), and Windows (WSL2).
 
@@ -37,17 +36,19 @@ All local providers use `host.docker.internal` which is mapped to the host gatew
 
 When a local provider is selected, the following env vars are set on the `claude` container:
 
-| Variable                                   | Value                                    |
-| ------------------------------------------ | ---------------------------------------- |
-| `ANTHROPIC_BASE_URL`                       | Provider URL (no `/v1` suffix)           |
-| `ANTHROPIC_AUTH_TOKEN`                     | `sk-no-key-required` (dummy)[^8]         |
-| `ANTHROPIC_DEFAULT_SONNET_MODEL`           | User-configured model name               |
-| `ANTHROPIC_DEFAULT_OPUS_MODEL`             | User-configured model name               |
-| `ANTHROPIC_DEFAULT_HAIKU_MODEL`            | User-configured model name               |
-| `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` | `1` (disables model validation)[^5]      |
-| `CLAUDE_CODE_ATTRIBUTION_HEADER`           | `0` (prevents 90% KV cache slowdown)[^6] |
+| Variable                                    | Value                                                |
+| ------------------------------------------- | ---------------------------------------------------- |
+| `ANTHROPIC_BASE_URL`                        | Provider URL (no `/v1` suffix)                       |
+| `ANTHROPIC_AUTH_TOKEN`                      | `sk-no-key-required` (dummy)[^8]                     |
+| `ANTHROPIC_CUSTOM_MODEL_OPTION`             | User-configured model name[^9]                       |
+| `ANTHROPIC_CUSTOM_MODEL_OPTION_NAME`        | `<model> (<Provider Label>)` for the `/model` picker |
+| `ANTHROPIC_CUSTOM_MODEL_OPTION_DESCRIPTION` | `Local model served by <Provider Label>`             |
+| `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`  | `1` (disables model validation)[^5]                  |
+| `CLAUDE_CODE_ATTRIBUTION_HEADER`            | `0` (prevents 90% KV cache slowdown)[^6]             |
 
 For `anthropic` provider, no injection occurs — Claude Code connects directly to `api.anthropic.com`.
+
+`ANTHROPIC_CUSTOM_MODEL_OPTION` is preferred over `ANTHROPIC_DEFAULT_{SONNET,OPUS,HAIKU}_MODEL`: the latter silently remaps the built-in Sonnet/Opus/Haiku aliases to the same local model, leaving the `/model` picker showing three misleading Anthropic names. The former adds a single explicit, validation-skipped entry (e.g. `llama3.3 (Ollama)`) so the user sees exactly what is running.[^9]
 
 ## Architecture
 
@@ -84,6 +85,21 @@ Arbitrary host is allowed — the security boundary is that the container cannot
 
 A malicious `.speedwave.json` in a cloned repository could previously set `provider` and `base_url` to redirect Claude Code to an attacker-controlled server. As of this ADR, `merge_llm_repo()` ignores `provider` and `base_url` from repo config — only `model` is merged. Only the user's `~/.speedwave/config.json` may set the provider and base URL.
 
+## CLI Flag Injection for Local Providers
+
+When a local provider is active, `resolve_project_config` appends two flags to the Claude Code command:
+
+- `--system-prompt-file /speedwave/resources/system-prompts/local-llm.md` — replaces Claude Code's default system prompt with a compact, local-LLM-optimised variant. The default prompt is Anthropic-centric and verbose; small-context local models benefit from a shorter, model-agnostic prompt.
+- `--model <user_model>` — pins the user-configured model name as the default in Claude Code's `/model` picker, so the session starts with the correct local model selected rather than the Anthropic default.
+
+Neither flag is injected for the `anthropic` provider. See ADR-041[^10] for the model discovery flow that populates `<user_model>`.
+
+## Authentication Bypass for Local Providers
+
+`check_claude_auth` normally verifies that a valid Anthropic OAuth token is present before allowing a session to start. For local providers (`ollama`, `lmstudio`, `llamacpp`), this check short-circuits to `Ok(true)` — no Anthropic account or API key is required.
+
+This is safe because local providers use a dummy `ANTHROPIC_AUTH_TOKEN` (`sk-no-key-required`[^8]) and route all traffic to `host.docker.internal`; no Anthropic API call is made. Requiring a real token would block users who are running entirely on local hardware with no Anthropic subscription.
+
 ## Rollback
 
 To restore LiteLLM support:
@@ -109,4 +125,8 @@ Note: the stale llm-proxy container (if any) is automatically removed by `--remo
 
 [^7]: Trend Micro analysis of LiteLLM compromise: https://www.trendmicro.com/en_us/research/26/c/inside-litellm-supply-chain-compromise.html
 
-[^8]: `ANTHROPIC_DEFAULT_*_MODEL` and dummy auth token usage documented at: https://docs.vllm.ai/en/stable/serving/integrations/claude_code/
+[^8]: Dummy auth token usage for local OpenAI-compatible endpoints documented at: https://docs.vllm.ai/en/stable/serving/integrations/claude_code/
+
+[^9]: `ANTHROPIC_CUSTOM_MODEL_OPTION` (with `_NAME`, `_DESCRIPTION`, `_SUPPORTED_CAPABILITIES` suffixes) adds a single entry to the `/model` picker and skips validation of the model ID: https://code.claude.com/docs/en/model-config
+
+[^10]: ADR-041: Local LLM Model Discovery and SSRF Policy — `docs/adr/ADR-041-local-llm-model-discovery.md`

--- a/docs/adr/ADR-041-local-llm-model-discovery.md
+++ b/docs/adr/ADR-041-local-llm-model-discovery.md
@@ -1,0 +1,122 @@
+# ADR-041: Local LLM Model Discovery and SSRF Policy
+
+**Status:** Accepted
+**Date:** 2026-04-20
+
+## Context
+
+After ADR-040 removed the LiteLLM proxy and wired Claude Code directly to a local LLM server (`ollama`, `lmstudio`, or `llamacpp`), a UX failure surfaced during integration testing: `llama.cpp` silently ignores the `model` field in an Anthropic `/v1/messages` request and answers with whatever model the user loaded at server startup.[^15] If the user typed a model name in Settings that did not match the server's loaded model, requests still went through — on the wrong model, with no visible error. Chat UI appeared to hang while a 35 B reasoning model ran; the session_stats field showed a model name the user never asked for.
+
+At the same time, the Settings save path (`containers_cmd::update_llm_config`) validated only URL syntax (scheme, no path, no query). A user could save `http://169.254.169.254` and Speedwave would render it into `ANTHROPIC_BASE_URL` on the claude container, causing every Claude Code request to hit the cloud metadata endpoint — a textbook SSRF primitive.[^11][^16]
+
+Both problems had one solution in common: query the server's advertised model list, and apply a uniform SSRF policy to both the discovery probe and the save path.
+
+## Decision
+
+Add a Tauri command `discover_llm_models(provider, base_url) -> Vec<String>` that probes the local LLM server and returns the list of available models, so Settings can render a `<select>` instead of a free-text input. Introduce a shared URL validator `validate_llm_base_url` used by **both** the discovery command and `update_llm_config`. The validator follows the existing Redmine pattern (`validate_redmine_host_url`[^18]) but allows loopback — required because Speedwave's `default_base_url` for every local provider uses `host.docker.internal`, which the Desktop host-side code rewrites to `127.0.0.1` before probing.
+
+**Single SSRF policy, two callsites:**
+
+| Address class                            | Policy      | Rationale                                                                 |
+| ---------------------------------------- | ----------- | ------------------------------------------------------------------------- |
+| Loopback (127.0.0.0/8, ::1)              | Allow, warn | `default_base_url` resolves here after container-alias rewrite            |
+| RFC 1918 private (IPv4)[^3]              | Allow, warn | LAN LLM servers, self-hosted Ollama on a private address                  |
+| IPv6 ULA (`fc00::/7`, RFC 4193)[^4]      | Allow, warn | Same rationale as RFC 1918 for IPv6 networks                              |
+| Link-local (169.254.0.0/16, `fe80::/10`) | Block       | Cloud metadata endpoints[^11][^12] live here; never a legitimate LLM host |
+| RFC 5737 TEST-NET[^5], RFC 2544[^6]      | Block       | Reserved documentation/benchmarking ranges                                |
+| RFC 3849 IPv6 documentation prefix[^8]   | Block       | Reserved documentation range                                              |
+| RFC 6666 IPv6 discard prefix[^9]         | Block       | Reserved                                                                  |
+| Multicast, unspecified (`0.0.0.0`, `::`) | Block       | Not valid HTTP destinations                                               |
+| Public IP / public domain                | Allow, warn | User-written URL is user's threat; same as Redmine                        |
+| `http://` scheme on private address      | Allow, warn | Local LAN; cleartext on loopback/RFC1918 is acceptable                    |
+| Embedded credentials (`user:pass@`)      | Block       | Credentials do not belong in base URLs                                    |
+| Query string / fragment                  | Block       | LLM endpoints are canonical paths                                         |
+| Non-`http`/`https` scheme                | Block       | `file://`, `javascript:`, `ssh://`, `ftp://`, `data:` all rejected        |
+
+IPv6-mapped IPv4 bypasses (`::ffff:169.254.169.254`) are handled by the underlying `url_validation::validate_url`, which checks `Ipv6Addr::to_ipv4_mapped()` against the same classifier.[^16]
+
+**Layered HTTP hardening for the discovery probe:**
+
+1. `reqwest::ClientBuilder::redirect(Policy::none())`[^1] — prevents `302 Location: http://169.254.169.254/` bypass.
+2. 5-second request timeout[^2] — a stuck model load should fall back to the free-text input, not freeze Settings.
+3. Response body capped at 5 MiB via `http_util::read_body_limited` (shared with Redmine) — prevents OOM from a hostile endpoint.
+4. Case-insensitive prefix check on `Content-Type`: `text/html` responses are rejected (user pointed at Grafana/a 404 page instead of an LLM server).
+
+**Endpoint selection:**
+
+- `ollama` → `GET {base}/api/tags`[^13]
+- `lmstudio`, `llamacpp` → `GET {base}/v1/models`[^14][^15]
+
+Empty model lists return `Err("empty")` so the UI falls back to the free-text input. A `404` on `/v1/models` (or any other non-2xx response) triggers the same graceful fallback.
+
+**Container-host alias rewrite.** The `host.*.internal` aliases injected into `extra_hosts` (`compose.template.yml`) do not resolve from the Desktop host process — Speedwave does not bundle Docker Desktop, so Docker's /etc/hosts injection does not happen. A new helper `speedwave_runtime::compose::rewrite_container_alias_to_loopback` rewrites `host.docker.internal`, `host.lima.internal`, `host.containers.internal`, `host.speedwave.internal` to `127.0.0.1` before the probe. All four aliases live in a single `CONTAINER_HOST_ALIASES` constant composed from the existing per-platform `LIMA_HOST`, `NERDCTL_LINUX_HOST`, `WSL_HOST`, `CONTAINERS_HOST` named consts — one SSOT.
+
+**Delta vs Redmine policy.** The only difference between `validate_redmine_host_url` (ADR sibling documented at[^18]) and the new `validate_llm_base_url` is loopback: Redmine blocks loopback because a self-hosted Redmine on 127.0.0.1 is an unusual config likely to indicate a mistake; LLM discovery needs loopback because the default base URLs all resolve there. This delta is implemented with a single enum parameter `PrivatePolicy::{BlockLoopback, AllowLoopback}` on the shared helper `url_validation::is_private_on_premise`.
+
+## Consequences
+
+### Positive
+
+- Silent model-name mismatch bug eliminated at the UX layer: the select cannot contain a name the server doesn't know.
+- Save path gains SSRF protection symmetric to the discovery probe. Historical configs containing `http://169.254.169.254` log a warning on load and are rejected on the next save.
+- `is_private_on_premise` logic consolidated — Redmine and LLM discovery share one policy function; a future tightening (e.g. new IPv6 bypass) automatically reaches both.
+- `read_body_limited` + `MAX_RESPONSE_BODY_BYTES` extracted to `http_util.rs` (Rule of Three — second concrete consumer).
+
+### Neutral
+
+- ~400 new lines of Rust code + ~100 lines of Angular. Largely test harness (53 Rust unit/integration tests in `llm_cmd` + 16 policy-branch tests in `url_validation` + 9 save-path tests in `containers_cmd` + 10 Angular tests + 8 alias / template guards).
+- Frontend adds a discriminated-union `DiscoveryState` with a monotonic counter for stale-response discard. Replaces an earlier design that used 5 loose booleans — fewer invariants to reason about.
+
+### Negative (residual risks, accepted)
+
+1. **DNS rebinding in the discovery probe.** `Policy::none()` eliminates the redirect vector, but a user-written hostname (`http://attacker.example.com`) whose DNS returns a public IP on first resolve and `169.254.169.254` on a subsequent connect can still bypass the IP classifier. Mitigations: (a) discovery output is a typed `Vec<String>` rendered as `<option>` text — attacker cannot pivot from reading an internal service, (b) user-initiated only (per click/blur), (c) 5-second total request timeout.[^17] We explicitly do not use `reqwest::ClientBuilder::resolve()` pre-resolve — that mitigation is architecturally partial (redirect + idle-connection reconnect + IDN re-lookup all reintroduce the race) and gives a false sense of immunity.
+
+2. **Save-path public-domain SSRF.** A user can save `http://my-ollama.company.com` whose DNS later resolves to `169.254.169.254`. Every Claude Code request would then hit metadata. Decision: this is user-originated input; we apply the same threat model as Redmine (`validate_redmine_host_url` accepts public domains).[^18] If a future codepath adds a way for an attacker to inject URLs into the config without user consent, this decision must be revisited.
+
+3. **Rust-style constraint.** The SSRF policy lives in `desktop/src-tauri/src/url_validation.rs`, not in `speedwave-runtime`. Runtime is pure Rust with no Tauri coupling (per `.claude/rules/rust-style.md`) — networking policy must not leak there. The host-alias rewrite helper lives in runtime because it is a pure string→string mapping (no I/O, no policy).
+
+## Known Limitations
+
+- Discovery does not cache results. Every trigger re-probes. Localhost is fast enough; over a LAN the latency is bounded by the 5-second timeout.
+- Discovery does not validate that the chosen model actually serves Anthropic-compatible `/v1/messages`. Upstream compatibility errors surface only on the first chat message.
+- `rustls-tls` uses bundled CA roots, inherited from Redmine[^18]. Corporate users with custom CAs may see TLS errors on public-domain HTTPS endpoints.
+
+## References
+
+[^1]: reqwest `redirect::Policy` — https://docs.rs/reqwest/latest/reqwest/redirect/enum.Policy.html
+
+[^2]: reqwest `ClientBuilder::timeout` — https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.timeout
+
+[^3]: RFC 1918 — "Address Allocation for Private Internets" — https://www.rfc-editor.org/rfc/rfc1918
+
+[^4]: RFC 4193 — "Unique Local IPv6 Unicast Addresses" — https://www.rfc-editor.org/rfc/rfc4193
+
+[^5]: RFC 5737 — "IPv4 Address Blocks Reserved for Documentation" — https://www.rfc-editor.org/rfc/rfc5737
+
+[^6]: RFC 2544 — "Benchmarking Methodology for Network Interconnect Devices" — https://www.rfc-editor.org/rfc/rfc2544
+
+[^7]: RFC 6598 — "IANA-Reserved IPv4 Prefix for Shared Address Space" (CGNAT) — https://www.rfc-editor.org/rfc/rfc6598
+
+[^8]: RFC 3849 — "IPv6 Address Prefix Reserved for Documentation" — https://www.rfc-editor.org/rfc/rfc3849
+
+[^9]: RFC 6666 — "A Discard Prefix for IPv6" — https://www.rfc-editor.org/rfc/rfc6666
+
+[^10]: RFC 1122 — "Requirements for Internet Hosts" (incl. 0.0.0.0/8 "this host") — https://www.rfc-editor.org/rfc/rfc1122
+
+[^11]: AWS EC2 Instance Metadata Service — https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
+
+[^12]: Google Cloud Metadata server — https://cloud.google.com/compute/docs/metadata/overview
+
+[^13]: Ollama API — `/api/tags` list local models — https://github.com/ollama/ollama/blob/main/docs/api.md#list-local-models
+
+[^14]: LM Studio — OpenAI-compatible API endpoints — https://lmstudio.ai/docs/app/api/endpoints/openai
+
+[^15]: llama.cpp — HTTP server — https://github.com/ggml-org/llama.cpp/tree/master/examples/server
+
+[^16]: OWASP — Server-Side Request Forgery Prevention Cheat Sheet — https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html
+
+[^17]: OWASP — DNS Rebinding — https://owasp.org/www-community/attacks/DNS_rebinding
+
+[^18]: Speedwave Redmine SSRF policy — `../architecture/security.md#redmine-api-proxy-commands`
+
+[^19]: ADR-040 — Remove LiteLLM, direct provider injection — `./ADR-040-remove-litellm-direct-provider-injection.md`

--- a/docs/adr/ADR-041-local-llm-model-discovery.md
+++ b/docs/adr/ADR-041-local-llm-model-discovery.md
@@ -17,21 +17,22 @@ Add a Tauri command `discover_llm_models(provider, base_url) -> Vec<String>` tha
 
 **Single SSRF policy, two callsites:**
 
-| Address class                            | Policy      | Rationale                                                                 |
-| ---------------------------------------- | ----------- | ------------------------------------------------------------------------- |
-| Loopback (127.0.0.0/8, ::1)              | Allow, warn | `default_base_url` resolves here after container-alias rewrite            |
-| RFC 1918 private (IPv4)[^3]              | Allow, warn | LAN LLM servers, self-hosted Ollama on a private address                  |
-| IPv6 ULA (`fc00::/7`, RFC 4193)[^4]      | Allow, warn | Same rationale as RFC 1918 for IPv6 networks                              |
-| Link-local (169.254.0.0/16, `fe80::/10`) | Block       | Cloud metadata endpoints[^11][^12] live here; never a legitimate LLM host |
-| RFC 5737 TEST-NET[^5], RFC 2544[^6]      | Block       | Reserved documentation/benchmarking ranges                                |
-| RFC 3849 IPv6 documentation prefix[^8]   | Block       | Reserved documentation range                                              |
-| RFC 6666 IPv6 discard prefix[^9]         | Block       | Reserved                                                                  |
-| Multicast, unspecified (`0.0.0.0`, `::`) | Block       | Not valid HTTP destinations                                               |
-| Public IP / public domain                | Allow, warn | User-written URL is user's threat; same as Redmine                        |
-| `http://` scheme on private address      | Allow, warn | Local LAN; cleartext on loopback/RFC1918 is acceptable                    |
-| Embedded credentials (`user:pass@`)      | Block       | Credentials do not belong in base URLs                                    |
-| Query string / fragment                  | Block       | LLM endpoints are canonical paths                                         |
-| Non-`http`/`https` scheme                | Block       | `file://`, `javascript:`, `ssh://`, `ftp://`, `data:` all rejected        |
+| Address class                            | Policy      | Rationale                                                                         |
+| ---------------------------------------- | ----------- | --------------------------------------------------------------------------------- |
+| Loopback (127.0.0.0/8, ::1)              | Allow, warn | `default_base_url` resolves here after container-alias rewrite                    |
+| RFC 1918 private (IPv4)[^3]              | Allow, warn | LAN LLM servers, self-hosted Ollama on a private address                          |
+| RFC 6598 CGNAT (100.64.0.0/10)[^7]       | Allow, warn | Tailscale / carrier NAT shared address space; functionally equivalent to RFC 1918 |
+| IPv6 ULA (`fc00::/7`, RFC 4193)[^4]      | Allow, warn | Same rationale as RFC 1918 for IPv6 networks                                      |
+| Link-local (169.254.0.0/16, `fe80::/10`) | Block       | Cloud metadata endpoints[^11][^12] live here; never a legitimate LLM host         |
+| RFC 5737 TEST-NET[^5], RFC 2544[^6]      | Block       | Reserved documentation/benchmarking ranges                                        |
+| RFC 3849 IPv6 documentation prefix[^8]   | Block       | Reserved documentation range                                                      |
+| RFC 6666 IPv6 discard prefix[^9]         | Block       | Reserved                                                                          |
+| Multicast, unspecified (`0.0.0.0`, `::`) | Block       | Not valid HTTP destinations                                                       |
+| Public IP / public domain                | Allow, warn | User-written URL is user's threat; same as Redmine                                |
+| `http://` scheme on private address      | Allow, warn | Local LAN; cleartext on loopback/RFC1918 is acceptable                            |
+| Embedded credentials (`user:pass@`)      | Block       | Credentials do not belong in base URLs                                            |
+| Query string / fragment                  | Block       | LLM endpoints are canonical paths                                                 |
+| Non-`http`/`https` scheme                | Block       | `file://`, `javascript:`, `ssh://`, `ftp://`, `data:` all rejected                |
 
 IPv6-mapped IPv4 bypasses (`::ffff:169.254.169.254`) are handled by the underlying `url_validation::validate_url`, which checks `Ipv6Addr::to_ipv4_mapped()` against the same classifier.[^16]
 
@@ -51,7 +52,10 @@ Empty model lists return `Err("empty")` so the UI falls back to the free-text in
 
 **Container-host alias rewrite.** The `host.*.internal` aliases injected into `extra_hosts` (`compose.template.yml`) do not resolve from the Desktop host process — Speedwave does not bundle Docker Desktop, so Docker's /etc/hosts injection does not happen. A new helper `speedwave_runtime::compose::rewrite_container_alias_to_loopback` rewrites `host.docker.internal`, `host.lima.internal`, `host.containers.internal`, `host.speedwave.internal` to `127.0.0.1` before the probe. All four aliases live in a single `CONTAINER_HOST_ALIASES` constant composed from the existing per-platform `LIMA_HOST`, `NERDCTL_LINUX_HOST`, `WSL_HOST`, `CONTAINERS_HOST` named consts — one SSOT.
 
-**Delta vs Redmine policy.** The only difference between `validate_redmine_host_url` (ADR sibling documented at[^18]) and the new `validate_llm_base_url` is loopback: Redmine blocks loopback because a self-hosted Redmine on 127.0.0.1 is an unusual config likely to indicate a mistake; LLM discovery needs loopback because the default base URLs all resolve there. This delta is implemented with a single enum parameter `PrivatePolicy::{BlockLoopback, AllowLoopback}` on the shared helper `url_validation::is_private_on_premise`.
+**Delta vs Redmine policy.** Two differences between `validate_redmine_host_url` (ADR sibling documented at[^18]) and the new `validate_llm_base_url`:
+
+1. **Loopback** — `AllowLoopback` for LLM (default base URLs resolve to 127.0.0.1), `BlockLoopback` for Redmine (a self-hosted Redmine on 127.0.0.1 is an unusual config likely to indicate a mistake). Implemented via `PrivatePolicy::{BlockLoopback, AllowLoopback}` on the shared helper.
+2. **CGNAT (100.64.0.0/10)** — classified as on-premise for **both** paths. Previously the Redmine-local `is_private_on_premise` used `ipv4.is_private()` which covers only RFC 1918, so CGNAT fell through to `validate_url` → `is_private_or_reserved` → rejected. The new shared helper explicitly accepts CGNAT because it is non-routable on the public internet and legitimate for Tailscale-hosted instances.
 
 ## Consequences
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -47,6 +47,7 @@ This directory contains all Architecture Decision Records (ADRs) for Speedwave. 
 | [ADR-038](ADR-038-single-internal-worker-port.md)                      | Single Internal Worker Port                             | Accepted              |
 | [ADR-039](ADR-039-playwright-shared-browser-service.md)                | Playwright Shared Browser Service                       | Accepted              |
 | [ADR-040](ADR-040-remove-litellm-direct-provider-injection.md)         | Remove LiteLLM — Direct Local Provider Injection        | Accepted              |
+| [ADR-041](ADR-041-local-llm-model-discovery.md)                        | Local LLM Model Discovery and SSRF Policy               | Accepted              |
 
 ## Creating a New ADR
 

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -232,6 +232,32 @@ The Desktop app includes two Tauri commands that make HTTP requests to external 
 - No automatic system proxy detection (`default-features = false` in reqwest). Corporate users behind HTTP proxies may see connection timeouts.
 - HTTP cleartext warning logged when `http://` scheme is used (credentials transmitted without encryption).
 
+## LLM Model Discovery Commands
+
+The Desktop app includes a Tauri command `discover_llm_models` that probes a local LLM server during Settings configuration, and a companion validator `validate_llm_base_url` reused by `update_llm_config` (the save path). Both run on the Desktop host process, not inside containers — see ADR-041 for the full threat model.
+
+**SSRF mitigations:**
+
+- Shared validator `validate_llm_base_url` (`desktop/src-tauri/src/llm_cmd.rs`) is called by BOTH the discovery probe and the save path. One policy, two callsites — a future tightening of URL validation reaches both automatically.
+- **Blocked:** link-local / metadata IPs (169.254.0.0/16, fe80::/10, IPv6-mapped variants), RFC 5737 TEST-NET, RFC 2544 benchmarking, RFC 3849 documentation prefix, RFC 6666 discard prefix, multicast, unspecified (0.0.0.0, ::).
+- **Allowed with warning:** loopback (127.0.0.0/8, ::1), RFC 1918 private IPv4, IPv6 ULA (fc00::/7), public IPs, public domains — consistent with the user-input threat model applied to Redmine (self-written URLs are user's own decision).
+- Redirects blocked via `reqwest::redirect::Policy::none()` — `302 Location: http://169.254.169.254/` cannot bypass the classifier.
+- Response body capped at 5 MiB via shared `http_util::read_body_limited` (same helper as Redmine).
+- 5-second request timeout; mid-load models fall back to the free-text input.
+- Case-insensitive `Content-Type` check rejects `text/html` responses (user pointed at a non-LLM URL).
+- Fixed endpoints per provider (`/api/tags` for Ollama, `/v1/models` for OpenAI-compatible servers) — never arbitrary paths.
+- Response shape validated via typed deserialization (`OllamaTagsResponse`, `OpenAIModelsResponse`) — non-matching JSON rejected.
+- No cookies, no auth headers, custom `User-Agent` header.
+
+**Policy divergence from Redmine:** both commands share 95% of the policy. Redmine blocks loopback (`PrivatePolicy::BlockLoopback`) because a self-hosted Redmine on 127.0.0.1 is unusual and likely a misconfiguration. LLM discovery allows loopback (`PrivatePolicy::AllowLoopback`) because `default_base_url` for every local provider resolves to `host.docker.internal` (rewritten to `127.0.0.1` on the host side — see `rewrite_container_alias_to_loopback`). Both policies share a single implementation (`url_validation::is_private_on_premise` with a `PrivatePolicy` parameter) so future IP-classification tightening reaches both.
+
+**Residual risk, documented and accepted** (see ADR-041):
+
+- DNS rebinding — a user-written hostname whose first DNS lookup returns a public IP but subsequent connects return a metadata IP can bypass the validator. Mitigation: probe output is a typed `Vec<String>` rendered as `<option>` text (no pivot); user-initiated only; 5s timeout bounds the race.
+- Save-path public-domain SSRF — analogous to Redmine. User-written URL is user's own threat. If a codepath ever allows URL injection without user consent, this decision must revisit.
+
+**SecurityCheck scope:** Same as Redmine — these commands run on the Desktop host process, outside SecurityCheck's compose validation scope. SSRF protection is implemented directly in the command handlers.
+
 ## Authentication Gate
 
 Claude Code must be authenticated (OAuth or API key) before the app allows

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -48,8 +48,19 @@ The user-level config file stores project definitions, the active project, IDE s
 A `.speedwave.json` file in the project repository root provides repo-level defaults. These are overridden by the user-level config:
 
 - `claude.env` — environment variables passed to Claude Code inside the container
-- `claude.llm` — LLM provider (`anthropic`, `ollama`, `lmstudio`, `llamacpp`, `custom`), model name, and optional base URL. See [ADR-040](../adr/ADR-040-remove-litellm-direct-provider-injection.md) for provider details.
+- `claude.llm` — LLM provider (`anthropic`, `ollama`, `lmstudio`, `llamacpp`), model name, and optional base URL. See [ADR-040](../adr/ADR-040-remove-litellm-direct-provider-injection.md) for provider details and [ADR-041](../adr/ADR-041-local-llm-model-discovery.md) for model auto-discovery.
 - `integrations` — enable/disable individual integrations per project
+
+### Model auto-discovery (local providers)
+
+When the selected provider is local (`ollama`, `lmstudio`, `llamacpp`) and a `base_url` is configured (or the provider default is reachable), the Settings → LLM Provider panel probes the server for the list of available models and presents them as a `<select>`:
+
+- `ollama` uses `GET /api/tags`.
+- `lmstudio`, `llamacpp` use `GET /v1/models` (OpenAI-compatible).
+- Anthropic is NOT probed — the model list is fixed.
+- If the server is offline or returns an unexpected response, the UI gracefully falls back to a free-text input so you can pre-configure the app before starting your server.
+- A Refresh button re-probes on demand (useful after pulling a new model).
+- The same URL validator runs on Save, rejecting `http://169.254.169.254`, `file://`, `http://user:pass@…`, URLs with query strings/fragments, etc. See [ADR-041](../adr/ADR-041-local-llm-model-discovery.md) for the full SSRF policy.
 
 ## Environment Variables
 

--- a/docs/guides/integrations.md
+++ b/docs/guides/integrations.md
@@ -211,7 +211,7 @@ You can run Claude Code inside Speedwave against a local LLM server instead of A
    > **Important:** Ollama binds to `127.0.0.1` by default. The `claude` container cannot reach the loopback interface — set `OLLAMA_HOST=0.0.0.0` before starting `ollama serve`.
 
 2. In Speedwave Settings → LLM Provider → select **Ollama**
-3. Set **Model** to the model you pulled (e.g. `llama3.3`)
+3. The Settings UI fetches the model list from Ollama's `/api/tags` endpoint and pre-selects one automatically. You only need to type the model name manually if the Ollama server is offline when you open Settings.
 4. Leave **Base URL** empty to use the default (`http://host.docker.internal:11434`)
 5. Restart containers
 
@@ -228,9 +228,9 @@ You can run Claude Code inside Speedwave against a local LLM server instead of A
 2. Select **llama.cpp** in Settings → LLM Provider
 3. Default port: `http://host.docker.internal:8080`
 
-### Custom endpoint
+### Non-standard addresses
 
-Select **Custom endpoint** if your LLM server is at a non-standard address (e.g. another machine on your LAN at `http://192.168.1.100:11434`). Enter the full URL including port in the **Base URL** field. The URL must use `http://` or `https://` and must not include a path.
+The `custom` provider no longer exists. If your LLM server is at a non-standard address (e.g. another machine on your LAN at `http://192.168.1.100:11434`), pick the closest matching provider (Ollama, LM Studio, or llama.cpp) and override the **Base URL** field to point at your server. The URL must use `http://` or `https://` and must not include a path.
 
 ## See Also
 
@@ -239,3 +239,4 @@ Select **Custom endpoint** if your LLM server is at a non-standard address (e.g.
 - [ADR-015: Plugin System](../adr/ADR-015-plugin-system.md)
 - [ADR-036: Self-Declaring Worker Policy](../adr/ADR-036-self-declaring-worker-policy.md)
 - [ADR-040: Remove LiteLLM — Direct Local Provider Injection](../adr/ADR-040-remove-litellm-direct-provider-injection.md)
+- [ADR-041: Local LLM Model Discovery and SSRF Policy](../adr/ADR-041-local-llm-model-discovery.md)

--- a/mcp-servers/package-lock.json
+++ b/mcp-servers/package-lock.json
@@ -18,7 +18,7 @@
     },
     "gitlab": {
       "name": "@speedwave/mcp-gitlab",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@gitbeaker/rest": "^43.8.0",
@@ -42,7 +42,7 @@
     },
     "hub": {
       "name": "@speedwave/mcp-hub",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@speedwave/mcp-shared": "file:../shared",
@@ -4433,7 +4433,7 @@
     },
     "os": {
       "name": "@speedwave/mcp-os",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@speedwave/mcp-shared": "file:../shared"
@@ -4456,7 +4456,7 @@
     },
     "redmine": {
       "name": "@speedwave/mcp-redmine",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@speedwave/mcp-shared": "file:../shared",
@@ -4479,7 +4479,7 @@
     },
     "shared": {
       "name": "@speedwave/mcp-shared",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "express": "^5.1.0"
@@ -4502,7 +4502,7 @@
     },
     "sharepoint": {
       "name": "@speedwave/mcp-sharepoint",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@speedwave/mcp-shared": "file:../shared",
@@ -4525,7 +4525,7 @@
     },
     "slack": {
       "name": "@speedwave/mcp-slack",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@slack/web-api": "^7.0.0",

--- a/mcp-servers/playwright/Containerfile
+++ b/mcp-servers/playwright/Containerfile
@@ -72,8 +72,22 @@ EXPOSE 3000
 #                        home directory for the browser cache, which the
 #                        hardened compose profile (read_only rootfs) makes
 #                        impossible.
-# --allowed-hosts mcp-hub: restrict to hub hostname. Other containers on the
-#                        compose network cannot call Playwright directly.
+# --allowed-hosts "*":   disable playwright-mcp's Host-header check.
+#                        This flag is designed against DNS rebinding on
+#                        loopback-bound dev servers — irrelevant here:
+#                        (a) the container has no published ports
+#                            (enforced by check_no_ports_on_workers in
+#                            compose.rs — built-in workers cannot expose
+#                            ports), so no browser can reach us;
+#                        (b) any container already on the compose network
+#                            can set an arbitrary Host header and bypass
+#                            the check in one line — it does not
+#                            authenticate the caller.
+#                        Real isolation comes from the compose network +
+#                        cap_drop:ALL + read-only rootfs, not from this
+#                        string match. Pinning to a specific hostname just
+#                        breaks the Hub's legitimate calls (fetch sets
+#                        Host: mcp-playwright:3000, not the caller's name).
 # --headless:            no display server inside the container.
 # --no-sandbox:          required because the container drops all capabilities;
 #                        the VM + container hardening layer takes over
@@ -106,6 +120,6 @@ CMD ["/usr/bin/playwright-mcp", \
      "--executable-path", "/ms-playwright/chromium_headless_shell-1217/chrome-linux/headless_shell", \
      "--user-data-dir", "/tmp/playwright-mcp-userdata", \
      "--output-dir", "/tmp/playwright-mcp-output", \
-     "--allowed-hosts", "mcp-hub", \
+     "--allowed-hosts", "*", \
      "--headless", \
      "--no-sandbox"]


### PR DESCRIPTION
## Summary

- Adds automatic LLM model discovery for Ollama, LM Studio, and llama.cpp — Settings fetches `/api/tags` or `/v1/models` from the configured base URL and presents a `<select>` of available models instead of a free-text input.
- Introduces SSRF policy (`validate_llm_base_url`) applied on BOTH discover and save paths; blocks link-local/metadata IPs, rejects embedded credentials/query/fragment, warns on public/cleartext HTTP. Auto-probe on Settings open is gated to hardcoded defaults only — user-supplied URLs require explicit Refresh/blur.
- Removes the `custom` provider (replaced by per-provider Base URL override); injects `--system-prompt-file` + `--model` CLI flags for local providers so Claude Code's `/model` picker matches Settings; `check_claude_auth` skips Anthropic OAuth for local providers.

## What changed

**Security / SSRF**
- New `validate_llm_base_url` with `PrivatePolicy::{BlockLoopback, AllowLoopback}` consolidating Redmine + LLM on-premise classification
- CGNAT (RFC 6598) accepted as on-premise (Tailscale / mesh VPN use case)
- `Policy::none()` on HTTP client + 5 MiB body cap via shared `http_util::read_body_limited`
- `rewrite_container_alias_to_loopback` moved to `desktop/src-tauri/src/http_util.rs` (topological SSOT — can't be called from runtime/container paths)

**UX**
- DiscoveryState discriminated union (`idle | in-flight | ready | failed`) with monotonic counter for stale-response discard
- Per-provider base URL session cache preserves user input across provider switches
- Auto-select first discovered model when stale/missing
- Failure message distinguishes offline / unsupported / empty reasons

**Docs**
- ADR-041 (new): local LLM model discovery + SSRF threat model
- ADR-040 extended: `--system-prompt-file`/`--model` flag injection, `check_claude_auth` bypass
- ADR-011, `integrations.md`, `configuration.md`, `security.md` — updated for provider schema + model auto-discovery

## Test plan
- [x] `make check` — clippy, fmt, ESLint all green
- [x] `make test` — 932 desktop + 896 runtime Rust tests + Angular suite (+94 new tests: parsers, URL validation branch coverage, mockito integration for Ollama/LM Studio/llama.cpp, CGNAT, localhost hostname, flag injection, SaveConfig fallback, DiscoveryState reason categories, SSRF regression)
- [x] Manual UI smoke: Ollama → dropdown pre-selects model; llama.cpp Tailscale `100.64.x.x` works; offline server shows failure message; Settings → Chat visible without Anthropic login