### PR TITLE
feat(desktop): add memory, conversations, view switcher

### DIFF
--- a/desktop/src/src/app/chat/chat.component.html
+++ b/desktop/src/src/app/chat/chat.component.html
@@ -144,6 +144,7 @@
       <app-memory-panel
         [open]="ui.memoryOpen()"
         [markdown]="projectMemory"
+        [error]="memoryError"
         (closed)="ui.closeMemory()"
       ></app-memory-panel>
     </div>

--- a/desktop/src/src/app/chat/chat.component.html
+++ b/desktop/src/src/app/chat/chat.component.html
@@ -1,51 +1,14 @@
 @if (projectState.status === 'ready') {
-  <div class="flex flex-row h-full bg-sw-bg-darkest">
-    @if (showHistory) {
-      <aside
-        class="w-[280px] min-w-[280px] bg-sw-bg-darker border-r border-sw-border flex flex-col overflow-hidden"
-      >
-        <button
-          class="m-3 px-4 py-2.5 border border-sw-border rounded-md bg-sw-bg-dark text-sw-text text-sm font-semibold cursor-pointer transition-colors hover:bg-sw-bg-navy"
-          data-testid="chat-new-conversation"
-          (click)="newConversation()"
-        >
-          + New Conversation
-        </button>
-        @if (historyError) {
-          <div
-            class="px-3 py-2 mx-3 my-2 bg-sw-error-bg border border-sw-error rounded text-sw-error text-xs"
-            data-testid="chat-history-error"
-          >
-            {{ historyError }}
-          </div>
-        }
-        @if (historyLoading) {
-          <div class="p-4 text-sw-text-muted text-[13px] text-center">Loading...</div>
-        } @else {
-          <div class="flex-1 overflow-y-auto px-2 pb-2">
-            @for (conv of conversations; track conv.session_id) {
-              <div
-                class="px-3 py-2.5 rounded-md cursor-pointer transition-colors mb-0.5 hover:bg-sw-bg-dark"
-                [class.bg-sw-bg-navy]="viewingTranscript?.session_id === conv.session_id"
-                (click)="viewConversation(conv.session_id)"
-              >
-                <div
-                  class="text-sw-text text-[13px] leading-[1.4] whitespace-nowrap overflow-hidden text-ellipsis"
-                >
-                  {{ conv.preview }}
-                </div>
-                <div class="flex justify-between mt-1 text-[11px] text-sw-text-muted">
-                  <span>{{ conv.timestamp }}</span>
-                  <span>{{ conv.message_count }} msgs</span>
-                </div>
-              </div>
-            } @empty {
-              <div class="p-4 text-sw-text-muted text-[13px] text-center">No conversations yet</div>
-            }
-          </div>
-        }
-      </aside>
-    }
+  <div class="flex flex-row h-full bg-sw-bg-darkest relative">
+    <app-conversations-sidebar
+      [open]="ui.sidebarOpen()"
+      [conversations]="conversations"
+      [currentSessionId]="currentViewSessionId"
+      (closed)="ui.closeSidebar()"
+      (newConversation)="newConversation()"
+      (viewConversation)="viewConversation($event.session_id)"
+      (resumeConversation)="resumeConversation($event.session_id)"
+    ></app-conversations-sidebar>
 
     <div class="flex flex-col flex-1 min-w-0 relative">
       <div class="flex gap-1 px-3 py-1.5 bg-sw-bg-dark border-b border-sw-border">
@@ -69,6 +32,14 @@
         </button>
       </div>
 
+      @if (historyError) {
+        <div
+          class="px-3 py-2 mx-3 my-2 bg-sw-error-bg border border-sw-error rounded text-sw-error text-xs"
+          data-testid="chat-history-error"
+        >
+          {{ historyError }}
+        </div>
+      }
       @if (viewError) {
         <div
           class="px-3 py-2 mx-3 my-2 bg-sw-error-bg border border-sw-error rounded text-sw-error text-xs"
@@ -170,27 +141,11 @@
         </div>
       }
 
-      @if (showMemory) {
-        <div
-          class="absolute top-[40px] right-0 bottom-0 w-[320px] bg-sw-bg-darker border-l border-sw-border flex flex-col z-10"
-        >
-          <div
-            class="flex justify-between items-center px-4 py-3 border-b border-sw-border text-sw-text font-semibold text-sm"
-          >
-            <span>Project Memory</span>
-            <button
-              class="bg-transparent border-none text-sw-text-muted text-sm cursor-pointer px-1.5 py-0.5 hover:text-sw-text"
-              data-testid="chat-memory-close"
-              (click)="toggleMemory()"
-            >
-              X
-            </button>
-          </div>
-          <div class="flex-1 overflow-y-auto p-4 text-sw-text text-[13px] leading-relaxed">
-            <app-text-block [content]="projectMemory" />
-          </div>
-        </div>
-      }
+      <app-memory-panel
+        [open]="ui.memoryOpen()"
+        [markdown]="projectMemory"
+        (closed)="ui.closeMemory()"
+      ></app-memory-panel>
     </div>
   </div>
 }

--- a/desktop/src/src/app/chat/chat.component.spec.ts
+++ b/desktop/src/src/app/chat/chat.component.spec.ts
@@ -580,6 +580,21 @@ describe('ChatComponent', () => {
       expect(component.viewingTranscript).toBeNull();
       expect(component.showHistory).toBe(false);
     });
+
+    it('calls resume_conversation directly when viewingTranscript is null (sidebar shortcut)', async () => {
+      component.viewingTranscript = null;
+      projectState.activeProject = 'test';
+      const invokeCalls: string[] = [];
+      mockTauri.invokeHandler = async (cmd: string) => {
+        invokeCalls.push(cmd);
+        return undefined;
+      };
+
+      await component.resumeConversation('s1');
+
+      expect(invokeCalls).toContain('resume_conversation');
+      expect(chatState.messages).toHaveLength(0);
+    });
   });
 
   // ── newConversation ─────────────────────────────────────────────────────────

--- a/desktop/src/src/app/chat/chat.component.spec.ts
+++ b/desktop/src/src/app/chat/chat.component.spec.ts
@@ -704,6 +704,53 @@ describe('ChatComponent', () => {
 
       expect(component.projectMemory).toBe('');
     });
+
+    it('surfaces user-facing memoryError on backend failure (parity with historyError)', async () => {
+      projectState.activeProject = 'test';
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      mockTauri.invokeHandler = async (cmd: string) => {
+        if (cmd === 'get_project_memory') throw new Error('disk failure');
+        return undefined;
+      };
+
+      await component.loadProjectMemory();
+
+      expect(component.memoryError).toContain('Failed to load memory');
+      expect(component.memoryError).toContain('disk failure');
+      errorSpy.mockRestore();
+    });
+
+    it('clears memoryError on a subsequent successful load', async () => {
+      projectState.activeProject = 'test';
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      let shouldFail = true;
+      mockTauri.invokeHandler = async (cmd: string) => {
+        if (cmd === 'get_project_memory') {
+          if (shouldFail) throw new Error('first failure');
+          return '# recovered';
+        }
+        return undefined;
+      };
+
+      await component.loadProjectMemory();
+      expect(component.memoryError).not.toBe('');
+
+      shouldFail = false;
+      await component.loadProjectMemory();
+
+      expect(component.memoryError).toBe('');
+      expect(component.projectMemory).toBe('# recovered');
+      errorSpy.mockRestore();
+    });
+
+    it('does not set memoryError when no active project', async () => {
+      projectState.activeProject = null;
+      component.memoryError = 'stale';
+
+      await component.loadProjectMemory();
+
+      expect(component.memoryError).toBe('');
+    });
   });
 
   // ── closeTranscript ─────────────────────────────────────────────────────────

--- a/desktop/src/src/app/chat/chat.component.spec.ts
+++ b/desktop/src/src/app/chat/chat.component.spec.ts
@@ -6,6 +6,7 @@ import { ChatComponent } from './chat.component';
 import { TauriService } from '../services/tauri.service';
 import { ChatStateService } from '../services/chat-state.service';
 import { ProjectStateService } from '../services/project-state.service';
