### PR TITLE
feat(runtime): add JSON Patch stream protocol backbone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1001,6 +1023,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "json-patch"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f300e415e2134745ef75f04562dd0145405c2f7fd92065db029ac4b16b57fe90"
+dependencies = [
+ "jsonptr",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "jsonptr"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5a3cc660ba5d72bce0b3bb295bf20847ccbb40fd423f3f05b61273672e561fe"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1021,7 +1065,7 @@ dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -1035,6 +1079,15 @@ name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -1113,6 +1166,29 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.18",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1223,7 +1299,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1244,7 +1320,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1346,6 +1422,15 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
@@ -1361,7 +1446,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1522,6 +1607,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "self-replace"
@@ -1719,11 +1810,15 @@ name = "speedwave-runtime"
 version = "0.8.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "base64",
  "dirs",
  "ed25519-dalek",
  "fs2",
+ "futures-core",
+ "json-patch",
  "log",
+ "parking_lot",
  "rand 0.8.5",
  "regex",
  "semver",
@@ -1732,6 +1827,7 @@ dependencies = [
  "serde_yaml_ng",
  "sha2 0.11.0",
  "tempfile",
+ "tokio",
  "url",
  "uuid",
  "zip 8.5.1",
@@ -1816,11 +1912,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1889,7 +2005,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2690,7 +2818,7 @@ dependencies = [
  "displaydoc",
  "indexmap",
  "memchr",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -2716,7 +2844,7 @@ checksum = "dba6063ff82cdbd9a765add16d369abe81e520f836054e997c2db217ceca40c0"
 dependencies = [
  "base64",
  "ed25519-dalek",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/crates/speedwave-runtime/Cargo.toml
+++ b/crates/speedwave-runtime/Cargo.toml
@@ -26,9 +26,15 @@ base64 = "0.22"
 rand = "0.8"
 semver = "1"
 url = "2"
+json-patch = "4"
+tokio = { version = "1", default-features = false, features = ["sync"] }
+futures-core = "0.3"
+async-stream = "0.3"
+parking_lot = "0.12"
 
 [dev-dependencies]
 tempfile = "3"
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "time"] }
 
 [lints]
 workspace = true

--- a/crates/speedwave-runtime/src/lib.rs
+++ b/crates/speedwave-runtime/src/lib.rs
@@ -15,5 +15,6 @@ pub mod project;
 pub mod resources;
 pub mod runtime;
 pub mod signing;
+pub mod stream;
 pub mod update;
 pub mod validation;

--- a/crates/speedwave-runtime/src/stream/entry_index.rs
+++ b/crates/speedwave-runtime/src/stream/entry_index.rs
@@ -28,13 +28,17 @@ impl EntryIndexProvider {
     }
 
     /// Allocate the next index. Monotonic, never reused.
+    ///
+    /// `Relaxed` ordering is sufficient: the only requirement is that each
+    /// call returns a unique value. We do not use the counter to synchronize
+    /// any other memory, so a full `SeqCst` fence is unnecessary overhead.
     pub fn next(&self) -> usize {
-        self.0.fetch_add(1, Ordering::SeqCst)
+        self.0.fetch_add(1, Ordering::Relaxed)
     }
 
     /// Read the current counter value without consuming an index.
     pub fn current(&self) -> usize {
-        self.0.load(Ordering::SeqCst)
+        self.0.load(Ordering::Relaxed)
     }
 
     /// Recover the next value by scanning an existing `MsgStore`'s history.

--- a/crates/speedwave-runtime/src/stream/entry_index.rs
+++ b/crates/speedwave-runtime/src/stream/entry_index.rs
@@ -1,0 +1,145 @@
+//! Atomic counter for stable conversation-entry indices (ADR-044).
+//!
+//! Each session owns a single `EntryIndexProvider`. Indices are monotonic,
+//! never reused, and serve as the only stable identifier for UI addressing
+//! (Angular `trackBy`) and JSON-Patch paths (`/entries/<index>`).
+//! UUIDs (ADR-046) are for message identity across resume/retry — never mix
+//! the two.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use super::msg_store::MsgStore;
+
+/// Shared monotonic counter producing conversation-entry indices.
+#[derive(Clone, Debug)]
+pub struct EntryIndexProvider(Arc<AtomicUsize>);
+
+impl Default for EntryIndexProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EntryIndexProvider {
+    /// Start from zero — used for a fresh session.
+    pub fn new() -> Self {
+        Self(Arc::new(AtomicUsize::new(0)))
+    }
+
+    /// Allocate the next index. Monotonic, never reused.
+    pub fn next(&self) -> usize {
+        self.0.fetch_add(1, Ordering::SeqCst)
+    }
+
+    /// Read the current counter value without consuming an index.
+    pub fn current(&self) -> usize {
+        self.0.load(Ordering::SeqCst)
+    }
+
+    /// Recover the next value by scanning an existing `MsgStore`'s history.
+    ///
+    /// Used on resume/reconnect: replay produces the current state, the
+    /// highest entry index + 1 becomes the next allocation.
+    pub fn start_from(store: &MsgStore) -> Self {
+        let state = store.snapshot_state();
+        let next = state
+            .entries
+            .iter()
+            .map(|e| e.index)
+            .max()
+            .map(|h| h + 1)
+            .unwrap_or(0);
+        Self(Arc::new(AtomicUsize::new(next)))
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::stream::msg_store::LogMsg;
+    use crate::stream::patch::ConversationPatch;
+    use crate::stream::state_tree::{ConversationEntry, EntryRole, MessageBlock, UuidStatus};
+    use std::collections::HashSet;
+
+    fn entry(idx: usize) -> ConversationEntry {
+        ConversationEntry {
+            index: idx,
+            role: EntryRole::User,
+            uuid: None,
+            uuid_status: UuidStatus::Pending,
+            blocks: vec![MessageBlock::Text {
+                content: "x".into(),
+            }],
+            meta: None,
+            edited_at: None,
+            timestamp: 0,
+        }
+    }
+
+    #[test]
+    fn new_starts_at_zero() {
+        let p = EntryIndexProvider::new();
+        assert_eq!(p.current(), 0);
+    }
+
+    #[test]
+    fn next_is_monotonic() {
+        let p = EntryIndexProvider::new();
+        for expected in 0..5 {
+            assert_eq!(p.next(), expected);
+        }
+        assert_eq!(p.current(), 5);
+    }
+
+    #[test]
+    fn clone_shares_counter() {
+        let a = EntryIndexProvider::new();
+        let b = a.clone();
+        assert_eq!(a.next(), 0);
+        assert_eq!(b.next(), 1);
+        assert_eq!(a.current(), 2);
+    }
+
+    #[test]
+    fn start_from_empty_store_returns_zero() {
+        let store = MsgStore::new();
+        let p = EntryIndexProvider::start_from(&store);
+        assert_eq!(p.current(), 0);
+    }
+
+    #[test]
+    fn start_from_recovers_highest_index_plus_one() {
+        let store = MsgStore::new();
+        store.push(LogMsg::JsonPatch(ConversationPatch::add_entry(0, entry(0))));
+        store.push(LogMsg::JsonPatch(ConversationPatch::add_entry(1, entry(7))));
+        let p = EntryIndexProvider::start_from(&store);
+        assert_eq!(p.current(), 8);
+        assert_eq!(p.next(), 8);
+    }
+
+    #[tokio::test]
+    async fn concurrent_next_yields_unique_values() {
+        let provider = EntryIndexProvider::new();
+        let mut handles = vec![];
+        for _ in 0..10 {
+            let p = provider.clone();
+            handles.push(tokio::spawn(async move {
+                let mut locals = Vec::with_capacity(100);
+                for _ in 0..100 {
+                    locals.push(p.next());
+                }
+                locals
+            }));
+        }
+        let mut all = HashSet::new();
+        for h in handles {
+            for v in h.await.unwrap() {
+                assert!(all.insert(v), "duplicate index: {v}");
+            }
+        }
+        assert_eq!(all.len(), 1000);
+        assert_eq!(provider.current(), 1000);
+    }
+}

--- a/crates/speedwave-runtime/src/stream/mod.rs
+++ b/crates/speedwave-runtime/src/stream/mod.rs
@@ -1,0 +1,29 @@
+//! JSON-Patch stream protocol backbone (ADRs 042 / 043 / 044).
+//!
+//! This module is the SSOT for the Rust side of the Tauri event contract:
+//!
+//! - [`state_tree`] — `ConversationState` and its child types, the single
+//!   state-tree shape held by the Angular frontend as a signal.
+//! - [`patch`] — `ConversationPatch` typed helpers and the `apply` reducer.
+//!   All mutations flow through this module so the state-shape change
+//!   surface is auditable.
+//! - [`msg_store`] — per-session broadcast + bounded-history store with a
+//!   100 MB replay cap.
+//! - [`entry_index`] — atomic counter producing the stable entry indices
+//!   used as UI keys and JSON-Patch path segments.
+//!
+//! Downstream units (Wave 5 Features 2 / 3 and the Tauri bridge) consume
+//! this module; it has no Tauri coupling per `.claude/rules/rust-style.md`.
+
+pub mod entry_index;
+pub mod msg_store;
+pub mod patch;
+pub mod state_tree;
+
+pub use entry_index::EntryIndexProvider;
+pub use msg_store::{LogMsg, MsgStore, DEFAULT_HISTORY_BYTES};
+pub use patch::{apply, ConversationPatch};
+pub use state_tree::{
+    AskUserOption, ConversationEntry, ConversationState, EntryMeta, EntryRole, MessageBlock,
+    QueuedMessage, SessionTotals, TurnUsage, UuidStatus,
+};

--- a/crates/speedwave-runtime/src/stream/msg_store.rs
+++ b/crates/speedwave-runtime/src/stream/msg_store.rs
@@ -29,8 +29,14 @@ pub const DEFAULT_HISTORY_BYTES: usize = 100 * 1024 * 1024;
 const BROADCAST_CAPACITY: usize = 1024;
 
 /// One message in the session stream (ADR-042 event protocol).
+///
+/// Uses **adjacently tagged** serde representation (`{"type": "...",
+/// "data": ...}`) because the `JsonPatch` variant wraps `json_patch::Patch`
+/// — a newtype over `Vec<PatchOperation>` that serializes as a JSON array.
+/// Internally tagged enums cannot embed a tag field into an array; the
+/// `JsonPatch` variant would silently fail to serialize otherwise.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[serde(tag = "type", content = "data", rename_all = "snake_case")]
 pub enum LogMsg {
     /// A JSON-Patch to apply to the current `ConversationState`.
     JsonPatch(Patch),
@@ -47,7 +53,9 @@ pub enum LogMsg {
 
 /// Approximate the serialized byte cost of a message for the history cap.
 fn size_of(msg: &LogMsg) -> usize {
-    serde_json::to_vec(msg).map(|v| v.len()).unwrap_or(0)
+    serde_json::to_vec(msg)
+        .map(|v| v.len())
+        .expect("LogMsg variants are always serde-serializable")
 }
 
 struct Inner {
@@ -109,11 +117,15 @@ impl MsgStore {
     /// Never fails: broadcast returns `Err` only when no subscribers exist,
     /// which is not an error condition — history still holds the message for
     /// future subscribers.
+    ///
+    /// The broadcast `send` happens while the inner lock is held. This
+    /// pairs with `history_plus_stream`, which takes the same lock across
+    /// `subscribe` + snapshot: together, a concurrent push cannot land the
+    /// same message in both a subscriber's receive queue and the snapshot
+    /// (duplicate-delivery race).
     pub fn push(&self, msg: LogMsg) {
-        {
-            let mut inner = self.inner.lock();
-            inner.push(msg.clone());
-        }
+        let mut inner = self.inner.lock();
+        inner.push(msg.clone());
         let _ = self.sender.send(msg);
     }
 
@@ -166,9 +178,18 @@ impl MsgStore {
     /// A lagged subscriber (one that falls behind by more than the broadcast
     /// capacity) receives a single `Resync` message with the current snapshot
     /// and then continues from live — never panics, never silently drops.
+    ///
+    /// Subscribing and snapshotting history happens atomically under the
+    /// inner lock: `push()` also takes the lock before broadcasting, so a
+    /// concurrent push cannot land the same message in both the snapshot
+    /// and the newly created receiver.
     pub fn history_plus_stream(&self) -> BoxStream<'static, LogMsg> {
-        let mut rx = self.sender.subscribe();
-        let history_snapshot = self.history_vec();
+        let (mut rx, history_snapshot) = {
+            let inner = self.inner.lock();
+            let rx = self.sender.subscribe();
+            let snap: Vec<LogMsg> = inner.history.iter().cloned().collect();
+            (rx, snap)
+        };
         let inner = self.inner.clone();
 
         Box::pin(stream! {
@@ -335,7 +356,7 @@ mod tests {
         store2.push(LogMsg::SessionEnded);
         let live = collect_n(stream2, 1).await;
         assert_eq!(live.len(), 1);
-        matches!(live[0], LogMsg::SessionEnded);
+        assert!(matches!(live[0], LogMsg::SessionEnded));
     }
 
     #[test]
@@ -404,5 +425,86 @@ mod tests {
             h.await.unwrap();
         }
         assert_eq!(store.history_len(), 1000);
+    }
+
+    /// Regression: `LogMsg::JsonPatch` must serialize to non-zero bytes so
+    /// that the history cap actually counts patch messages. An internally
+    /// tagged serde representation cannot embed a tag into the array
+    /// produced by `json_patch::Patch` and silently returns zero bytes —
+    /// that made the 100 MB cap inapplicable to the dominant variant.
+    #[test]
+    fn history_bytes_accounts_for_json_patch_messages() {
+        let store = MsgStore::new();
+        store.push(LogMsg::JsonPatch(ConversationPatch::add_entry(
+            0,
+            entry(0, "hello world"),
+        )));
+        assert_eq!(store.history_len(), 1);
+        assert!(
+            store.history_bytes() > 0,
+            "JsonPatch messages must contribute non-zero bytes to the history cap; \
+             got {} bytes for a non-empty patch",
+            store.history_bytes()
+        );
+    }
+
+    /// Regression: `history_plus_stream` must not duplicate messages that
+    /// race against the subscribe/snapshot pair. A push from a parallel
+    /// OS thread while the stream is being constructed would, with the
+    /// pre-fix code, land the message in both the snapshot and the
+    /// subscriber's queue — yielding a duplicate. A multi-threaded runtime
+    /// is required to exercise that interleaving because both
+    /// `subscribe()` and `history_vec()` are synchronous.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn history_plus_stream_no_duplicate_under_concurrent_push() {
+        const N: usize = 200;
+        let store = Arc::new(MsgStore::new());
+        // Pre-seed some history entries so the snapshot branch is exercised.
+        for i in 0..5 {
+            store.push(LogMsg::SessionStarted {
+                session_id: format!("pre-{i}"),
+            });
+        }
+        let initial = store.history_len();
+
+        // Spawn the pusher first so pushes are already in flight by the
+        // time the consumer starts constructing the combined stream.
+        let push_store = store.clone();
+        let pusher = tokio::task::spawn_blocking(move || {
+            for i in 0..N {
+                push_store.push(LogMsg::SessionStarted {
+                    session_id: format!("live-{i}"),
+                });
+            }
+        });
+
+        let stream_store = store.clone();
+        let consumer = tokio::spawn(async move {
+            let stream = stream_store.history_plus_stream();
+            collect_n(stream, initial + N).await
+        });
+
+        pusher.await.unwrap();
+        let collected = consumer.await.unwrap();
+
+        // Every unique session_id must appear exactly once.
+        let mut seen = std::collections::HashSet::new();
+        for msg in &collected {
+            if let LogMsg::SessionStarted { session_id } = msg {
+                assert!(
+                    seen.insert(session_id.clone()),
+                    "duplicate delivery for session_id: {session_id}"
+                );
+            }
+        }
+        // Total must equal initial + N — no duplicates, no drops.
+        assert_eq!(
+            collected.len(),
+            initial + N,
+            "expected {} messages, got {}; duplicates would inflate this count",
+            initial + N,
+            collected.len()
+        );
+        assert_eq!(seen.len(), initial + N);
     }
 }

--- a/crates/speedwave-runtime/src/stream/msg_store.rs
+++ b/crates/speedwave-runtime/src/stream/msg_store.rs
@@ -35,7 +35,14 @@ const BROADCAST_CAPACITY: usize = 1024;
 /// — a newtype over `Vec<PatchOperation>` that serializes as a JSON array.
 /// Internally tagged enums cannot embed a tag field into an array; the
 /// `JsonPatch` variant would silently fail to serialize otherwise.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+///
+/// `Debug` is implemented manually rather than derived: `session_id`
+/// values are not secrets in the sense of API keys, but they are
+/// per-session identifiers that have no place in diagnostic logs (per
+/// `.claude/rules/logging.md`). The manual impl redacts `session_id` to
+/// `"…"` so accidental `format!("{msg:?}")` calls in handlers, panic
+/// hooks, or test assertions cannot leak it.
+#[derive(Clone, Serialize, Deserialize)]
 #[serde(tag = "type", content = "data", rename_all = "snake_case")]
 pub enum LogMsg {
     /// A JSON-Patch to apply to the current `ConversationState`.
@@ -49,6 +56,20 @@ pub enum LogMsg {
     },
     /// Session lifecycle marker — the session has ended.
     SessionEnded,
+}
+
+impl std::fmt::Debug for LogMsg {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::JsonPatch(p) => f.debug_tuple("JsonPatch").field(p).finish(),
+            Self::Resync(_) => f.debug_tuple("Resync").field(&"<state>").finish(),
+            Self::SessionStarted { .. } => f
+                .debug_struct("SessionStarted")
+                .field("session_id", &"…")
+                .finish(),
+            Self::SessionEnded => f.write_str("SessionEnded"),
+        }
+    }
 }
 
 /// Approximate the serialized byte cost of a message for the history cap.

--- a/crates/speedwave-runtime/src/stream/msg_store.rs
+++ b/crates/speedwave-runtime/src/stream/msg_store.rs
@@ -41,7 +41,9 @@ const BROADCAST_CAPACITY: usize = 1024;
 /// per-session identifiers that have no place in diagnostic logs (per
 /// `.claude/rules/logging.md`). The manual impl redacts `session_id` to
 /// `"…"` so accidental `format!("{msg:?}")` calls in handlers, panic
-/// hooks, or test assertions cannot leak it.
+/// hooks, or test assertions cannot leak it. `Resync` delegates to
+/// `ConversationState`'s own redacting `Debug` impl — keeping the
+/// redaction policy in one place (the type that owns the field).
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(tag = "type", content = "data", rename_all = "snake_case")]
 pub enum LogMsg {
@@ -62,7 +64,11 @@ impl std::fmt::Debug for LogMsg {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::JsonPatch(p) => f.debug_tuple("JsonPatch").field(p).finish(),
-            Self::Resync(_) => f.debug_tuple("Resync").field(&"<state>").finish(),
+            // Delegate to `ConversationState`'s `Debug` impl, which already
+            // redacts `session_id`. Keeping the redaction policy in one place
+            // means a future field added to `ConversationState` is covered
+            // automatically here too.
+            Self::Resync(state) => f.debug_tuple("Resync").field(state).finish(),
             Self::SessionStarted { .. } => f
                 .debug_struct("SessionStarted")
                 .field("session_id", &"…")
@@ -467,6 +473,88 @@ mod tests {
              got {} bytes for a non-empty patch",
             store.history_bytes()
         );
+    }
+
+    /// `Debug` for `LogMsg::SessionStarted` must redact `session_id` so
+    /// accidental `format!("{msg:?}")` (e.g. from a `panic!`, `dbg!`, or
+    /// `tracing::debug!`) cannot leak the per-session identifier. This
+    /// pairs with `.claude/rules/logging.md`: `session_id` values are not
+    /// API-key-grade secrets, but they have no place in diagnostic logs.
+    #[test]
+    fn debug_redacts_session_started_session_id() {
+        let msg = LogMsg::SessionStarted {
+            session_id: "secret-uuid".into(),
+        };
+        let dbg = format!("{msg:?}");
+        assert!(
+            dbg.contains('…'),
+            "expected redaction marker in Debug output, got: {dbg}"
+        );
+        assert!(
+            !dbg.contains("secret-uuid"),
+            "session_id leaked through Debug: {dbg}"
+        );
+    }
+
+    /// `Debug` for `LogMsg::Resync` must redact `session_id` carried inside
+    /// the wrapped `ConversationState`. Delegating to
+    /// `ConversationState::fmt` keeps the redaction policy in one place;
+    /// this test guards against a future change accidentally re-deriving
+    /// `Debug` on `ConversationState` (which would leak the field).
+    #[test]
+    fn debug_resync_propagates_state_redaction() {
+        let state = ConversationState {
+            session_id: Some("secret-uuid".into()),
+            entries: vec![entry(0, "hello")],
+            ..Default::default()
+        };
+        let msg = LogMsg::Resync(Box::new(state));
+        let dbg = format!("{msg:?}");
+        assert!(
+            dbg.starts_with("Resync("),
+            "expected debug_tuple wrapping, got: {dbg}"
+        );
+        assert!(
+            dbg.contains('…'),
+            "expected session_id redaction marker in Resync Debug, got: {dbg}"
+        );
+        assert!(
+            !dbg.contains("secret-uuid"),
+            "session_id leaked through Resync Debug: {dbg}"
+        );
+        // Non-secret state is still observable for diagnostics.
+        assert!(
+            dbg.contains("hello"),
+            "expected non-secret entry text in Resync Debug, got: {dbg}"
+        );
+    }
+
+    /// `Debug` for `LogMsg::JsonPatch` round-trips the inner `Patch`
+    /// verbatim — patches do not carry secrets, so there is nothing to
+    /// redact, and stripping them would hurt diagnostics.
+    #[test]
+    fn debug_json_patch_round_trips_without_redaction() {
+        let patch = ConversationPatch::add_entry(0, entry(0, "diagnostic-text"));
+        let msg = LogMsg::JsonPatch(patch.clone());
+        let dbg = format!("{msg:?}");
+        assert!(
+            dbg.starts_with("JsonPatch("),
+            "expected debug_tuple wrapping, got: {dbg}"
+        );
+        // The full `Patch` Debug must be present — no redaction marker.
+        assert_eq!(dbg, format!("JsonPatch({:?})", patch));
+        assert!(
+            !dbg.contains('…'),
+            "JsonPatch must not be redacted (no secrets to hide): {dbg}"
+        );
+    }
+
+    /// `LogMsg::SessionEnded` carries no payload — `Debug` must render the
+    /// bare variant name, with no parens, fields, or wrapping.
+    #[test]
+    fn debug_session_ended_renders_bare_variant() {
+        let msg = LogMsg::SessionEnded;
+        assert_eq!(format!("{msg:?}"), "SessionEnded");
     }
 
     /// Regression: `history_plus_stream` must not duplicate messages that

--- a/crates/speedwave-runtime/src/stream/msg_store.rs
+++ b/crates/speedwave-runtime/src/stream/msg_store.rs
@@ -1,0 +1,408 @@
+//! Broadcast + bounded history store for a single session (ADR-043).
+//!
+//! Each active Claude Code session owns one `MsgStore` with two parts:
+//! a `tokio::sync::broadcast` channel for live events and a
+//! `VecDeque<LogMsg>` capped at 100 MB of serialized bytes for replay.
+//! `history_plus_stream()` yields the history first, then switches to live
+//! — a new subscriber sees a consistent snapshot without racing against
+//! simultaneous pushes.
+
+use std::collections::VecDeque;
+use std::sync::Arc;
+
+use async_stream::stream;
+use futures_core::stream::BoxStream;
+use json_patch::Patch;
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+use tokio::sync::broadcast::{self, error::RecvError};
+
+use super::patch::apply;
+use super::state_tree::ConversationState;
+
+/// Default cap on history size in bytes (100 MB).
+pub const DEFAULT_HISTORY_BYTES: usize = 100 * 1024 * 1024;
+
+/// Broadcast channel capacity — the number of in-flight messages a subscriber
+/// may fall behind before being marked `Lagged`. Chosen large enough to
+/// smooth normal UI jitter; lagged subscribers recover via `Resync`.
+const BROADCAST_CAPACITY: usize = 1024;
+
+/// One message in the session stream (ADR-042 event protocol).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum LogMsg {
+    /// A JSON-Patch to apply to the current `ConversationState`.
+    JsonPatch(Patch),
+    /// A full-state snapshot — emitted to lagged subscribers and on reconnect.
+    Resync(Box<ConversationState>),
+    /// Session lifecycle marker — a session has started with this id.
+    SessionStarted {
+        /// Claude Code session identifier.
+        session_id: String,
+    },
+    /// Session lifecycle marker — the session has ended.
+    SessionEnded,
+}
+
+/// Approximate the serialized byte cost of a message for the history cap.
+fn size_of(msg: &LogMsg) -> usize {
+    serde_json::to_vec(msg).map(|v| v.len()).unwrap_or(0)
+}
+
+struct Inner {
+    history: VecDeque<LogMsg>,
+    history_bytes: usize,
+    max_bytes: usize,
+}
+
+impl Inner {
+    fn push(&mut self, msg: LogMsg) {
+        let size = size_of(&msg);
+        self.history.push_back(msg);
+        self.history_bytes = self.history_bytes.saturating_add(size);
+        // Drop the oldest messages while over the cap, but always keep at
+        // least the just-pushed message: the UI still needs to see it, and
+        // dropping the only message available would leave the store in a
+        // worse state than a bit of overshoot.
+        while self.history_bytes > self.max_bytes && self.history.len() > 1 {
+            if let Some(old) = self.history.pop_front() {
+                self.history_bytes = self.history_bytes.saturating_sub(size_of(&old));
+            }
+        }
+    }
+}
+
+/// Per-session store of live broadcast + bounded history.
+pub struct MsgStore {
+    inner: Arc<Mutex<Inner>>,
+    sender: broadcast::Sender<LogMsg>,
+}
+
+impl Default for MsgStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MsgStore {
+    /// Create a store with the default 100 MB history cap.
+    pub fn new() -> Self {
+        Self::with_capacity(DEFAULT_HISTORY_BYTES)
+    }
+
+    /// Create a store with a custom history cap (bytes).
+    pub fn with_capacity(max_bytes: usize) -> Self {
+        let (sender, _) = broadcast::channel(BROADCAST_CAPACITY);
+        Self {
+            inner: Arc::new(Mutex::new(Inner {
+                history: VecDeque::new(),
+                history_bytes: 0,
+                max_bytes,
+            })),
+            sender,
+        }
+    }
+
+    /// Append a message to history and broadcast it to live subscribers.
+    ///
+    /// Never fails: broadcast returns `Err` only when no subscribers exist,
+    /// which is not an error condition — history still holds the message for
+    /// future subscribers.
+    pub fn push(&self, msg: LogMsg) {
+        {
+            let mut inner = self.inner.lock();
+            inner.push(msg.clone());
+        }
+        let _ = self.sender.send(msg);
+    }
+
+    /// Subscribe to live events only (no history replay).
+    pub fn subscribe(&self) -> broadcast::Receiver<LogMsg> {
+        self.sender.subscribe()
+    }
+
+    /// Current history length in bytes (approximate — serialization cost).
+    pub fn history_bytes(&self) -> usize {
+        self.inner.lock().history_bytes
+    }
+
+    /// Current history length in messages.
+    pub fn history_len(&self) -> usize {
+        self.inner.lock().history.len()
+    }
+
+    /// Snapshot current history without holding the lock across the reducer.
+    fn history_vec(&self) -> Vec<LogMsg> {
+        self.inner.lock().history.iter().cloned().collect()
+    }
+
+    /// Replay a sequence of messages through the reducer to produce a state.
+    /// Lossy patches (malformed, unknown paths) are skipped with a warning —
+    /// the snapshot is best-effort recovery.
+    fn replay(history: Vec<LogMsg>) -> ConversationState {
+        let mut state = ConversationState::default();
+        for msg in history {
+            match msg {
+                LogMsg::JsonPatch(p) => match apply(state.clone(), &p) {
+                    Ok(next) => state = next,
+                    Err(e) => log::warn!("msg_store replay: skipping bad patch: {e:#}"),
+                },
+                LogMsg::Resync(snapshot) => state = *snapshot,
+                LogMsg::SessionStarted { session_id } => state.session_id = Some(session_id),
+                LogMsg::SessionEnded => {}
+            }
+        }
+        state
+    }
+
+    /// Replay the stored history to produce a current state snapshot.
+    pub fn snapshot_state(&self) -> ConversationState {
+        Self::replay(self.history_vec())
+    }
+
+    /// Yield history first, then switch to live events.
+    ///
+    /// A lagged subscriber (one that falls behind by more than the broadcast
+    /// capacity) receives a single `Resync` message with the current snapshot
+    /// and then continues from live — never panics, never silently drops.
+    pub fn history_plus_stream(&self) -> BoxStream<'static, LogMsg> {
+        let mut rx = self.sender.subscribe();
+        let history_snapshot = self.history_vec();
+        let inner = self.inner.clone();
+
+        Box::pin(stream! {
+            for msg in history_snapshot {
+                yield msg;
+            }
+            loop {
+                match rx.recv().await {
+                    Ok(msg) => yield msg,
+                    Err(RecvError::Closed) => break,
+                    Err(RecvError::Lagged(_)) => {
+                        let history: Vec<LogMsg> =
+                            inner.lock().history.iter().cloned().collect();
+                        let state = Self::replay(history);
+                        yield LogMsg::Resync(Box::new(state));
+                    }
+                }
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::stream::patch::ConversationPatch;
+    use crate::stream::state_tree::{ConversationEntry, EntryRole, MessageBlock, UuidStatus};
+    use futures_core::Stream;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+    use tokio::time::{timeout, Duration};
+
+    fn entry(idx: usize, text: &str) -> ConversationEntry {
+        ConversationEntry {
+            index: idx,
+            role: EntryRole::User,
+            uuid: None,
+            uuid_status: UuidStatus::Pending,
+            blocks: vec![MessageBlock::Text {
+                content: text.to_string(),
+            }],
+            meta: None,
+            edited_at: None,
+            timestamp: 0,
+        }
+    }
+
+    async fn collect_n<S>(mut stream: S, n: usize) -> Vec<S::Item>
+    where
+        S: Stream + Unpin,
+    {
+        let mut out = Vec::with_capacity(n);
+        for _ in 0..n {
+            match timeout(Duration::from_millis(500), next(&mut stream)).await {
+                Ok(Some(v)) => out.push(v),
+                _ => break,
+            }
+        }
+        out
+    }
+
+    // Tiny hand-rolled `next` to avoid pulling the full `futures` crate for tests.
+    fn next<S: Stream + Unpin>(s: &mut S) -> NextFut<'_, S> {
+        NextFut(s)
+    }
+    struct NextFut<'a, S>(&'a mut S);
+    impl<'a, S: Stream + Unpin> std::future::Future for NextFut<'a, S> {
+        type Output = Option<S::Item>;
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            Pin::new(&mut *self.0).poll_next(cx)
+        }
+    }
+
+    #[test]
+    fn push_records_history_and_bytes() {
+        let store = MsgStore::new();
+        assert_eq!(store.history_len(), 0);
+        assert_eq!(store.history_bytes(), 0);
+        store.push(LogMsg::SessionStarted {
+            session_id: "s1".into(),
+        });
+        assert_eq!(store.history_len(), 1);
+        assert!(store.history_bytes() > 0);
+    }
+
+    #[test]
+    fn snapshot_replays_patches() {
+        let store = MsgStore::new();
+        store.push(LogMsg::SessionStarted {
+            session_id: "s1".into(),
+        });
+        store.push(LogMsg::JsonPatch(ConversationPatch::add_entry(
+            0,
+            entry(0, "hi"),
+        )));
+        let state = store.snapshot_state();
+        assert_eq!(state.session_id.as_deref(), Some("s1"));
+        assert_eq!(state.entries.len(), 1);
+    }
+
+    #[test]
+    fn snapshot_resync_replaces_prior_state() {
+        let store = MsgStore::new();
+        store.push(LogMsg::JsonPatch(ConversationPatch::add_entry(
+            0,
+            entry(0, "a"),
+        )));
+        let snapshot = ConversationState {
+            session_id: Some("fresh".into()),
+            entries: vec![entry(0, "b")],
+            ..Default::default()
+        };
+        store.push(LogMsg::Resync(Box::new(snapshot.clone())));
+        assert_eq!(store.snapshot_state(), snapshot);
+    }
+
+    #[tokio::test]
+    async fn subscribe_receives_only_future_messages() {
+        let store = MsgStore::new();
+        store.push(LogMsg::SessionStarted {
+            session_id: "old".into(),
+        });
+        let mut rx = store.subscribe();
+        store.push(LogMsg::SessionStarted {
+            session_id: "new".into(),
+        });
+        let got = timeout(Duration::from_millis(500), rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        match got {
+            LogMsg::SessionStarted { session_id } => assert_eq!(session_id, "new"),
+            other => panic!("unexpected msg: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn history_plus_stream_yields_history_then_live() {
+        let store = MsgStore::new();
+        store.push(LogMsg::SessionStarted {
+            session_id: "s1".into(),
+        });
+        store.push(LogMsg::JsonPatch(ConversationPatch::add_entry(
+            0,
+            entry(0, "x"),
+        )));
+        let stream = store.history_plus_stream();
+
+        let collected = collect_n(stream, 2).await;
+        assert_eq!(collected.len(), 2);
+        match &collected[0] {
+            LogMsg::SessionStarted { session_id } => assert_eq!(session_id, "s1"),
+            other => panic!("expected SessionStarted, got {other:?}"),
+        }
+        match &collected[1] {
+            LogMsg::JsonPatch(_) => {}
+            other => panic!("expected JsonPatch, got {other:?}"),
+        }
+
+        // After the history is drained, the stream continues with live events.
+        let store2 = MsgStore::new();
+        let stream2 = store2.history_plus_stream();
+        store2.push(LogMsg::SessionEnded);
+        let live = collect_n(stream2, 1).await;
+        assert_eq!(live.len(), 1);
+        matches!(live[0], LogMsg::SessionEnded);
+    }
+
+    #[test]
+    fn history_cap_drops_oldest() {
+        // Tiny cap to exercise overflow with small messages.
+        let store = MsgStore::with_capacity(200);
+        for i in 0..20 {
+            store.push(LogMsg::SessionStarted {
+                session_id: format!("sess-{i}"),
+            });
+        }
+        assert!(store.history_bytes() <= 200);
+        // Some oldest entries must have been dropped.
+        assert!(store.history_len() < 20);
+    }
+
+    #[test]
+    fn history_cap_keeps_single_oversized_message() {
+        // A cap smaller than one message must not produce an empty history.
+        let store = MsgStore::with_capacity(1);
+        let big = "x".repeat(1000);
+        store.push(LogMsg::SessionStarted { session_id: big });
+        assert_eq!(store.history_len(), 1);
+    }
+
+    #[tokio::test]
+    async fn lagged_subscriber_receives_resync() {
+        // Cap the broadcast channel pressure by filling it beyond capacity.
+        // We need more than BROADCAST_CAPACITY pending messages so RecvError::Lagged fires.
+        let store = MsgStore::new();
+        let stream = store.history_plus_stream();
+        // Send way more than BROADCAST_CAPACITY before the stream is polled.
+        for i in 0..(BROADCAST_CAPACITY + 16) {
+            store.push(LogMsg::SessionStarted {
+                session_id: format!("s{i}"),
+            });
+        }
+        let collected = collect_n(stream, BROADCAST_CAPACITY + 17).await;
+        // At least one Resync must appear to recover from the lag.
+        let has_resync = collected.iter().any(|m| matches!(m, LogMsg::Resync(_)));
+        assert!(
+            has_resync,
+            "expected Resync after lag, got: {:?}",
+            collected
+                .iter()
+                .map(std::mem::discriminant)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_push_is_safe() {
+        let store = Arc::new(MsgStore::new());
+        let mut handles = vec![];
+        for i in 0..10 {
+            let s = store.clone();
+            handles.push(tokio::spawn(async move {
+                for j in 0..100 {
+                    s.push(LogMsg::SessionStarted {
+                        session_id: format!("t{i}-{j}"),
+                    });
+                }
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+        assert_eq!(store.history_len(), 1000);
+    }
+}

--- a/crates/speedwave-runtime/src/stream/patch.rs
+++ b/crates/speedwave-runtime/src/stream/patch.rs
@@ -1,0 +1,285 @@
+//! Typed helpers that produce RFC 6902 `json_patch::Patch` values (ADR-042).
+//!
+//! All mutations to `ConversationState` flow through this module. Never
+//! hand-craft a `Patch` inline in a handler — add a helper here instead,
+//! which keeps the state-shape change surface auditable.
+
+use anyhow::{Context, Result};
+use json_patch::{
+    jsonptr::PointerBuf, AddOperation, Patch, PatchOperation, RemoveOperation, ReplaceOperation,
+};
+
+use super::state_tree::{ConversationEntry, ConversationState, EntryMeta, QueuedMessage};
+
+/// Build a JSON Pointer (RFC 6901) from a printf-style path.
+fn pointer(path: &str) -> PointerBuf {
+    // Safe: all call sites use constant or numeric-index paths that are
+    // guaranteed to be valid pointers. A malformed path is a programmer error.
+    PointerBuf::parse(path).unwrap_or_else(|e| panic!("invalid JSON pointer {path:?}: {e}"))
+}
+
+fn value_of<T: serde::Serialize>(value: &T) -> serde_json::Value {
+    // serde_json::to_value cannot fail for our state types.
+    serde_json::to_value(value).unwrap_or(serde_json::Value::Null)
+}
+
+/// Builder for `json_patch::Patch` values that operate on
+/// `ConversationState`.
+pub struct ConversationPatch;
+
+impl ConversationPatch {
+    /// Add a new entry at `/entries/<idx>`. Pass the target vector index —
+    /// this maps to RFC 6902 `add` which inserts at that position.
+    pub fn add_entry(idx: usize, entry: ConversationEntry) -> Patch {
+        Patch(vec![PatchOperation::Add(AddOperation {
+            path: pointer(&format!("/entries/{idx}")),
+            value: value_of(&entry),
+        })])
+    }
+
+    /// Replace the entry at `/entries/<idx>` with a new one.
+    pub fn replace_entry(idx: usize, entry: ConversationEntry) -> Patch {
+        Patch(vec![PatchOperation::Replace(ReplaceOperation {
+            path: pointer(&format!("/entries/{idx}")),
+            value: value_of(&entry),
+        })])
+    }
+
+    /// Remove the entry at `/entries/<idx>`. Subsequent entries shift left;
+    /// callers that rely on stable indices (ADR-044) should only remove
+    /// trailing entries (e.g. during retry per ADR-046).
+    pub fn remove_entry(idx: usize) -> Patch {
+        Patch(vec![PatchOperation::Remove(RemoveOperation {
+            path: pointer(&format!("/entries/{idx}")),
+        })])
+    }
+
+    /// Replace a block's full text content with the provided full string.
+    ///
+    /// RFC 6902 has no "append" op; streaming callers therefore pass the
+    /// accumulated text so far. Keeping the patch within the RFC lets the
+    /// frontend use a stock `json-patch` library without a custom extension.
+    pub fn replace_text(entry_idx: usize, block_idx: usize, full_text: &str) -> Patch {
+        Patch(vec![PatchOperation::Replace(ReplaceOperation {
+            path: pointer(&format!("/entries/{entry_idx}/blocks/{block_idx}/content")),
+            value: serde_json::Value::String(full_text.to_string()),
+        })])
+    }
+
+    /// Replace the per-entry metadata for an assistant turn.
+    pub fn replace_meta(idx: usize, meta: EntryMeta) -> Patch {
+        Patch(vec![PatchOperation::Replace(ReplaceOperation {
+            path: pointer(&format!("/entries/{idx}/meta")),
+            value: value_of(&meta),
+        })])
+    }
+
+    /// Set whether a turn is currently streaming.
+    pub fn set_streaming(is_streaming: bool) -> Patch {
+        Patch(vec![PatchOperation::Replace(ReplaceOperation {
+            path: pointer("/is_streaming"),
+            value: serde_json::Value::Bool(is_streaming),
+        })])
+    }
+
+    /// Set (or clear with `None`) the one-slot queued message (ADR-045).
+    pub fn set_pending_queue(queued: Option<QueuedMessage>) -> Patch {
+        Patch(vec![PatchOperation::Replace(ReplaceOperation {
+            path: pointer("/pending_queue"),
+            value: value_of(&queued),
+        })])
+    }
+}
+
+/// Apply a patch to a conversation state, returning the new state.
+///
+/// Pure function — the input state is consumed and the patched state
+/// returned. Errors surface malformed patches (bad paths, missing targets).
+pub fn apply(state: ConversationState, patch: &Patch) -> Result<ConversationState> {
+    let mut value = serde_json::to_value(&state).context("failed to serialize state")?;
+    json_patch::patch(&mut value, &patch.0).context("failed to apply json patch")?;
+    serde_json::from_value(value).context("patched state failed to deserialize")
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::stream::state_tree::{
+        EntryMeta, EntryRole, MessageBlock, QueuedMessage, TurnUsage, UuidStatus,
+    };
+
+    fn entry(idx: usize, text: &str) -> ConversationEntry {
+        ConversationEntry {
+            index: idx,
+            role: EntryRole::Assistant,
+            uuid: None,
+            uuid_status: UuidStatus::Pending,
+            blocks: vec![MessageBlock::Text {
+                content: text.to_string(),
+            }],
+            meta: None,
+            edited_at: None,
+            timestamp: 0,
+        }
+    }
+
+    #[test]
+    fn add_entry_patch_shape() {
+        let p = ConversationPatch::add_entry(0, entry(0, "hi"));
+        let encoded = serde_json::to_value(&p).unwrap();
+        let arr = encoded.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["op"], "add");
+        assert_eq!(arr[0]["path"], "/entries/0");
+        assert_eq!(arr[0]["value"]["index"], 0);
+    }
+
+    #[test]
+    fn apply_add_entry_happy_path() {
+        let state = ConversationState::default();
+        let patch = ConversationPatch::add_entry(0, entry(0, "hi"));
+        let next = apply(state, &patch).unwrap();
+        assert_eq!(next.entries.len(), 1);
+        assert_eq!(next.entries[0].index, 0);
+    }
+
+    #[test]
+    fn apply_replace_entry_idempotent() {
+        let state = ConversationState {
+            entries: vec![entry(0, "first")],
+            ..Default::default()
+        };
+        let patch = ConversationPatch::replace_entry(0, entry(0, "second"));
+        let once = apply(state.clone(), &patch).unwrap();
+        let twice = apply(once.clone(), &patch).unwrap();
+        assert_eq!(once, twice);
+        match &twice.entries[0].blocks[0] {
+            MessageBlock::Text { content } => assert_eq!(content, "second"),
+            other => panic!("unexpected block: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn apply_remove_entry() {
+        let state = ConversationState {
+            entries: vec![entry(0, "a"), entry(1, "b")],
+            ..Default::default()
+        };
+        let patch = ConversationPatch::remove_entry(1);
+        let next = apply(state, &patch).unwrap();
+        assert_eq!(next.entries.len(), 1);
+        assert_eq!(next.entries[0].index, 0);
+    }
+
+    #[test]
+    fn apply_replace_text_streams_progressively() {
+        let state = ConversationState {
+            entries: vec![entry(0, "")],
+            ..Default::default()
+        };
+        let p1 = ConversationPatch::replace_text(0, 0, "he");
+        let p2 = ConversationPatch::replace_text(0, 0, "hello");
+        let s1 = apply(state, &p1).unwrap();
+        let s2 = apply(s1, &p2).unwrap();
+        match &s2.entries[0].blocks[0] {
+            MessageBlock::Text { content } => assert_eq!(content, "hello"),
+            other => panic!("unexpected block: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn apply_replace_meta() {
+        let state = ConversationState {
+            entries: vec![entry(0, "hi")],
+            ..Default::default()
+        };
+        let meta = EntryMeta {
+            model: Some("opus".into()),
+            usage: Some(TurnUsage {
+                input_tokens: 10,
+                output_tokens: 20,
+                cache_read_tokens: 0,
+                cache_write_tokens: 0,
+            }),
+            cost: Some(0.001),
+        };
+        let patch = ConversationPatch::replace_meta(0, meta.clone());
+        let next = apply(state, &patch).unwrap();
+        assert_eq!(next.entries[0].meta.as_ref().unwrap(), &meta);
+    }
+
+    #[test]
+    fn apply_set_streaming_toggles_flag() {
+        let state = ConversationState::default();
+        let on = apply(state, &ConversationPatch::set_streaming(true)).unwrap();
+        assert!(on.is_streaming);
+        let off = apply(on, &ConversationPatch::set_streaming(false)).unwrap();
+        assert!(!off.is_streaming);
+    }
+
+    #[test]
+    fn apply_set_pending_queue_roundtrip() {
+        let state = ConversationState::default();
+        let msg = QueuedMessage {
+            text: "next".into(),
+            queued_at: 1,
+        };
+        let set = apply(
+            state,
+            &ConversationPatch::set_pending_queue(Some(msg.clone())),
+        )
+        .unwrap();
+        assert_eq!(set.pending_queue.as_ref().unwrap(), &msg);
+        let cleared = apply(set, &ConversationPatch::set_pending_queue(None)).unwrap();
+        assert!(cleared.pending_queue.is_none());
+    }
+
+    #[test]
+    fn apply_rejects_out_of_range_replace() {
+        let state = ConversationState::default();
+        // /entries/5 does not exist — replace must fail.
+        let patch = ConversationPatch::replace_entry(5, entry(5, "x"));
+        let err = apply(state, &patch).unwrap_err();
+        assert!(format!("{err:#}").contains("json patch"));
+    }
+
+    #[test]
+    fn apply_rejects_remove_of_missing_index() {
+        let state = ConversationState::default();
+        let patch = ConversationPatch::remove_entry(0);
+        let err = apply(state, &patch).unwrap_err();
+        assert!(!format!("{err:#}").is_empty());
+    }
+
+    #[test]
+    fn sequential_apply_equals_composed_apply() {
+        // Emulate the property the reducer must preserve:
+        // apply(apply(s, p1), p2) == apply(s, compose(p1, p2))
+        let state = ConversationState::default();
+        let p1 = ConversationPatch::add_entry(0, entry(0, "a"));
+        let p2 = ConversationPatch::replace_text(0, 0, "aa");
+
+        let step_by_step = apply(apply(state.clone(), &p1).unwrap(), &p2).unwrap();
+
+        let mut composed = p1.clone();
+        composed.0.extend(p2.0.clone());
+        let composed_state = apply(state, &composed).unwrap();
+
+        assert_eq!(step_by_step, composed_state);
+    }
+
+    #[test]
+    fn multi_entry_sequence_applies_in_order() {
+        let state = ConversationState::default();
+        let mut cur = state;
+        for i in 0..5 {
+            let patch = ConversationPatch::add_entry(i, entry(i, &format!("e{i}")));
+            cur = apply(cur, &patch).unwrap();
+        }
+        assert_eq!(cur.entries.len(), 5);
+        for (i, e) in cur.entries.iter().enumerate() {
+            assert_eq!(e.index, i);
+        }
+    }
+}

--- a/crates/speedwave-runtime/src/stream/patch.rs
+++ b/crates/speedwave-runtime/src/stream/patch.rs
@@ -19,8 +19,10 @@ fn pointer(path: &str) -> PointerBuf {
 }
 
 fn value_of<T: serde::Serialize>(value: &T) -> serde_json::Value {
-    // serde_json::to_value cannot fail for our state types.
-    serde_json::to_value(value).unwrap_or(serde_json::Value::Null)
+    // Panicking is correct here: a silent `Null` fallback would corrupt the
+    // patched state in a way that is hard to debug. Our state types are
+    // always serde-serializable.
+    serde_json::to_value(value).expect("state types are always serde-serializable")
 }
 
 /// Builder for `json_patch::Patch` values that operate on
@@ -30,6 +32,11 @@ pub struct ConversationPatch;
 impl ConversationPatch {
     /// Add a new entry at `/entries/<idx>`. Pass the target vector index —
     /// this maps to RFC 6902 `add` which inserts at that position.
+    ///
+    /// `idx` is the JSON Pointer path segment, i.e. the current vector
+    /// position in `/entries`. It is NOT the logical `ConversationEntry.index`
+    /// allocated by `EntryIndexProvider`. They coincide only when entries are
+    /// appended in order with no removals.
     pub fn add_entry(idx: usize, entry: ConversationEntry) -> Patch {
         Patch(vec![PatchOperation::Add(AddOperation {
             path: pointer(&format!("/entries/{idx}")),
@@ -38,6 +45,11 @@ impl ConversationPatch {
     }
 
     /// Replace the entry at `/entries/<idx>` with a new one.
+    ///
+    /// `idx` is the JSON Pointer path segment, i.e. the current vector
+    /// position in `/entries`. It is NOT the logical `ConversationEntry.index`
+    /// allocated by `EntryIndexProvider`. They coincide only when entries are
+    /// appended in order with no removals.
     pub fn replace_entry(idx: usize, entry: ConversationEntry) -> Patch {
         Patch(vec![PatchOperation::Replace(ReplaceOperation {
             path: pointer(&format!("/entries/{idx}")),
@@ -48,6 +60,11 @@ impl ConversationPatch {
     /// Remove the entry at `/entries/<idx>`. Subsequent entries shift left;
     /// callers that rely on stable indices (ADR-044) should only remove
     /// trailing entries (e.g. during retry per ADR-046).
+    ///
+    /// `idx` is the JSON Pointer path segment, i.e. the current vector
+    /// position in `/entries`. It is NOT the logical `ConversationEntry.index`
+    /// allocated by `EntryIndexProvider`. They coincide only when entries are
+    /// appended in order with no removals.
     pub fn remove_entry(idx: usize) -> Patch {
         Patch(vec![PatchOperation::Remove(RemoveOperation {
             path: pointer(&format!("/entries/{idx}")),
@@ -87,6 +104,18 @@ impl ConversationPatch {
         Patch(vec![PatchOperation::Replace(ReplaceOperation {
             path: pointer("/pending_queue"),
             value: value_of(&queued),
+        })])
+    }
+
+    /// Replace `/session_id` with the given Claude Code session identifier.
+    ///
+    /// The JSON shape matches `ConversationState::session_id`
+    /// (`Option<String>` → `Some(id)`), so the patch round-trips through
+    /// `apply()` without touching other fields.
+    pub fn set_session_id(id: &str) -> Patch {
+        Patch(vec![PatchOperation::Replace(ReplaceOperation {
+            path: pointer("/session_id"),
+            value: value_of(&Some(id.to_string())),
         })])
     }
 }
@@ -233,6 +262,36 @@ mod tests {
         assert_eq!(set.pending_queue.as_ref().unwrap(), &msg);
         let cleared = apply(set, &ConversationPatch::set_pending_queue(None)).unwrap();
         assert!(cleared.pending_queue.is_none());
+    }
+
+    #[test]
+    fn set_session_id_patch_shape() {
+        let p = ConversationPatch::set_session_id("abc-123");
+        let encoded = serde_json::to_value(&p).unwrap();
+        let arr = encoded.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["op"], "replace");
+        assert_eq!(arr[0]["path"], "/session_id");
+        assert_eq!(arr[0]["value"], "abc-123");
+    }
+
+    #[test]
+    fn apply_set_session_id_sets_field() {
+        let state = ConversationState::default();
+        let patch = ConversationPatch::set_session_id("sess-42");
+        let next = apply(state, &patch).unwrap();
+        assert_eq!(next.session_id.as_deref(), Some("sess-42"));
+    }
+
+    #[test]
+    fn apply_set_session_id_overwrites_previous() {
+        let state = ConversationState {
+            session_id: Some("old".into()),
+            ..Default::default()
+        };
+        let patch = ConversationPatch::set_session_id("new");
+        let next = apply(state, &patch).unwrap();
+        assert_eq!(next.session_id.as_deref(), Some("new"));
     }
 
     #[test]

--- a/crates/speedwave-runtime/src/stream/state_tree.rs
+++ b/crates/speedwave-runtime/src/stream/state_tree.rs
@@ -1,0 +1,414 @@
+//! State-tree types for JSON-Patch stream protocol (ADR-042).
+//!
+//! Defines the conversation state shape that the Angular frontend holds as a
+//! signal and updates via `json_patch::Patch` operations. Every type is
+//! `serde`-serializable so patches can be applied via `json_patch::patch`.
+
+use serde::{Deserialize, Serialize};
+
+/// Root conversation state held by the UI as a single signal.
+///
+/// Every Tauri event emitted from Rust is a `json_patch::Patch` applied to a
+/// value of this type (see ADR-042). Reducer must stay pure: history replay +
+/// patch sequence must converge on the same state regardless of delivery time.
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
+pub struct ConversationState {
+    /// Claude Code session identifier. `None` before the first `SystemInit`.
+    #[serde(default)]
+    pub session_id: Option<String>,
+    /// Ordered list of conversation entries — indices are stable keys per
+    /// ADR-044 (monotonic, never reused).
+    #[serde(default)]
+    pub entries: Vec<ConversationEntry>,
+    /// Rolling session totals. Maintained by the same delta handler that
+    /// populates per-entry `meta` so both paths stay consistent.
+    #[serde(default)]
+    pub session_totals: SessionTotals,
+    /// One-slot queued message per session (ADR-045). Wave 5 populates this.
+    #[serde(default)]
+    pub pending_queue: Option<QueuedMessage>,
+    /// Model id surfaced by the latest `SystemInit` event.
+    #[serde(default)]
+    pub model: Option<String>,
+    /// `true` while a turn is being streamed from Claude Code.
+    #[serde(default)]
+    pub is_streaming: bool,
+}
+
+/// One entry in the conversation — user or assistant. Tool uses and errors
+/// live inside the entry's `blocks` vector.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct ConversationEntry {
+    /// Stable monotonic index allocated by `EntryIndexProvider` (ADR-044).
+    pub index: usize,
+    /// Who authored this entry.
+    pub role: EntryRole,
+    /// Message UUID tracked for native resume (ADR-046). `None` until the
+    /// relevant `user`/`assistant` stream-json event is seen.
+    #[serde(default)]
+    pub uuid: Option<String>,
+    /// Whether `uuid` is final (committed on `Result`) or provisional.
+    #[serde(default)]
+    pub uuid_status: UuidStatus,
+    /// Union of block variants — text, thinking, tool_use, ask_user, error.
+    #[serde(default)]
+    pub blocks: Vec<MessageBlock>,
+    /// Optional per-turn metadata for assistant entries (model, usage, cost).
+    /// Wave 5 Feature 3 populates this; user entries always have `None`.
+    #[serde(default)]
+    pub meta: Option<EntryMeta>,
+    /// Unix-ms timestamp set when a preceding retry bumped this entry.
+    #[serde(default)]
+    pub edited_at: Option<u64>,
+    /// Unix-ms timestamp of entry creation.
+    pub timestamp: u64,
+}
+
+/// Conversation role.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum EntryRole {
+    /// User-authored message.
+    User,
+    /// Assistant-authored message.
+    Assistant,
+}
+
+/// Whether an entry's `uuid` is provisional or final.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum UuidStatus {
+    /// Not yet committed — e.g. assistant entry streaming, still to see
+    /// a `Result` event.
+    #[default]
+    Pending,
+    /// Final — safe to use as a retry target.
+    Committed,
+}
+
+/// Per-turn metadata attached to assistant entries (Feature 3 / ADR-042).
+///
+/// All fields are optional so the frontend degrades gracefully when the
+/// stream does not carry usage data (older session resumes, edge cases).
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default)]
+pub struct EntryMeta {
+    /// Model id used for this turn (e.g. `claude-opus-4-7-20260501`).
+    #[serde(default)]
+    pub model: Option<String>,
+    /// Token usage for this turn (deltas vs the session snapshot at turn start).
+    #[serde(default)]
+    pub usage: Option<TurnUsage>,
+    /// Cost in USD for this turn. Backend may supply verbatim from
+    /// `Result.total_cost_usd`; otherwise frontend `pricing.ts` computes it.
+    #[serde(default)]
+    pub cost: Option<f64>,
+}
+
+/// Per-turn token usage. Missing fields are zeroed, not absent, because the
+/// frontend arithmetic needs defined values.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Default)]
+pub struct TurnUsage {
+    /// Input tokens consumed this turn.
+    #[serde(default)]
+    pub input_tokens: u64,
+    /// Output tokens generated this turn.
+    #[serde(default)]
+    pub output_tokens: u64,
+    /// Cache-read tokens this turn.
+    #[serde(default)]
+    pub cache_read_tokens: u64,
+    /// Cache-write tokens this turn.
+    #[serde(default)]
+    pub cache_write_tokens: u64,
+}
+
+/// Rolling totals for the whole session. Bound by the same handler that
+/// emits per-entry `meta` patches so `sum(entries.meta.*) == session_totals`.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Default)]
+pub struct SessionTotals {
+    /// Cumulative input tokens across the session.
+    #[serde(default)]
+    pub input_tokens: u64,
+    /// Cumulative output tokens across the session.
+    #[serde(default)]
+    pub output_tokens: u64,
+    /// Cumulative cache-read tokens.
+    #[serde(default)]
+    pub cache_read_tokens: u64,
+    /// Cumulative cache-write tokens.
+    #[serde(default)]
+    pub cache_write_tokens: u64,
+    /// Cumulative cost in USD.
+    #[serde(default)]
+    pub cost: f64,
+    /// Number of completed turns in this session.
+    #[serde(default)]
+    pub turn_count: u64,
+}
+
+/// One-slot queued message waiting for the active turn to finish (ADR-045).
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct QueuedMessage {
+    /// Full text content (not a preview — the UI derives previews).
+    pub text: String,
+    /// Unix-ms timestamp the queue slot was last set.
+    pub queued_at: u64,
+}
+
+/// One block inside a conversation entry. Matches the union shape of the
+/// desktop `StreamChunk` event family (`desktop/src-tauri/src/chat.rs`) but
+/// represents the aggregated state after delta application — not the event.
+///
+/// Tagged enum: serde serializes as `{"kind":"Text","content":"..."}` so a
+/// JSON Patch can replace a block in-place without a re-typing dance.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum MessageBlock {
+    /// Rendered assistant/user text. Markdown preserved verbatim; rendering
+    /// happens in the UI. Streaming appends to `content` via `Replace` patches.
+    Text {
+        /// Current text content (may grow during streaming).
+        content: String,
+    },
+    /// Extended thinking / interleaved thinking content.
+    Thinking {
+        /// Accumulated thinking content.
+        content: String,
+    },
+    /// Tool invocation. The UI normalizes `kind` to a renderer.
+    ToolUse {
+        /// Tool-use id from the stream event.
+        tool_id: String,
+        /// Tool name as reported by Claude (e.g. `Bash`, `Read`).
+        tool_name: String,
+        /// Current accumulated input JSON (may be partial during streaming).
+        #[serde(default)]
+        input: String,
+        /// Final tool result body when available.
+        #[serde(default)]
+        result: Option<String>,
+        /// `true` when the tool reported an error.
+        #[serde(default)]
+        is_error: bool,
+    },
+    /// Interactive question from Claude (the `AskUserQuestion` tool variant).
+    AskUser {
+        /// Tool-use id from the stream event.
+        tool_id: String,
+        /// Short header shown above the question.
+        header: String,
+        /// Full question text.
+        question: String,
+        /// Available options.
+        options: Vec<AskUserOption>,
+        /// Whether more than one option can be selected.
+        multi_select: bool,
+        /// Selected values once the user answered. `None` while pending.
+        #[serde(default)]
+        answer: Option<Vec<String>>,
+    },
+    /// Terminal error surfaced as a block (rate_limit, network, etc.).
+    Error {
+        /// Error payload content suitable for display.
+        content: String,
+    },
+}
+
+/// Single option inside an `AskUser` block.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct AskUserOption {
+    /// Human-readable label.
+    pub label: String,
+    /// Value sent back as the answer.
+    pub value: String,
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn default_state_is_empty() {
+        let state = ConversationState::default();
+        assert!(state.entries.is_empty());
+        assert!(state.session_id.is_none());
+        assert!(state.pending_queue.is_none());
+        assert!(!state.is_streaming);
+        assert_eq!(state.session_totals, SessionTotals::default());
+    }
+
+    #[test]
+    fn conversation_state_roundtrip() {
+        let state = ConversationState {
+            session_id: Some("sess-1".into()),
+            entries: vec![ConversationEntry {
+                index: 0,
+                role: EntryRole::User,
+                uuid: Some("u-1".into()),
+                uuid_status: UuidStatus::Committed,
+                blocks: vec![MessageBlock::Text {
+                    content: "hello".into(),
+                }],
+                meta: None,
+                edited_at: None,
+                timestamp: 1,
+            }],
+            session_totals: SessionTotals {
+                input_tokens: 10,
+                output_tokens: 20,
+                cache_read_tokens: 5,
+                cache_write_tokens: 3,
+                cost: 0.012,
+                turn_count: 1,
+            },
+            pending_queue: Some(QueuedMessage {
+                text: "queued".into(),
+                queued_at: 2,
+            }),
+            model: Some("opus-4.7".into()),
+            is_streaming: false,
+        };
+        let encoded = serde_json::to_value(&state).unwrap();
+        let decoded: ConversationState = serde_json::from_value(encoded).unwrap();
+        assert_eq!(state, decoded);
+    }
+
+    #[test]
+    fn entry_role_serializes_lowercase() {
+        assert_eq!(
+            serde_json::to_value(EntryRole::User).unwrap(),
+            json!("user")
+        );
+        assert_eq!(
+            serde_json::to_value(EntryRole::Assistant).unwrap(),
+            json!("assistant")
+        );
+    }
+
+    #[test]
+    fn uuid_status_default_is_pending() {
+        assert_eq!(UuidStatus::default(), UuidStatus::Pending);
+        let v: UuidStatus = serde_json::from_value(json!("committed")).unwrap();
+        assert_eq!(v, UuidStatus::Committed);
+    }
+
+    #[test]
+    fn message_block_tag_roundtrip() {
+        let blocks = vec![
+            MessageBlock::Text {
+                content: "hi".into(),
+            },
+            MessageBlock::Thinking {
+                content: "…".into(),
+            },
+            MessageBlock::ToolUse {
+                tool_id: "t1".into(),
+                tool_name: "Bash".into(),
+                input: "{\"cmd\":\"ls\"}".into(),
+                result: Some("/".into()),
+                is_error: false,
+            },
+            MessageBlock::AskUser {
+                tool_id: "q1".into(),
+                header: "h".into(),
+                question: "q?".into(),
+                options: vec![AskUserOption {
+                    label: "Yes".into(),
+                    value: "yes".into(),
+                }],
+                multi_select: false,
+                answer: None,
+            },
+            MessageBlock::Error {
+                content: "boom".into(),
+            },
+        ];
+        let encoded = serde_json::to_value(&blocks).unwrap();
+        let decoded: Vec<MessageBlock> = serde_json::from_value(encoded).unwrap();
+        assert_eq!(blocks, decoded);
+    }
+
+    #[test]
+    fn tool_use_optional_fields_default() {
+        let blocks: Vec<MessageBlock> = serde_json::from_value(json!([{
+            "kind": "tool_use",
+            "tool_id": "t1",
+            "tool_name": "Read"
+        }]))
+        .unwrap();
+        match &blocks[0] {
+            MessageBlock::ToolUse {
+                input,
+                result,
+                is_error,
+                ..
+            } => {
+                assert!(input.is_empty());
+                assert!(result.is_none());
+                assert!(!*is_error);
+            }
+            other => panic!("unexpected variant: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn turn_usage_missing_fields_default_to_zero() {
+        let usage: TurnUsage = serde_json::from_value(json!({})).unwrap();
+        assert_eq!(usage, TurnUsage::default());
+    }
+
+    #[test]
+    fn session_totals_roundtrip_with_fractional_cost() {
+        let totals = SessionTotals {
+            input_tokens: 1,
+            output_tokens: 2,
+            cache_read_tokens: 3,
+            cache_write_tokens: 4,
+            cost: 1.2345,
+            turn_count: 7,
+        };
+        let encoded = serde_json::to_value(totals).unwrap();
+        let decoded: SessionTotals = serde_json::from_value(encoded).unwrap();
+        assert_eq!(totals, decoded);
+    }
+
+    #[test]
+    fn queued_message_roundtrip() {
+        let q = QueuedMessage {
+            text: "next".into(),
+            queued_at: 42,
+        };
+        let encoded = serde_json::to_value(&q).unwrap();
+        let decoded: QueuedMessage = serde_json::from_value(encoded).unwrap();
+        assert_eq!(q, decoded);
+    }
+
+    #[test]
+    fn entry_meta_defaults_are_none() {
+        let meta = EntryMeta::default();
+        assert!(meta.model.is_none());
+        assert!(meta.usage.is_none());
+        assert!(meta.cost.is_none());
+    }
+
+    #[test]
+    fn entry_defaults_for_unicode_content() {
+        let entry = ConversationEntry {
+            index: 0,
+            role: EntryRole::User,
+            uuid: None,
+            uuid_status: UuidStatus::Pending,
+            blocks: vec![MessageBlock::Text {
+                content: "héllo 🌊".into(),
+            }],
+            meta: None,
+            edited_at: None,
+            timestamp: 0,
+        };
+        let encoded = serde_json::to_string(&entry).unwrap();
+        let decoded: ConversationEntry = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(entry, decoded);
+    }
+}

--- a/crates/speedwave-runtime/src/stream/state_tree.rs
+++ b/crates/speedwave-runtime/src/stream/state_tree.rs
@@ -11,7 +11,11 @@ use serde::{Deserialize, Serialize};
 /// Every Tauri event emitted from Rust is a `json_patch::Patch` applied to a
 /// value of this type (see ADR-042). Reducer must stay pure: history replay +
 /// patch sequence must converge on the same state regardless of delivery time.
-#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
+/// Manual `Debug` is implemented below to redact `session_id`; per
+/// `.claude/rules/logging.md`, structs containing per-session identifiers
+/// must redact them in `Debug` output so accidental `format!("{state:?}")`
+/// calls cannot leak them to logs.
+#[derive(Serialize, Deserialize, Clone, Default, PartialEq)]
 pub struct ConversationState {
     /// Claude Code session identifier. `None` before the first `SystemInit`.
     #[serde(default)]
@@ -33,6 +37,19 @@ pub struct ConversationState {
     /// `true` while a turn is being streamed from Claude Code.
     #[serde(default)]
     pub is_streaming: bool,
+}
+
+impl std::fmt::Debug for ConversationState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ConversationState")
+            .field("session_id", &self.session_id.as_ref().map(|_| "…"))
+            .field("entries", &self.entries)
+            .field("session_totals", &self.session_totals)
+            .field("pending_queue", &self.pending_queue)
+            .field("model", &self.model)
+            .field("is_streaming", &self.is_streaming)
+            .finish()
+    }
 }
 
 /// One entry in the conversation — user or assistant. Tool uses and errors

--- a/crates/speedwave-runtime/src/stream/state_tree.rs
+++ b/crates/speedwave-runtime/src/stream/state_tree.rs
@@ -410,6 +410,73 @@ mod tests {
         assert!(meta.cost.is_none());
     }
 
+    /// `Debug` for `ConversationState` must redact `session_id` so
+    /// accidental `format!("{state:?}")` (e.g. from `dbg!`, `panic!`, or
+    /// `tracing::debug!`) cannot leak the per-session identifier. Per
+    /// `.claude/rules/logging.md`, structs carrying per-session identifiers
+    /// must redact them in `Debug` output. Other diagnostic fields stay
+    /// visible — only the identifier is hidden.
+    #[test]
+    fn debug_redacts_session_id() {
+        let state = ConversationState {
+            session_id: Some("secret-uuid".into()),
+            entries: vec![ConversationEntry {
+                index: 0,
+                role: EntryRole::User,
+                uuid: None,
+                uuid_status: UuidStatus::Pending,
+                blocks: vec![MessageBlock::Text {
+                    content: "diagnostic-text".into(),
+                }],
+                meta: None,
+                edited_at: None,
+                timestamp: 1,
+            }],
+            model: Some("opus-4.7".into()),
+            is_streaming: true,
+            ..Default::default()
+        };
+        let dbg = format!("{state:?}");
+        assert!(
+            !dbg.contains("secret-uuid"),
+            "session_id leaked through Debug: {dbg}"
+        );
+        assert!(
+            dbg.contains('…'),
+            "expected redaction marker for session_id, got: {dbg}"
+        );
+        // Non-secret diagnostic fields must still be visible.
+        assert!(
+            dbg.contains("diagnostic-text"),
+            "expected entry text in Debug, got: {dbg}"
+        );
+        assert!(
+            dbg.contains("opus-4.7"),
+            "expected model in Debug, got: {dbg}"
+        );
+        assert!(
+            dbg.contains("is_streaming"),
+            "expected struct field name in Debug, got: {dbg}"
+        );
+    }
+
+    /// When `session_id` is `None`, the redaction marker must not appear —
+    /// the redaction maps `Some(_) -> Some("…")` and `None -> None` so
+    /// the absence of an identifier is honestly reported.
+    #[test]
+    fn debug_session_id_none_renders_as_none() {
+        let state = ConversationState::default();
+        let dbg = format!("{state:?}");
+        assert!(
+            dbg.contains("session_id: None"),
+            "expected None for absent session_id, got: {dbg}"
+        );
+        assert!(
+            !dbg.contains('…'),
+            "redaction marker leaked when no session_id present: {dbg}"
+        );
+    }
+
     #[test]
     fn entry_defaults_for_unicode_content() {
         let entry = ConversationEntry {


### PR DESCRIPTION
## Summary
- Introduces `crates/speedwave-runtime/src/stream/` as the SSOT for the JSON-Patch stream protocol documented in ADRs 042, 043, 044 — the foundation for the terminal-minimal desktop rewrite.
- Ships `ConversationState` and its child types (state-tree shape), typed `ConversationPatch` helpers producing `json_patch::Patch` values, the pure `apply()` reducer, a per-session `MsgStore` with broadcast channel + 100 MB bounded history + lagged-subscriber `Resync`, and an `EntryIndexProvider` atomic counter with `start_from` recovery.
- Zero Tauri coupling — crate stays pure Rust per `.claude/rules/rust-style.md`; Wave 5 units 13/14/15 will consume this library.

## What this unit is NOT
- No frontend wiring (Angular consumes this in a later unit).
- No Tauri command (added in the bridge unit).
- No `QueuedMessageService` — ADR-045 adds that later, this crate only exposes the `pending_queue` slot shape so future patches can target it.
- No ADRs merged yet — this unit is the foundation; the ADRs merge in a separate docs-only PR (see implementation prompt step 1).

## Tests — 38 all passing
- `state_tree`: defaults, serde roundtrip for every type (including Unicode in `Text` content), tagged-enum shape for `MessageBlock`, `#[serde(default)]` behavior for optional fields.
- `patch`: happy path + idempotency on `Replace` + sequential-equals-composed property check + out-of-range rejection + multi-entry sequence.
- `msg_store`: push/history, snapshot replay, subscribe-sees-future-only, `history_plus_stream` yields history then live, cap drops oldest but keeps a sole oversized message, lagged subscriber receives `Resync`, 10×100 concurrent pushes safe.
- `entry_index`: monotonic `next`, shared counter across clones, `start_from` empty store returns 0, `start_from` picks highest+1, 10×100 concurrent `next` calls produce 1000 unique values.

## Live UI
Not exercised — backbone library only; consumed by future units.

## Test plan
- [x] `make test-rust` — 38 new tests pass; one pre-existing compose test (`test_hub_worker_urls_use_port_worker`) fails on this dev machine due to a stale `~/.speedwave/mcp-os-port` (unrelated to this change — reproduces on `origin/dev` without any of this PR's code).
- [x] `make check-clippy` — 0 warnings.
- [x] `make check-fmt` — clean (cargo fmt + prettier).
- [ ] `make test` — full suite needs CI to verify the non-Rust side since the local flake blocks green on the Rust integration test.