### PR TITLE
style(desktop): port terminal-minimal design tokens

### DIFF
--- a/desktop/src/src/styles.css
+++ b/desktop/src/src/styles.css
@@ -7,6 +7,10 @@
  * --bg / --ink / --accent / --teal / --amber / --green / --violet / --line
  * (and their variants) — never hex literals, never the legacy --color-sw-*
  * tokens below.
+ *
+ * Tokens are unprefixed — Tauri closed WebView means we control all CSS;
+ * the mockup uses these names verbatim and adopting them preserves 1:1
+ * fidelity with the design source.
  */
 :root {
   color-scheme: dark;
@@ -39,7 +43,7 @@
   --violet: #a78bfa;
 }
 
-/* Accent themes share the neutral crimson backgrounds; only the accent and
+/* Accent themes share the neutral dark backgrounds; only the accent and
  * its derived alphas change. Switched via `data-theme` on the root element.
  */
 
@@ -49,16 +53,16 @@
   --accent-soft: rgba(94, 234, 212, 0.1);
 }
 
-[data-theme='amber'] {
+[data-theme='gold'] {
   --accent: #f5b942;
   --accent-dim: #d99a24;
   --accent-soft: rgba(245, 185, 66, 0.1);
 }
 
-[data-theme='iris'] {
+[data-theme='purple'] {
   --accent: #a78bfa;
   --accent-dim: #8b5cf6;
-  --accent-soft: rgba(167, 139, 250, 0.12);
+  --accent-soft: rgba(167, 139, 250, 0.1);
 }
 
 [data-theme='cyan'] {
@@ -259,6 +263,7 @@
     padding-left: 1rem;
   }
 
+  /* explicit override, same as default `--shape-color: var(--accent)` — kept for readable markup */
   .timeline-event-accent {
     --shape-color: var(--accent);
   }
@@ -281,9 +286,11 @@
     box-shadow: 0 0 0 1px color-mix(in oklab, var(--shape-color) 40%, transparent);
     background-color: color-mix(in oklab, var(--shape-color) 6%, transparent);
     padding: 0.75rem;
+    /* clips corner overflow from rounded ring descendants */
     overflow: hidden;
   }
 
+  /* explicit override, same as default `--shape-color: var(--accent)` — kept for readable markup */
   .callout-box-accent {
     --shape-color: var(--accent);
   }
@@ -299,10 +306,9 @@
   .callout-box-violet {
     --shape-color: var(--violet);
   }
-}
 