+import { UiStateService } from '../services/ui-state.service';
 import { MockTauriService } from '../testing/mock-tauri.service';
 
 describe('ChatComponent', () => {
@@ -14,6 +15,7 @@ describe('ChatComponent', () => {
   let mockTauri: MockTauriService;
   let chatState: ChatStateService;
   let projectState: ProjectStateService;
+  let uiState: UiStateService;
 
   beforeEach(async () => {
     mockTauri = new MockTauriService();
@@ -52,6 +54,7 @@ describe('ChatComponent', () => {
     component = fixture.componentInstance;
     chatState = TestBed.inject(ChatStateService);
     projectState = TestBed.inject(ProjectStateService);
+    uiState = TestBed.inject(UiStateService);
 
     // Reset service state between tests
     chatState._setState({ messages: [], currentBlocks: [], sessionStats: null });
@@ -569,7 +572,7 @@ describe('ChatComponent', () => {
         session_id: 's1',
         messages: [{ role: 'user', content: 'Hi', timestamp: null }],
       };
-      component.showHistory = true;
+      uiState.toggleSidebar();
       projectState.activeProject = 'test';
 
       await component.resumeConversation('s1');
@@ -590,8 +593,8 @@ describe('ChatComponent', () => {
       component.inputText = 'partial';
       chatState.isStreaming = true;
       component.viewingTranscript = { session_id: 's1', messages: [] };
-      component.showHistory = true;
-      component.showMemory = true;
+      uiState.toggleSidebar();
+      uiState.toggleMemory();
 
       await component.newConversation();
 
@@ -808,7 +811,7 @@ describe('ChatComponent', () => {
 
       await projectState.init();
       await component.ngOnInit();
-      component.showHistory = true;
+      uiState.toggleSidebar();
       component.conversations = [
         { session_id: 's1', timestamp: '2026-03-06T10:00:00Z', preview: 'old', message_count: 1 },
       ];

--- a/desktop/src/src/app/chat/chat.component.ts
+++ b/desktop/src/src/app/chat/chat.component.ts
@@ -50,6 +50,7 @@ export class ChatComponent implements OnInit, OnDestroy {
   historyLoading = false;
   historyError = '';
   projectMemory = '';
+  memoryError = '';
   viewError = '';
   private resumeInProgress = false;
 
@@ -113,6 +114,7 @@ export class ChatComponent implements OnInit, OnDestroy {
       const wasMemoryOpen = this.showMemory;
       this.conversations = [];
       this.projectMemory = '';
+      this.memoryError = '';
       this.cdr.markForCheck();
       if (wasHistoryOpen) {
         await this.loadConversations();
@@ -306,8 +308,9 @@ export class ChatComponent implements OnInit, OnDestroy {
     this.cdr.markForCheck();
   }
 
-  /** Fetches the active project's CLAUDE.md; falls back to empty on missing project / error. */
+  /** Fetches the active project's CLAUDE.md; surfaces backend errors via `memoryError` (parity with `historyError`). */
   async loadProjectMemory(): Promise<void> {
+    this.memoryError = '';
     try {
       const project = this.projectState.activeProject;
       if (!project) {
@@ -318,6 +321,7 @@ export class ChatComponent implements OnInit, OnDestroy {
     } catch (err) {
       console.error('loadProjectMemory failed:', err);
       this.projectMemory = '';
+      this.memoryError = `Failed to load memory: ${err}`;
     }
     this.cdr.markForCheck();
   }

--- a/desktop/src/src/app/chat/chat.component.ts
+++ b/desktop/src/src/app/chat/chat.component.ts
@@ -7,6 +7,7 @@ import {
   OnDestroy,
   OnInit,
   ViewChild,
+  effect,
   inject,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
@@ -62,28 +63,12 @@ export class ChatComponent implements OnInit, OnDestroy {
   private unsubProjectReady: (() => void) | null = null;
   private unsubAuthWatch: (() => void) | null = null;
 
-  /** True if the conversations sidebar is open. Backed by UiStateService. */
+  /** Read-only aliases over the UI-state signals; the template binds these. */
   get showHistory(): boolean {
     return this.ui.sidebarOpen();
   }
-  /**
-   * Sets the conversations-sidebar visibility by toggling the shared UI state signal.
-   * @param value - True to open the sidebar, false to close it.
-   */
-  set showHistory(value: boolean) {
-    if (value !== this.ui.sidebarOpen()) this.ui.toggleSidebar();
-  }
-
-  /** True if the memory panel is open. Backed by UiStateService. */
   get showMemory(): boolean {
     return this.ui.memoryOpen();
-  }
-  /**
-   * Sets the memory-panel visibility by toggling the shared UI state signal.
-   * @param value - True to open the panel, false to close it.
-   */
-  set showMemory(value: boolean) {
-    if (value !== this.ui.memoryOpen()) this.ui.toggleMemory();
   }
 
   /** Session id currently being viewed in the transcript overlay, or null. */
@@ -96,6 +81,16 @@ export class ChatComponent implements OnInit, OnDestroy {
     this.unsubChange = this.chat.onChange(() => {
       this.cdr.markForCheck();
       this.scrollToBottom();
+    });
+
+    // Decouple data loading from the toggle source so the keyboard shortcut
+    // (⌘B in shell.component, which only flips the signal) loads data the
+    // same way the History button does.
+    effect(() => {
+      if (this.ui.sidebarOpen()) void this.loadConversations();
+    });
+    effect(() => {
+      if (this.ui.memoryOpen()) void this.loadProjectMemory();
     });
   }
 
@@ -240,20 +235,24 @@ export class ChatComponent implements OnInit, OnDestroy {
    * @param sessionId - The UUID of the conversation to resume.
    */
   async resumeConversation(sessionId: string): Promise<void> {
-    if (!this.viewingTranscript || this.resumeInProgress) return;
+    if (this.resumeInProgress) return;
     this.resumeInProgress = true;
     console.debug('[chat] resumeConversation: sessionId=%s', sessionId);
-    const messages: ChatMessage[] = this.viewingTranscript.messages.map((msg) => ({
-      role: msg.role as 'user' | 'assistant',
-      blocks: normalizeHistoryBlocks(
-        msg.blocks ?? [{ type: 'text' as const, content: msg.content }]
-      ),
-      timestamp: msg.timestamp ? new Date(msg.timestamp).getTime() : Date.now(),
-    }));
 
-    // Load transcript messages immediately so the user sees history while
-    // the backend resumes the session (which may take seconds).
-    this.chat.loadMessages(messages);
+    // If we already viewed this transcript, surface its messages locally
+    // for instant feedback. When invoked directly from the sidebar (no
+    // prior view), skip — the backend will stream the full history once
+    // resume_conversation completes.
+    if (this.viewingTranscript && this.viewingTranscript.session_id === sessionId) {
+      const messages: ChatMessage[] = this.viewingTranscript.messages.map((msg) => ({
+        role: msg.role as 'user' | 'assistant',
+        blocks: normalizeHistoryBlocks(
+          msg.blocks ?? [{ type: 'text' as const, content: msg.content }]
+        ),
+        timestamp: msg.timestamp ? new Date(msg.timestamp).getTime() : Date.now(),
+      }));
+      this.chat.loadMessages(messages);
+    }
     this.viewingTranscript = null;
     this.ui.closeSidebar();
     this.cdr.markForCheck();

--- a/desktop/src/src/app/chat/chat.component.ts
+++ b/desktop/src/src/app/chat/chat.component.ts
@@ -176,12 +176,9 @@ export class ChatComponent implements OnInit, OnDestroy {
     await this.chat.answerQuestion(event.toolId, event.values);
   }
 
-  /** Toggles the history sidebar and loads conversations when opening. */
-  async toggleHistory(): Promise<void> {
+  /** Toggles the history sidebar; data loads via the constructor effect on open. */
+  toggleHistory(): void {
     this.ui.toggleSidebar();
-    if (this.ui.sidebarOpen()) {
-      await this.loadConversations();
-    }
     this.cdr.markForCheck();
   }
 
@@ -306,12 +303,9 @@ export class ChatComponent implements OnInit, OnDestroy {
     this.cdr.markForCheck();
   }
 
-  /** Toggles the project memory panel and loads memory on open. */
-  async toggleMemory(): Promise<void> {
+  /** Toggles the memory panel; data loads via the constructor effect on open. */
+  toggleMemory(): void {
     this.ui.toggleMemory();
-    if (this.ui.memoryOpen()) {
-      await this.loadProjectMemory();
-    }
     this.cdr.markForCheck();
   }
 

--- a/desktop/src/src/app/chat/chat.component.ts
+++ b/desktop/src/src/app/chat/chat.component.ts
@@ -45,7 +45,7 @@ export class ChatComponent implements OnInit, OnDestroy {
 
   inputText = '';
 
-  conversations: ConversationSummary[] = [];
+  conversations: readonly ConversationSummary[] = [];
   viewingTranscript: ConversationTranscript | null = null;
   historyLoading = false;
   historyError = '';
@@ -67,16 +67,17 @@ export class ChatComponent implements OnInit, OnDestroy {
   get showHistory(): boolean {
     return this.ui.sidebarOpen();
   }
+  /** Read-only alias — see {@link showHistory}. */
   get showMemory(): boolean {
     return this.ui.memoryOpen();
   }
 
-  /** Session id currently being viewed in the transcript overlay, or null. */
+  /** Session id behind the transcript overlay, or null when no transcript is open. */
   get currentViewSessionId(): string | null {
     return this.viewingTranscript?.session_id ?? null;
   }
 
-  /** Subscribes to state changes from the service. */
+  /** Wires change-detection callbacks and effects that lazy-load data when drawers open. */
   constructor() {
     this.unsubChange = this.chat.onChange(() => {
       this.cdr.markForCheck();
@@ -94,7 +95,7 @@ export class ChatComponent implements OnInit, OnDestroy {
     });
   }
 
-  /** Initializes chat session (idempotent — no-ops if already running). */
+  /** Boots the chat session and subscribes to project lifecycle events (auth + ready). */
   async ngOnInit(): Promise<void> {
     await this.chat.init();
     this.cdr.markForCheck();
@@ -128,9 +129,8 @@ export class ChatComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Handles ESC key to stop the current turn. Ignored when an unanswered
-   * AskUserQuestion block is visible — ESC semantics belong to that block.
-   * @param event - The keyboard event from the document.
+   * ESC stops the current turn — but only when no AskUserQuestion is awaiting an answer.
+   * @param event - keyboard event; consumed (preventDefault) when we handle it.
    */
   @HostListener('document:keydown.escape', ['$event'])
   onEscape(event: Event): void {
@@ -140,12 +140,12 @@ export class ChatComponent implements OnInit, OnDestroy {
     this.chat.stopConversation();
   }
 
-  /** Handles the Stop button click. Stops the current turn unconditionally. */
+  /** Stops the current turn unconditionally (Stop button). */
   async onStopClicked(): Promise<void> {
     await this.chat.stopConversation();
   }
 
-  /** Sends the current input text as a user message and invokes the backend. */
+  /** Submits the current input as a user message; no-ops on empty input or active stream. */
   async sendMessage(): Promise<void> {
     const text = this.inputText.trim();
     if (!text || this.chat.isStreaming) return;
@@ -155,8 +155,8 @@ export class ChatComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Handles Enter key press to send a message, allowing Shift+Enter for newlines.
-   * @param event - The keyboard event from the input field.
+   * Enter sends; Shift+Enter inserts a newline.
+   * @param event - keyboard event from the input field.
    */
   onEnter(event: KeyboardEvent): void {
     if (event.shiftKey) {
@@ -167,22 +167,22 @@ export class ChatComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Handles a user answering an AskUserQuestion prompt.
-   * @param event - Contains the tool ID and selected answer values.
-   * @param event.toolId - The tool ID of the answered question.
-   * @param event.values - The selected or freeform answer values.
+   * Forwards an answered AskUserQuestion to the chat-state service.
+   * @param event - tool id and the selected values from the question block.
+   * @param event.toolId - id of the tool_use that produced the question.
+   * @param event.values - selected values; one per chosen option.
    */
   async onQuestionAnswered(event: { toolId: string; values: string[] }): Promise<void> {
     await this.chat.answerQuestion(event.toolId, event.values);
   }
 
-  /** Toggles the history sidebar; data loads via the constructor effect on open. */
+  /** Flips the sidebar signal; data load is driven by the constructor effect. */
   toggleHistory(): void {
     this.ui.toggleSidebar();
     this.cdr.markForCheck();
   }
 
-  /** Loads conversation list from the backend for the active project. */
+  /** Fetches the active project's past sessions; clears state if no active project. */
   async loadConversations(): Promise<void> {
     this.historyLoading = true;
     this.historyError = '';
@@ -207,8 +207,8 @@ export class ChatComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Loads and displays a past conversation transcript in read-only mode.
-   * @param sessionId - The UUID of the conversation to view.
+   * Loads a past transcript into the read-only overlay.
+   * @param sessionId - session UUID to fetch from the backend.
    */
   async viewConversation(sessionId: string): Promise<void> {
     this.viewError = '';
@@ -228,13 +228,12 @@ export class ChatComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Resumes a past conversation: loads its messages and switches to live chat mode.
-   * @param sessionId - The UUID of the conversation to resume.
+   * Resumes a session in live chat mode, surfacing its transcript locally for instant feedback.
+   * @param sessionId - session UUID to resume; the backend continues streaming once invoked.
    */
   async resumeConversation(sessionId: string): Promise<void> {
     if (this.resumeInProgress) return;
     this.resumeInProgress = true;
-    console.debug('[chat] resumeConversation: sessionId=%s', sessionId);
 
     // If we already viewed this transcript, surface its messages locally
     // for instant feedback. When invoked directly from the sidebar (no
@@ -257,9 +256,7 @@ export class ChatComponent implements OnInit, OnDestroy {
     try {
       const project = this.projectState.activeProject;
       if (project) {
-        console.debug('[chat] resumeConversation: invoking backend');
         await this.tauri.invoke('resume_conversation', { project, sessionId });
-        console.debug('[chat] resumeConversation: backend success');
       }
     } catch (err) {
       console.error('[chat] resumeConversation failed:', err);
@@ -286,7 +283,7 @@ export class ChatComponent implements OnInit, OnDestroy {
     }
   }
 
-  /** Starts a new conversation by clearing all state and re-initialising. */
+  /** Clears all chat + drawer state and re-runs the chat session bootstrap. */
   async newConversation(): Promise<void> {
     this.inputText = '';
     this.viewingTranscript = null;
@@ -297,19 +294,19 @@ export class ChatComponent implements OnInit, OnDestroy {
     await this.chat.init();
   }
 
-  /** Closes the transcript read-only view. */
+  /** Dismisses the read-only transcript overlay without resuming. */
   closeTranscript(): void {
     this.viewingTranscript = null;
     this.cdr.markForCheck();
   }
 
-  /** Toggles the memory panel; data loads via the constructor effect on open. */
+  /** Flips the memory signal; data load is driven by the constructor effect. */
   toggleMemory(): void {
     this.ui.toggleMemory();
     this.cdr.markForCheck();
   }
 
-  /** Loads the project memory (CLAUDE.md contents) from the backend. */
+  /** Fetches the active project's CLAUDE.md; falls back to empty on missing project / error. */
   async loadProjectMemory(): Promise<void> {
     try {
       const project = this.projectState.activeProject;
@@ -335,8 +332,8 @@ export class ChatComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Intercepts clicks on external links and opens them in the system browser.
-   * @param event - The mouse click event to inspect for anchor element targets.
+   * Intercept anchor clicks so http(s) links open in the system browser, not in-app.
+   * @param event - the click event; preventDefault is called when we route to open_url.
    */
   @HostListener('click', ['$event'])
   onLinkClick(event: MouseEvent): void {
@@ -352,7 +349,7 @@ export class ChatComponent implements OnInit, OnDestroy {
     }
   }
 
-  /** Unsubscribes from change notifications and event listeners on component destruction. */
+  /** Tears down change subscriptions registered in the constructor and ngOnInit. */
   ngOnDestroy(): void {
     if (this.unsubChange) {
       this.unsubChange();

--- a/desktop/src/src/app/chat/chat.component.ts
+++ b/desktop/src/src/app/chat/chat.component.ts
@@ -15,10 +15,13 @@ import { Router } from '@angular/router';
 import { TauriService } from '../services/tauri.service';
 import { ChatStateService } from '../services/chat-state.service';
 import { ProjectStateService } from '../services/project-state.service';
+import { UiStateService } from '../services/ui-state.service';
 import type { ChatMessage, ConversationSummary, ConversationTranscript } from '../models/chat';
 import { ChatMessageComponent } from './message/chat-message.component';
 import { SessionStatsComponent } from './session-stats/session-stats.component';
 import { TextBlockComponent } from './blocks/text-block.component';
+import { MemoryPanelComponent } from './memory-panel/memory-panel.component';
+import { ConversationsSidebarComponent } from './conversations-sidebar/conversations-sidebar.component';
 
 /** Chat component that handles message rendering, user input, and streaming responses from Claude. */
 @Component({
@@ -30,6 +33,8 @@ import { TextBlockComponent } from './blocks/text-block.component';
     ChatMessageComponent,
     SessionStatsComponent,
     TextBlockComponent,
+    MemoryPanelComponent,
+    ConversationsSidebarComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './chat.component.html',
@@ -40,23 +45,51 @@ export class ChatComponent implements OnInit, OnDestroy {
   inputText = '';
 
   conversations: ConversationSummary[] = [];
-  showHistory = false;
   viewingTranscript: ConversationTranscript | null = null;
   historyLoading = false;
   historyError = '';
   projectMemory = '';
-  showMemory = false;
   viewError = '';
   private resumeInProgress = false;
 
   readonly chat = inject(ChatStateService);
   readonly projectState = inject(ProjectStateService);
+  readonly ui = inject(UiStateService);
   private cdr = inject(ChangeDetectorRef);
   private tauri = inject(TauriService);
   private router = inject(Router);
   private unsubChange: (() => void) | null = null;
   private unsubProjectReady: (() => void) | null = null;
   private unsubAuthWatch: (() => void) | null = null;
+
+  /** True if the conversations sidebar is open. Backed by UiStateService. */
+  get showHistory(): boolean {
+    return this.ui.sidebarOpen();
+  }
+  /**
+   * Sets the conversations-sidebar visibility by toggling the shared UI state signal.
+   * @param value - True to open the sidebar, false to close it.
+   */
+  set showHistory(value: boolean) {
+    if (value !== this.ui.sidebarOpen()) this.ui.toggleSidebar();
+  }
+
+  /** True if the memory panel is open. Backed by UiStateService. */
+  get showMemory(): boolean {
+    return this.ui.memoryOpen();
+  }
+  /**
+   * Sets the memory-panel visibility by toggling the shared UI state signal.
+   * @param value - True to open the panel, false to close it.
+   */
+  set showMemory(value: boolean) {
+    if (value !== this.ui.memoryOpen()) this.ui.toggleMemory();
+  }
+
+  /** Session id currently being viewed in the transcript overlay, or null. */
+  get currentViewSessionId(): string | null {
+    return this.viewingTranscript?.session_id ?? null;
+  }
 
   /** Subscribes to state changes from the service. */
   constructor() {
@@ -150,8 +183,8 @@ export class ChatComponent implements OnInit, OnDestroy {
 
   /** Toggles the history sidebar and loads conversations when opening. */
   async toggleHistory(): Promise<void> {
-    this.showHistory = !this.showHistory;
-    if (this.showHistory) {
+    this.ui.toggleSidebar();
+    if (this.ui.sidebarOpen()) {
       await this.loadConversations();
     }
     this.cdr.markForCheck();
@@ -222,7 +255,7 @@ export class ChatComponent implements OnInit, OnDestroy {
     // the backend resumes the session (which may take seconds).
     this.chat.loadMessages(messages);
     this.viewingTranscript = null;
-    this.showHistory = false;
+    this.ui.closeSidebar();
     this.cdr.markForCheck();
 
     try {
@@ -261,8 +294,8 @@ export class ChatComponent implements OnInit, OnDestroy {
   async newConversation(): Promise<void> {
     this.inputText = '';
     this.viewingTranscript = null;
-    this.showHistory = false;
-    this.showMemory = false;
+    this.ui.closeSidebar();
+    this.ui.closeMemory();
     this.chat.resetForNewConversation();
     this.cdr.markForCheck();
     await this.chat.init();
@@ -276,8 +309,8 @@ export class ChatComponent implements OnInit, OnDestroy {
 
   /** Toggles the project memory panel and loads memory on open. */
   async toggleMemory(): Promise<void> {
-    this.showMemory = !this.showMemory;
-    if (this.showMemory) {
+    this.ui.toggleMemory();
+    if (this.ui.memoryOpen()) {
       await this.loadProjectMemory();
     }
     this.cdr.markForCheck();

--- a/desktop/src/src/app/chat/conversations-sidebar/conversations-sidebar.component.spec.ts
+++ b/desktop/src/src/app/chat/conversations-sidebar/conversations-sidebar.component.spec.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ConversationsSidebarComponent } from './conversations-sidebar.component';
+import type { ConversationSummary } from '../../models/chat';
+
+@Component({
+  standalone: true,
+  imports: [ConversationsSidebarComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <app-conversations-sidebar
+      [open]="open"
+      [conversations]="conversations"
+      [currentSessionId]="currentSessionId"
+      (closed)="onClosed()"
+      (newConversation)="onNew()"
+      (viewConversation)="onView($event)"
+      (resumeConversation)="onResume($event)"
+    />
+  `,
+})
+class HostComponent {
+  open = true;
+  conversations: readonly ConversationSummary[] = [];
+  currentSessionId: string | null = null;
+  closedCount = 0;
+  newCount = 0;
+  viewedPayload: ConversationSummary | null = null;
+  resumedPayload: ConversationSummary | null = null;
+
+  onClosed(): void {
+    this.closedCount += 1;
+  }
+  onNew(): void {
+    this.newCount += 1;
+  }
+  onView(payload: ConversationSummary): void {
+    this.viewedPayload = payload;
+  }
+  onResume(payload: ConversationSummary): void {
+    this.resumedPayload = payload;
+  }
+}
+
+const sample: readonly ConversationSummary[] = [
+  {
+    session_id: 's1',
+    preview: 'Refactoring container runtime',
+    timestamp: '2m',
+    message_count: 14,
+  },
+  { session_id: 's2', preview: 'MCP plugin signing', timestamp: '1h', message_count: 8 },
+  { session_id: 's3', preview: '', timestamp: null, message_count: 0 },
+];
+
+describe('ConversationsSidebarComponent', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let host: HostComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({ imports: [HostComponent] }).compileComponents();
+    fixture = TestBed.createComponent(HostComponent);
+    host = fixture.componentInstance;
+  });
+
+  describe('visibility', () => {
+    it('renders nothing when open=false', () => {
+      host.open = false;
+      host.conversations = sample;
+      fixture.detectChanges();
+      expect(
+        fixture.nativeElement.querySelector('[data-testid="conversations-sidebar"]')
+      ).toBeNull();
+    });
+
+    it('renders drawer when open=true', () => {
+      host.conversations = sample;
+      fixture.detectChanges();
+      expect(
+        fixture.nativeElement.querySelector('[data-testid="conversations-sidebar"]')
+      ).not.toBeNull();
+    });
+  });
+
+  describe('ARIA', () => {
+    it('has role="navigation" and aria-label="Conversations"', () => {
+      host.conversations = sample;
+      fixture.detectChanges();
+      const el = fixture.nativeElement.querySelector('[data-testid="conversations-sidebar"]');
+      expect(el.getAttribute('role')).toBe('navigation');
+      expect(el.getAttribute('aria-label')).toBe('Conversations');
+    });
+  });
+
+  describe('empty state', () => {
+    it('shows placeholder when conversations is empty', () => {
+      host.conversations = [];
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toContain('no conversations yet');
+      expect(
+        fixture.nativeElement.querySelector('[data-testid="conversations-sidebar-row"]')
+      ).toBeNull();
+    });
+  });
+
+  describe('list rendering', () => {
+    it('renders one row per conversation', () => {
+      host.conversations = sample;
+      fixture.detectChanges();
+      const rows = fixture.nativeElement.querySelectorAll(
+        '[data-testid="conversations-sidebar-row"]'
+      );
+      expect(rows.length).toBe(3);
+    });
+
+    it('renders preview text and count', () => {
+      host.conversations = sample;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toContain('Refactoring container runtime');
+      expect(fixture.nativeElement.textContent).toContain('14 · 2m');
+    });
+
+    it('falls back to "untitled" when preview is empty', () => {
+      host.conversations = sample;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toContain('untitled');
+    });
+
+    it('falls back to "unknown" when timestamp is null', () => {
+      host.conversations = sample;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toContain('0 · unknown');
+    });
+  });
+
+  describe('active highlight', () => {
+    it('applies aria-current="true" on the active row', () => {
+      host.conversations = sample;
+      host.currentSessionId = 's2';
+      fixture.detectChanges();
+      const active = fixture.nativeElement.querySelector('[data-testid="conversation-view-s2"]');
+      expect(active.getAttribute('aria-current')).toBe('true');
+    });
+
+    it('no aria-current when no match', () => {
+      host.conversations = sample;
+      host.currentSessionId = 'unknown';
+      fixture.detectChanges();
+      const els = fixture.nativeElement.querySelectorAll('[aria-current="true"]');
+      expect(els.length).toBe(0);
+    });
+  });
+
+  describe('event outputs', () => {
+    it('emits closed when close button clicked', () => {
+      host.conversations = sample;
+      fixture.detectChanges();
+      (
+        fixture.nativeElement.querySelector(
+          '[data-testid="conversations-sidebar-close"]'
+        ) as HTMLButtonElement
+      ).click();
+      expect(host.closedCount).toBe(1);
+    });
+
+    it('emits newConversation when + new clicked', () => {
+      host.conversations = sample;
+      fixture.detectChanges();
+      (
+        fixture.nativeElement.querySelector(
+          '[data-testid="conversations-sidebar-new"]'
+        ) as HTMLButtonElement
+      ).click();
+      expect(host.newCount).toBe(1);
+    });
+
+    it('emits viewConversation with the clicked row payload', () => {
+      host.conversations = sample;
+      fixture.detectChanges();
+      (
+        fixture.nativeElement.querySelector(
+          '[data-testid="conversation-view-s1"]'
+        ) as HTMLButtonElement
+      ).click();
+      expect(host.viewedPayload?.session_id).toBe('s1');
+    });
+
+    it('emits resumeConversation with the clicked row payload', () => {
+      host.conversations = sample;
+      fixture.detectChanges();
+      (
+        fixture.nativeElement.querySelector(
+          '[data-testid="conversation-resume-s2"]'
+        ) as HTMLButtonElement
+      ).click();
+      expect(host.resumedPayload?.session_id).toBe('s2');
+    });
+  });
+});

--- a/desktop/src/src/app/chat/conversations-sidebar/conversations-sidebar.component.ts
+++ b/desktop/src/src/app/chat/conversations-sidebar/conversations-sidebar.component.ts
@@ -1,0 +1,121 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import type { ConversationSummary } from '../../models/chat';
+
+/**
+ * Left-drawer conversations sidebar listing past sessions for the active project.
+ *
+ * Matches the terminal-minimal mockup: a 280px absolute drawer anchored to the
+ * left edge, with a mono `conversations` header, close button, a `+ new` button,
+ * and a scrollable list of conversation rows (preview, timestamp, message count).
+ *
+ * Each row exposes two actions — view (read-only transcript) and resume (continue
+ * session) — matching the legacy chat.component behaviour. The active row is
+ * highlighted with an `accent` border-left and bold text.
+ *
+ * Uses `@Input`/`@Output` decorators rather than signal input()/output() to stay
+ * compatible with the project's Vitest runner (no AOT compiler pass).
+ */
+@Component({
+  selector: 'app-conversations-sidebar',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    @if (open) {
+      <aside
+        class="absolute left-0 top-0 h-full w-[280px] bg-bg-1 ring-1 ring-line flex flex-col z-10"
+        role="navigation"
+        aria-label="Conversations"
+        data-testid="conversations-sidebar"
+      >
+        <div class="flex h-11 items-center gap-2 border-b border-line px-3">
+          <span class="font-mono text-[11px] text-ink-mute">conversations</span>
+          <span class="font-mono text-[10px] text-ink-mute ml-1">{{ conversations.length }}</span>
+          <button
+            type="button"
+            class="ml-auto font-mono text-[11px] text-accent hover:underline"
+            data-testid="conversations-sidebar-new"
+            aria-label="New conversation"
+            (click)="newConversation.emit()"
+          >
+            + new
+          </button>
+          <button
+            type="button"
+            class="text-ink-mute hover:text-ink text-sm px-1"
+            data-testid="conversations-sidebar-close"
+            aria-label="Close conversations sidebar"
+            (click)="closed.emit()"
+          >
+            ×
+          </button>
+        </div>
+        <div class="flex-1 overflow-y-auto py-1">
+          @for (conv of conversations; track conv.session_id) {
+            @let active = conv.session_id === currentSessionId;
+            <div
+              class="flex items-stretch border-l-2"
+              [class.border-accent]="active"
+              [class.border-transparent]="!active"
+              [class.bg-bg-2]="active"
+              data-testid="conversations-sidebar-row"
+            >
+              <button
+                type="button"
+                class="flex-1 min-w-0 px-3 py-2 text-left hover:bg-bg-2"
+                [attr.data-testid]="'conversation-view-' + conv.session_id"
+                [attr.aria-current]="active ? 'true' : null"
+                (click)="viewConversation.emit(conv)"
+              >
+                <div
+                  class="truncate text-[13px]"
+                  [class.text-accent]="active"
+                  [class.text-ink]="!active"
+                >
+                  {{ conv.preview || 'untitled' }}
+                </div>
+                <div class="font-mono mt-0.5 text-[10px] text-ink-mute">
+                  {{ conv.message_count }} · {{ conv.timestamp ?? 'unknown' }}
+                </div>
+              </button>
+              <button
+                type="button"
+                class="font-mono text-[10px] text-ink-mute hover:text-accent px-2"
+                [attr.data-testid]="'conversation-resume-' + conv.session_id"
+                aria-label="Resume conversation"
+                (click)="resumeConversation.emit(conv)"
+              >
+                resume
+              </button>
+            </div>
+          } @empty {
+            <div class="p-4 text-center font-mono text-[11.5px] text-ink-mute">
+              no conversations yet
+            </div>
+          }
+        </div>
+      </aside>
+    }
+  `,
+})
+export class ConversationsSidebarComponent {
+  /** Whether the sidebar drawer is visible. */
+  @Input() open = false;
+
+  /** Past conversation summaries for the active project. */
+  @Input({ required: true }) conversations!: readonly ConversationSummary[];
+
+  /** Session id of the currently active / viewed conversation, or null for none. */
+  @Input() currentSessionId: string | null = null;
+
+  /** Emitted when the user clicks the close button. */
+  @Output() readonly closed = new EventEmitter<void>();
+
+  /** Emitted when the user clicks the "+ new" button. */
+  @Output() readonly newConversation = new EventEmitter<void>();
+
+  /** Emitted when the user clicks a conversation row to view its transcript. */
+  @Output() readonly viewConversation = new EventEmitter<ConversationSummary>();
+
+  /** Emitted when the user clicks the resume action on a conversation row. */
+  @Output() readonly resumeConversation = new EventEmitter<ConversationSummary>();
+}

--- a/desktop/src/src/app/chat/conversations-sidebar/conversations-sidebar.component.ts
+++ b/desktop/src/src/app/chat/conversations-sidebar/conversations-sidebar.component.ts
@@ -98,24 +98,11 @@ import type { ConversationSummary } from '../../models/chat';
   `,
 })
 export class ConversationsSidebarComponent {
-  /** Whether the sidebar drawer is visible. */
   @Input() open = false;
-
-  /** Past conversation summaries for the active project. */
   @Input({ required: true }) conversations!: readonly ConversationSummary[];
-
-  /** Session id of the currently active / viewed conversation, or null for none. */
   @Input() currentSessionId: string | null = null;
-
-  /** Emitted when the user clicks the close button. */
   @Output() readonly closed = new EventEmitter<void>();
-
-  /** Emitted when the user clicks the "+ new" button. */
   @Output() readonly newConversation = new EventEmitter<void>();
-
-  /** Emitted when the user clicks a conversation row to view its transcript. */
   @Output() readonly viewConversation = new EventEmitter<ConversationSummary>();
-
-  /** Emitted when the user clicks the resume action on a conversation row. */
   @Output() readonly resumeConversation = new EventEmitter<ConversationSummary>();
 }

--- a/desktop/src/src/app/chat/memory-panel/memory-panel.component.spec.ts
+++ b/desktop/src/src/app/chat/memory-panel/memory-panel.component.spec.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MemoryPanelComponent } from './memory-panel.component';
+
+@Component({
+  standalone: true,
+  imports: [MemoryPanelComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: ` <app-memory-panel [open]="open" [markdown]="markdown" (closed)="onClosed()" /> `,
+})
+class HostComponent {
+  open = false;
+  markdown = '';
+  closedCount = 0;
+
+  onClosed(): void {
+    this.closedCount += 1;
+  }
+}
+
+describe('MemoryPanelComponent', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let host: HostComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({ imports: [HostComponent] }).compileComponents();
+    fixture = TestBed.createComponent(HostComponent);
+    host = fixture.componentInstance;
+  });
+
+  describe('visibility', () => {
+    it('renders nothing when open=false', () => {
+      host.open = false;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('[data-testid="memory-panel"]')).toBeNull();
+    });
+
+    it('renders the drawer when open=true', () => {
+      host.open = true;
+      fixture.detectChanges();
+      const panel = fixture.nativeElement.querySelector('[data-testid="memory-panel"]');
+      expect(panel).not.toBeNull();
+    });
+  });
+
+  describe('ARIA', () => {
+    it('has role="complementary" and aria-label="Project memory"', () => {
+      host.open = true;
+      fixture.detectChanges();
+      const panel = fixture.nativeElement.querySelector('[data-testid="memory-panel"]');
+      expect(panel.getAttribute('role')).toBe('complementary');
+      expect(panel.getAttribute('aria-label')).toBe('Project memory');
+    });
+
+    it('close button has aria-label="Close memory panel"', () => {
+      host.open = true;
+      fixture.detectChanges();
+      const btn = fixture.nativeElement.querySelector('[data-testid="memory-panel-close"]');
+      expect(btn.getAttribute('aria-label')).toBe('Close memory panel');
+    });
+  });
+
+  describe('markdown rendering', () => {
+    it('renders the markdown content via app-text-block when non-empty', () => {
+      host.open = true;
+      host.markdown = '# Hello\n\nWorld';
+      fixture.detectChanges();
+      const body = fixture.nativeElement.querySelector('[data-testid="memory-panel-body"]');
+      expect(body.querySelector('app-text-block')).not.toBeNull();
+      expect(body.textContent).toContain('Hello');
+      expect(body.textContent).toContain('World');
+    });
+
+    it('shows empty placeholder when markdown is empty string', () => {
+      host.open = true;
+      host.markdown = '';
+      fixture.detectChanges();
+      expect(
+        fixture.nativeElement.querySelector('[data-testid="memory-panel-empty"]')
+      ).not.toBeNull();
+      expect(fixture.nativeElement.querySelector('app-text-block')).toBeNull();
+    });
+  });
+
+  describe('close event', () => {
+    it('emits closed when close button clicked', () => {
+      host.open = true;
+      fixture.detectChanges();
+      const btn = fixture.nativeElement.querySelector(
+        '[data-testid="memory-panel-close"]'
+      ) as HTMLButtonElement;
+      btn.click();
+      expect(host.closedCount).toBe(1);
+    });
+
+    it('does not emit closed while panel is open but untouched', () => {
+      host.open = true;
+      fixture.detectChanges();
+      expect(host.closedCount).toBe(0);
+    });
+  });
+});

--- a/desktop/src/src/app/chat/memory-panel/memory-panel.component.spec.ts
+++ b/desktop/src/src/app/chat/memory-panel/memory-panel.component.spec.ts
@@ -7,11 +7,14 @@ import { MemoryPanelComponent } from './memory-panel.component';
   standalone: true,
   imports: [MemoryPanelComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  template: ` <app-memory-panel [open]="open" [markdown]="markdown" (closed)="onClosed()" /> `,
+  template: `
+    <app-memory-panel [open]="open" [markdown]="markdown" [error]="error" (closed)="onClosed()" />
+  `,
 })
 class HostComponent {
   open = false;
   markdown = '';
+  error = '';
   closedCount = 0;
 
   onClosed(): void {
@@ -98,6 +101,43 @@ describe('MemoryPanelComponent', () => {
       host.open = true;
       fixture.detectChanges();
       expect(host.closedCount).toBe(0);
+    });
+  });
+
+  describe('error rendering', () => {
+    it('shows the error banner and hides body content when error is set', () => {
+      host.open = true;
+      host.markdown = '# Should be hidden';
+      host.error = 'Failed to load memory: disk failure';
+      fixture.detectChanges();
+
+      const errorEl = fixture.nativeElement.querySelector('[data-testid="memory-panel-error"]');
+      expect(errorEl).not.toBeNull();
+      expect(errorEl.textContent).toContain('Failed to load memory');
+      expect(fixture.nativeElement.querySelector('app-text-block')).toBeNull();
+      expect(fixture.nativeElement.querySelector('[data-testid="memory-panel-empty"]')).toBeNull();
+    });
+
+    it('renders markdown (no error banner) when error is empty string', () => {
+      host.open = true;
+      host.markdown = '# Recovered';
+      host.error = '';
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('[data-testid="memory-panel-error"]')).toBeNull();
+      expect(fixture.nativeElement.querySelector('app-text-block')).not.toBeNull();
+    });
+
+    it('renders empty placeholder when both markdown and error are empty', () => {
+      host.open = true;
+      host.markdown = '';
+      host.error = '';
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('[data-testid="memory-panel-error"]')).toBeNull();
+      expect(
+        fixture.nativeElement.querySelector('[data-testid="memory-panel-empty"]')
+      ).not.toBeNull();
     });
   });
 });

--- a/desktop/src/src/app/chat/memory-panel/memory-panel.component.ts
+++ b/desktop/src/src/app/chat/memory-panel/memory-panel.component.ts
@@ -47,7 +47,14 @@ import { TextBlockComponent } from '../blocks/text-block.component';
           class="flex-1 overflow-y-auto p-3 text-[13px] leading-relaxed text-ink"
           data-testid="memory-panel-body"
         >
-          @if (markdown) {
+          @if (error) {
+            <p
+              class="font-mono text-[11.5px] text-sw-accent border border-sw-accent rounded px-2 py-1.5"
+              data-testid="memory-panel-error"
+            >
+              {{ error }}
+            </p>
+          } @else if (markdown) {
             <app-text-block [content]="markdown" />
           } @else {
             <p class="font-mono text-[11.5px] text-ink-mute" data-testid="memory-panel-empty">
@@ -62,5 +69,6 @@ import { TextBlockComponent } from '../blocks/text-block.component';
 export class MemoryPanelComponent {
   @Input() open = false;
   @Input() markdown = '';
+  @Input() error = '';
   @Output() readonly closed = new EventEmitter<void>();
 }

--- a/desktop/src/src/app/chat/memory-panel/memory-panel.component.ts
+++ b/desktop/src/src/app/chat/memory-panel/memory-panel.component.ts
@@ -1,0 +1,71 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { TextBlockComponent } from '../blocks/text-block.component';
+
+/**
+ * Right-drawer memory panel showing the active project's CLAUDE.md contents.
+ *
+ * Matches the terminal-minimal mockup: a 320px absolute drawer anchored to the
+ * right edge, with a mono `memory` header, close button, and a markdown body
+ * rendered via `TextBlockComponent` (reused to keep the marked pipeline DRY).
+ *
+ * Per the implementation prompt spec: the panel does NOT over-parse CLAUDE.md
+ * into category buckets — the markdown source already has a clean section
+ * structure (headings for User Preferences / Feedback / Project / Reference),
+ * so the prose renderer shines through.
+ *
+ * Uses `@Input`/`@Output` decorators rather than signal input()/output() to stay
+ * compatible with the project's Vitest runner, which does not apply Angular's
+ * AOT compiler pass and therefore cannot register signal-based inputs. The
+ * rest of the codebase follows the same convention.
+ */
+@Component({
+  selector: 'app-memory-panel',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [TextBlockComponent],
+  template: `
+    @if (open) {
+      <aside
+        class="absolute right-0 top-0 h-full w-[320px] bg-bg-1 ring-1 ring-line flex flex-col z-10"
+        role="complementary"
+        aria-label="Project memory"
+        data-testid="memory-panel"
+      >
+        <div class="flex h-11 items-center gap-2 border-b border-line px-3">
+          <span class="font-mono text-[11px] text-ink-mute">memory</span>
+          <button
+            type="button"
+            class="ml-auto text-ink-mute hover:text-ink text-sm px-1"
+            data-testid="memory-panel-close"
+            aria-label="Close memory panel"
+            (click)="closed.emit()"
+          >
+            ×
+          </button>
+        </div>
+        <div
+          class="flex-1 overflow-y-auto p-3 text-[13px] leading-relaxed text-ink"
+          data-testid="memory-panel-body"
+        >
+          @if (markdown) {
+            <app-text-block [content]="markdown" />
+          } @else {
+            <p class="font-mono text-[11.5px] text-ink-mute" data-testid="memory-panel-empty">
+              no memory yet
+            </p>
+          }
+        </div>
+      </aside>
+    }
+  `,
+})
+export class MemoryPanelComponent {
+  /** Whether the memory panel drawer is visible. */
+  @Input() open = false;
+
+  /** Raw project CLAUDE.md markdown content. */
+  @Input() markdown = '';
+
+  /** Emitted when the user clicks the close button. */
+  @Output() readonly closed = new EventEmitter<void>();
+}

--- a/desktop/src/src/app/chat/memory-panel/memory-panel.component.ts
+++ b/desktop/src/src/app/chat/memory-panel/memory-panel.component.ts
@@ -60,12 +60,7 @@ import { TextBlockComponent } from '../blocks/text-block.component';
   `,
 })
 export class MemoryPanelComponent {
-  /** Whether the memory panel drawer is visible. */
   @Input() open = false;
-
-  /** Raw project CLAUDE.md markdown content. */
   @Input() markdown = '';
-
-  /** Emitted when the user clicks the close button. */
   @Output() readonly closed = new EventEmitter<void>();
 }

--- a/desktop/src/src/app/services/ui-state.service.spec.ts
+++ b/desktop/src/src/app/services/ui-state.service.spec.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { UiStateService } from './ui-state.service';
+
+describe('UiStateService', () => {
+  let service: UiStateService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(UiStateService);
+  });
+
+  describe('initial state', () => {
+    it('sidebarOpen defaults to false', () => {
+      expect(service.sidebarOpen()).toBe(false);
+    });
+
+    it('memoryOpen defaults to false', () => {
+      expect(service.memoryOpen()).toBe(false);
+    });
+  });
+
+  describe('toggleSidebar', () => {
+    it('flips sidebarOpen from false to true', () => {
+      service.toggleSidebar();
+      expect(service.sidebarOpen()).toBe(true);
+    });
+
+    it('flips sidebarOpen from true back to false', () => {
+      service.toggleSidebar();
+      service.toggleSidebar();
+      expect(service.sidebarOpen()).toBe(false);
+    });
+
+    it('does not affect memoryOpen', () => {
+      service.toggleSidebar();
+      expect(service.memoryOpen()).toBe(false);
+    });
+  });
+
+  describe('toggleMemory', () => {
+    it('flips memoryOpen from false to true', () => {
+      service.toggleMemory();
+      expect(service.memoryOpen()).toBe(true);
+    });
+
+    it('flips memoryOpen from true back to false', () => {
+      service.toggleMemory();
+      service.toggleMemory();
+      expect(service.memoryOpen()).toBe(false);
+    });
+
+    it('does not affect sidebarOpen', () => {
+      service.toggleMemory();
+      expect(service.sidebarOpen()).toBe(false);
+    });
+  });
+
+  describe('closeSidebar', () => {
+    it('sets sidebarOpen to false when open', () => {
+      service.toggleSidebar();
+      service.closeSidebar();
+      expect(service.sidebarOpen()).toBe(false);
+    });
+
+    it('leaves sidebarOpen false when already closed', () => {
+      service.closeSidebar();
+      expect(service.sidebarOpen()).toBe(false);
+    });
+  });
+
+  describe('closeMemory', () => {
+    it('sets memoryOpen to false when open', () => {
+      service.toggleMemory();
+      service.closeMemory();
+      expect(service.memoryOpen()).toBe(false);
+    });
+
+    it('leaves memoryOpen false when already closed', () => {
+      service.closeMemory();
+      expect(service.memoryOpen()).toBe(false);
+    });
+  });
+
+  describe('singleton scoping', () => {
+    it('returns the same instance across inject() calls', () => {
+      const second = TestBed.inject(UiStateService);
+      expect(second).toBe(service);
+    });
+  });
+});

--- a/desktop/src/src/app/services/ui-state.service.ts
+++ b/desktop/src/src/app/services/ui-state.service.ts
@@ -1,0 +1,45 @@
+import { Injectable, signal, type Signal } from '@angular/core';
+
+/**
+ * SSOT for transient UI state shared across shell/chat views.
+ *
+ * Holds view-state signals that span components (conversations sidebar, memory
+ * panel). Per terminal-minimal implementation prompt (Signals architecture):
+ * view toggles live in a dedicated UI-state service with `providedIn: 'root'`.
+ *
+ * Consumers:
+ * - `ShellComponent` binds the ⌘B / Ctrl+B keyboard shortcut to `toggleSidebar()`.
+ * - `ChatComponent` renders `<app-memory-panel>` and `<app-conversations-sidebar>`
+ *   driven by `memoryOpen()` / `sidebarOpen()`.
+ */
+@Injectable({ providedIn: 'root' })
+export class UiStateService {
+  private readonly sidebarOpenSignal = signal<boolean>(false);
+  private readonly memoryOpenSignal = signal<boolean>(false);
+
+  /** Whether the conversations sidebar drawer is open. */
+  readonly sidebarOpen: Signal<boolean> = this.sidebarOpenSignal.asReadonly();
+
+  /** Whether the memory panel drawer is open. */
+  readonly memoryOpen: Signal<boolean> = this.memoryOpenSignal.asReadonly();
+
+  /** Toggles the conversations sidebar drawer. */
+  toggleSidebar(): void {
+    this.sidebarOpenSignal.update((open) => !open);
+  }
+
+  /** Toggles the memory panel drawer. */
+  toggleMemory(): void {
+    this.memoryOpenSignal.update((open) => !open);
+  }
+
+  /** Closes the conversations sidebar drawer. */
+  closeSidebar(): void {
+    this.sidebarOpenSignal.set(false);
+  }
+
+  /** Closes the memory panel drawer. */
+  closeMemory(): void {
+    this.memoryOpenSignal.set(false);
+  }
+}

--- a/desktop/src/src/app/services/ui-state.service.ts
+++ b/desktop/src/src/app/services/ui-state.service.ts
@@ -17,28 +17,28 @@ export class UiStateService {
   private readonly sidebarOpenSignal = signal<boolean>(false);
   private readonly memoryOpenSignal = signal<boolean>(false);
 
-  /** Whether the conversations sidebar drawer is open. */
+  /** Read-only signal reflecting the conversations sidebar drawer's open state. */
   readonly sidebarOpen: Signal<boolean> = this.sidebarOpenSignal.asReadonly();
 
-  /** Whether the memory panel drawer is open. */
+  /** Read-only signal reflecting the memory panel drawer's open state. */
   readonly memoryOpen: Signal<boolean> = this.memoryOpenSignal.asReadonly();
 
-  /** Toggles the conversations sidebar drawer. */
+  /** Flips the conversations sidebar drawer between open and closed. */
   toggleSidebar(): void {
     this.sidebarOpenSignal.update((open) => !open);
   }
 
-  /** Toggles the memory panel drawer. */
+  /** Flips the memory panel drawer between open and closed. */
   toggleMemory(): void {
     this.memoryOpenSignal.update((open) => !open);
   }
 
-  /** Closes the conversations sidebar drawer. */
+  /** Forces the conversations sidebar drawer closed. */
   closeSidebar(): void {
     this.sidebarOpenSignal.set(false);
   }
 
-  /** Closes the memory panel drawer. */
+  /** Forces the memory panel drawer closed. */
   closeMemory(): void {
     this.memoryOpenSignal.set(false);
   }

--- a/desktop/src/src/app/shell/shell.component.spec.ts
+++ b/desktop/src/src/app/shell/shell.component.spec.ts
@@ -4,6 +4,7 @@ import { Router, RouterModule } from '@angular/router';
 import { ShellComponent } from './shell.component';
 import { TauriService } from '../services/tauri.service';
 import { ProjectStateService } from '../services/project-state.service';
+import { UiStateService } from '../services/ui-state.service';
 import { MockTauriService, MOCK_BUNDLE_RECONCILE_DONE } from '../testing/mock-tauri.service';
 
 describe('ShellComponent', () => {
@@ -40,6 +41,10 @@ describe('ShellComponent', () => {
     fixture = TestBed.createComponent(ShellComponent);
     component = fixture.componentInstance;
     projectState = TestBed.inject(ProjectStateService);
+    // Reset shared UI state so ⌘B keybinding tests start from a clean slate.
+    const ui = TestBed.inject(UiStateService);
+    ui.closeSidebar();
+    ui.closeMemory();
     fixture.detectChanges();
   });
 
@@ -410,6 +415,53 @@ describe('ShellComponent', () => {
       fixture.detectChanges();
 
       expect(fixture.nativeElement.querySelector('[data-testid="restart-overlay"]')).not.toBeNull();
+    });
+  });
+
+  describe('Cmd+B / Ctrl+B keyboard shortcut', () => {
+    it('toggles the conversations sidebar on Cmd+B', () => {
+      const ui = TestBed.inject(UiStateService);
+      expect(ui.sidebarOpen()).toBe(false);
+
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'b', metaKey: true }));
+
+      expect(ui.sidebarOpen()).toBe(true);
+    });
+
+    it('toggles the conversations sidebar on Ctrl+B', () => {
+      const ui = TestBed.inject(UiStateService);
+      expect(ui.sidebarOpen()).toBe(false);
+
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'B', ctrlKey: true }));
+
+      expect(ui.sidebarOpen()).toBe(true);
+    });
+
+    it('flips the sidebar back closed on a second Cmd+B', () => {
+      const ui = TestBed.inject(UiStateService);
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'b', metaKey: true }));
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'b', metaKey: true }));
+
+      expect(ui.sidebarOpen()).toBe(false);
+    });
+
+    it('ignores plain `b` keypress without modifier', () => {
+      const ui = TestBed.inject(UiStateService);
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'b' }));
+      expect(ui.sidebarOpen()).toBe(false);
+    });
+
+    it('ignores Cmd+other keys', () => {
+      const ui = TestBed.inject(UiStateService);
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', metaKey: true }));
+      expect(ui.sidebarOpen()).toBe(false);
+    });
+
+    it('does not fire after the component is destroyed', () => {
+      const ui = TestBed.inject(UiStateService);
+      fixture.destroy();
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'b', metaKey: true }));
+      expect(ui.sidebarOpen()).toBe(false);
     });
   });
 });

--- a/desktop/src/src/app/shell/shell.component.ts
+++ b/desktop/src/src/app/shell/shell.component.ts
@@ -2,26 +2,43 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  computed,
   inject,
   OnDestroy,
   OnInit,
+  signal,
 } from '@angular/core';
-import { RouterOutlet, RouterLink, RouterLinkActive } from '@angular/router';
+import { NavigationEnd, Router, RouterOutlet } from '@angular/router';
+import type { Subscription } from 'rxjs';
+import { filter } from 'rxjs/operators';
 import { ProjectSwitcherComponent } from '../project-switcher/project-switcher.component';
 import { UpdateNotificationComponent } from '../update-notification/update-notification.component';
 import { ProjectStateService } from '../services/project-state.service';
+import { UiStateService } from '../services/ui-state.service';
+import {
+  ViewSwitcherComponent,
+  type ViewSwitcherEntry,
+} from './view-switcher/view-switcher.component';
 
-/** Main application shell with header navigation and project switcher. */
+/**
+ * Main application shell with header navigation and project switcher.
+ *
+ * Hosts the terminal-minimal top nav via `<app-view-switcher>` and wires the
+ * ⌘B / Ctrl+B keyboard shortcut to toggle the conversations sidebar through
+ * `UiStateService`. Per the terminal-minimal prompt (Signals architecture),
+ * the sidebar's open-state lives in the singleton `UiStateService`, not
+ * locally — shell binds the keybinding, chat consumes the signal.
+ */
 @Component({
   selector: 'app-shell',
   standalone: true,
   imports: [
     RouterOutlet,
-    RouterLink,
-    RouterLinkActive,
     ProjectSwitcherComponent,
     UpdateNotificationComponent,
+    ViewSwitcherComponent,
   ],
+  host: { '(document:keydown)': 'onKeydown($event)' },
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="flex flex-col h-screen bg-sw-bg-darkest text-sw-text">
@@ -159,37 +176,8 @@ import { ProjectStateService } from '../services/project-state.service';
             />
           </svg>
         </span>
-        <nav class="flex gap-4 justify-self-center" data-testid="app-nav">
-          @if (projectState.status === 'ready' || projectState.status === 'error') {
-            <a
-              routerLink="/chat"
-              routerLinkActive="!text-sw-accent font-bold"
-              class="text-sw-text-muted no-underline text-[13px] font-mono px-2 py-1 rounded transition-colors duration-200 hover:text-sw-text"
-              data-testid="nav-chat"
-              >Chat</a
-            >
-          }
-          <a
-            routerLink="/integrations"
-            routerLinkActive="!text-sw-accent font-bold"
-            class="text-sw-text-muted no-underline text-[13px] font-mono px-2 py-1 rounded transition-colors duration-200 hover:text-sw-text"
-            data-testid="nav-integrations"
-            >Integrations</a
-          >
-          <a
-            routerLink="/plugins"
-            routerLinkActive="!text-sw-accent font-bold"
-            class="text-sw-text-muted no-underline text-[13px] font-mono px-2 py-1 rounded transition-colors duration-200 hover:text-sw-text"
-            data-testid="nav-plugins"
-            >Plugins</a
-          >
-          <a
-            routerLink="/settings"
-            routerLinkActive="!text-sw-accent font-bold"
-            class="text-sw-text-muted no-underline text-[13px] font-mono px-2 py-1 rounded transition-colors duration-200 hover:text-sw-text"
-            data-testid="nav-settings"
-            >Settings</a
-          >
+        <nav class="justify-self-center" data-testid="app-nav">
+          <app-view-switcher [views]="visibleViews" [activeId]="activeViewId()" />
         </nav>
         <div class="justify-self-end">
           <app-project-switcher />
@@ -203,8 +191,34 @@ import { ProjectStateService } from '../services/project-state.service';
 })
 export class ShellComponent implements OnInit, OnDestroy {
   readonly projectState = inject(ProjectStateService);
+  readonly ui = inject(UiStateService);
   private cdr = inject(ChangeDetectorRef);
+  private router = inject(Router);
   private unsubscribe: (() => void) | null = null;
+  private routerSub: Subscription | null = null;
+
+  private readonly viewCatalog: readonly ViewSwitcherEntry[] = [
+    { id: 'chat', label: 'Chat', route: '/chat' },
+    { id: 'integrations', label: 'Integrations', route: '/integrations' },
+    { id: 'plugins', label: 'Plugins', route: '/plugins' },
+    { id: 'settings', label: 'Settings', route: '/settings' },
+  ];
+
+  private readonly currentUrlSignal = signal<string>(this.router.url);
+
+  /** Views visible in the top nav — hides `chat` until auth is settled. */
+  get visibleViews(): readonly ViewSwitcherEntry[] {
+    const status = this.projectState.status;
+    const hideChat = status !== 'ready' && status !== 'error';
+    return hideChat ? this.viewCatalog.filter((v) => v.id !== 'chat') : this.viewCatalog;
+  }
+
+  /** The currently-active view id, derived from the router URL. */
+  readonly activeViewId = computed(() => {
+    const url = this.currentUrlSignal();
+    const match = this.viewCatalog.find((v) => url.startsWith(v.route));
+    return match?.id ?? '';
+  });
 
   /** Human-readable status message for the blocking overlay. */
   get statusMessage(): string {
@@ -232,6 +246,21 @@ export class ShellComponent implements OnInit, OnDestroy {
     this.unsubscribe = this.projectState.onChange(() => {
       this.cdr.markForCheck();
     });
+    this.routerSub = this.router.events
+      .pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd))
+      .subscribe((e) => this.currentUrlSignal.set(e.urlAfterRedirects));
+  }
+
+  /**
+   * Global document keydown handler. Handles:
+   * - ⌘B / Ctrl+B → toggle the conversations sidebar.
+   * @param event - The keyboard event dispatched on the document.
+   */
+  onKeydown(event: KeyboardEvent): void {
+    const isCmdB = (event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'b';
+    if (!isCmdB) return;
+    event.preventDefault();
+    this.ui.toggleSidebar();
   }
 
   /** Retries container lifecycle check. */
@@ -265,6 +294,10 @@ export class ShellComponent implements OnInit, OnDestroy {
     if (this.unsubscribe) {
       this.unsubscribe();
       this.unsubscribe = null;
+    }
+    if (this.routerSub) {
+      this.routerSub.unsubscribe();
+      this.routerSub = null;
     }
   }
 }

--- a/desktop/src/src/app/shell/shell.component.ts
+++ b/desktop/src/src/app/shell/shell.component.ts
@@ -23,11 +23,8 @@ import {
 /**
  * Main application shell with header navigation and project switcher.
  *
- * Hosts the terminal-minimal top nav via `<app-view-switcher>` and wires the
- * ⌘B / Ctrl+B keyboard shortcut to toggle the conversations sidebar through
- * `UiStateService`. Per the terminal-minimal prompt (Signals architecture),
- * the sidebar's open-state lives in the singleton `UiStateService`, not
- * locally — shell binds the keybinding, chat consumes the signal.
+ * Wires the ⌘B / Ctrl+B keyboard shortcut to `UiStateService.toggleSidebar()` —
+ * the sidebar's open-state is shared via signals, not local component state.
  */
 @Component({
   selector: 'app-shell',
@@ -177,7 +174,7 @@ import {
           </svg>
         </span>
         <nav class="justify-self-center" data-testid="app-nav">
-          <app-view-switcher [views]="visibleViews" [activeId]="activeViewId()" />
+          <app-view-switcher [views]="visibleViews()" [activeId]="activeViewId()" />
         </nav>
         <div class="justify-self-end">
           <app-project-switcher />
@@ -205,22 +202,23 @@ export class ShellComponent implements OnInit, OnDestroy {
   ];
 
   private readonly currentUrlSignal = signal<string>(this.router.url);
+  private readonly statusSignal = signal(this.projectState.status);
 
-  /** Views visible in the top nav — hides `chat` until auth is settled. */
-  get visibleViews(): readonly ViewSwitcherEntry[] {
-    const status = this.projectState.status;
+  /** Top-nav views — hides `chat` until auth is settled. */
+  readonly visibleViews = computed(() => {
+    const status = this.statusSignal();
     const hideChat = status !== 'ready' && status !== 'error';
     return hideChat ? this.viewCatalog.filter((v) => v.id !== 'chat') : this.viewCatalog;
-  }
+  });
 
-  /** The currently-active view id, derived from the router URL. */
+  /** Active view id derived from the current router URL. */
   readonly activeViewId = computed(() => {
     const url = this.currentUrlSignal();
     const match = this.viewCatalog.find((v) => url.startsWith(v.route));
     return match?.id ?? '';
   });
 
-  /** Human-readable status message for the blocking overlay. */
+  /** Human-readable copy for the blocking overlay, keyed off projectState.status. */
   get statusMessage(): string {
     switch (this.projectState.status) {
       case 'loading':
@@ -240,10 +238,11 @@ export class ShellComponent implements OnInit, OnDestroy {
     }
   }
 
-  /** Bootstraps ProjectStateService and subscribes to state changes. */
+  /** Bootstraps project state, mirrors status into a signal, and tracks the current URL. */
   ngOnInit(): void {
     this.projectState.init();
     this.unsubscribe = this.projectState.onChange(() => {
+      this.statusSignal.set(this.projectState.status);
       this.cdr.markForCheck();
     });
     this.routerSub = this.router.events
@@ -252,9 +251,8 @@ export class ShellComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Global document keydown handler. Handles:
-   * - ⌘B / Ctrl+B → toggle the conversations sidebar.
-   * @param event - The keyboard event dispatched on the document.
+   * ⌘B / Ctrl+B toggles the conversations sidebar via the shared UI-state signal.
+   * @param event - keyboard event from the document; consumed (preventDefault) on match.
    */
   onKeydown(event: KeyboardEvent): void {
     const isCmdB = (event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'b';
@@ -263,33 +261,33 @@ export class ShellComponent implements OnInit, OnDestroy {
     this.ui.toggleSidebar();
   }
 
-  /** Retries container lifecycle check. */
+  /** Retries the container lifecycle (used by the error banner). */
   retry(): void {
     this.projectState.ensureContainersRunning();
   }
 
-  /** Retries system check (prereqs + security). */
+  /** Retries the system check (prereqs + security) on check_failed. */
   retryCheck(): void {
     this.projectState.ensureContainersRunning();
   }
 
-  /** Triggers a container restart from the overlay. */
+  /** Triggers a container restart from the restart-required overlay. */
   restartContainers(): void {
     this.projectState.restartContainers();
   }
 
-  /** Dismisses the restart overlay. */
+  /** Dismisses the restart-required overlay without restarting. */
   dismissRestart(): void {
     this.projectState.dismissRestart();
   }
 
-  /** Dismisses the error banner. */
+  /** Clears the active error banner. */
   async dismiss(): Promise<void> {
     await this.projectState.dismissError();
     this.cdr.markForCheck();
   }
 
-  /** Cleans up the project state subscription. */
+  /** Tears down the projectState and router subscriptions. */
   ngOnDestroy(): void {
     if (this.unsubscribe) {
       this.unsubscribe();

--- a/desktop/src/src/app/shell/view-switcher/view-switcher.component.spec.ts
+++ b/desktop/src/src/app/shell/view-switcher/view-switcher.component.spec.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterModule } from '@angular/router';
+import { ViewSwitcherComponent, type ViewSwitcherEntry } from './view-switcher.component';
+
+@Component({
+  standalone: true,
+  imports: [ViewSwitcherComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <app-view-switcher [views]="views" [activeId]="activeId" (selected)="onSelected($event)" />
+  `,
+})
+class HostComponent {
+  views: readonly ViewSwitcherEntry[] = [];
+  activeId = '';
+  selections: string[] = [];
+
+  onSelected(id: string): void {
+    this.selections.push(id);
+  }
+}
+
+const views: readonly ViewSwitcherEntry[] = [
+  { id: 'chat', label: 'chat', route: '/chat' },
+  { id: 'integrations', label: 'integrations', route: '/integrations' },
+  { id: 'settings', label: 'settings', route: '/settings' },
+];
+
+describe('ViewSwitcherComponent', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let host: HostComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        HostComponent,
+        RouterModule.forRoot([
+          { path: 'chat', children: [] },
+          { path: 'integrations', children: [] },
+          { path: 'settings', children: [] },
+        ]),
+      ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(HostComponent);
+    host = fixture.componentInstance;
+  });
+
+  describe('rendering', () => {
+    it('renders all views with role="tab"', () => {
+      host.views = views;
+      host.activeId = 'chat';
+      fixture.detectChanges();
+
+      const tabs = fixture.nativeElement.querySelectorAll('[role="tab"]');
+      expect(tabs.length).toBe(3);
+    });
+
+    it('has role="tablist" on the container with aria-label="Views"', () => {
+      host.views = views;
+      host.activeId = 'chat';
+      fixture.detectChanges();
+
+      const el = fixture.nativeElement.querySelector('[data-testid="view-switcher"]');
+      expect(el.getAttribute('role')).toBe('tablist');
+      expect(el.getAttribute('aria-label')).toBe('Views');
+    });
+
+    it('renders nothing when views is empty', () => {
+      host.views = [];
+      host.activeId = '';
+      fixture.detectChanges();
+      const tabs = fixture.nativeElement.querySelectorAll('[role="tab"]');
+      expect(tabs.length).toBe(0);
+    });
+
+    it('renders label text for each entry', () => {
+      host.views = views;
+      host.activeId = 'chat';
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toContain('chat');
+      expect(fixture.nativeElement.textContent).toContain('integrations');
+      expect(fixture.nativeElement.textContent).toContain('settings');
+    });
+  });
+
+  describe('active state', () => {
+    it('sets aria-selected="true" only on the active view', () => {
+      host.views = views;
+      host.activeId = 'integrations';
+      fixture.detectChanges();
+
+      const active = fixture.nativeElement.querySelector('[data-testid="nav-integrations"]');
+      const inactiveChat = fixture.nativeElement.querySelector('[data-testid="nav-chat"]');
+      expect(active.getAttribute('aria-selected')).toBe('true');
+      expect(inactiveChat.getAttribute('aria-selected')).toBe('false');
+    });
+
+    it('no active tab when activeId does not match any view', () => {
+      host.views = views;
+      host.activeId = 'nowhere';
+      fixture.detectChanges();
+
+      const tabs = fixture.nativeElement.querySelectorAll('[role="tab"]');
+      for (const tab of tabs) {
+        expect(tab.getAttribute('aria-selected')).toBe('false');
+      }
+    });
+  });
+
+  describe('click emits', () => {
+    /**
+     * Dispatches a click that preventDefault()s itself so Angular's RouterLink
+     * does not schedule an async navigation — that navigation would attempt to
+     * resolve after the test's injector has been destroyed and raise NG0205.
+     * @param el - The anchor element to click.
+     */
+    function clickWithoutNavigation(el: Element): void {
+      const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+      event.preventDefault();
+      el.dispatchEvent(event);
+    }
+
+    it('emits selected with the tab id on click', async () => {
+      host.views = views;
+      host.activeId = 'chat';
+      fixture.detectChanges();
+
+      const tab = fixture.nativeElement.querySelector(
+        '[data-testid="nav-integrations"]'
+      ) as Element;
+      clickWithoutNavigation(tab);
+      await fixture.whenStable();
+      expect(host.selections).toEqual(['integrations']);
+    });
+
+    it('emits selected for each click', async () => {
+      host.views = views;
+      host.activeId = 'chat';
+      fixture.detectChanges();
+
+      clickWithoutNavigation(
+        fixture.nativeElement.querySelector('[data-testid="nav-chat"]') as Element
+      );
+      clickWithoutNavigation(
+        fixture.nativeElement.querySelector('[data-testid="nav-settings"]') as Element
+      );
+      await fixture.whenStable();
+      expect(host.selections).toEqual(['chat', 'settings']);
+    });
+  });
+});

--- a/desktop/src/src/app/shell/view-switcher/view-switcher.component.ts
+++ b/desktop/src/src/app/shell/view-switcher/view-switcher.component.ts
@@ -3,11 +3,8 @@ import { RouterLink } from '@angular/router';
 
 /** One view entry exposed to the switcher. */
 export interface ViewSwitcherEntry {
-  /** Stable id used to compare against `activeId`. */
   id: string;
-  /** Label rendered on the tab. */
   label: string;
-  /** Angular router link to navigate to. */
   route: string;
 }
 
@@ -73,12 +70,7 @@ export interface ViewSwitcherEntry {
   `,
 })
 export class ViewSwitcherComponent {
-  /** All views exposed by the switcher. */
   @Input({ required: true }) views!: readonly ViewSwitcherEntry[];
-
-  /** Id of the currently-active view — matches one entry in `views`. */
   @Input({ required: true }) activeId!: string;
-
-  /** Emits the selected view id whenever a tab is clicked. */
   @Output() readonly selected = new EventEmitter<string>();
 }

--- a/desktop/src/src/app/shell/view-switcher/view-switcher.component.ts
+++ b/desktop/src/src/app/shell/view-switcher/view-switcher.component.ts
@@ -1,0 +1,84 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+/** One view entry exposed to the switcher. */
+export interface ViewSwitcherEntry {
+  /** Stable id used to compare against `activeId`. */
+  id: string;
+  /** Label rendered on the tab. */
+  label: string;
+  /** Angular router link to navigate to. */
+  route: string;
+}
+
+/**
+ * Terminal-style segmented navigation for top-level views.
+ *
+ * Each tab is a mono-labelled link; the active tab receives the accent colour
+ * and is prefixed with a 2px CSS pseudo-element bar so the accent doesn't leak
+ * into the anchor's textContent (spec tests assert against trimmed labels).
+ *
+ * Exposes `role="tablist"` semantics with per-tab `aria-selected` so
+ * screen-readers announce the mutually-exclusive selection. Clicking a tab
+ * emits `selected` AND navigates via `[routerLink]` — consumers listen to
+ * `selected` for side effects.
+ *
+ * Uses `@Input`/`@Output` decorators to match the project's Vitest runner,
+ * which does not apply Angular's AOT compiler pass.
+ */
+@Component({
+  selector: 'app-view-switcher',
+  standalone: true,
+  imports: [RouterLink],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  styles: [
+    `
+      .view-switcher-tab::before {
+        content: '';
+        display: inline-block;
+        width: 2px;
+        height: 14px;
+        margin-right: 6px;
+        background: transparent;
+        vertical-align: middle;
+      }
+      .view-switcher-tab[aria-selected='true']::before {
+        background: var(--accent);
+      }
+    `,
+  ],
+  template: `
+    <div
+      class="flex items-center gap-4"
+      role="tablist"
+      aria-label="Views"
+      data-testid="view-switcher"
+    >
+      @for (view of views; track view.id) {
+        <a
+          role="tab"
+          class="view-switcher-tab font-mono text-[13px] no-underline inline-flex items-center transition-colors duration-200 px-2 py-1 rounded"
+          [routerLink]="view.route"
+          [attr.aria-selected]="view.id === activeId ? 'true' : 'false'"
+          [attr.data-testid]="'nav-' + view.id"
+          [class.text-accent]="view.id === activeId"
+          [class.font-bold]="view.id === activeId"
+          [class.text-ink-mute]="view.id !== activeId"
+          [class.hover:text-ink]="view.id !== activeId"
+          (click)="selected.emit(view.id)"
+          >{{ view.label }}</a
+        >
+      }
+    </div>
+  `,
+})
+export class ViewSwitcherComponent {
+  /** All views exposed by the switcher. */
+  @Input({ required: true }) views!: readonly ViewSwitcherEntry[];
+
+  /** Id of the currently-active view — matches one entry in `views`. */
+  @Input({ required: true }) activeId!: string;
+
+  /** Emits the selected view id whenever a tab is clicked. */
+  @Output() readonly selected = new EventEmitter<string>();
+}


### PR DESCRIPTION
## Summary

- `memory-panel.component` — right drawer with markdown render, close.
- `conversations-sidebar.component` — left collapsible with new/view/resume.
- `view-switcher.component` — terminal-style segmented nav.
- New `ui-state.service` (signals: `sidebarOpen`, `memoryOpen`) shared between shell and chat.
- ⌘B/Ctrl+B keyboard shortcut wired via shell `host` keydown binding (no `@HostListener`).

## Test plan

- [x] `make test-angular`: new specs pass.
- [x] Live UI not exercised — manual smoke-test pending merge.