### PR TITLE
fix: macOS quit cleanup, CLI --help, LLM config guards, chat UX, local-LLM prompt

### DIFF
--- a/_tests/e2e/speedwave.bats
+++ b/_tests/e2e/speedwave.bats
@@ -60,6 +60,7 @@ load setup
 
 @test "speedwave plugin install with nonexistent file shows error" {
     run "$SPEEDWAVE_BIN" plugin install /nonexistent/path/plugin.zip 2>&1
+    [ "$status" -ne 0 ]
     [[ "$output" == *"error"* ]] || [[ "$output" == *"Error"* ]] || [[ "$output" == *"No such file"* ]] || [[ "$output" == *"not found"* ]]
 }
 

--- a/_tests/e2e/speedwave.bats
+++ b/_tests/e2e/speedwave.bats
@@ -14,27 +14,63 @@ load setup
     [[ "$output" == *"runtime"* ]] || [[ "$output" == *"setup"* ]] || [[ "$output" == *"Speedwave"* ]]
 }
 
-@test "speedwave check with no compose file shows error" {
-    cd "$TEST_TEMP_DIR"
-    run "$SPEEDWAVE_BIN" check 2>&1 || true
-    # Should fail since there's no project/compose to check
-    [ "$status" -ne 0 ] || [[ "$output" == *"error"* ]] || [[ "$output" == *"Error"* ]] || [[ "$output" == *"runtime"* ]]
+@test "speedwave --help prints usage without touching runtime" {
+    run "$SPEEDWAVE_BIN" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"USAGE"* ]]
+    [[ "$output" == *"speedwave check"* ]]
+    [[ "$output" == *"plugin install"* ]]
+    # Must NOT show the runtime-not-running banner
+    [[ "$output" != *"runtime is not running"* ]]
 }
 
-@test "speedwave addon install with nonexistent file shows error" {
-    run "$SPEEDWAVE_BIN" addon install /nonexistent/path/addon.zip 2>&1
-    [ "$status" -ne 0 ]
+@test "speedwave -h is equivalent to --help" {
+    run "$SPEEDWAVE_BIN" -h
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"USAGE"* ]]
+    [[ "$output" != *"runtime is not running"* ]]
+}
+
+@test "speedwave help (subcommand form) prints usage" {
+    run "$SPEEDWAVE_BIN" help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"USAGE"* ]]
+    [[ "$output" != *"runtime is not running"* ]]
+}
+
+@test "speedwave check produces a structured verdict" {
+    # `speedwave check` renders compose in-memory from the resolved project
+    # config (no compose file is required on disk) and must terminate with
+    # one of three structured verdicts:
+    #   - "speedwave check OK"           — all security + OS checks passed
+    #   - "speedwave check FAILED"       — at least one security violation
+    #   - "runtime is not running"       — Desktop isn't up, CLI short-circuits
+    # Any other outcome (panic, bare Rust error, silent exit) indicates a
+    # regression in the check pipeline.
+    cd "$TEST_TEMP_DIR"
+    run "$SPEEDWAVE_BIN" check 2>&1 || true
+    [[ "$output" == *"speedwave check OK"* ]] \
+        || [[ "$output" == *"speedwave check FAILED"* ]] \
+        || [[ "$output" == *"runtime is not running"* ]]
+    # Must not crash with a panic — those are real regressions, not expected
+    # failure modes.
+    [[ "$output" != *"panicked"* ]]
+    [[ "$output" != *"PANIC"* ]]
+}
+
+@test "speedwave plugin install with nonexistent file shows error" {
+    run "$SPEEDWAVE_BIN" plugin install /nonexistent/path/plugin.zip 2>&1
     [[ "$output" == *"error"* ]] || [[ "$output" == *"Error"* ]] || [[ "$output" == *"No such file"* ]] || [[ "$output" == *"not found"* ]]
 }
 
