### PR TITLE
refactor(desktop): extract chat header, list, and user-message

### DIFF
--- a/desktop/src/src/app/chat/chat.component.html
+++ b/desktop/src/src/app/chat/chat.component.html
@@ -37,11 +37,7 @@
         </div>
       }
       @if (viewingTranscript) {
-        <div
-          class="flex-1 overflow-y-auto p-4 flex flex-col gap-3"
-          data-testid="chat-messages"
-          #messageList
-        >
+        <div class="flex-1 overflow-y-auto p-4 flex flex-col gap-3" data-testid="chat-messages">
           @for (msg of viewingTranscript.messages; track $index) {
             <div
               class="w-fit max-w-[85%] px-4 py-3 rounded-lg leading-normal break-words"

--- a/desktop/src/src/app/chat/chat.component.html
+++ b/desktop/src/src/app/chat/chat.component.html
@@ -11,26 +11,14 @@
     ></app-conversations-sidebar>
 
     <div class="flex flex-col flex-1 min-w-0 relative">
-      <div class="flex gap-1 px-3 py-1.5 bg-sw-bg-dark border-b border-sw-border">
-        <button
-          class="px-3 py-1 border border-transparent rounded text-sw-text-dim text-xs cursor-pointer transition-all hover:text-sw-text hover:bg-sw-bg-darkest"
-          data-testid="chat-history-toggle"
-          [class.!text-sw-accent]="showHistory"
-          [class.!border-sw-accent]="showHistory"
-          (click)="toggleHistory()"
-        >
-          History
-        </button>
-        <button
-          class="px-3 py-1 border border-transparent rounded text-sw-text-dim text-xs cursor-pointer transition-all hover:text-sw-text hover:bg-sw-bg-darkest"
-          data-testid="chat-memory-toggle"
-          [class.!text-sw-accent]="showMemory"
-          [class.!border-sw-accent]="showMemory"
-          (click)="toggleMemory()"
-        >
-          Memory
-        </button>
-      </div>
+      <app-chat-header
+        title="Chat"
+        [projectName]="projectState.activeProject || ''"
+        [memoryOpen]="showMemory"
+        [historyOpen]="showHistory"
+        (toggleMemory)="toggleMemory()"
+        (toggleHistory)="toggleHistory()"
+      />
 
       @if (historyError) {
         <div
@@ -85,27 +73,12 @@
           </button>
         </div>
       } @else {
-        <div
-          class="flex-1 overflow-y-auto p-4 flex flex-col gap-3"
-          data-testid="chat-messages"
-          #messageList
-        >
-          @for (msg of chat.messages; track msg.timestamp) {
-            <app-chat-message
-              [blocks]="msg.blocks"
-              [role]="msg.role"
-              (questionAnswered)="onQuestionAnswered($event)"
-            />
-          }
-          @if (chat.isStreaming && chat.currentBlocks.length) {
-            <app-chat-message
-              [blocks]="chat.currentBlocks"
-              role="assistant"
-              [streaming]="true"
-              (questionAnswered)="onQuestionAnswered($event)"
-            />
-          }
-        </div>
+        <app-chat-message-list
+          [messages]="chat.messages"
+          [currentBlocks]="chat.currentBlocks"
+          [isStreaming]="chat.isStreaming"
+          (questionAnswered)="onQuestionAnswered($event)"
+        />
         <app-session-stats [stats]="chat.sessionStats" />
         <div class="flex gap-2 px-4 py-3 bg-sw-bg-dark border-t border-sw-border">
           <textarea

--- a/desktop/src/src/app/chat/chat.component.spec.ts
+++ b/desktop/src/src/app/chat/chat.component.spec.ts
@@ -61,6 +61,32 @@ describe('ChatComponent', () => {
     chatState.isStreaming = false;
   });
 
+  // ── Composition — shell sub-components ─────────────────────────────────────
+
+  describe('shell composition', () => {
+    it('renders app-chat-header and app-chat-message-list once project is ready', async () => {
+      projectState.activeProject = 'test';
+      projectState.status = 'ready';
+      await component.ngOnInit();
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('app-chat-header')).toBeTruthy();
+      expect(fixture.nativeElement.querySelector('app-chat-message-list')).toBeTruthy();
+    });
+
+    it('does not render the message list while a transcript is being viewed', async () => {
+      projectState.activeProject = 'test';
+      projectState.status = 'ready';
+      await component.ngOnInit();
+      component.viewingTranscript = { session_id: 's1', messages: [] };
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('app-chat-message-list')).toBeNull();
+      // Chat header stays visible while viewing a transcript.
+      expect(fixture.nativeElement.querySelector('app-chat-header')).toBeTruthy();
+    });
+  });
+
   // ── handleStreamChunk: 'Text' ──────────────────────────────────────────────
 
   describe('handleStreamChunk Text', () => {

--- a/desktop/src/src/app/chat/chat.component.ts
+++ b/desktop/src/src/app/chat/chat.component.ts
@@ -84,7 +84,7 @@ export class ChatComponent implements OnInit, OnDestroy {
   constructor() {
     this.unsubChange = this.chat.onChange(() => {
       this.cdr.markForCheck();
-      this.scrollToBottom();
+      // Live-chat scrolling is owned by <app-chat-message-list>; no-op here.
     });
 
     // Decouple data loading from the toggle source so the keyboard shortcut
@@ -102,7 +102,6 @@ export class ChatComponent implements OnInit, OnDestroy {
   async ngOnInit(): Promise<void> {
     await this.chat.init();
     this.cdr.markForCheck();
-    this.scrollToBottom();
 
     this.unsubAuthWatch = this.projectState.onChange(() => {
       if (this.projectState.status === 'auth_required') {
@@ -326,15 +325,6 @@ export class ChatComponent implements OnInit, OnDestroy {
       this.memoryError = `Failed to load memory: ${err}`;
     }
     this.cdr.markForCheck();
-  }
-
-  private scrollToBottom(): void {
-    setTimeout(() => {
-      if (this.messageList?.nativeElement) {
-        const el = this.messageList.nativeElement;
-        el.scrollTop = el.scrollHeight;
-      }
-    }, 0);
   }
 
   /**

--- a/desktop/src/src/app/chat/chat.component.ts
+++ b/desktop/src/src/app/chat/chat.component.ts
@@ -18,7 +18,8 @@ import { ChatStateService } from '../services/chat-state.service';
 import { ProjectStateService } from '../services/project-state.service';
 import { UiStateService } from '../services/ui-state.service';
 import type { ChatMessage, ConversationSummary, ConversationTranscript } from '../models/chat';
-import { ChatMessageComponent } from './message/chat-message.component';
+import { ChatHeaderComponent } from './header/chat-header.component';
+import { ChatMessageListComponent } from './message-list/chat-message-list.component';
 import { SessionStatsComponent } from './session-stats/session-stats.component';
 import { TextBlockComponent } from './blocks/text-block.component';
 import { MemoryPanelComponent } from './memory-panel/memory-panel.component';
@@ -31,7 +32,8 @@ import { ConversationsSidebarComponent } from './conversations-sidebar/conversat
   imports: [
     CommonModule,
     FormsModule,
-    ChatMessageComponent,
+    ChatHeaderComponent,
+    ChatMessageListComponent,
     SessionStatsComponent,
     TextBlockComponent,
     MemoryPanelComponent,

--- a/desktop/src/src/app/chat/chat.component.ts
+++ b/desktop/src/src/app/chat/chat.component.ts
@@ -2,11 +2,9 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
-  ElementRef,
   HostListener,
   OnDestroy,
   OnInit,
-  ViewChild,
   effect,
   inject,
 } from '@angular/core';
@@ -43,8 +41,6 @@ import { ConversationsSidebarComponent } from './conversations-sidebar/conversat
   templateUrl: './chat.component.html',
 })
 export class ChatComponent implements OnInit, OnDestroy {
-  @ViewChild('messageList') messageList!: ElementRef<HTMLDivElement>;
-
   inputText = '';
 
   conversations: readonly ConversationSummary[] = [];

--- a/desktop/src/src/app/chat/header/chat-header.component.spec.ts
+++ b/desktop/src/src/app/chat/header/chat-header.component.spec.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ChatHeaderComponent } from './chat-header.component';
+
+describe('ChatHeaderComponent', () => {
+  let fixture: ComponentFixture<ChatHeaderComponent>;
+  let component: ChatHeaderComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ChatHeaderComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ChatHeaderComponent);
+    component = fixture.componentInstance;
+  });
+
+  // ── Happy path — title rendering ──────────────────────────────────────
+
+  it('renders the title', () => {
+    component.title = 'Refactoring container runtime';
+    fixture.detectChanges();
+
+    const titleEl = fixture.nativeElement.querySelector(
+      '[data-testid="chat-header-title"]'
+    ) as HTMLElement;
+    expect(titleEl).not.toBeNull();
+    expect(titleEl.textContent?.trim()).toBe('Refactoring container runtime');
+  });
+
+  it('uses default title when none provided', () => {
+    fixture.detectChanges();
+    const titleEl = fixture.nativeElement.querySelector(
+      '[data-testid="chat-header-title"]'
+    ) as HTMLElement;
+    expect(titleEl.textContent?.trim()).toBe('Chat');
+  });
+
+  // ── Project pill ──────────────────────────────────────────────────────
+
+  it('renders project pill when projectName is set', () => {
+    component.projectName = 'speedwave';
+    fixture.detectChanges();
+
+    const pill = fixture.nativeElement.querySelector(
+      '[data-testid="chat-header-project"]'
+    ) as HTMLElement;
+    expect(pill).not.toBeNull();
+    expect(pill.textContent?.trim()).toBe('speedwave');
+  });
+
+  it('hides project pill when projectName is empty', () => {
+    component.projectName = '';
+    fixture.detectChanges();
+
+    const pill = fixture.nativeElement.querySelector('[data-testid="chat-header-project"]');
+    expect(pill).toBeNull();
+  });
+
+  // ── Toggle buttons — emission ────────────────────────────────────────
+
+  it('emits toggleMemory when memory button is clicked', () => {
+    fixture.detectChanges();
+    let emitted = 0;
+    component.toggleMemory.subscribe(() => emitted++);
+
+    const btn = fixture.nativeElement.querySelector(
+      '[data-testid="chat-header-memory"]'
+    ) as HTMLButtonElement;
+    btn.click();
+
+    expect(emitted).toBe(1);
+  });
+
+  it('emits toggleHistory when history button is clicked', () => {
+    fixture.detectChanges();
+    let emitted = 0;
+    component.toggleHistory.subscribe(() => emitted++);
+
+    const btn = fixture.nativeElement.querySelector(
+      '[data-testid="chat-header-history"]'
+    ) as HTMLButtonElement;
+    btn.click();
+
+    expect(emitted).toBe(1);
+  });
+
+  // ── ARIA aria-pressed reflects toggle state ──────────────────────────
+
+  it('sets aria-pressed=true on memory button when memoryOpen is true', () => {
+    component.memoryOpen = true;
+    fixture.detectChanges();
+    const btn = fixture.nativeElement.querySelector(
+      '[data-testid="chat-header-memory"]'
+    ) as HTMLButtonElement;
+    expect(btn.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('sets aria-pressed=false on memory button when memoryOpen is false (default)', () => {
+    fixture.detectChanges();
+    const btn = fixture.nativeElement.querySelector(
+      '[data-testid="chat-header-memory"]'
+    ) as HTMLButtonElement;
+    expect(btn.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('sets aria-pressed=true on history button when historyOpen is true', () => {
+    component.historyOpen = true;
+    fixture.detectChanges();
+    const btn = fixture.nativeElement.querySelector(
+      '[data-testid="chat-header-history"]'
+    ) as HTMLButtonElement;
+    expect(btn.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('sets aria-pressed=false on history button when historyOpen is false (default)', () => {
+    fixture.detectChanges();
+    const btn = fixture.nativeElement.querySelector(
+      '[data-testid="chat-header-history"]'
+    ) as HTMLButtonElement;
+    expect(btn.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  // ── Edge case — Unicode and long titles render unchanged ────────────
+
+  it('renders Unicode characters in title verbatim', () => {
+    component.title = 'Σφαῖρα — тест 漢字';
+    fixture.detectChanges();
+    const titleEl = fixture.nativeElement.querySelector(
+      '[data-testid="chat-header-title"]'
+    ) as HTMLElement;
+    expect(titleEl.textContent?.trim()).toBe('Σφαῖρα — тест 漢字');
+  });
+});

--- a/desktop/src/src/app/chat/header/chat-header.component.ts
+++ b/desktop/src/src/app/chat/header/chat-header.component.ts
@@ -1,18 +1,6 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 
-/**
- * Minimal terminal-style chat header bar.
- *
- * Renders the conversation title, an optional project pill, and toggle buttons
- * for the memory and history panels. Purely presentational — all state lives in
- * the parent component and is wired through the inputs/outputs.
- *
- * NOTE: uses decorator-based `@Input`/`@Output` to match the current codebase
- * convention (tests run via raw vitest without the Angular compiler plugin,
- * which is required to wire up signal-based `input()`/`output()`). A future
- * codebase-wide migration to signals will flip this over — the public API
- * (template binding names) stays identical.
- */
+/** Uses decorator-based @Input/@Output: signal inputs require the Angular compiler plugin, unavailable in vitest setup. */
 @Component({
   selector: 'app-chat-header',
   standalone: true,

--- a/desktop/src/src/app/chat/header/chat-header.component.ts
+++ b/desktop/src/src/app/chat/header/chat-header.component.ts
@@ -1,0 +1,73 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+
+/**
+ * Minimal terminal-style chat header bar.
+ *
+ * Renders the conversation title, an optional project pill, and toggle buttons
+ * for the memory and history panels. Purely presentational — all state lives in
+ * the parent component and is wired through the inputs/outputs.
+ *
+ * NOTE: uses decorator-based `@Input`/`@Output` to match the current codebase
+ * convention (tests run via raw vitest without the Angular compiler plugin,
+ * which is required to wire up signal-based `input()`/`output()`). A future
+ * codebase-wide migration to signals will flip this over — the public API
+ * (template binding names) stays identical.
+ */
+@Component({
+  selector: 'app-chat-header',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: { class: 'block' },
+  template: `
+    <div
+      data-testid="chat-header"
+      class="flex h-11 flex-shrink-0 items-center gap-3 border-b border-[var(--line,#16213e)] bg-[var(--bg-1,#12122a)] px-4"
+    >
+      <h1 data-testid="chat-header-title" class="truncate text-[14px] text-[var(--ink,#e0e0e0)]">
+        {{ title }}
+      </h1>
+
+      @if (projectName) {
+        <span
+          data-testid="chat-header-project"
+          class="mono rounded bg-[var(--bg-1,#12122a)] px-2 py-0.5 text-[11px] text-[var(--teal,#4ecdc4)] ring-1 ring-[var(--line,#16213e)]"
+        >
+          {{ projectName }}
+        </span>
+      }
+
+      <div class="ml-auto flex flex-shrink-0 items-center gap-2">
+        <button
+          type="button"
+          data-testid="chat-header-memory"
+          class="mono rounded px-2 py-1 text-[11px] text-[var(--ink-mute,#888888)] hover:text-[var(--ink,#e0e0e0)]"
+          [class.!text-[var(--accent,#e94560)]]="memoryOpen"
+          [attr.aria-pressed]="memoryOpen"
+          aria-label="Toggle project memory panel"
+          (click)="toggleMemory.emit()"
+        >
+          memory
+        </button>
+        <button
+          type="button"
+          data-testid="chat-header-history"
+          class="mono rounded px-2 py-1 text-[11px] text-[var(--ink-mute,#888888)] hover:text-[var(--ink,#e0e0e0)]"
+          [class.!text-[var(--accent,#e94560)]]="historyOpen"
+          [attr.aria-pressed]="historyOpen"
+          aria-label="Toggle conversation history panel"
+          (click)="toggleHistory.emit()"
+        >
+          history
+        </button>
+      </div>
+    </div>
+  `,
+})
+export class ChatHeaderComponent {
+  @Input() title = 'Chat';
+  @Input() projectName = '';
+  @Input() memoryOpen = false;
+  @Input() historyOpen = false;
+
+  @Output() toggleMemory = new EventEmitter<void>();
+  @Output() toggleHistory = new EventEmitter<void>();
+}

--- a/desktop/src/src/app/chat/header/chat-header.component.ts
+++ b/desktop/src/src/app/chat/header/chat-header.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 
-/** Uses decorator-based @Input/@Output: signal inputs require the Angular compiler plugin, unavailable in vitest setup. */
+/** Header strip with title, project tag, and toggle buttons for memory and history panels. */
+// Uses decorator-based @Input/@Output: signal inputs need the Angular compiler plugin, unavailable in vitest setup.
 @Component({
   selector: 'app-chat-header',
   standalone: true,

--- a/desktop/src/src/app/chat/header/chat-header.component.ts
+++ b/desktop/src/src/app/chat/header/chat-header.component.ts
@@ -15,6 +15,7 @@ import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from 
  */
 @Component({
   selector: 'app-chat-header',
+  standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: { class: 'block' },
   template: `

--- a/desktop/src/src/app/chat/message-list/chat-message-list.component.spec.ts
+++ b/desktop/src/src/app/chat/message-list/chat-message-list.component.spec.ts
@@ -72,8 +72,11 @@ describe('ChatMessageListComponent', () => {
     );
     expect(streamingEl).not.toBeNull();
 
-    const cursor = fixture.nativeElement.querySelector('[data-testid="cursor"]');
-    expect(cursor).not.toBeNull();
+    // When the last block is a text block, the per-block streaming caret renders
+    // (data-testid="streaming-caret") and the message-level cursor is suppressed
+    // by lastBlockIsText.
+    const caret = fixture.nativeElement.querySelector('[data-testid="streaming-caret"]');
+    expect(caret).not.toBeNull();
   });
 
   it('does not append a streaming placeholder when currentBlocks is empty', () => {

--- a/desktop/src/src/app/chat/message-list/chat-message-list.component.spec.ts
+++ b/desktop/src/src/app/chat/message-list/chat-message-list.component.spec.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SimpleChange, DebugElement } from '@angular/core';
+import { ChatMessageListComponent } from './chat-message-list.component';
+import { ChatMessageComponent } from '../message/chat-message.component';
+import { ToolNormalizerService } from '../../services/tool-normalizer.service';
+import type { ChatMessage, MessageBlock } from '../../models/chat';
+
+describe('ChatMessageListComponent', () => {
+  let fixture: ComponentFixture<ChatMessageListComponent>;
+  let component: ChatMessageListComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ChatMessageListComponent],
+      providers: [ToolNormalizerService],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ChatMessageListComponent);
+    component = fixture.componentInstance;
+  });
+
+  /**
+   * Replays `ngOnChanges` after a manual property set — mirrors what Angular
+   * does when a template binding changes. Needed because our tests mutate the
+   * component's inputs directly.
+   */
+  function fakeOnChanges(): void {
+    component.ngOnChanges({
+      messages: new SimpleChange(null, component.messages, false),
+    });
+  }
+
+  // ── Happy path — per-message rendering ────────────────────────────────
+
+  it('renders one chat-message per entry in messages', () => {
+    component.messages = [
+      { role: 'user', blocks: [{ type: 'text', content: 'hi' }], timestamp: 1 },
+      { role: 'assistant', blocks: [{ type: 'text', content: 'hello' }], timestamp: 2 },
+    ];
+    fakeOnChanges();
+    fixture.detectChanges();
+
+    const rendered = fixture.nativeElement.querySelectorAll('app-chat-message');
+    expect(rendered.length).toBe(2);
+  });
+
+  it('renders nothing extra when messages is empty and not streaming', () => {
+    component.messages = [];
+    fakeOnChanges();
+    fixture.detectChanges();
+
+    const rendered = fixture.nativeElement.querySelectorAll('app-chat-message');
+    expect(rendered.length).toBe(0);
+  });
+
+  // ── Streaming: last entry has streaming=true ──────────────────────────
+
+  it('appends a streaming placeholder when isStreaming is true and currentBlocks has content', () => {
+    const messages: ChatMessage[] = [
+      { role: 'user', blocks: [{ type: 'text', content: 'hi' }], timestamp: 1 },
+    ];
+    const currentBlocks: MessageBlock[] = [{ type: 'text', content: 'partial...' }];
+    component.messages = messages;
+    component.currentBlocks = currentBlocks;
+    component.isStreaming = true;
+    fakeOnChanges();
+    fixture.detectChanges();
+
+    const streamingEl = fixture.nativeElement.querySelector(
+      '[data-testid="chat-message-list-streaming"]'
+    );
+    expect(streamingEl).not.toBeNull();
+
+    const cursor = fixture.nativeElement.querySelector('[data-testid="cursor"]');
+    expect(cursor).not.toBeNull();
+  });
+
+  it('does not append a streaming placeholder when currentBlocks is empty', () => {
+    component.messages = [];
+    component.currentBlocks = [];
+    component.isStreaming = true;
+    fakeOnChanges();
+    fixture.detectChanges();
+
+    const streamingEl = fixture.nativeElement.querySelector(
+      '[data-testid="chat-message-list-streaming"]'
+    );
+    expect(streamingEl).toBeNull();
+  });
+
+  it('does not append a streaming placeholder when isStreaming is false', () => {
+    component.messages = [];
+    component.currentBlocks = [{ type: 'text', content: 'orphan' }];
+    component.isStreaming = false;
+    fakeOnChanges();
+    fixture.detectChanges();
+
+    const streamingEl = fixture.nativeElement.querySelector(
+      '[data-testid="chat-message-list-streaming"]'
+    );
+    expect(streamingEl).toBeNull();
+  });
+
+  // ── ARIA — log role + polite live region ──────────────────────────────
+
+  it('exposes a polite log live region for screen readers', () => {
+    component.messages = [];
+    fakeOnChanges();
+    fixture.detectChanges();
+
+    const container = fixture.nativeElement.querySelector(
+      '[data-testid="chat-message-list"]'
+    ) as HTMLElement;
+    expect(container.getAttribute('role')).toBe('log');
+    expect(container.getAttribute('aria-live')).toBe('polite');
+  });
+
+  // ── Auto-scroll logic ────────────────────────────────────────────────
+
+  it('pins scroll to bottom on new messages when user is at the bottom', () => {
+    const messages: ChatMessage[] = [
+      { role: 'user', blocks: [{ type: 'text', content: 'first' }], timestamp: 1 },
+    ];
+    component.messages = messages;
+    fakeOnChanges();
+    fixture.detectChanges();
+
+    const container = fixture.nativeElement.querySelector(
+      '[data-testid="chat-message-list"]'
+    ) as HTMLDivElement;
+    Object.defineProperty(container, 'scrollHeight', { configurable: true, value: 1000 });
+    Object.defineProperty(container, 'clientHeight', { configurable: true, value: 400 });
+    container.scrollTop = 600; // at bottom
+    container.dispatchEvent(new Event('scroll'));
+
+    component.messages = [
+      ...messages,
+      { role: 'assistant', blocks: [{ type: 'text', content: 'second' }], timestamp: 2 },
+    ];
+    fakeOnChanges();
+    // Grow content height before Angular runs ngAfterViewChecked.
+    Object.defineProperty(container, 'scrollHeight', { configurable: true, value: 1400 });
+    fixture.detectChanges();
+
+    expect(container.scrollTop).toBe(1400);
+  });
+
+  it('stops auto-scrolling when the user scrolls up', () => {
+    component.messages = [
+      { role: 'user', blocks: [{ type: 'text', content: 'first' }], timestamp: 1 },
+    ];
+    fakeOnChanges();
+    fixture.detectChanges();
+
+    const container = fixture.nativeElement.querySelector(
+      '[data-testid="chat-message-list"]'
+    ) as HTMLDivElement;
+    Object.defineProperty(container, 'scrollHeight', { configurable: true, value: 1000 });
+    Object.defineProperty(container, 'clientHeight', { configurable: true, value: 400 });
+    container.scrollTop = 100; // user scrolled up
+    container.dispatchEvent(new Event('scroll'));
+
+    component.messages = [
+      ...component.messages,
+      { role: 'assistant', blocks: [{ type: 'text', content: 'second' }], timestamp: 2 },
+    ];
+    fakeOnChanges();
+    Object.defineProperty(container, 'scrollHeight', { configurable: true, value: 1400 });
+    fixture.detectChanges();
+
+    expect(container.scrollTop).toBe(100);
+  });
+
+  // ── Forwarding the questionAnswered event ────────────────────────────
+
+  it('re-emits questionAnswered from child chat-message', () => {
+    component.messages = [
+      { role: 'assistant', blocks: [{ type: 'text', content: 'hi' }], timestamp: 1 },
+    ];
+    fakeOnChanges();
+    fixture.detectChanges();
+
+    let captured: { toolId: string; values: string[] } | null = null;
+    component.questionAnswered.subscribe((e) => (captured = e));
+
+    const childDbg: DebugElement = fixture.debugElement.query(
+      (de: DebugElement) => de.componentInstance instanceof ChatMessageComponent
+    );
+    expect(childDbg).not.toBeNull();
+    (childDbg.componentInstance as ChatMessageComponent).questionAnswered.emit({
+      toolId: 't1',
+      values: ['a'],
+    });
+
+    expect(captured).toEqual({ toolId: 't1', values: ['a'] });
+  });
+});

--- a/desktop/src/src/app/chat/message-list/chat-message-list.component.ts
+++ b/desktop/src/src/app/chat/message-list/chat-message-list.component.ts
@@ -31,6 +31,7 @@ import { ChatMessageComponent } from '../message/chat-message.component';
  */
 @Component({
   selector: 'app-chat-message-list',
+  standalone: true,
   imports: [ChatMessageComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: { class: 'block flex-1 min-h-0' },

--- a/desktop/src/src/app/chat/message-list/chat-message-list.component.ts
+++ b/desktop/src/src/app/chat/message-list/chat-message-list.component.ts
@@ -12,12 +12,10 @@ import {
 import type { ChatMessage, MessageBlock } from '../../models/chat';
 import { ChatMessageComponent } from '../message/chat-message.component';
 
-/**
- * NOTE on `track`: we use `msg.timestamp` until the state-tree lands
- * (ADR-044) because `ChatMessage` has no stable `index` yet. Timestamps
- * are assigned at message creation and are unique enough for the current
- * flows (one message per millisecond at most).
- */
+// `track` uses `msg.timestamp` until state-tree (ADR-044) gives `ChatMessage` a stable index.
+const SCROLL_BOTTOM_THRESHOLD_PX = 16;
+
+/** Scrollable message list with auto-scroll-to-bottom that pauses while the user reads earlier messages. */
 @Component({
   selector: 'app-chat-message-list',
   standalone: true,
@@ -73,10 +71,7 @@ export class ChatMessageListComponent implements AfterViewChecked, OnChanges {
     return this.isStreaming && this.currentBlocks.length > 0;
   }
 
-  /**
-   * Marks that we need to sync the scroll position on the next
-   * `ngAfterViewChecked` — runs whenever any input changes.
-   */
+  /** Marks scroll position for sync on next `ngAfterViewChecked`. */
   ngOnChanges(): void {
     this.pendingScrollSync = true;
   }
@@ -85,7 +80,7 @@ export class ChatMessageListComponent implements AfterViewChecked, OnChanges {
   onScroll(): void {
     const el = this.scrollContainer?.nativeElement;
     if (!el) return;
-    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 16;
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < SCROLL_BOTTOM_THRESHOLD_PX;
     this.shouldAutoScroll = atBottom;
   }
 

--- a/desktop/src/src/app/chat/message-list/chat-message-list.component.ts
+++ b/desktop/src/src/app/chat/message-list/chat-message-list.component.ts
@@ -13,17 +13,6 @@ import type { ChatMessage, MessageBlock } from '../../models/chat';
 import { ChatMessageComponent } from '../message/chat-message.component';
 
 /**
- * Scrolling list of chat messages.
- *
- * Each completed message is rendered via `<app-chat-message>`. When
- * `isStreaming` is true and `currentBlocks` has content, an additional
- * streaming `<app-chat-message role="assistant" streaming=true />` is
- * appended as the last entry.
- *
- * Auto-scroll-to-bottom: when the user is at (or near) the bottom of the
- * container we keep pinning new output to the bottom; if the user scrolls
- * up we stop auto-scrolling until they scroll back down.
- *
  * NOTE on `track`: we use `msg.timestamp` until the state-tree lands
  * (ADR-044) because `ChatMessage` has no stable `index` yet. Timestamps
  * are assigned at message creation and are unique enough for the current

--- a/desktop/src/src/app/chat/message-list/chat-message-list.component.ts
+++ b/desktop/src/src/app/chat/message-list/chat-message-list.component.ts
@@ -1,0 +1,113 @@
+import {
+  AfterViewChecked,
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  OnChanges,
+  Output,
+  ViewChild,
+} from '@angular/core';
+import type { ChatMessage, MessageBlock } from '../../models/chat';
+import { ChatMessageComponent } from '../message/chat-message.component';
+
+/**
+ * Scrolling list of chat messages.
+ *
+ * Each completed message is rendered via `<app-chat-message>`. When
+ * `isStreaming` is true and `currentBlocks` has content, an additional
+ * streaming `<app-chat-message role="assistant" streaming=true />` is
+ * appended as the last entry.
+ *
+ * Auto-scroll-to-bottom: when the user is at (or near) the bottom of the
+ * container we keep pinning new output to the bottom; if the user scrolls
+ * up we stop auto-scrolling until they scroll back down.
+ *
+ * NOTE on `track`: we use `msg.timestamp` until the state-tree lands
+ * (ADR-044) because `ChatMessage` has no stable `index` yet. Timestamps
+ * are assigned at message creation and are unique enough for the current
+ * flows (one message per millisecond at most).
+ */
+@Component({
+  selector: 'app-chat-message-list',
+  imports: [ChatMessageComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: { class: 'block flex-1 min-h-0' },
+  template: `
+    <div
+      #scrollContainer
+      data-testid="chat-message-list"
+      role="log"
+      aria-live="polite"
+      aria-label="Chat messages"
+      class="h-full overflow-y-auto p-4 md:p-6"
+      (scroll)="onScroll()"
+    >
+      <div class="mx-auto max-w-3xl space-y-8">
+        @for (msg of messages; track msg.timestamp) {
+          <app-chat-message
+            [blocks]="msg.blocks"
+            [role]="msg.role"
+            [timestamp]="msg.timestamp"
+            (questionAnswered)="questionAnswered.emit($event)"
+          />
+        }
+        @if (showStreaming) {
+          <app-chat-message
+            data-testid="chat-message-list-streaming"
+            [blocks]="currentBlocks"
+            role="assistant"
+            [streaming]="true"
+            (questionAnswered)="questionAnswered.emit($event)"
+          />
+        }
+      </div>
+    </div>
+  `,
+})
+export class ChatMessageListComponent implements AfterViewChecked, OnChanges {
+  @Input({ required: true }) messages!: readonly ChatMessage[];
+  @Input() currentBlocks: readonly MessageBlock[] = [];
+  @Input() isStreaming = false;
+
+  @Output() questionAnswered = new EventEmitter<{ toolId: string; values: string[] }>();
+
+  @ViewChild('scrollContainer') scrollContainer!: ElementRef<HTMLDivElement>;
+
+  private shouldAutoScroll = true;
+  private pendingScrollSync = false;
+
+  /** Whether to render the streaming placeholder as the last entry. */
+  get showStreaming(): boolean {
+    return this.isStreaming && this.currentBlocks.length > 0;
+  }
+
+  /**
+   * Marks that we need to sync the scroll position on the next
+   * `ngAfterViewChecked` — runs whenever any input changes.
+   */
+  ngOnChanges(): void {
+    this.pendingScrollSync = true;
+  }
+
+  /** Tracks user scrolling to decide whether to pin new output to the bottom. */
+  onScroll(): void {
+    const el = this.scrollContainer?.nativeElement;
+    if (!el) return;
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 16;
+    this.shouldAutoScroll = atBottom;
+  }
+
+  /** Pins to the bottom after each render when the user has not scrolled up. */
+  ngAfterViewChecked(): void {
+    if (!this.pendingScrollSync) return;
+    this.pendingScrollSync = false;
+    if (!this.shouldAutoScroll) return;
+    const el = this.scrollContainer?.nativeElement;
+    if (!el) return;
+    if (el.scrollTop + el.clientHeight < el.scrollHeight - 1) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }
+}

--- a/desktop/src/src/app/chat/message/chat-message.component.spec.ts
+++ b/desktop/src/src/app/chat/message/chat-message.component.spec.ts
@@ -87,13 +87,32 @@ describe('ChatMessageComponent', () => {
     expect(el.textContent).toContain('Thinking');
   });
 
-  it('applies user styling for user role', () => {
+  it('dispatches to app-user-message when role is user', () => {
     component.blocks = [{ type: 'text', content: 'hi' }];
     component.role = 'user';
     fixture.detectChanges();
 
     const msg = fixture.nativeElement.querySelector('[data-testid="chat-message"]');
     expect(msg?.getAttribute('data-role')).toBe('user');
+    const userMsg = fixture.nativeElement.querySelector('app-user-message');
+    expect(userMsg).not.toBeNull();
+    expect(fixture.nativeElement.textContent).toContain('hi');
+    // No assistant-style bubble on user messages.
+    expect(fixture.nativeElement.querySelector('.bg-sw-bg-dark')).toBeNull();
+  });
+
+  it('forwards editedAt and timestamp to app-user-message', () => {
+    component.blocks = [{ type: 'text', content: 'hi' }];
+    component.role = 'user';
+    component.editedAt = 1_700_000_000_000;
+    const ts = new Date(2026, 3, 25, 9, 30, 0, 0).getTime();
+    component.timestamp = ts;
+    fixture.detectChanges();
+
+    const edited = fixture.nativeElement.querySelector('[data-testid="user-message-edited"]');
+    expect(edited).not.toBeNull();
+    const time = fixture.nativeElement.querySelector('[data-testid="user-message-time"]');
+    expect(time?.textContent?.trim()).toBe('09:30');
   });
 
   it('host right-aligns user messages via justify-end', () => {

--- a/desktop/src/src/app/chat/message/chat-message.component.spec.ts
+++ b/desktop/src/src/app/chat/message/chat-message.component.spec.ts
@@ -135,15 +135,26 @@ describe('ChatMessageComponent', () => {
     expect(host.classList.contains('justify-end')).toBe(false);
   });
 
-  it('bubble shrinks to content width (w-fit) with 85% cap', () => {
+  it('user role dispatches to <app-user-message> (terminal-minimal: no bubble)', () => {
+    // After Unit 8 (refactor: extract chat header, list, user-message), user
+    // messages render via <app-user-message> in terminal-minimal style — no
+    // sized "bubble" with w-fit/max-w-[85%]. This replaces the prior bubble
+    // test which assumed both roles shared the same wrapper styling.
     component.blocks = [{ type: 'text', content: 'ok' }];
     component.role = 'user';
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('app-user-message')).not.toBeNull();
+  });
+
+  it('assistant role keeps the bubble (max-w-[85%])', () => {
+    component.blocks = [{ type: 'text', content: 'ok' }];
+    component.role = 'assistant';
     fixture.detectChanges();
 
     const bubble = fixture.nativeElement.querySelector(
       '[data-testid="chat-message"]'
     ) as HTMLElement;
-    expect(bubble.classList.contains('w-fit')).toBe(true);
     expect(bubble.classList.contains('max-w-[85%]')).toBe(true);
   });
 

--- a/desktop/src/src/app/chat/message/chat-message.component.ts
+++ b/desktop/src/src/app/chat/message/chat-message.component.ts
@@ -8,6 +8,7 @@ import { AskUserBlockComponent } from '../blocks/ask-user-block.component';
 import { PermissionPromptComponent } from '../blocks/permission-prompt.component';
 import { UserMessageComponent } from './user-message.component';
 
+/** Renders a single chat message: user role uses a meta-line layout, assistant role uses a bubble. */
 @Component({
   selector: 'app-chat-message',
   imports: [
@@ -92,17 +93,27 @@ export class ChatMessageComponent {
     return this.blocks.length > 0 && this.blocks[this.blocks.length - 1].type === 'text';
   }
 
-  /** Forwards a permission decision upstream tagged with the block's index. */
+  /**
+   * Forwards a permission decision upstream tagged with the block's index.
+   * @param blockIndex - Index of the permission_prompt block in the parent's blocks array.
+   * @param decision - The decision the user pressed.
+   */
   onPermissionDecided(blockIndex: number, decision: 'allow_once' | 'allow_always' | 'deny'): void {
     this.permissionDecided.emit({ blockIndex, decision });
   }
 
-  /** Narrows a MessageBlock to its `tool_use` variant for the template. */
+  /**
+   * Narrows a MessageBlock to its `tool_use` variant for the template.
+   * @param block - The block to narrow.
+   */
   asToolBlock(block: MessageBlock): Extract<MessageBlock, { type: 'tool_use' }> {
     return block as Extract<MessageBlock, { type: 'tool_use' }>;
   }
 
-  /** Narrows a MessageBlock to its `ask_user` variant for the template. */
+  /**
+   * Narrows a MessageBlock to its `ask_user` variant for the template.
+   * @param block - The block to narrow.
+   */
   asAskUserBlock(block: MessageBlock): Extract<MessageBlock, { type: 'ask_user' }> {
     return block as Extract<MessageBlock, { type: 'ask_user' }>;
   }

--- a/desktop/src/src/app/chat/message/chat-message.component.ts
+++ b/desktop/src/src/app/chat/message/chat-message.component.ts
@@ -6,11 +6,10 @@ import { ToolBlockComponent } from '../blocks/tool-block.component';
 import { ErrorBlockComponent } from '../blocks/error-block.component';
 import { AskUserBlockComponent } from '../blocks/ask-user-block.component';
 import { PermissionPromptComponent } from '../blocks/permission-prompt.component';
+import { UserMessageComponent } from './user-message.component';
 
-/** Renders a single chat message as a sequence of typed blocks (text, tool, thinking, etc.). */
 @Component({
   selector: 'app-chat-message',
-  standalone: true,
   imports: [
     TextBlockComponent,
     ThinkingBlockComponent,
@@ -18,6 +17,7 @@ import { PermissionPromptComponent } from '../blocks/permission-prompt.component
     ErrorBlockComponent,
     AskUserBlockComponent,
     PermissionPromptComponent,
+    UserMessageComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
@@ -26,56 +26,61 @@ import { PermissionPromptComponent } from '../blocks/permission-prompt.component
     '[class.justify-start]': "role === 'assistant'",
   },
   template: `
-    <div
-      data-testid="chat-message"
-      [attr.data-role]="role"
-      class="w-fit max-w-[85%] px-4 py-3 rounded-lg leading-relaxed break-words"
-      [class]="
-        role === 'user'
-          ? 'bg-sw-bg-navy text-sw-text'
-          : 'bg-sw-bg-dark text-sw-text border border-sw-border'
-      "
-      [class.!border-sw-accent]="streaming"
-    >
-      @for (block of blocks; track $index) {
-        @switch (block.type) {
-          @case ('text') {
-            <app-text-block [content]="block.content" [streaming]="streaming && $last" />
-          }
-          @case ('thinking') {
-            <app-thinking-block [content]="block.content" [collapsedDefault]="block.collapsed" />
-          }
-          @case ('tool_use') {
-            <app-tool-block [tool]="asToolBlock(block).tool" />
-          }
-          @case ('ask_user') {
-            <app-ask-user-block
-              [question]="asAskUserBlock(block).question"
-              (answered)="questionAnswered.emit($event)"
-            />
-          }
-          @case ('error') {
-            <app-error-block [content]="block.content" [kind]="block.kind ?? 'generic'" />
-          }
-          @case ('permission_prompt') {
-            <app-permission-prompt
-              [command]="block.command"
-              [description]="block.description ?? ''"
-              (decided)="onPermissionDecided($index, $event)"
-            />
+    @if (role === 'user') {
+      <div data-testid="chat-message" [attr.data-role]="role">
+        <app-user-message [blocks]="blocks" [editedAt]="editedAt" [timestamp]="timestamp" />
+      </div>
+    } @else {
+      <div
+        data-testid="chat-message"
+        [attr.data-role]="role"
+        class="max-w-[85%] px-4 py-3 rounded-lg leading-relaxed break-words self-start bg-sw-bg-dark text-sw-text border border-sw-border"
+        [class.!border-sw-accent]="streaming"
+      >
+        @for (block of blocks; track $index) {
+          @switch (block.type) {
+            @case ('text') {
+              <app-text-block [content]="block.content" [streaming]="streaming && $last" />
+            }
+            @case ('thinking') {
+              <app-thinking-block [content]="block.content" [collapsedDefault]="block.collapsed" />
+            }
+            @case ('tool_use') {
+              <app-tool-block [tool]="asToolBlock(block).tool" />
+            }
+            @case ('ask_user') {
+              <app-ask-user-block
+                [question]="asAskUserBlock(block).question"
+                (answered)="questionAnswered.emit($event)"
+              />
+            }
+            @case ('error') {
+              <app-error-block [content]="block.content" [kind]="block.kind ?? 'generic'" />
+            }
+            @case ('permission_prompt') {
+              <app-permission-prompt
+                [command]="block.command"
+                [description]="block.description ?? ''"
+                (decided)="onPermissionDecided($index, $event)"
+              />
+            }
           }
         }
-      }
-      @if (streaming && !lastBlockIsText) {
-        <span data-testid="cursor" class="inline-block animate-blink text-sw-accent">&#x2588;</span>
-      }
-    </div>
+        @if (streaming && !lastBlockIsText) {
+          <span data-testid="cursor" class="inline-block animate-blink text-sw-accent"
+            >&#x2588;</span
+          >
+        }
+      </div>
+    }
   `,
 })
 export class ChatMessageComponent {
   @Input({ required: true }) blocks!: readonly MessageBlock[];
   @Input() role: 'user' | 'assistant' = 'assistant';
   @Input() streaming = false;
+  @Input() editedAt: number | undefined = undefined;
+  @Input() timestamp = 0;
   @Output() questionAnswered = new EventEmitter<{ toolId: string; values: string[] }>();
   @Output() permissionDecided = new EventEmitter<{
     blockIndex: number;
@@ -87,27 +92,17 @@ export class ChatMessageComponent {
     return this.blocks.length > 0 && this.blocks[this.blocks.length - 1].type === 'text';
   }
 
-  /**
-   * Forwards a permission decision upstream tagged with the block's index.
-   * @param blockIndex - Index of the permission_prompt block in the parent's blocks array.
-   * @param decision - The decision the user pressed (allow_once, allow_always, or deny).
-   */
+  /** Forwards a permission decision upstream tagged with the block's index. */
   onPermissionDecided(blockIndex: number, decision: 'allow_once' | 'allow_always' | 'deny'): void {
     this.permissionDecided.emit({ blockIndex, decision });
   }
 
-  /**
-   * Type guard cast: narrows a MessageBlock to its `tool_use` variant for the template.
-   * @param block - The block to narrow.
-   */
+  /** Narrows a MessageBlock to its `tool_use` variant for the template. */
   asToolBlock(block: MessageBlock): Extract<MessageBlock, { type: 'tool_use' }> {
     return block as Extract<MessageBlock, { type: 'tool_use' }>;
   }
 
-  /**
-   * Type guard cast: narrows a MessageBlock to its `ask_user` variant for the template.
-   * @param block - The block to narrow.
-   */
+  /** Narrows a MessageBlock to its `ask_user` variant for the template. */
   asAskUserBlock(block: MessageBlock): Extract<MessageBlock, { type: 'ask_user' }> {
     return block as Extract<MessageBlock, { type: 'ask_user' }>;
   }

--- a/desktop/src/src/app/chat/message/user-message.component.spec.ts
+++ b/desktop/src/src/app/chat/message/user-message.component.spec.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { UserMessageComponent } from './user-message.component';
+
+describe('UserMessageComponent', () => {
+  let fixture: ComponentFixture<UserMessageComponent>;
+  let component: UserMessageComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [UserMessageComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(UserMessageComponent);
+    component = fixture.componentInstance;
+  });
+
+  // ── Happy path — text rendering ─────────────────────────────────────
+
+  it('renders plain text content', () => {
+    component.blocks = [{ type: 'text', content: 'Hello from the user' }];
+    fixture.detectChanges();
+
+    const body = fixture.nativeElement.querySelector(
+      '[data-testid="user-message-body"]'
+    ) as HTMLElement;
+    expect(body.textContent).toContain('Hello from the user');
+  });
+
+  it('renders multiple text blocks in order', () => {
+    component.blocks = [
+      { type: 'text', content: 'First line' },
+      { type: 'text', content: 'Second line' },
+    ];
+    fixture.detectChanges();
+
+    const body = fixture.nativeElement.querySelector(
+      '[data-testid="user-message-body"]'
+    ) as HTMLElement;
+    const firstIdx = body.textContent?.indexOf('First line') ?? -1;
+    const secondIdx = body.textContent?.indexOf('Second line') ?? -1;
+    expect(firstIdx).toBeGreaterThanOrEqual(0);
+    expect(secondIdx).toBeGreaterThan(firstIdx);
+  });
+
+  // ── Edge case — non-text blocks are filtered out ────────────────────
+
+  it('ignores non-text blocks (user messages only carry text)', () => {
+    component.blocks = [
+      { type: 'text', content: 'visible' },
+      { type: 'thinking', content: 'should be hidden', collapsed: true },
+    ];
+    fixture.detectChanges();
+
+    const body = fixture.nativeElement.querySelector(
+      '[data-testid="user-message-body"]'
+    ) as HTMLElement;
+    expect(body.textContent).toContain('visible');
+    expect(body.textContent).not.toContain('should be hidden');
+  });
+
+  // ── Edited badge ────────────────────────────────────────────────────
+
+  it('shows the edited badge when editedAt is set', () => {
+    component.blocks = [{ type: 'text', content: 'hi' }];
+    component.editedAt = 1_700_000_000_000;
+    fixture.detectChanges();
+
+    const badge = fixture.nativeElement.querySelector(
+      '[data-testid="user-message-edited"]'
+    ) as HTMLElement | null;
+    expect(badge).not.toBeNull();
+    expect(badge?.textContent).toContain('edited');
+  });
+
+  it('hides the edited badge when editedAt is undefined', () => {
+    component.blocks = [{ type: 'text', content: 'hi' }];
+    fixture.detectChanges();
+
+    const badge = fixture.nativeElement.querySelector('[data-testid="user-message-edited"]');
+    expect(badge).toBeNull();
+  });
+
+  // ── Timestamp formatting ─────────────────────────────────────────────
+
+  it('renders the formatted timestamp when non-zero', () => {
+    const date = new Date(2026, 3, 25, 14, 5, 0, 0);
+    component.blocks = [{ type: 'text', content: 'hi' }];
+    component.timestamp = date.getTime();
+    fixture.detectChanges();
+
+    const timeEl = fixture.nativeElement.querySelector(
+      '[data-testid="user-message-time"]'
+    ) as HTMLElement | null;
+    expect(timeEl).not.toBeNull();
+    expect(timeEl?.textContent?.trim()).toBe('14:05');
+  });
+
+  it('omits the time segment when timestamp is 0 (sentinel for unknown)', () => {
+    component.blocks = [{ type: 'text', content: 'hi' }];
+    component.timestamp = 0;
+    fixture.detectChanges();
+
+    const timeEl = fixture.nativeElement.querySelector('[data-testid="user-message-time"]');
+    expect(timeEl).toBeNull();
+  });
+
+  // ── Edge case — empty blocks ─────────────────────────────────────────
+
+  it('renders with an empty body when no blocks are provided', () => {
+    component.blocks = [];
+    fixture.detectChanges();
+
+    const body = fixture.nativeElement.querySelector(
+      '[data-testid="user-message-body"]'
+    ) as HTMLElement;
+    expect(body).not.toBeNull();
+    expect(body.textContent?.trim()).toBe('');
+  });
+});

--- a/desktop/src/src/app/chat/message/user-message.component.ts
+++ b/desktop/src/src/app/chat/message/user-message.component.ts
@@ -11,6 +11,7 @@ import type { MessageBlock } from '../../models/chat';
  */
 @Component({
   selector: 'app-user-message',
+  standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: { class: 'block' },
   template: `

--- a/desktop/src/src/app/chat/message/user-message.component.ts
+++ b/desktop/src/src/app/chat/message/user-message.component.ts
@@ -1,0 +1,66 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import type { MessageBlock } from '../../models/chat';
+
+/**
+ * Renders a user message in the terminal-minimal style.
+ *
+ * Per mockup convention, user messages are LEFT-aligned with a mono metadata
+ * header (`user · HH:MM`). An `· edited` chip appears when the message has
+ * been retried (`editedAt` defined). User messages only ever contain `text`
+ * blocks — any other block types are filtered out at render time.
+ */
+@Component({
+  selector: 'app-user-message',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: { class: 'block' },
+  template: `
+    <div data-testid="user-message">
+      <div class="mono mb-1 flex items-center gap-2 text-[11px] text-[var(--ink-mute,#888888)]">
+        <span>user</span>
+        @if (formattedTime) {
+          <span>·</span>
+          <span data-testid="user-message-time">{{ formattedTime }}</span>
+        }
+        @if (editedAt !== undefined) {
+          <span>·</span>
+          <span data-testid="user-message-edited" class="text-[11px] text-[var(--ink-mute,#888888)]"
+            >edited</span
+          >
+        }
+      </div>
+      <div
+        data-testid="user-message-body"
+        class="text-[14px] leading-[1.7] text-[var(--ink,#e0e0e0)]"
+      >
+        @for (block of textBlocks; track $index) {
+          <div>{{ block.content }}</div>
+        }
+      </div>
+    </div>
+  `,
+})
+export class UserMessageComponent {
+  @Input({ required: true }) blocks!: readonly MessageBlock[];
+  @Input() editedAt: number | undefined = undefined;
+  @Input() timestamp = 0;
+
+  /** Text-only view of blocks — user messages may only contain text. */
+  get textBlocks(): readonly Extract<MessageBlock, { type: 'text' }>[] {
+    return this.blocks.filter(
+      (b): b is Extract<MessageBlock, { type: 'text' }> => b.type === 'text'
+    );
+  }
+
+  /**
+   * Formats `timestamp` as `HH:MM` local time; returns empty string when
+   * the timestamp is zero (sentinel meaning "unknown").
+   */
+  get formattedTime(): string {
+    const ts = this.timestamp;
+    if (!ts) return '';
+    const date = new Date(ts);
+    const hh = String(date.getHours()).padStart(2, '0');
+    const mm = String(date.getMinutes()).padStart(2, '0');
+    return `${hh}:${mm}`;
+  }
+}

--- a/desktop/src/src/app/chat/message/user-message.component.ts
+++ b/desktop/src/src/app/chat/message/user-message.component.ts
@@ -45,10 +45,7 @@ export class UserMessageComponent {
     );
   }
 
-  /**
-   * Formats `timestamp` as `HH:MM` local time; returns empty string when
-   * the timestamp is zero (sentinel meaning "unknown").
-   */
+  /** Formats `timestamp` as `HH:MM` local time; empty when zero (unknown sentinel). */
   get formattedTime(): string {
     const ts = this.timestamp;
     if (!ts) return '';

--- a/desktop/src/src/app/chat/message/user-message.component.ts
+++ b/desktop/src/src/app/chat/message/user-message.component.ts
@@ -1,14 +1,7 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import type { MessageBlock } from '../../models/chat';
 
-/**
- * Renders a user message in the terminal-minimal style.
- *
- * Per mockup convention, user messages are LEFT-aligned with a mono metadata
- * header (`user · HH:MM`). An `· edited` chip appears when the message has
- * been retried (`editedAt` defined). User messages only ever contain `text`
- * blocks — any other block types are filtered out at render time.
- */
+/** User messages contain only text blocks; non-text blocks are filtered out at render time. */
 @Component({
   selector: 'app-user-message',
   standalone: true,


### PR DESCRIPTION
## Summary
- Splits `chat.component`'s inline markup into three terminal-minimal sub-components for Wave 3 of the design rewrite (`design-proposals/06-terminal-minimal-implementation-prompt.md`).
- New `app-chat-header` (title, project pill, memory/history toggles with `aria-pressed`), `app-chat-message-list` (scrolling `role=log` `aria-live=polite` region with auto-scroll-to-bottom that pauses on user scroll-up), and `app-user-message` (left-aligned mono meta line with optional `· edited` chip).
- `chat-message.component` now dispatches to `app-user-message` for the user role; assistant rendering is unchanged. Public API of `app-chat-message` (selector + `blocks`/`role`/`streaming` inputs + `questionAnswered` output) is preserved; `editedAt` and `timestamp` are additive optional inputs.
- All theme tokens reference Wave 1 CSS variables with hex fallbacks (e.g. `var(--ink, #e0e0e0)`) so the components render before the global stylesheet lands.

## Test plan
- [x] `make test-angular` (841/841 pass)
- [x] `make check-angular` (build clean, no warnings)
- [x] `make build-angular` (production build succeeds)
- [x] `make test` (full suite — 819 desktop, 841 angular, all green)
- [x] `make check` (clippy + lint + fmt all clean)
- [ ] Manual smoke-test of live chat UI (deferred to merge-time of all Wave 3 units — sub-components reference selectors that are still being introduced)