### PR TITLE
fix(e2e): assert shell title via aria-label

### DIFF
--- a/desktop/e2e/specs/02-setup-wizard.spec.ts
+++ b/desktop/e2e/specs/02-setup-wizard.spec.ts
@@ -66,7 +66,7 @@ async function waitForStepTerminal(index: number, timeout: number): Promise<stri
         }
         return false;
       },
-      { timeout, timeoutMsg: `Step ${index} did not reach terminal state within ${timeout}ms` },
+      { timeout, timeoutMsg: `Step ${index} did not reach terminal state within ${timeout}ms` }
     );
   } catch (e) {
     // DOM poll timed out — check Tauri state as fallback.
@@ -87,7 +87,9 @@ async function assertStepDone(index: number, timeout: number): Promise<void> {
   const status = await waitForStepTerminal(index, timeout);
   if (status === 'error') {
     const errorBanner = await $('[data-testid="setup-error"]');
-    const errorText = (await errorBanner.isExisting()) ? await errorBanner.getText() : 'unknown error';
+    const errorText = (await errorBanner.isExisting())
+      ? await errorBanner.getText()
+      : 'unknown error';
     throw new Error(`Step ${index} failed: ${errorText}`);
   }
   expect(status).toBe('done');
@@ -118,10 +120,10 @@ describe('Setup Wizard — Full Flow', function () {
     // Use setup-step elements (data-status attribute) rather than nested step-title
     // because msedge WebDriver intermittently fails to resolve child text nodes
     // inside Angular @for loops on Windows.
-    await browser.waitUntil(
-      async () => (await $$('[data-testid="setup-step"]')).length === 6,
-      { timeout: 30_000, timeoutMsg: 'Expected 6 setup steps but not all rendered' },
-    );
+    await browser.waitUntil(async () => (await $$('[data-testid="setup-step"]')).length === 6, {
+      timeout: 30_000,
+      timeoutMsg: 'Expected 6 setup steps but not all rendered',
+    });
     const stepElements = await $$('[data-testid="setup-step"]');
     expect(stepElements.length).toBe(6);
 
@@ -192,10 +194,10 @@ describe('Setup Wizard — Full Flow', function () {
 
     const createBtn = await $('[data-testid="setup-create-project-btn"]');
     // Button should now be enabled
-    await browser.waitUntil(
-      async () => await createBtn.isEnabled(),
-      { timeout: 5_000, timeoutMsg: 'Create Project button did not become enabled' },
-    );
+    await browser.waitUntil(async () => await createBtn.isEnabled(), {
+      timeout: 5_000,
+      timeoutMsg: 'Create Project button did not become enabled',
+    });
 
     await createBtn.click();
 
@@ -230,6 +232,6 @@ describe('Setup Wizard — Full Flow', function () {
 
     const shellTitle = await $('[data-testid="shell-title"]');
     await shellTitle.waitForExist({ timeout: 15_000 });
-    expect((await shellTitle.getText()).trim()).toBe('Speedwave');
+    expect(await shellTitle.getAttribute('aria-label')).toBe('Speedwave');
   });
 });

--- a/desktop/e2e/specs/03-navigation.spec.ts
+++ b/desktop/e2e/specs/03-navigation.spec.ts
@@ -12,14 +12,15 @@ describe('Navigation', function () {
     const shellTitle = await $('[data-testid="shell-title"]');
     await shellTitle.waitForExist({
       timeout: 15_000,
-      timeoutMsg: 'Shell not found — spec 02 (setup wizard) must complete successfully before navigation tests can run',
+      timeoutMsg:
+        'Shell not found — spec 02 (setup wizard) must complete successfully before navigation tests can run',
     });
   });
 
   it('should display Speedwave title in the shell header', async function () {
     this.timeout(15_000);
     const title = await $('[data-testid="shell-title"]');
-    expect((await title.getText()).trim()).toBe('Speedwave');
+    expect(await title.getAttribute('aria-label')).toBe('Speedwave');
   });
 
   it('should have Integrations and Settings nav links (Chat conditional on auth)', async function () {
@@ -51,7 +52,10 @@ describe('Navigation', function () {
         async () =>
           (await $('[data-testid="chat-messages"]').isExisting()) ||
           (await $('[data-testid="chat-status-overlay"]').isExisting()),
-        { timeout: 20_000, timeoutMsg: 'Chat view did not render (neither messages nor status overlay found)' },
+        {
+          timeout: 20_000,
+          timeoutMsg: 'Chat view did not render (neither messages nor status overlay found)',
+        }
       );
     }
   });
@@ -62,7 +66,10 @@ describe('Navigation', function () {
     await integrations.click();
 
     const section = await $('[data-testid="integrations-services"]');
-    await section.waitForExist({ timeout: 10_000, timeoutMsg: 'Integrations services section did not appear after clicking Integrations link' });
+    await section.waitForExist({
+      timeout: 10_000,
+      timeoutMsg: 'Integrations services section did not appear after clicking Integrations link',
+    });
     expect(await section.isDisplayed()).toBe(true);
   });
 
@@ -72,14 +79,20 @@ describe('Navigation', function () {
     await settings.click();
 
     const activeProject = await $('[data-testid="settings-active-project"]');
-    await activeProject.waitForExist({ timeout: 10_000, timeoutMsg: 'Settings active project did not appear after clicking Settings link' });
+    await activeProject.waitForExist({
+      timeout: 10_000,
+      timeoutMsg: 'Settings active project did not appear after clicking Settings link',
+    });
     expect(await activeProject.isDisplayed()).toBe(true);
   });
 
   it('should show project switcher with e2e-test project', async function () {
     this.timeout(15_000);
     const switcher = await $('[data-testid="project-switcher-btn"]');
-    await switcher.waitForExist({ timeout: 5_000, timeoutMsg: 'Project switcher button not found — expected e2e-test project to be active' });
+    await switcher.waitForExist({
+      timeout: 5_000,
+      timeoutMsg: 'Project switcher button not found — expected e2e-test project to be active',
+    });
     const text = await switcher.getText();
     expect(text).toContain('e2e-test');
   });

--- a/desktop/e2e/specs/04-navigation.spec.ts
+++ b/desktop/e2e/specs/04-navigation.spec.ts
@@ -13,7 +13,8 @@ describe('Navigation', function () {
     const shellTitle = await $('[data-testid="shell-title"]');
     await shellTitle.waitForExist({
       timeout: 15_000,
-      timeoutMsg: 'Shell not found — spec 02 (setup wizard) must complete successfully before navigation tests can run',
+      timeoutMsg:
+        'Shell not found — spec 02 (setup wizard) must complete successfully before navigation tests can run',
     });
     // Fail fast if project is in error state — gives a clear message instead
     // of letting every navigation test individually time out.
@@ -37,7 +38,7 @@ describe('Navigation', function () {
   it('should display Speedwave title in the shell header', async function () {
     this.timeout(15_000);
     const title = await $('[data-testid="shell-title"]');
-    expect((await title.getText()).trim()).toBe('Speedwave');
+    expect(await title.getAttribute('aria-label')).toBe('Speedwave');
   });
 
   it('should have Integrations and Settings nav links (Chat conditional on auth)', async function () {


### PR DESCRIPTION
## Summary
- Shell title element no longer has visible text content — assert `aria-label` instead of `getText()` in setup-wizard and navigation specs
- Apply Prettier formatting to the three touched specs

## Test plan
- [ ] `make test-e2e-desktop` passes on macOS