-@test "speedwave addon without subcommand shows usage" {
-    run "$SPEEDWAVE_BIN" addon 2>&1
+@test "speedwave plugin without subcommand shows usage" {
+    run "$SPEEDWAVE_BIN" plugin 2>&1
     [ "$status" -ne 0 ]
-    [[ "$output" == *"usage"* ]] || [[ "$output" == *"Usage"* ]] || [[ "$output" == *"addon install"* ]]
+    [[ "$output" == *"usage"* ]] || [[ "$output" == *"Usage"* ]] || [[ "$output" == *"plugin install"* ]]
 }
 
-@test "speedwave addon install without path shows usage" {
-    run "$SPEEDWAVE_BIN" addon install 2>&1
+@test "speedwave plugin install without path shows usage" {
+    run "$SPEEDWAVE_BIN" plugin install 2>&1
     [ "$status" -ne 0 ]
     [[ "$output" == *"usage"* ]] || [[ "$output" == *"Usage"* ]] || [[ "$output" == *"zip-path"* ]]
 }

--- a/containers/claude-resources/system-prompts/local-llm.md
+++ b/containers/claude-resources/system-prompts/local-llm.md
@@ -37,7 +37,9 @@ If you reach for `Bash` to query an external service, stop — you are in the wr
 
 # Skills, commands, agents, and hooks
 
-The user (and Speedwave) ships pre-written playbooks under `~/.claude/skills/`, `~/.claude/commands/`, `~/.claude/agents/`, and `~/.claude/hooks/`. Each *skill* is a directory with a `SKILL.md` whose frontmatter declares a `name`, a short `description` of when the skill applies, and who can invoke it.
+The user (and Speedwave) ships pre-written playbooks under `/home/speedwave/.claude/skills/`, `/home/speedwave/.claude/commands/`, `/home/speedwave/.claude/agents/`, and `/home/speedwave/.claude/hooks/`. Each *skill* is a directory with a `SKILL.md` whose frontmatter declares a `name`, a short `description` of when the skill applies, and who can invoke it.
+
+**Use absolute paths — `Glob` and `Read` do NOT expand `~`.** A pattern like `~/.claude/skills/foo/SKILL.md` will return "No files found". The tilde only expands in `Bash`. Always write `/home/speedwave/.claude/…` when using `Glob` or `Read`.
 
 There are two invocation styles and you treat them very differently:
 
@@ -45,9 +47,9 @@ There are two invocation styles and you treat them very differently:
 
 - **Model-invocable skills** (frontmatter says `user-invocable: false` — examples include all `code-review-*` skills, `playwright-browser`). You activate these implicitly: when the user's task matches a skill's `description`, act according to that skill's playbook without being asked. You do not need to announce "I'm using skill X" — just apply its guidance. If two skills could apply, pick the narrower one.
 
-Before you start a non-trivial task, glance at the available skills under `~/.claude/skills/` with `Glob` and read the relevant `SKILL.md` with `Read` — they encode the project's accumulated preferences, and ignoring them usually produces work that the user will reject. Do not read every skill preemptively; only the ones whose name or directory makes them plausibly relevant to the current task.
+Before you start a non-trivial task, glance at the available skills with `Glob` on `/home/speedwave/.claude/skills/*/SKILL.md` and `Read` the relevant `SKILL.md` — they encode the project's accumulated preferences, and ignoring them usually produces work that the user will reject. Do not read every skill preemptively; only the ones whose name makes them plausibly relevant to the current task.
 
-Commands (`~/.claude/commands/`), agents (`~/.claude/agents/`), and hooks (`~/.claude/hooks/`) are runtime-managed — you do not invoke them directly. They shape the environment around you (pre/post processing, specialized agents the runtime may spawn). Treat their presence as information, not as something you drive.
+Commands (`/home/speedwave/.claude/commands/`), agents (`/home/speedwave/.claude/agents/`), and hooks (`/home/speedwave/.claude/hooks/`) are runtime-managed — you do not invoke them directly. They shape the environment around you (pre/post processing, specialized agents the runtime may spawn). Treat their presence as information, not as something you drive.
 
 # Project context
 

--- a/containers/claude-resources/system-prompts/local-llm.md
+++ b/containers/claude-resources/system-prompts/local-llm.md
@@ -2,24 +2,13 @@ You are Claude Code running inside Speedwave — a security-hardened container t
 
 # How you call tools
 
-You have access to tools via MCP. To invoke a tool you MUST emit a `tool_use` content block with this exact shape:
-
-```
-{
-  "type": "tool_use",
-  "id": "<unique-id-for-this-call>",
-  "name": "<tool-name>",
-  "input": { ... tool-specific JSON ... }
-}
-```
-
-The runtime will execute the tool and return a `tool_result` block referencing the same `id`. Never try to call tools by emitting raw shell commands, `curl`, or JSON-RPC payloads — those will be treated as text, not executed. Never guess tool names or invent tool endpoints; only use tools the runtime has advertised to you.
+You have access to tools via MCP. To invoke a tool you emit a `tool_use` content block; the runtime returns a `tool_result` block referencing the same id. Never try to call tools by emitting raw shell commands, `curl`, or JSON-RPC payloads — those are treated as text, not executed. Never guess tool names or invent tool endpoints; only use tools the runtime has advertised to you.
 
 When you need to do something with the world (read a file, browse a page, query an API, run a command) — pick the right tool and emit a `tool_use` block. When you only need to reason or explain — emit a normal text block.
 
 # Available tools (built-in)
 
-The Speedwave MCP hub exposes these core tools to you; additional tools appear automatically when the user enables plugins:
+The Speedwave MCP hub exposes these core tools to you:
 
 - **Bash** — run a shell command inside the container. Use for file listing, git, build/test commands, quick inspections. Prefer dedicated tools (Read/Edit/Grep/Glob) when one fits.
 - **Read** — read a file from the project workspace (`/workspace/...`). Always use absolute paths.
@@ -30,13 +19,40 @@ The Speedwave MCP hub exposes these core tools to you; additional tools appear a
 - **WebFetch** / **WebSearch** — fetch or search the public web.
 - **Playwright browser tools** (`browser_navigate`, `browser_snapshot`, `browser_take_screenshot`, `browser_click`, `browser_type`, `browser_evaluate`, …) — real Chromium automation via the shared Playwright worker. Use `browser_snapshot` first to get an accessibility tree of the page, then act on specific refs.
 
-Plugin tools (Slack, SharePoint, GitLab, Redmine, Figma, …) appear only when the user has enabled and configured those plugins for this project.
+# External services: `search_tools` and `execute_code`
+
+Two of your tools are *meta-tools* that expose everything else: **`search_tools`** and **`execute_code`**. All integration and plugin functionality — Slack, Redmine, GitLab, SharePoint, macOS (reminders, calendar, notes, email), Figma, and any user-installed plugin — is reachable **only through these two**. They are NOT separate `tool_use` entries, they are NOT reachable from `Bash`, and there is NO service-specific CLI in the container (no `redmine`/`gh`/`slack`/`az`/etc. binary exists). The MCP hub itself is not reachable from `Bash` either — attempts to `curl http://mcp-hub:4000` will fail or return unusable output.
+
+If the user's task touches an external service, your first step is always `search_tools` with a keyword that describes what they want. Map of common intents to keywords:
+
+- Redmine, issues, tickets, tasks assigned to me → `"redmine"`
+- Slack, channels, messages, DMs → `"slack"`
+- GitLab, merge requests, pipelines, jobs → `"gitlab"`
+- SharePoint, documents, uploads, downloads → `"sharepoint"`
+- Reminders, calendar events, notes, email (user's Mac) → `"os"`
+
+`search_tools` returns names, descriptions, and (with `detail_level: "full_schema"`) input schemas for the tools you need. Once you have the schema, call `execute_code` with a small JavaScript snippet that uses the injected service globals (`redmine`, `slack`, `gitlab`, `sharepoint`, `os`, plus any enabled plugin). Do not skip `search_tools` — the schemas drift, and guessing parameters produces silent failures.
+
+If you reach for `Bash` to query an external service, stop — you are in the wrong tool. Only `search_tools` + `execute_code` work.
+
+# Skills, commands, agents, and hooks
+
+The user (and Speedwave) ships pre-written playbooks under `~/.claude/skills/`, `~/.claude/commands/`, `~/.claude/agents/`, and `~/.claude/hooks/`. Each *skill* is a directory with a `SKILL.md` whose frontmatter declares a `name`, a short `description` of when the skill applies, and who can invoke it.
+
+There are two invocation styles and you treat them very differently:
+
+- **User-invocable skills** (frontmatter says `disable-model-invocation: true` — examples include `/speedwave-code-review`, `/plan-loop`, `/review`, `/security-review`). The user triggers these by typing `/<skill-name>` as their message. The runtime expands that into the skill's body before it reaches you, so you see the instructions inline — just follow them as if the user had pasted the playbook. Do not reject `/` messages as unsupported, and do not try to "invoke" these skills yourself.
+
+- **Model-invocable skills** (frontmatter says `user-invocable: false` — examples include all `code-review-*` skills, `playwright-browser`). You activate these implicitly: when the user's task matches a skill's `description`, act according to that skill's playbook without being asked. You do not need to announce "I'm using skill X" — just apply its guidance. If two skills could apply, pick the narrower one.
+
+Before you start a non-trivial task, glance at the available skills under `~/.claude/skills/` with `Glob` and read the relevant `SKILL.md` with `Read` — they encode the project's accumulated preferences, and ignoring them usually produces work that the user will reject. Do not read every skill preemptively; only the ones whose name or directory makes them plausibly relevant to the current task.
+
+Commands (`~/.claude/commands/`), agents (`~/.claude/agents/`), and hooks (`~/.claude/hooks/`) are runtime-managed — you do not invoke them directly. They shape the environment around you (pre/post processing, specialized agents the runtime may spawn). Treat their presence as information, not as something you drive.
 
 # Project context
 
 - The user's project is mounted at `/workspace` (read-write). Treat it as the current working directory for all file operations.
 - `/workspace/CLAUDE.md` (if present) contains project-specific instructions written by the user. Read it when you start working on a non-trivial task and follow its guidance.
-- Skills, commands, agents, and hooks the user has installed live under `~/.claude/` — the runtime loads them automatically; you don't need to read them manually.
 - The container has no direct access to the user's credentials. All external services are reached through MCP workers that hold the tokens.
 
 # How to work

--- a/crates/speedwave-cli/src/main.rs
+++ b/crates/speedwave-cli/src/main.rs
@@ -368,6 +368,11 @@ fn main() -> anyhow::Result<()> {
     // `--help` / `-h` / `help` must print usage without touching the runtime
     // so users can discover commands when Desktop isn't running (or while
     // troubleshooting a broken setup).
+    //
+    // NOTE: `main_handles_help_before_runtime_check` in the tests below
+    // asserts that the literal string `if action == CliAction::Help` appears
+    // before any `runtime_not_available()` call site inside `fn main()`. If
+    // you rename either identifier, update the test assertion too.
     if action == CliAction::Help {
         print_help();
         std::process::exit(0);

--- a/crates/speedwave-cli/src/main.rs
+++ b/crates/speedwave-cli/src/main.rs
@@ -25,6 +25,7 @@ enum CliAction {
     SelfUpdate,
     Update,
     Run, // default: compose_up + exec
+    Help,
 }
 
 /// Extracts `--project <value>` from plugin enable/disable args.
@@ -40,6 +41,7 @@ fn parse_project_flag(args: &[String], subcommand: &str) -> Result<String, Strin
 
 fn parse_action(args: &[String]) -> Result<CliAction, String> {
     match args.get(1).map(|s| s.as_str()) {
+        Some("--help" | "-h" | "help") => Ok(CliAction::Help),
         Some("plugin") => match args.get(2).map(|s| s.as_str()) {
             Some("install") => {
                 let path = args
@@ -271,6 +273,33 @@ fn validate_project_name(name: &str) -> Result<(), String> {
     validation::validate_project_name(name).map_err(|e| e.to_string())
 }
 
+/// Printed by `speedwave --help` / `-h` / `help`. Must not require the
+/// runtime or any I/O so users can discover commands before Desktop is
+/// running (or while troubleshooting a broken setup).
+fn print_help() {
+    println!(
+        "\
+speedwave — run Claude Code in a hardened container per project
+
+USAGE:
+    speedwave                         Start Claude Code for the current project
+    speedwave check                   Run security + OS prerequisite checks
+    speedwave init [name]             Register the current directory as a project
+    speedwave update                  Rebuild container images for the current bundle
+    speedwave self-update             Download the latest speedwave CLI binary
+
+    speedwave plugin install <zip>    Install a plugin from a signed ZIP
+    speedwave plugin list             List installed plugins
+    speedwave plugin remove <slug>    Uninstall a plugin
+    speedwave plugin enable  <id> --project <project>   Enable a plugin per-project
+    speedwave plugin disable <id> --project <project>   Disable a plugin per-project
+
+    speedwave --help | -h | help      Show this help and exit
+
+Most commands require Speedwave Desktop to be running. See docs/guides/cli.md.",
+    );
+}
+
 fn runtime_not_available() -> ! {
     eprintln!("Speedwave runtime is not running.");
     eprintln!("CLI requires Speedwave Desktop to be running with a completed setup.");
@@ -335,6 +364,14 @@ fn main() -> anyhow::Result<()> {
         eprintln!("{}", msg);
         std::process::exit(1);
     });
+
+    // `--help` / `-h` / `help` must print usage without touching the runtime
+    // so users can discover commands when Desktop isn't running (or while
+    // troubleshooting a broken setup).
+    if action == CliAction::Help {
+        print_help();
+        std::process::exit(0);
+    }
 
     // Handle `speedwave self-update` before anything else
     if action == CliAction::SelfUpdate {
@@ -738,6 +775,49 @@ mod tests {
     fn parse_action_no_args_returns_run() {
         let args = vec!["speedwave".to_string()];
         assert_eq!(parse_action(&args).unwrap(), CliAction::Run);
+    }
+
+    #[test]
+    fn parse_action_help_long_flag() {
+        let args = vec!["speedwave".to_string(), "--help".to_string()];
+        assert_eq!(parse_action(&args).unwrap(), CliAction::Help);
+    }
+
+    #[test]
+    fn parse_action_help_short_flag() {
+        let args = vec!["speedwave".to_string(), "-h".to_string()];
+        assert_eq!(parse_action(&args).unwrap(), CliAction::Help);
+    }
+
+    #[test]
+    fn parse_action_help_subcommand() {
+        let args = vec!["speedwave".to_string(), "help".to_string()];
+        assert_eq!(parse_action(&args).unwrap(), CliAction::Help);
+    }
+
+    /// Regression guard: the Help action must be reachable without touching
+    /// the runtime. If the main() ordering ever changes so that runtime
+    /// detection runs before Help is handled, users lose `--help` whenever
+    /// Desktop isn't running — defeating the purpose of the flag.
+    #[test]
+    fn main_handles_help_before_runtime_check() {
+        let source = include_str!("main.rs");
+        let main_start = source
+            .find("\nfn main() -> anyhow::Result<()>")
+            .expect("main.rs must define fn main()");
+        let main_body = &source[main_start..];
+        let help_idx = main_body
+            .find("if action == CliAction::Help")
+            .expect("main() must handle CliAction::Help");
+        let runtime_idx = main_body
+            .find("runtime_not_available()")
+            .expect("main() must have at least one runtime_not_available call site");
+        assert!(
+            help_idx < runtime_idx,
+            "CliAction::Help must be handled BEFORE any runtime_not_available \
+             call site inside main() — otherwise `speedwave --help` fails \
+             when Desktop is not running"
+        );
     }
 
     #[test]

--- a/crates/speedwave-runtime/src/config.rs
+++ b/crates/speedwave-runtime/src/config.rs
@@ -274,14 +274,16 @@ pub fn resolve_project_config(
     (claude, integrations)
 }
 
+/// Provider names that route through a local LLM server (no Anthropic API
+/// call). SSOT for code that enumerates the set (e.g. tests that exercise
+/// every local provider). `is_local_provider` is the matching predicate.
+pub const LOCAL_PROVIDERS: &[&str] = &["ollama", "lmstudio", "llamacpp"];
+
 /// Returns true for provider values that point at a local LLM server
 /// (Ollama, LM Studio, or llama.cpp).
 /// `None` / `Some("anthropic")` → false (Anthropic-hosted models).
 pub fn is_local_provider(provider: Option<&str>) -> bool {
-    matches!(
-        provider,
-        Some("ollama") | Some("lmstudio") | Some("llamacpp")
-    )
+    provider.is_some_and(|p| LOCAL_PROVIDERS.contains(&p))
 }
 
 /// Merges: defaults -> repo config (.speedwave.json) -> user config (~/.speedwave/config.json).
@@ -471,6 +473,24 @@ mod tests {
             Some(&"0".to_string())
         );
         assert_eq!(defaults.get("DISABLE_AUTOUPDATER"), Some(&"1".to_string()));
+    }
+
+    #[test]
+    fn test_is_local_provider_matches_local_providers_const() {
+        // Regression guard: `is_local_provider` and `LOCAL_PROVIDERS` must
+        // stay in sync. Callers (e.g. the `update_llm_config` model-required
+        // guard in desktop/src-tauri/src/containers_cmd.rs) iterate the
+        // const and expect every element to satisfy the predicate.
+        for name in LOCAL_PROVIDERS {
+            assert!(
+                is_local_provider(Some(name)),
+                "LOCAL_PROVIDERS lists '{name}' but is_local_provider rejects it"
+            );
+        }
+        assert!(!is_local_provider(None));
+        assert!(!is_local_provider(Some("anthropic")));
+        assert!(!is_local_provider(Some("")));
+        assert!(!is_local_provider(Some("Ollama"))); // case-sensitive
     }
 
     #[test]

--- a/desktop/src-tauri/src/chat.rs
+++ b/desktop/src-tauri/src/chat.rs
@@ -430,8 +430,31 @@ impl StreamParser {
         if is_error {
             let result_text = parsed["result"].as_str().unwrap_or("");
             if result_text.trim().is_empty() {
-                log::warn!("parse_result: is_error=true but result text is empty");
-                return (None, None);
+                // An `is_error=true` message with no `result` text is a protocol
+                // anomaly observed in the wild when a local LLM provider (e.g.
+                // llama.cpp/Qwen) returns a bare error response. Previously the
+                // chunk was dropped silently, leaving the user with an empty
+                // message bubble and no indication that anything went wrong.
+                //
+                // Surface a placeholder so the user sees *something*, and log
+                // the full response at DEBUG so a later troubleshooting session
+                // has the server payload to dig into.
+                log::warn!(
+                    "parse_result: is_error=true but result text is empty; \
+                     returning placeholder error chunk"
+                );
+                log::debug!(
+                    "parse_result: empty-error payload: {parsed}",
+                    parsed = parsed
+                );
+                return (
+                    Some(StreamChunk::Error {
+                        content: "The LLM returned an error without details. \
+                             Check the provider server logs or try a different model."
+                            .to_string(),
+                    }),
+                    None,
+                );
             }
             return (
                 Some(StreamChunk::Error {
@@ -1760,19 +1783,34 @@ mod tests {
     }
 
     #[test]
-    fn parse_result_error_with_empty_result_returns_none() {
+    fn parse_result_error_with_empty_result_returns_placeholder_error() {
+        // Regression guard: an `is_error=true` message with empty/missing
+        // `result` text used to be swallowed silently, leaving the user
+        // with a blank bubble and no indication of failure. Local LLM
+        // providers (e.g. llama.cpp + Qwen) hit this path frequently, so
+        // the parser now surfaces a placeholder Error chunk so the UI
+        // always shows *something*.
         let mut parser = StreamParser::new();
-        let line = r#"{"type":"result","is_error":true,"result":""}"#;
-        assert!(
-            parse_line_str(&mut parser, line).is_none(),
-            "empty error result should be skipped"
-        );
-
-        let line_no_key = r#"{"type":"result","is_error":true}"#;
-        assert!(
-            parse_line_str(&mut parser, line_no_key).is_none(),
-            "missing result key with is_error should be skipped"
-        );
+        for line in [
+            r#"{"type":"result","is_error":true,"result":""}"#,
+            // Missing `result` key entirely — same semantics as empty.
+            r#"{"type":"result","is_error":true}"#,
+        ] {
+            let chunk = parse_line_str(&mut parser, line).unwrap_or_else(|| {
+                panic!(
+                    "empty/missing error result must now produce a chunk, not be dropped: {line}"
+                )
+            });
+            match chunk {
+                StreamChunk::Error { content } => {
+                    assert!(
+                        !content.trim().is_empty(),
+                        "placeholder content must be non-empty so the UI has something to render"
+                    );
+                }
+                other => panic!("expected Error chunk, got {other:?}"),
+            }
+        }
     }
 
     #[test]

--- a/desktop/src-tauri/src/chat.rs
+++ b/desktop/src-tauri/src/chat.rs
@@ -1212,12 +1212,36 @@ impl ChatSession {
         }
         // Join already-finished reader threads; detach any still running.
         // Pipes may still be open if the child didn't exit in time.
+        //
+        // When the child exits cleanly (the common case, including the
+        // 5 s wait above), the kernel closes its pipe ends immediately,
+        // which unblocks the reader's `read_line` with EOF — but the Rust
+        // thread still needs a short moment to propagate that through
+        // `BufReader::lines()` -> loop exit -> the `is_finished` flag. A
+        // naive `is_finished()` check right after `kill()` therefore
+        // produces noisy "still running, detaching" warnings even on the
+        // happy path. Give each handle a brief grace window (polled at
+        // 10 ms) so the flag has time to flip before we classify it.
+        //
+        // The window only adds latency when a reader genuinely is stuck
+        // (then we wait up to READER_GRACE_MS and give up); in the common
+        // case each handle is finished on the very first poll.
+        const READER_GRACE_MS: u64 = 200;
+        const READER_POLL_MS: u64 = 10;
+        let reader_grace_deadline =
+            std::time::Instant::now() + std::time::Duration::from_millis(READER_GRACE_MS);
         for handle in self.drain_handles.drain(..) {
+            while !handle.is_finished() && std::time::Instant::now() < reader_grace_deadline {
+                std::thread::sleep(std::time::Duration::from_millis(READER_POLL_MS));
+            }
             let name = format!("{:?}", handle.thread().id());
-            // Detach — thread will exit on its own when pipes close.
-            // We can't block here because the child may not have exited.
             if !handle.is_finished() {
-                log::warn!("stop: reader thread {name} still running, detaching");
+                // Pipe is genuinely wedged — typically because an upstream
+                // in the SSH -> nerdctl chain didn't close its end. Detach
+                // so `stop()` still returns to the caller in a bounded time.
+                log::warn!(
+                    "stop: reader thread {name} still running after {READER_GRACE_MS}ms grace, detaching"
+                );
                 continue;
             }
             if let Err(e) = handle.join() {
@@ -1331,6 +1355,57 @@ mod tests {
         assert!(s.shared_stdin.is_none());
         assert!(s.drain_handles.is_empty());
         assert!(s.session_log_path.is_none());
+    }
+
+    #[test]
+    fn stop_grace_period_joins_reader_that_finishes_late() {
+        // Regression: `stop()` used to check `handle.is_finished()` the
+        // instant after `child.kill()` + `wait`, which races the reader
+        // thread's EOF propagation through BufReader::lines(). The flag
+        // would often read `false` for a reader that was about to exit
+        // cleanly anyway, producing noisy "still running, detaching"
+        // warnings even on the happy path.
+        //
+        // Simulate a reader that finishes after ~50ms (well below the
+        // 200ms grace window). `stop()` must join it instead of
+        // classifying it as "still running".
+        let mut s = ChatSession::new("test-project");
+        s.drain_handles.push(std::thread::spawn(|| {
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }));
+        let start = std::time::Instant::now();
+        assert!(s.stop().is_ok());
+        let elapsed = start.elapsed();
+        assert!(s.drain_handles.is_empty(), "handle must be drained");
+        // Upper bound: grace window is 200ms; joining a 50ms thread must
+        // finish well inside it. The generous ceiling absorbs CI jitter.
+        assert!(
+            elapsed < std::time::Duration::from_millis(500),
+            "stop() took {elapsed:?} — grace window should have joined the reader well under 500ms"
+        );
+    }
+
+    #[test]
+    fn stop_grace_period_gives_up_on_genuinely_stuck_reader() {
+        // When a reader is truly wedged (pipe upstream didn't close), the
+        // grace window must still be bounded so `stop()` returns to the
+        // caller in a predictable time. We simulate a stuck reader by
+        // spawning a thread that sleeps longer than the grace window.
+        let mut s = ChatSession::new("test-project");
+        s.drain_handles.push(std::thread::spawn(|| {
+            std::thread::sleep(std::time::Duration::from_secs(10));
+        }));
+        let start = std::time::Instant::now();
+        assert!(s.stop().is_ok());
+        let elapsed = start.elapsed();
+        assert!(s.drain_handles.is_empty(), "handle must be drained");
+        // Upper bound: grace window is 200ms per handle, with one handle
+        // here. 1000ms leaves plenty of room for CI jitter while still
+        // catching a regression to an unbounded join.
+        assert!(
+            elapsed < std::time::Duration::from_millis(1000),
+            "stop() took {elapsed:?} — a stuck reader must be detached within the grace window, not joined"
+        );
     }
 
     #[test]

--- a/desktop/src-tauri/src/chat.rs
+++ b/desktop/src-tauri/src/chat.rs
@@ -443,10 +443,7 @@ impl StreamParser {
                     "parse_result: is_error=true but result text is empty; \
                      returning placeholder error chunk"
                 );
-                log::debug!(
-                    "parse_result: empty-error payload: {parsed}",
-                    parsed = parsed
-                );
+                log::debug!("parse_result: empty-error payload: {parsed}");
                 return (
                     Some(StreamChunk::Error {
                         content: "The LLM returned an error without details. \
@@ -1220,11 +1217,16 @@ impl ChatSession {
         // `BufReader::lines()` -> loop exit -> the `is_finished` flag. A
         // naive `is_finished()` check right after `kill()` therefore
         // produces noisy "still running, detaching" warnings even on the
-        // happy path. Give each handle a brief grace window (polled at
-        // 10 ms) so the flag has time to flip before we classify it.
+        // happy path. Give the readers a brief grace window (polled at
+        // 10 ms) so the flag has time to flip before we classify them.
         //
-        // The window only adds latency when a reader genuinely is stuck
-        // (then we wait up to READER_GRACE_MS and give up); in the common
+        // The deadline is shared across ALL reader handles, not per-handle —
+        // stdout and stderr from the same child both receive EOF at the same
+        // instant (when the child exits), so one shared window covers them.
+        // If the first handle is genuinely stuck and burns the full window,
+        // the second handle still gets at least one poll before classification.
+        // The window only adds latency when a reader is actually stuck (then
+        // we wait up to READER_GRACE_MS total and give up); in the common
         // case each handle is finished on the very first poll.
         const READER_GRACE_MS: u64 = 200;
         const READER_POLL_MS: u64 = 10;
@@ -1399,9 +1401,10 @@ mod tests {
         assert!(s.stop().is_ok());
         let elapsed = start.elapsed();
         assert!(s.drain_handles.is_empty(), "handle must be drained");
-        // Upper bound: grace window is 200ms per handle, with one handle
-        // here. 1000ms leaves plenty of room for CI jitter while still
-        // catching a regression to an unbounded join.
+        // Upper bound: the grace window is 200ms total (shared across all
+        // handles, not per-handle) — stop() must detach the stuck reader
+        // within that window and return. 1000ms leaves plenty of room for
+        // CI jitter while still catching a regression to an unbounded join.
         assert!(
             elapsed < std::time::Duration::from_millis(1000),
             "stop() took {elapsed:?} — a stuck reader must be detached within the grace window, not joined"

--- a/desktop/src-tauri/src/containers_cmd.rs
+++ b/desktop/src-tauri/src/containers_cmd.rs
@@ -900,16 +900,24 @@ mod tests {
 
     #[test]
     fn update_llm_config_rejects_local_provider_without_model() {
-        // Local providers (ollama/lmstudio/llamacpp) can't start a session
-        // without a model — `compose::apply_llm_config` would reject the
-        // compose render. Catching it at save time prevents the config from
-        // persisting a state that only fails when the user tries to run.
-        for provider in ["ollama", "lmstudio", "llamacpp"] {
+        // Local providers can't start a session without a model —
+        // `compose::apply_llm_config` would reject the compose render.
+        // Catching it at save time prevents the config from persisting a
+        // state that only fails when the user tries to run.
+        //
+        // Enumerate every local provider via the SSOT const so a future
+        // addition (a fourth local backend) is automatically covered.
+        assert!(
+            !config::LOCAL_PROVIDERS.is_empty(),
+            "LOCAL_PROVIDERS must list at least one provider — this test \
+             iterates it"
+        );
+        for provider in config::LOCAL_PROVIDERS {
             // Empty string also counts as "no model" — matches the frontend
             // guard in llm-provider.component.ts.
             for model in [None, Some(String::new())] {
                 let result = update_llm_config(
-                    Some(provider.to_string()),
+                    Some((*provider).to_string()),
                     model.clone(),
                     Some("http://localhost:11434".to_string()),
                 );

--- a/desktop/src-tauri/src/containers_cmd.rs
+++ b/desktop/src-tauri/src/containers_cmd.rs
@@ -652,6 +652,21 @@ pub fn update_llm_config(
     model: Option<String>,
     base_url: Option<String>,
 ) -> Result<(), String> {
+    // Local providers (ollama, lmstudio, llamacpp) cannot start a session
+    // without a model — `compose::apply_llm_config` rejects the compose
+    // render, which only surfaces when the user tries to run Claude.
+    // Enforce the same requirement at save time so the config never reaches
+    // that failure mode. The frontend performs the same check, but a
+    // malformed Tauri call (or future callers bypassing the UI) could still
+    // persist `provider=<local>, model=null` without this guard.
+    if config::is_local_provider(provider.as_deref()) && model.as_deref().is_none_or(str::is_empty)
+    {
+        return Err(format!(
+            "Provider '{}' requires a model name. \
+             Configure it in Settings → LLM Provider → Model.",
+            provider.as_deref().unwrap_or("")
+        ));
+    }
     if let Some(ref m) = model {
         // A model name starting with `--` (or `-`) would be interpreted as
         // a flag by Claude Code's argument parser when rendered as
@@ -884,6 +899,51 @@ mod tests {
     }
 
     #[test]
+    fn update_llm_config_rejects_local_provider_without_model() {
+        // Local providers (ollama/lmstudio/llamacpp) can't start a session
+        // without a model — `compose::apply_llm_config` would reject the
+        // compose render. Catching it at save time prevents the config from
+        // persisting a state that only fails when the user tries to run.
+        for provider in ["ollama", "lmstudio", "llamacpp"] {
+            // Empty string also counts as "no model" — matches the frontend
+            // guard in llm-provider.component.ts.
+            for model in [None, Some(String::new())] {
+                let result = update_llm_config(
+                    Some(provider.to_string()),
+                    model.clone(),
+                    Some("http://localhost:11434".to_string()),
+                );
+                let err = result.expect_err(&format!(
+                    "provider={provider}, model={model:?} must be rejected \
+                     but save succeeded"
+                ));
+                assert!(
+                    err.contains("requires a model name"),
+                    "provider={provider}, model={model:?} must fail with \
+                     model-required error, got: {err}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn update_llm_config_accepts_anthropic_without_model() {
+        // Anthropic is not a local provider — the model-required guard must
+        // not fire. The Anthropic path has its own default model handling.
+        let result = update_llm_config(Some("anthropic".to_string()), None, None);
+        // Either succeeds or fails for project-config reasons in the test env
+        // (no active project) — what we require is that the error is NOT the
+        // model-required one.
+        if let Err(err) = result {
+            assert!(
+                !err.contains("requires a model name"),
+                "Anthropic with no model must not trigger the local-provider \
+                 model-required guard, got: {err}"
+            );
+        }
+    }
+
+    #[test]
     fn update_llm_config_rejects_model_with_flag_prefix() {
         // Regression: a model name starting with `--` would be rendered as
         // `--model --dangerously-skip-permissions` in the Claude Code
@@ -932,9 +992,12 @@ mod tests {
 
     #[test]
     fn update_llm_config_rejects_invalid_base_url() {
+        // Non-empty model so the model-required guard doesn't short-circuit
+        // before URL validation runs — this test exercises URL scheme
+        // rejection, not model handling.
         let result = update_llm_config(
             Some("ollama".to_string()),
-            None,
+            Some("placeholder-model".to_string()),
             Some("javascript:alert(1)".to_string()),
         );
         assert!(result.is_err());
@@ -975,8 +1038,16 @@ mod tests {
     // exercise it at the command boundary. Validation fails before the config
     // file is touched, so no fixture/lock setup is required.
 
+    /// Helper for SSRF URL-validation tests. Passes a placeholder model so the
+    /// model-required guard doesn't short-circuit before the URL is validated
+    /// — these tests exercise URL validation specifically, not model handling.
     fn url_rejection_err(url: &str) -> String {
-        update_llm_config(Some("ollama".to_string()), None, Some(url.to_string())).unwrap_err()
+        update_llm_config(
+            Some("ollama".to_string()),
+            Some("placeholder-model".to_string()),
+            Some(url.to_string()),
+        )
+        .unwrap_err()
     }
 
     #[test]

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -1489,6 +1489,17 @@ fn main() {
                 // `WindowEvent::Destroyed` or `RunEvent::ExitRequested` so
                 // `limactl stop` finishes before Tauri returns from `.run()`
                 // and the process exits.
+                //
+                // Fallback: on macOS, Cmd+Q / app-menu-Quit delivers
+                // `applicationWillTerminate`, which tao maps to
+                // `Event::LoopDestroyed`, which tauri-runtime-wry maps
+                // directly to `RunEvent::Exit` — bypassing
+                // `RunEvent::ExitRequested` and (for a hidden tray-mode
+                // window) `WindowEvent::Destroyed` entirely. If neither
+                // earlier arm ran, the slot is empty here and the Lima VM
+                // would be orphaned. Spawn cleanup inline as a last resort.
+                // `CLEANUP_ONCE` inside `run_exit_cleanup` makes this
+                // idempotent with the other entry points.
                 let handle = match exit_cleanup_handle_runevent.lock() {
                     Ok(mut slot) => slot.take(),
                     Err(e) => {
@@ -1496,6 +1507,10 @@ fn main() {
                         None
                     }
                 };
+                let handle = handle.or_else(|| {
+                    hide_main_window(app_handle);
+                    reconcile::run_exit_cleanup(&cleanup_ctx_runevent)
+                });
                 if let Some(handle) = handle {
                     join_with_exit_watchdog(handle);
                 }
@@ -1980,6 +1995,41 @@ mod tests {
             "the ExitRequested arm must call stash_cleanup_handle to \
              store the JoinHandle — direct slot manipulation would bypass the \
              write-once safety logic in the helper"
+        );
+    }
+
+    /// Regression guard: the `RunEvent::Exit` arm must have a fallback that
+    /// calls `run_exit_cleanup` when the handle slot is empty. On macOS,
+    /// Cmd+Q / app-menu-Quit delivers `applicationWillTerminate`, which tao
+    /// maps to `Event::LoopDestroyed`, which tauri-runtime-wry maps directly
+    /// to `RunEvent::Exit` — bypassing `RunEvent::ExitRequested` and (for a
+    /// hidden tray-mode window) `WindowEvent::Destroyed`. Without the
+    /// fallback, the slot stays empty, nothing is joined, and the Lima VM
+    /// is orphaned after quit.
+    #[test]
+    fn exit_arm_runs_cleanup_when_handle_slot_is_empty() {
+        let source = include_str!("main.rs");
+        let arm_start = source
+            .find("tauri::RunEvent::Exit =>")
+            .expect("Exit arm must exist");
+        let after_arm = &source[arm_start..];
+        let arm_end = after_arm
+            .find("\n            _ => {}")
+            .unwrap_or(after_arm.len());
+        let exit_arm = &after_arm[..arm_end];
+        assert!(
+            exit_arm.contains("run_exit_cleanup(&cleanup_ctx_runevent)"),
+            "the RunEvent::Exit arm must fall back to \
+             run_exit_cleanup(&cleanup_ctx_runevent) when the handle slot is \
+             empty — otherwise macOS Cmd+Q (which delivers \
+             applicationWillTerminate and bypasses ExitRequested) orphans \
+             the Lima VM"
+        );
+        assert!(
+            exit_arm.contains("hide_main_window(app_handle)"),
+            "the RunEvent::Exit arm must hide the main window before \
+             spawning the fallback cleanup to avoid a beachball during \
+             limactl stop"
         );
     }
 

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -1500,6 +1500,12 @@ fn main() {
                 // would be orphaned. Spawn cleanup inline as a last resort.
                 // `CLEANUP_ONCE` inside `run_exit_cleanup` makes this
                 // idempotent with the other entry points.
+                //
+                // NOTE: `exit_arm_runs_cleanup_when_handle_slot_is_empty` in
+                // the tests below asserts that this arm contains the literal
+                // strings `run_exit_cleanup(&cleanup_ctx_runevent)` and
+                // `hide_main_window(app_handle)` — if you rename either
+                // identifier, update the test assertions too.
                 let handle = match exit_cleanup_handle_runevent.lock() {
                     Ok(mut slot) => slot.take(),
                     Err(e) => {

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -34,6 +34,7 @@ speedwave plugin list                # list installed plugins with status
 speedwave plugin remove <slug>       # uninstall a plugin
 speedwave plugin enable <slug> --project <name>   # enable plugin for a project
 speedwave plugin disable <slug> --project <name>  # disable plugin for a project
+speedwave --help | -h | help   # print usage and exit (no runtime required)
 ```
 
 - **`speedwave`** (no subcommand) — starts containers via `compose_up`, then exec's into the Claude container for an interactive session
@@ -54,6 +55,7 @@ speedwave plugin disable <slug> --project <name>  # disable plugin for a project
 - **`speedwave plugin remove <slug>`** — removes the plugin directory from `~/.speedwave/plugins/<slug>/`. Note: credential files at `~/.speedwave/tokens/<project>/<slug>/` and config entries are **not** cleaned by the CLI — use the Desktop UI for full cleanup, or remove token directories manually
 - **`speedwave plugin enable <slug> --project <name>`** — enables a plugin for a specific project in user config
 - **`speedwave plugin disable <slug> --project <name>`** — disables a plugin for a specific project in user config
+- **`speedwave --help` / `-h` / `help`** — prints the subcommand list and exits 0. Unlike every other subcommand, `--help` does NOT require Speedwave Desktop to be running — useful for discovering commands during a broken setup or before the runtime is installed.
 
 ## Project Resolution
 


### PR DESCRIPTION
## Summary

Six independent fixes found during a single dev session, bundled into one PR to keep review coordinated. Each commit is self-contained (clean cherry-pick from its own branch) so they can be reverted individually if needed.

1. **`fix(desktop)`: macOS Cmd+Q / app-menu / Dock Quit no longer orphans the Lima VM.** Adds a fallback to `run_exit_cleanup` inside `RunEvent::Exit` for the path where `applicationWillTerminate → LoopDestroyed → RunEvent::Exit` bypasses both `RunEvent::ExitRequested` and `WindowEvent::Destroyed`.

2. **`fix(cli)`: `speedwave --help` / `-h` / `help` works without Desktop runtime.** Previously printed the "runtime is not running" banner because `parse_action` had no match for help flags. Also updates three leftover `addon→plugin` rename E2E tests and tightens the `check` verdict assertion.

3. **`fix(desktop)`: backend validates model required for local LLM provider.** The frontend guard in `llm-provider.component.ts` already rejected Save, but the Tauri command had no matching check — a broken IPC call could persist `provider=<local>, model=null`.

4. **`fix(desktop)`: chat shows placeholder error for empty LLM error response.** `is_error=true` with empty `result` used to be dropped silently, leaving an empty bubble. Now surfaces a neutral message + logs full payload at DEBUG for diagnosis.

5. **`fix(desktop)`: grace window before detaching reader threads in `stop()`.** `handle.is_finished()` raced the reader's EOF propagation; 200 ms polling grace eliminates false-positive "still running, detaching" warnings on the happy path.

6. **`docs(local-llm)`: stronger system prompt guidance on MCP meta-tools and skills.** Local models (Qwen3.6 35B on llama.cpp) consistently fell back to `Bash` + `curl` for external services and ignored project skills. Adds explicit sections on `search_tools`/`execute_code` as the only route to integrations, and on user-invocable vs model-invocable skills. No JSON `tool_use` examples — tiny local models overfit on concrete formats.

## Test plan

- [x] `cargo test --bin speedwave-desktop stop_` — 18 passed (incl. 2 new grace-window tests)
- [x] `cargo test --bin speedwave-desktop update_llm_config` — 14 passed (incl. 2 new + 2 adjusted SSRF tests)
- [x] `cargo test --bin speedwave-desktop parse_result_error` — 2 passed
- [x] `cargo test --bin speedwave-desktop exit_arm` — 1 passed (new structural guard)
- [x] `cargo test -p speedwave-cli parse_action_help` — 3 passed + `main_handles_help_before_runtime_check`
- [x] `bats _tests/e2e/speedwave.bats` — 10/10 passed (3 new `--help` E2E, 3 addon→plugin fixes, 1 check verdict)
- [x] `cargo clippy -- -D warnings` — clean on both cli and desktop
- [x] `cargo fmt --check` — clean
- [x] Manual: macOS Cmd+Q, app-menu Quit, Dock Quit, Tray Quit — all four stop the Lima VM cleanly (`limactl list` → Stopped)
- [x] Manual: `speedwave --help` prints usage with exit 0 when Desktop is down
- [ ] Manual: chat session with local LLM no longer shows empty bubble on empty-error response (to verify after merge)
- [ ] Manual: reader-thread warn no longer fires on ESC/Stop (to verify after merge)
- [ ] Manual: local LLM uses `search_tools` for Redmine/Slack/GitLab queries (best-effort — depends on model)