-/* ── Prose layer for rendered markdown (innerHTML) ── */
-@layer components {
+  /* ── Prose layer for rendered markdown (innerHTML) ── */
+
   /* Collapse margins at container edges */
   .prose-sw :first-child {
     margin-top: 0;

--- a/desktop/src/src/styles.css
+++ b/desktop/src/src/styles.css
@@ -1,7 +1,106 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 
-/* ── Speedwave custom theme ── */
+/* ── Speedwave design-system tokens ──
+ *
+ * Ported from design-proposals/06-terminal-minimal.html. Canonical color
+ * tokens for the terminal-minimal visual layer. New components MUST use
+ * --bg / --ink / --accent / --teal / --amber / --green / --violet / --line
+ * (and their variants) — never hex literals, never the legacy --color-sw-*
+ * tokens below.
+ */
+:root {
+  color-scheme: dark;
+
+  /* Backgrounds — deepest to lightest */
+  --bg: #07090f;
+  --bg-1: #0b0e18;
+  --bg-2: #10141f;
+  --bg-3: #161b2a;
+
+  /* Dividers */
+  --line: #1a2030;
+  --line-strong: #252c42;
+
+  /* Text */
+  --ink: #e8edf7;
+  --ink-dim: #9aa3ba;
+  --ink-mute: #707a96;
+
+  /* Primary accent — rose by default; themes below override. */
+  --accent: #ff4d6d;
+  --accent-dim: #c9304e;
+  --accent-soft: rgba(255, 77, 109, 0.1);
+  --on-accent: #07090f;
+
+  /* Semantic colors (stable across themes) */
+  --teal: #22d3b7;
+  --amber: #f5b942;
+  --green: #34d399;
+  --violet: #a78bfa;
+}
+
+/* Accent themes share the neutral crimson backgrounds; only the accent and
+ * its derived alphas change. Switched via `data-theme` on the root element.
+ */
+
+[data-theme='mint'] {
+  --accent: #5eead4;
+  --accent-dim: #2dd4bf;
+  --accent-soft: rgba(94, 234, 212, 0.1);
+}
+
+[data-theme='amber'] {
+  --accent: #f5b942;
+  --accent-dim: #d99a24;
+  --accent-soft: rgba(245, 185, 66, 0.1);
+}
+
+[data-theme='iris'] {
+  --accent: #a78bfa;
+  --accent-dim: #8b5cf6;
+  --accent-soft: rgba(167, 139, 250, 0.12);
+}
+
+[data-theme='cyan'] {
+  --accent: #38bdf8;
+  --accent-dim: #0ea5e9;
+  --accent-soft: rgba(56, 189, 248, 0.1);
+}
+
+[data-theme='sand'] {
+  --accent: #d4a574;
+  --accent-dim: #a97f4e;
+  --accent-soft: rgba(212, 165, 116, 0.1);
+}
+
+/* Expose design-system tokens as Tailwind utilities so components can write
+ * bg-bg-1, text-ink, text-accent, ring-line, etc. — no hex literals in markup.
+ */
 @theme {
+  /* Design-system tokens — primary set for new components. */
+  --color-bg: var(--bg);
+  --color-bg-1: var(--bg-1);
+  --color-bg-2: var(--bg-2);
+  --color-bg-3: var(--bg-3);
+  --color-line: var(--line);
+  --color-line-strong: var(--line-strong);
+  --color-ink: var(--ink);
+  --color-ink-dim: var(--ink-dim);
+  --color-ink-mute: var(--ink-mute);
+  --color-accent: var(--accent);
+  --color-accent-dim: var(--accent-dim);
+  --color-accent-soft: var(--accent-soft);
+  --color-on-accent: var(--on-accent);
+  --color-teal: var(--teal);
+  --color-amber: var(--amber);
+  --color-green: var(--green);
+  --color-violet: var(--violet);
+
+  /* Legacy tokens — superseded by the design-system tokens above.
+   * Do NOT use in new code. Removed in a follow-up sweep once all existing
+   * components have migrated.
+   */
+
   /* Background palette */
   --color-sw-bg-darkest: #1a1a2e;
   --color-sw-bg-darker: #12122a;
@@ -86,16 +185,20 @@
   --animate-blink: blink 1s step-end infinite;
 
   @keyframes sw-spin {
-    to { transform: rotate(360deg); }
+    to {
+      transform: rotate(360deg);
+    }
   }
   @keyframes blink {
-    50% { opacity: 0; }
+    50% {
+      opacity: 0;
+    }
   }
 }
 
-/* ── Base styles ── */
 @layer base {
-  html, body {
+  html,
+  body {
     height: 100%;
     font-family: var(--font-mono);
     font-size: 14px;
@@ -121,35 +224,158 @@
     font-family: inherit;
   }
 
-  code, pre {
+  code,
+  pre {
     font-family: var(--font-mono);
+  }
+
+  /* Global focus ring — double-ring ensures visibility on any background.
+   * Inner 2px = accent; outer 2px = page background carves a gap against
+   * sibling content. Components MUST NOT add their own focus rings.
+   */
+  :focus-visible {
+    outline: none;
+    box-shadow:
+      0 0 0 2px var(--accent),
+      0 0 0 4px var(--bg);
+  }
+}
+
+/* Two shapes for every message/block in the mockup:
+ *
+ *   .timeline-event — passive status (tool use, thinking, errors, stopped):
+ *     2px accent left border + 16px left padding; no background, no ring.
+ *
+ *   .callout-box — requires user attention (permission, ask_user, cards):
+ *     rounded + 1px accent ring + tinted background + 12px padding.
+ *
+ * Color is driven by `--shape-color` (defaulting to --accent). Semantic
+ * variants just override that property; the shape itself is defined once.
+ */
+@layer components {
+  .timeline-event {
+    --shape-color: var(--accent);
+    border-left: 2px solid color-mix(in oklab, var(--shape-color) 50%, transparent);
+    padding-left: 1rem;
+  }
+
+  .timeline-event-accent {
+    --shape-color: var(--accent);
+  }
+  .timeline-event-teal {
+    --shape-color: var(--teal);
+  }
+  .timeline-event-amber {
+    --shape-color: var(--amber);
+  }
+  .timeline-event-green {
+    --shape-color: var(--green);
+  }
+  .timeline-event-violet {
+    --shape-color: var(--violet);
+  }
+
+  .callout-box {
+    --shape-color: var(--accent);
+    border-radius: 0.25rem;
+    box-shadow: 0 0 0 1px color-mix(in oklab, var(--shape-color) 40%, transparent);
+    background-color: color-mix(in oklab, var(--shape-color) 6%, transparent);
+    padding: 0.75rem;
+    overflow: hidden;
+  }
+
+  .callout-box-accent {
+    --shape-color: var(--accent);
+  }
+  .callout-box-teal {
+    --shape-color: var(--teal);
+  }
+  .callout-box-amber {
+    --shape-color: var(--amber);
+  }
+  .callout-box-green {
+    --shape-color: var(--green);
+  }
+  .callout-box-violet {
+    --shape-color: var(--violet);
   }
 }
 
 /* ── Prose layer for rendered markdown (innerHTML) ── */
 @layer components {
   /* Collapse margins at container edges */
-  .prose-sw :first-child { margin-top: 0; }
-  .prose-sw :last-child  { margin-bottom: 0; }
+  .prose-sw :first-child {
+    margin-top: 0;
+  }
+  .prose-sw :last-child {
+    margin-bottom: 0;
+  }
 
   /* Headings */
-  .prose-sw h1 { font-size: 1.75em; font-weight: 700; color: var(--color-sw-text); margin: 24px 0 12px; }
-  .prose-sw h2 { font-size: 1.5em;  font-weight: 700; color: var(--color-sw-text); margin: 20px 0 10px; }
-  .prose-sw h3 { font-size: 1.25em; font-weight: 600; color: var(--color-sw-text); margin: 16px 0 8px; }
-  .prose-sw h4 { font-size: 1.1em;  font-weight: 600; color: var(--color-sw-text); margin: 14px 0 6px; }
-  .prose-sw h5 { font-size: 1em;    font-weight: 600; color: var(--color-sw-text); margin: 12px 0 4px; }
-  .prose-sw h6 { font-size: 0.9em;  font-weight: 600; color: var(--color-sw-text-dim); margin: 12px 0 4px; }
+  .prose-sw h1 {
+    font-size: 1.75em;
+    font-weight: 700;
+    color: var(--color-sw-text);
+    margin: 24px 0 12px;
+  }
+  .prose-sw h2 {
+    font-size: 1.5em;
+    font-weight: 700;
+    color: var(--color-sw-text);
+    margin: 20px 0 10px;
+  }
+  .prose-sw h3 {
+    font-size: 1.25em;
+    font-weight: 600;
+    color: var(--color-sw-text);
+    margin: 16px 0 8px;
+  }
+  .prose-sw h4 {
+    font-size: 1.1em;
+    font-weight: 600;
+    color: var(--color-sw-text);
+    margin: 14px 0 6px;
+  }
+  .prose-sw h5 {
+    font-size: 1em;
+    font-weight: 600;
+    color: var(--color-sw-text);
+    margin: 12px 0 4px;
+  }
+  .prose-sw h6 {
+    font-size: 0.9em;
+    font-weight: 600;
+    color: var(--color-sw-text-dim);
+    margin: 12px 0 4px;
+  }
 
   /* Paragraphs */
-  .prose-sw p { color: var(--color-sw-text); line-height: 1.6; margin: 8px 0; }
+  .prose-sw p {
+    color: var(--color-sw-text);
+    line-height: 1.6;
+    margin: 8px 0;
+  }
 
   /* Lists */
   .prose-sw ul,
-  .prose-sw ol { margin: 8px 0; padding-left: 24px; color: var(--color-sw-text); }
-  .prose-sw ul { list-style-type: disc; }
-  .prose-sw ol { list-style-type: decimal; }
-  .prose-sw li { margin: 4px 0; line-height: 1.6; }
-  .prose-sw li::marker { color: var(--color-sw-text-muted); }
+  .prose-sw ol {
+    margin: 8px 0;
+    padding-left: 24px;
+    color: var(--color-sw-text);
+  }
+  .prose-sw ul {
+    list-style-type: disc;
+  }
+  .prose-sw ol {
+    list-style-type: decimal;
+  }
+  .prose-sw li {
+    margin: 4px 0;
+    line-height: 1.6;
+  }
+  .prose-sw li::marker {
+    color: var(--color-sw-text-muted);
+  }
 
   /* Code blocks */
   .prose-sw pre {
@@ -190,25 +416,57 @@
   }
 
   /* Links */
-  .prose-sw a { color: var(--color-sw-accent); text-decoration: none; }
-  .prose-sw a:hover { text-decoration: underline; }
+  .prose-sw a {
+    color: var(--color-sw-accent);
+    text-decoration: none;
+  }
+  .prose-sw a:hover {
+    text-decoration: underline;
+  }
 
   /* Tables */
-  .prose-sw table { border-collapse: collapse; width: 100%; margin: 12px 0; }
+  .prose-sw table {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 12px 0;
+  }
   .prose-sw th,
-  .prose-sw td { border: 1px solid var(--color-sw-border); padding: 8px 12px; text-align: left; }
-  .prose-sw th { background: var(--color-sw-bg-abyss); color: var(--color-sw-text); font-weight: 600; }
-  .prose-sw td { color: var(--color-sw-text-dim); }
+  .prose-sw td {
+    border: 1px solid var(--color-sw-border);
+    padding: 8px 12px;
+    text-align: left;
+  }
+  .prose-sw th {
+    background: var(--color-sw-bg-abyss);
+    color: var(--color-sw-text);
+    font-weight: 600;
+  }
+  .prose-sw td {
+    color: var(--color-sw-text-dim);
+  }
 
   /* Horizontal rule */
-  .prose-sw hr { border: none; border-top: 1px solid var(--color-sw-border); margin: 16px 0; }
+  .prose-sw hr {
+    border: none;
+    border-top: 1px solid var(--color-sw-border);
+    margin: 16px 0;
+  }
 
   /* Emphasis */
-  .prose-sw strong { color: var(--color-sw-text); font-weight: 700; }
-  .prose-sw em { font-style: italic; }
+  .prose-sw strong {
+    color: var(--color-sw-text);
+    font-weight: 700;
+  }
+  .prose-sw em {
+    font-style: italic;
+  }
 
   /* Images */
-  .prose-sw img { max-width: 100%; border-radius: 6px; margin: 12px 0; }
+  .prose-sw img {
+    max-width: 100%;
+    border-radius: 6px;
+    margin: 12px 0;
+  }
 }
 
 /* ── Scrollbar (not supported by Tailwind) ── */

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,10 @@ Welcome to the Speedwave documentation. Speedwave is an AI platform that connect
 - [Testing](contributing/testing.md) — test strategy, coverage, CI
 - [Release Signing](contributing/release-signing.md) — macOS code signing, notarization, certificate rotation
 
+## Accessibility
+
+- [Contrast Report](accessibility/contrast-report.md) — WCAG AA verification for design-system color tokens
+
 ## Architecture Decision Records
 
 - [ADR Index](adr/README.md) — all architectural decisions

--- a/docs/accessibility/contrast-report.md
+++ b/docs/accessibility/contrast-report.md
@@ -32,6 +32,7 @@ Base palette (shared across every theme):
 | `--ink-mute`    | `#707a96`                 |
 | `--accent`      | `#ff4d6d` (rose, default) |
 | `--accent-dim`  | `#c9304e`                 |
+| `--on-accent`   | `#07090f`                 |
 | `--teal`        | `#22d3b7`                 |
 | `--amber`       | `#f5b942`                 |
 | `--green`       | `#34d399`                 |
@@ -43,8 +44,8 @@ Accent overrides per theme:
 | -------------- | ---------- | -------------- |
 | default (rose) | `#ff4d6d`  | `#c9304e`      |
 | `mint`         | `#5eead4`  | `#2dd4bf`      |
-| `amber`        | `#f5b942`  | `#d99a24`      |
-| `iris`         | `#a78bfa`  | `#8b5cf6`      |
+| `gold`         | `#f5b942`  | `#d99a24`      |
+| `purple`       | `#a78bfa`  | `#8b5cf6`      |
 | `cyan`         | `#38bdf8`  | `#0ea5e9`      |
 | `sand`         | `#d4a574`  | `#a97f4e`      |
 
@@ -79,9 +80,27 @@ Accent overrides per theme:
 | `--accent`     | `--bg-1`   | TBD   | 4.5:1   | TBD    |
 | `--accent-dim` | `--bg`     | TBD   | 4.5:1   | TBD    |
 
-### Mint, Amber, Iris, Cyan, Sand
+### Mint, Gold, Purple, Cyan, Sand
 
 TBD — Wave 6 fills with measured ratios per theme.
+
+## On-accent text contrast
+
+`--on-accent` (`#07090f`) is the text color that sits on top of a filled
+`--accent` button. This is arguably the highest-stakes contrast pair in the
+UI — button label text must meet the **4.5:1** body-text minimum against the
+filled accent surface of every theme.
+
+<!-- Content to be written: Wave 6 fills with measured ratios per theme. -->
+
+| Foreground    | Background (theme `--accent`) | Ratio | Minimum | Status |
+| ------------- | ----------------------------- | ----- | ------- | ------ |
+| `--on-accent` | `#ff4d6d` (rose, default)     | TBD   | 4.5:1   | TBD    |
+| `--on-accent` | `#5eead4` (mint)              | TBD   | 4.5:1   | TBD    |
+| `--on-accent` | `#f5b942` (gold)              | TBD   | 4.5:1   | TBD    |
+| `--on-accent` | `#a78bfa` (purple)            | TBD   | 4.5:1   | TBD    |
+| `--on-accent` | `#38bdf8` (cyan)              | TBD   | 4.5:1   | TBD    |
+| `--on-accent` | `#d4a574` (sand)              | TBD   | 4.5:1   | TBD    |
 
 ## Semantic colors on backgrounds
 

--- a/docs/accessibility/contrast-report.md
+++ b/docs/accessibility/contrast-report.md
@@ -1,0 +1,134 @@
+# Color Contrast Report
+
+WCAG 2.1 AA contrast measurements for every foreground/background token pair in
+the Speedwave terminal-minimal design system. Tokens are defined in
+[`desktop/src/src/styles.css`](../../desktop/src/src/styles.css) and ported
+from [`design-proposals/06-terminal-minimal.html`](../../design-proposals/06-terminal-minimal.html).
+
+WCAG AA targets:
+
+- Body text: **4.5:1**
+- Large text and UI chrome: **3.0:1**
+- Non-text UI components (focus indicators, dividers): **3.0:1**
+
+Each section below lists the measured ratio and a PASS/FAIL verdict for the
+token pair. The `TBD` rows are filled in by the accessibility sweep unit
+(Wave 6) using a reproducible tool (axe-core / Stark / Contrast Finder).
+
+## Token inventory
+
+Base palette (shared across every theme):
+
+| Token           | Hex                       |
+| --------------- | ------------------------- |
+| `--bg`          | `#07090f`                 |
+| `--bg-1`        | `#0b0e18`                 |
+| `--bg-2`        | `#10141f`                 |
+| `--bg-3`        | `#161b2a`                 |
+| `--line`        | `#1a2030`                 |
+| `--line-strong` | `#252c42`                 |
+| `--ink`         | `#e8edf7`                 |
+| `--ink-dim`     | `#9aa3ba`                 |
+| `--ink-mute`    | `#707a96`                 |
+| `--accent`      | `#ff4d6d` (rose, default) |
+| `--accent-dim`  | `#c9304e`                 |
+| `--teal`        | `#22d3b7`                 |
+| `--amber`       | `#f5b942`                 |
+| `--green`       | `#34d399`                 |
+| `--violet`      | `#a78bfa`                 |
+
+Accent overrides per theme:
+
+| Theme          | `--accent` | `--accent-dim` |
+| -------------- | ---------- | -------------- |
+| default (rose) | `#ff4d6d`  | `#c9304e`      |
+| `mint`         | `#5eead4`  | `#2dd4bf`      |
+| `amber`        | `#f5b942`  | `#d99a24`      |
+| `iris`         | `#a78bfa`  | `#8b5cf6`      |
+| `cyan`         | `#38bdf8`  | `#0ea5e9`      |
+| `sand`         | `#d4a574`  | `#a97f4e`      |
+
+## Body text on backgrounds
+
+<!-- Content to be written: Wave 6 fills with measured ratios. -->
+
+| Foreground   | Background | Ratio | Minimum | Status |
+| ------------ | ---------- | ----- | ------- | ------ |
+| `--ink`      | `--bg`     | TBD   | 4.5:1   | TBD    |
+| `--ink`      | `--bg-1`   | TBD   | 4.5:1   | TBD    |
+| `--ink`      | `--bg-2`   | TBD   | 4.5:1   | TBD    |
+| `--ink`      | `--bg-3`   | TBD   | 4.5:1   | TBD    |
+| `--ink-dim`  | `--bg`     | TBD   | 4.5:1   | TBD    |
+| `--ink-dim`  | `--bg-1`   | TBD   | 4.5:1   | TBD    |
+| `--ink-dim`  | `--bg-2`   | TBD   | 4.5:1   | TBD    |
+| `--ink-dim`  | `--bg-3`   | TBD   | 4.5:1   | TBD    |
+| `--ink-mute` | `--bg`     | TBD   | 4.5:1   | TBD    |
+| `--ink-mute` | `--bg-1`   | TBD   | 4.5:1   | TBD    |
+| `--ink-mute` | `--bg-2`   | TBD   | 4.5:1   | TBD    |
+| `--ink-mute` | `--bg-3`   | TBD   | 4.5:1   | TBD    |
+
+## Accent text on backgrounds (per theme)
+
+<!-- Content to be written: Wave 6 fills per-theme measurements. -->
+
+### Default (rose)
+
+| Foreground     | Background | Ratio | Minimum | Status |
+| -------------- | ---------- | ----- | ------- | ------ |
+| `--accent`     | `--bg`     | TBD   | 4.5:1   | TBD    |
+| `--accent`     | `--bg-1`   | TBD   | 4.5:1   | TBD    |
+| `--accent-dim` | `--bg`     | TBD   | 4.5:1   | TBD    |
+
+### Mint, Amber, Iris, Cyan, Sand
+
+TBD — Wave 6 fills with measured ratios per theme.
+
+## Semantic colors on backgrounds
+
+<!-- Content to be written: Wave 6 fills with measured ratios. -->
+
+| Foreground | Background | Ratio | Minimum | Status |
+| ---------- | ---------- | ----- | ------- | ------ |
+| `--teal`   | `--bg`     | TBD   | 4.5:1   | TBD    |
+| `--teal`   | `--bg-1`   | TBD   | 4.5:1   | TBD    |
+| `--amber`  | `--bg`     | TBD   | 4.5:1   | TBD    |
+| `--amber`  | `--bg-1`   | TBD   | 4.5:1   | TBD    |
+| `--green`  | `--bg`     | TBD   | 4.5:1   | TBD    |
+| `--green`  | `--bg-1`   | TBD   | 4.5:1   | TBD    |
+| `--violet` | `--bg`     | TBD   | 4.5:1   | TBD    |
+| `--violet` | `--bg-1`   | TBD   | 4.5:1   | TBD    |
+
+## UI chrome (dividers, borders)
+
+Non-text contrast target: 3.0:1 per WCAG 1.4.11.
+
+<!-- Content to be written: Wave 6 fills with measured ratios. -->
+
+| Element         | Against  | Ratio | Minimum | Status |
+| --------------- | -------- | ----- | ------- | ------ |
+| `--line`        | `--bg`   | TBD   | 3.0:1   | TBD    |
+| `--line`        | `--bg-1` | TBD   | 3.0:1   | TBD    |
+| `--line-strong` | `--bg`   | TBD   | 3.0:1   | TBD    |
+| `--line-strong` | `--bg-1` | TBD   | 3.0:1   | TBD    |
+
+## Focus indicator
+
+The global `:focus-visible` style uses a double-ring pattern — 2px `--accent`
+wrapped by 2px `--bg`. The outer `--bg` ring ensures the inner accent ring
+remains distinguishable against any neighbouring color.
+
+<!-- Content to be written: Wave 6 measures accent-on-bg contrast per theme. -->
+
+TBD — Wave 6 fills with measured ratios.
+
+## Methodology
+
+<!-- Content to be written: Wave 6 documents the tool used and steps. -->
+
+TBD.
+
+## Remediations
+
+<!-- Content to be written: Wave 6 lists any failing pair and the proposed replacement. -->
+
+TBD.


### PR DESCRIPTION
## Summary

Wave 1 foundation for the terminal-minimal visual rewrite plan in `design-proposals/06-terminal-minimal-implementation-prompt.md`. CSS-only — no component changes. Future Wave 2/3/4 component PRs consume the tokens introduced here.

- Port mockup CSS custom properties from `design-proposals/06-terminal-minimal.html` into `desktop/src/src/styles.css` `:root`: `--bg`, `--bg-1/2/3`, `--line`, `--line-strong`, `--ink`, `--ink-dim`, `--ink-mute`, `--accent`, `--accent-dim`, `--accent-soft`, `--on-accent`, `--teal`, `--amber`, `--green`, `--violet`.
- Add five accent themes gated on `[data-theme='…']`: `mint`, `amber`, `iris`, `cyan`, `sand`. Default is rose.
- Expose every design-system token as Tailwind utilities (`bg-bg-1`, `text-ink`, `ring-line`, `text-accent`, …) via a new `@theme {}` block alongside the legacy `--color-sw-*` set.
- Add two canonical shape utilities used by every future component: `.timeline-event` (passive status) and `.callout-box` (needs user attention), each with semantic variants (`-teal`, `-amber`, `-green`, `-violet`, `-accent`) driven by a `--shape-color` custom property. Shape is defined once; variants only override the color.
- Add global `:focus-visible` double-ring so components never roll their own focus ring (Wave 6 sweeps existing per-component rings).
- Keep legacy `--color-sw-*` tokens in place with a note that they are superseded; removal happens in a later Wave 6 sweep once components migrate.
- Add `docs/accessibility/contrast-report.md` skeleton — Wave 6 fills ratios.
- Link the new accessibility section from `docs/README.md`.

## Test plan

- [x] `make check-angular-lint` — passes
- [x] `make check-angular` — passes (production build + Tauri bundle verification)
- [x] `make test-angular` — 870/870 tests pass
- [x] `make test-mcp` — 468/468 tests pass
- [x] `make check-fmt` — prettier + cargo fmt clean
- [x] `make check` — passes end-to-end

Note: `make test-rust` has 3 pre-existing failures on `dev` (before this PR) due to a stale `~/.speedwave/mcp-os-port` file picked up by `compose::tests::test_hub_worker_urls_use_port_worker` and two related tests. Those are unrelated to this CSS-only change; confirmed reproducible on a clean `origin/dev` checkout.