### PR TITLE
feat(desktop): add system and logs views

### DIFF
--- a/desktop/src/src/app/app.routes.ts
+++ b/desktop/src/src/app/app.routes.ts
@@ -52,6 +52,16 @@ export const routes: Routes = [
         loadComponent: () =>
           import('./settings/settings.component').then((m) => m.SettingsComponent),
       },
+      {
+        path: 'system',
+        loadComponent: () =>
+          import('./system-view/system-view.component').then((m) => m.SystemViewComponent),
+      },
+      {
+        path: 'logs',
+        loadComponent: () =>
+          import('./logs-view/logs-view.component').then((m) => m.LogsViewComponent),
+      },
     ],
   },
 ];

--- a/desktop/src/src/app/logs-view/logs-view.component.html
+++ b/desktop/src/src/app/logs-view/logs-view.component.html
@@ -1,11 +1,12 @@
 <div class="mx-auto max-w-4xl flex flex-col h-full">
   <div class="mb-4 flex items-center justify-between">
-    <h1 class="mono text-[14px] text-sw-text m-0">Logs</h1>
+    <h2 class="mono text-[14px] text-sw-text m-0">Logs</h2>
     <button
       type="button"
-      class="mono text-[11px] text-sw-text-muted hover:text-sw-accent px-2 py-1 rounded"
+      class="mono text-[11px] text-sw-text-muted hover:text-sw-accent px-2 py-1 rounded disabled:opacity-50 disabled:cursor-not-allowed"
       data-testid="logs-refresh"
       aria-label="Refresh logs"
+      [disabled]="loading()"
       (click)="refresh()"
     >
       ↻ refresh

--- a/desktop/src/src/app/logs-view/logs-view.component.html
+++ b/desktop/src/src/app/logs-view/logs-view.component.html
@@ -1,0 +1,146 @@
+<div class="mx-auto max-w-4xl flex flex-col h-full">
+  <div class="mb-4 flex items-center justify-between">
+    <h1 class="mono text-[14px] text-sw-text m-0">Logs</h1>
+    <button
+      type="button"
+      class="mono text-[11px] text-sw-text-muted hover:text-sw-accent px-2 py-1 rounded"
+      data-testid="logs-refresh"
+      aria-label="Refresh logs"
+      (click)="refresh()"
+    >
+      ↻ refresh
+    </button>
+  </div>
+
+  @if (error()) {
+    <div
+      class="mb-3 px-3 py-2 bg-sw-error-bg border border-sw-accent rounded text-sw-accent text-[12px] mono"
+      data-testid="logs-error"
+      role="alert"
+    >
+      {{ error() }}
+    </div>
+  }
+
+  <div
+    class="mb-3 flex flex-wrap items-center gap-2"
+    data-testid="logs-filters"
+    aria-label="Log filters"
+  >
+    <div
+      class="mono flex overflow-hidden rounded ring-1 ring-line text-[11px]"
+      role="group"
+      aria-label="Log level filter"
+      data-testid="logs-level-chips"
+    >
+      @for (lvl of levelChips; track lvl) {
+        <button
+          type="button"
+          class="px-2.5 py-1"
+          [class.bg-bg-2]="filters().level === lvl"
+          [class.text-sw-text]="filters().level === lvl"
+          [class.text-sw-text-muted]="filters().level !== lvl"
+          [attr.aria-pressed]="filters().level === lvl"
+          [attr.data-testid]="'logs-level-' + lvl"
+          (click)="setLevel(lvl)"
+        >
+          {{ lvl }}
+        </button>
+      }
+    </div>
+
+    @if (sources().length > 1) {
+      <div
+        class="mono flex overflow-x-auto rounded ring-1 ring-line text-[11px]"
+        role="group"
+        aria-label="Log source filter"
+        data-testid="logs-source-chips"
+      >
+        @for (src of sources(); track src) {
+          <button
+            type="button"
+            class="px-2.5 py-1 whitespace-nowrap"
+            [class.bg-bg-2]="filters().source === src"
+            [class.text-sw-text]="filters().source === src"
+            [class.text-sw-text-muted]="filters().source !== src"
+            [attr.aria-pressed]="filters().source === src"
+            [attr.data-testid]="'logs-source-' + src"
+            (click)="setSource(src)"
+          >
+            {{ src }}
+          </button>
+        }
+      </div>
+    }
+  </div>
+
+  <div
+    #logScroll
+    class="flex-1 min-h-[40vh] max-h-[70vh] overflow-y-auto overflow-x-hidden rounded ring-1 ring-line bg-bg-1"
+    data-testid="logs-scroll"
+    role="log"
+    aria-live="polite"
+    aria-label="Application logs"
+  >
+    @if (loading() && lines().length === 0) {
+      <p
+        class="mono text-[12px] text-sw-text-muted py-8 text-center"
+        data-testid="logs-loading"
+      >
+        Loading logs…
+      </p>
+    } @else if (visibleLines().length === 0) {
+      <p
+        class="mono text-[12px] text-sw-text-muted py-8 text-center"
+        data-testid="logs-empty"
+      >
+        @if (lines().length === 0) {
+          No logs captured yet.
+        } @else {
+          No log lines match the selected filters.
+        }
+      </p>
+    } @else {
+      <div class="mono p-3 text-[12px]" data-testid="logs-list">
+        @for (line of visibleLines(); track $index) {
+          <div
+            class="flex gap-3 py-1"
+            data-testid="logs-line"
+            [class.bg-sw-error-bg]="line.level === 'error'"
+          >
+            <span
+              class="text-sw-text-muted w-24 flex-shrink-0"
+              data-testid="logs-time"
+            >
+              {{ line.time }}
+            </span>
+            <span
+              class="text-sw-teal hidden w-16 flex-shrink-0 md:inline-block"
+              data-testid="logs-source"
+            >
+              {{ line.source }}
+            </span>
+            <span
+              class="w-12 flex-shrink-0 md:w-14"
+              [class.text-sw-accent]="line.level === 'error'"
+              [class.text-sw-warning]="line.level === 'warn'"
+              [class.text-sw-text]="line.level === 'info'"
+              [class.text-sw-text-muted]="line.level === 'debug'"
+              data-testid="logs-level"
+            >
+              {{ line.level }}
+            </span>
+            <span
+              class="min-w-0 break-words"
+              [class.text-sw-text-dim]="line.level !== 'error'"
+              [class.text-sw-error-text]="line.level === 'error'"
+              data-testid="logs-message"
+            >
+              {{ line.message }}
+            </span>
+          </div>
+        }
+      </div>
+    }
+  </div>
+</div>

--- a/desktop/src/src/app/logs-view/logs-view.component.spec.ts
+++ b/desktop/src/src/app/logs-view/logs-view.component.spec.ts
@@ -107,7 +107,7 @@ describe('LogsViewComponent', () => {
     expect(chipAll?.getAttribute('aria-pressed')).toBe('true');
     expect(chipError?.getAttribute('aria-pressed')).toBe('false');
 
-    component.setLevel('error');
+    component['setLevel']('error');
     fixture.detectChanges();
 
     expect(
@@ -140,7 +140,7 @@ describe('LogsViewComponent', () => {
     await component.ngOnInit();
     fixture.detectChanges();
 
-    component.setSource('lima-does-not-exist');
+    component['setSource']('lima-does-not-exist');
     fixture.detectChanges();
 
     const empty = fixture.nativeElement.querySelector('[data-testid="logs-empty"]');
@@ -211,8 +211,8 @@ describe('LogsViewComponent', () => {
     await component.ngOnInit();
     fixture.detectChanges();
 
-    component.setLevel('info');
-    component.setSource('mcp-hub');
+    component['setLevel']('info');
+    component['setSource']('mcp-hub');
     fixture.detectChanges();
 
     const rows = fixture.nativeElement.querySelectorAll('[data-testid="logs-line"]');
@@ -224,7 +224,7 @@ describe('LogsViewComponent', () => {
     await component.ngOnInit();
     fixture.detectChanges();
 
-    component.setSource('redmine');
+    component['setSource']('redmine');
     fixture.detectChanges();
 
     const rows = fixture.nativeElement.querySelectorAll('[data-testid="logs-line"]');

--- a/desktop/src/src/app/logs-view/logs-view.component.spec.ts
+++ b/desktop/src/src/app/logs-view/logs-view.component.spec.ts
@@ -270,4 +270,11 @@ describe('parseLogLine', () => {
     expect(line.source).toBe('log');
     expect(line.message).toBe('');
   });
+
+  it('parses an ISO-timestamp line via the ISO_TIME_RE branch', () => {
+    const line = parseLogLine('hub_1 | 2024-01-15T14:34:02.814Z INFO started');
+    expect(line.time).toBe('2024-01-15T14:34:02.814Z');
+    expect(line.level).toBe('info');
+    expect(line.message).toBe('started');
+  });
 });

--- a/desktop/src/src/app/logs-view/logs-view.component.spec.ts
+++ b/desktop/src/src/app/logs-view/logs-view.component.spec.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { LogsViewComponent, parseLogLine } from './logs-view.component';
+import { TauriService } from '../services/tauri.service';
+import { ProjectStateService } from '../services/project-state.service';
+import { MockTauriService } from '../testing/mock-tauri.service';
+
+const MOCK_LOGS = [
+  'speedwave_test_mcp-hub_1 | [14:34:02.814] INFO  Dispatched tool call',
+  'speedwave_test_redmine_1 | [14:34:01.672] INFO  POST /projects/x → 201',
+  'speedwave_test_sharepoint_1 | [14:33:58.440] WARN  OAuth token expires soon',
+  'speedwave_test_slack_1 | [14:33:42.018] ERROR rate_limited: channels.history',
+  'speedwave_test_mcp-hub_1 | [14:33:57.182] DEBUG Low-level handshake chunk',
+].join('\n');
+
+describe('LogsViewComponent', () => {
+  let component: LogsViewComponent;
+  let fixture: ComponentFixture<LogsViewComponent>;
+  let mockTauri: MockTauriService;
+  let projectState: ProjectStateService;
+
+  beforeEach(async () => {
+    mockTauri = new MockTauriService();
+    mockTauri.invokeHandler = async (cmd: string) => {
+      if (cmd === 'get_compose_logs') return MOCK_LOGS;
+      return undefined;
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [LogsViewComponent],
+      providers: [{ provide: TauriService, useValue: mockTauri }],
+    }).compileComponents();
+
+    projectState = TestBed.inject(ProjectStateService);
+    projectState.activeProject = 'test';
+
+    fixture = TestBed.createComponent(LogsViewComponent);
+    component = fixture.componentInstance;
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  // -- Happy path --
+
+  it('renders a line per parsed log entry', async () => {
+    await component.ngOnInit();
+    fixture.detectChanges();
+
+    const lines = fixture.nativeElement.querySelectorAll('[data-testid="logs-line"]');
+    expect(lines).toHaveLength(5);
+  });
+
+  it('renders the parsed timestamp / source / level / message', async () => {
+    await component.ngOnInit();
+    fixture.detectChanges();
+
+    const times = Array.from(
+      fixture.nativeElement.querySelectorAll('[data-testid="logs-time"]')
+    ) as HTMLElement[];
+    expect(times[0].textContent?.trim()).toBe('14:34:02.814');
+
+    const sources = Array.from(
+      fixture.nativeElement.querySelectorAll('[data-testid="logs-source"]')
+    ) as HTMLElement[];
+    expect(sources[0].textContent?.trim()).toBe('mcp-hub');
+
+    const levels = Array.from(
+      fixture.nativeElement.querySelectorAll('[data-testid="logs-level"]')
+    ) as HTMLElement[];
+    expect(levels.map((l) => l.textContent?.trim())).toEqual([
+      'info',
+      'info',
+      'warn',
+      'error',
+      'debug',
+    ]);
+
+    const messages = Array.from(
+      fixture.nativeElement.querySelectorAll('[data-testid="logs-message"]')
+    ) as HTMLElement[];
+    expect(messages[3].textContent).toContain('rate_limited');
+  });
+
+  // -- ARIA --
+
+  it('marks the scroll region as role="log" with aria-live="polite"', async () => {
+    await component.ngOnInit();
+    fixture.detectChanges();
+
+    const scroll = fixture.nativeElement.querySelector('[data-testid="logs-scroll"]');
+    expect(scroll?.getAttribute('role')).toBe('log');
+    expect(scroll?.getAttribute('aria-live')).toBe('polite');
+  });
+
+  it('marks each level chip with aria-pressed reflecting active state', async () => {
+    await component.ngOnInit();
+    fixture.detectChanges();
+
+    const chipAll = fixture.nativeElement.querySelector('[data-testid="logs-level-all"]');
+    const chipError = fixture.nativeElement.querySelector('[data-testid="logs-level-error"]');
+    expect(chipAll?.getAttribute('aria-pressed')).toBe('true');
+    expect(chipError?.getAttribute('aria-pressed')).toBe('false');
+
+    component.setLevel('error');
+    fixture.detectChanges();
+
+    expect(
+      fixture.nativeElement
+        .querySelector('[data-testid="logs-level-all"]')
+        ?.getAttribute('aria-pressed')
+    ).toBe('false');
+    expect(
+      fixture.nativeElement
+        .querySelector('[data-testid="logs-level-error"]')
+        ?.getAttribute('aria-pressed')
+    ).toBe('true');
+  });
+
+  // -- Edge cases --
+
+  it('renders an empty-hint when no log lines are returned', async () => {
+    mockTauri.invokeHandler = async () => '';
+
+    await component.ngOnInit();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const empty = fixture.nativeElement.querySelector('[data-testid="logs-empty"]');
+    expect(empty).not.toBeNull();
+    expect(empty?.textContent).toContain('No logs captured');
+  });
+
+  it('renders a filter-empty hint when lines exist but filters exclude all', async () => {
+    await component.ngOnInit();
+    fixture.detectChanges();
+
+    component.setSource('lima-does-not-exist');
+    fixture.detectChanges();
+
+    const empty = fixture.nativeElement.querySelector('[data-testid="logs-empty"]');
+    expect(empty).not.toBeNull();
+    expect(empty?.textContent).toContain('No log lines match');
+  });
+
+  it('wraps a very long log message with break-words', async () => {
+    const longMessage = 'x'.repeat(2000);
+    mockTauri.invokeHandler = async () =>
+      `speedwave_test_claude_1 | [12:00:00] INFO  ${longMessage}`;
+
+    await component.ngOnInit();
+    fixture.detectChanges();
+
+    const message = fixture.nativeElement.querySelector(
+      '[data-testid="logs-message"]'
+    ) as HTMLElement;
+    expect(message.textContent).toContain(longMessage);
+    expect(message.className).toContain('break-words');
+  });
+
+  // -- Error path --
+
+  it('renders an error block when get_compose_logs rejects', async () => {
+    mockTauri.invokeHandler = async () => {
+      throw new Error('compose logs unavailable');
+    };
+
+    await component.ngOnInit();
+    fixture.detectChanges();
+
+    const error = fixture.nativeElement.querySelector('[data-testid="logs-error"]');
+    expect(error).not.toBeNull();
+    expect(error?.textContent).toContain('compose logs unavailable');
+    expect(error?.getAttribute('role')).toBe('alert');
+  });
+
+  it('shows "No active project" error when activeProject is null', async () => {
+    projectState.activeProject = null;
+
+    await component.ngOnInit();
+    fixture.detectChanges();
+
+    const error = fixture.nativeElement.querySelector('[data-testid="logs-error"]');
+    expect(error?.textContent).toContain('No active project');
+  });
+
+  // -- State transitions (filters combine) --
+
+  it('filtering by level=error leaves only the error row visible', async () => {
+    await component.ngOnInit();
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelectorAll('[data-testid="logs-line"]')).toHaveLength(5);
+
+    const errorChip = fixture.nativeElement.querySelector(
+      '[data-testid="logs-level-error"]'
+    ) as HTMLButtonElement;
+    errorChip.click();
+    fixture.detectChanges();
+
+    const remaining = fixture.nativeElement.querySelectorAll('[data-testid="logs-line"]');
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].textContent).toContain('rate_limited');
+  });
+
+  it('source + level filters combine (level=info and source=mcp-hub leaves the hub INFO row)', async () => {
+    await component.ngOnInit();
+    fixture.detectChanges();
+
+    component.setLevel('info');
+    component.setSource('mcp-hub');
+    fixture.detectChanges();
+
+    const rows = fixture.nativeElement.querySelectorAll('[data-testid="logs-line"]');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].textContent).toContain('Dispatched tool call');
+  });
+
+  it('switching the source filter from all to redmine narrows the list', async () => {
+    await component.ngOnInit();
+    fixture.detectChanges();
+
+    component.setSource('redmine');
+    fixture.detectChanges();
+
+    const rows = fixture.nativeElement.querySelectorAll('[data-testid="logs-line"]');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].textContent).toContain('POST /projects/x');
+  });
+});
+
+describe('parseLogLine', () => {
+  it('parses a compose-format line with timestamp and level', () => {
+    const line = parseLogLine('mcp_hub_1 | [14:34:02.814] INFO  Listening on :4000');
+    expect(line.source).toBe('mcp_hub');
+    expect(line.time).toBe('14:34:02.814');
+    expect(line.level).toBe('info');
+    expect(line.message).toBe('Listening on :4000');
+  });
+
+  it('strips the speedwave_<project>_ prefix from compose sources', () => {
+    const line = parseLogLine('speedwave_demo_mcp-hub_1 | [10:00:00] INFO  started');
+    expect(line.source).toBe('mcp-hub');
+  });
+
+  it('normalises WARNING to warn and TRACE to debug', () => {
+    expect(parseLogLine('hub_1 | [00:00:00] WARNING x').level).toBe('warn');
+    expect(parseLogLine('hub_1 | [00:00:00] TRACE x').level).toBe('debug');
+  });
+
+  it('handles lines with no level prefix', () => {
+    const line = parseLogLine('hub_1 | [00:00:00] raw text');
+    expect(line.level).toBe('info');
+    expect(line.message).toBe('raw text');
+  });
+
+  it('handles a completely unstructured line', () => {
+    const line = parseLogLine('a plain line with no pipe');
+    expect(line.source).toBe('log');
+    expect(line.level).toBe('info');
+    expect(line.message).toBe('a plain line with no pipe');
+  });
+
+  it('returns empty fields on blank input', () => {
+    const line = parseLogLine('   ');
+    expect(line.source).toBe('log');
+    expect(line.message).toBe('');
+  });
+});

--- a/desktop/src/src/app/logs-view/logs-view.component.ts
+++ b/desktop/src/src/app/logs-view/logs-view.component.ts
@@ -1,0 +1,211 @@
+import {
+  AfterViewChecked,
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  OnInit,
+  ViewChild,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { TauriService } from '../services/tauri.service';
+import { ProjectStateService } from '../services/project-state.service';
+
+/** Log severity levels recognised by the logs-view filter chips. */
+export type LogLevel = 'all' | 'debug' | 'info' | 'warn' | 'error';
+
+/** One parsed log line: source, level, timestamp, message. */
+export interface LogLine {
+  time: string;
+  source: string;
+  level: LogLevel;
+  message: string;
+}
+
+/** Filter state for level + source combined. `'all'` means no filter. */
+export interface LogFilters {
+  level: LogLevel;
+  source: string;
+}
+
+/** How many lines to request from the backend on each fetch. */
+export const LOGS_TAIL_LINES = 500;
+
+/** Available level chips rendered in the toolbar. */
+export const LEVEL_CHIPS: readonly LogLevel[] = ['all', 'debug', 'info', 'warn', 'error'];
+
+const COMPOSE_RE = /^([\w.-]+)\s*\|\s*(.*)$/;
+const BRACKETED_TIME_RE = /^\[(\d{2}:\d{2}:\d{2}(?:\.\d+)?)\]\s*(.*)$/;
+const ISO_TIME_RE = /^(\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?)\s+(.*)$/;
+const LEVEL_RE = /^(DEBUG|INFO|WARN|WARNING|ERROR|TRACE)\s+(.*)$/i;
+const CONTAINER_PREFIX_RE = /^speedwave_[^_]+_([^_]+)(?:_\d+)?$/;
+const TRAILING_INDEX_RE = /_\d+$/;
+
+/**
+ * Parse a single compose-log line into `LogLine`.
+ *
+ * Compose logs look like: `service_1  | [HH:MM:SS.sss] LEVEL  message`.
+ * This helper is tolerant — unparsed parts default to `source='log'`,
+ * `level='info'`, current wall-clock time. It never throws.
+ * @param raw - Raw log line text from the backend.
+ */
+export function parseLogLine(raw: string): LogLine {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return { time: '', source: 'log', level: 'info', message: '' };
+  }
+  const composeMatch = COMPOSE_RE.exec(trimmed);
+  const source = composeMatch ? stripContainerPrefix(composeMatch[1]) : 'log';
+  const rest = composeMatch ? composeMatch[2] : trimmed;
+
+  const timeMatch = BRACKETED_TIME_RE.exec(rest) ?? ISO_TIME_RE.exec(rest);
+  const time = timeMatch ? timeMatch[1] : '';
+  const afterTime = timeMatch ? timeMatch[2] : rest;
+
+  const levelMatch = LEVEL_RE.exec(afterTime);
+  const level: LogLevel = levelMatch ? normalizeLevel(levelMatch[1]) : 'info';
+  const message = levelMatch ? levelMatch[2] : afterTime;
+
+  return { time, source, level, message };
+}
+
+/**
+ * Normalise a raw level token to the small enum used by chips.
+ * @param raw - Level token from a log line, e.g. `INFO`, `WARN`, `ERROR`.
+ */
+function normalizeLevel(raw: string): LogLevel {
+  const upper = raw.toUpperCase();
+  if (upper === 'ERROR') return 'error';
+  if (upper === 'WARN' || upper === 'WARNING') return 'warn';
+  if (upper === 'DEBUG' || upper === 'TRACE') return 'debug';
+  return 'info';
+}
+
+/**
+ * Strip the `speedwave_<project>_` prefix from a container name so chips
+ * and row labels stay short ("redmine" vs "speedwave_test_redmine_1").
+ * @param container - Container name as emitted by the runtime.
+ */
+function stripContainerPrefix(container: string): string {
+  const match = CONTAINER_PREFIX_RE.exec(container);
+  if (match) return match[1];
+  return container.replace(TRAILING_INDEX_RE, '');
+}
+
+/**
+ * Terminal-minimal logs view.
+ *
+ * Reads compose logs for the active project, parses each line into
+ * timestamp / source / level / message, and renders them with filter
+ * chips at the top. Filters combine — selecting `level=error` and
+ * `source=redmine` shows only errors from redmine.
+ *
+ * The list auto-scrolls to bottom whenever new lines arrive and no
+ * user filter has been touched this frame (so mid-scroll reading is
+ * not interrupted).
+ */
+@Component({
+  selector: 'app-logs-view',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './logs-view.component.html',
+  host: { class: 'block bg-sw-bg-darkest min-h-screen p-6 text-sw-text' },
+})
+export class LogsViewComponent implements OnInit, AfterViewChecked {
+  @ViewChild('logScroll') private logScroll: ElementRef<HTMLDivElement> | null = null;
+
+  /** All parsed log lines from the most recent fetch. */
+  readonly lines = signal<LogLine[]>([]);
+  /** Active filter selection (level + source). */
+  readonly filters = signal<LogFilters>({ level: 'all', source: 'all' });
+  /** Loading state — true during the initial fetch. */
+  readonly loading = signal<boolean>(true);
+  /** Error message from the last fetch, empty when healthy. */
+  readonly error = signal<string>('');
+
+  /** Distinct source names found in the current log set plus `'all'`. */
+  readonly sources = computed<string[]>(() => {
+    const distinct = new Set<string>();
+    for (const line of this.lines()) distinct.add(line.source);
+    return ['all', ...Array.from(distinct).sort()];
+  });
+
+  /** Lines after applying the current filters. */
+  readonly visibleLines = computed<LogLine[]>(() => {
+    const f = this.filters();
+    return this.lines().filter((l) => {
+      if (f.level !== 'all' && l.level !== f.level) return false;
+      if (f.source !== 'all' && l.source !== f.source) return false;
+      return true;
+    });
+  });
+
+  readonly levelChips = LEVEL_CHIPS;
+
+  private readonly tauri = inject(TauriService);
+  private readonly projectState = inject(ProjectStateService);
+  private scrollDirty = false;
+
+  /** Kicks off the initial log fetch. */
+  async ngOnInit(): Promise<void> {
+    await this.refresh();
+  }
+
+  /** Auto-scroll to bottom when new lines arrive. */
+  ngAfterViewChecked(): void {
+    if (this.scrollDirty && this.logScroll) {
+      const el = this.logScroll.nativeElement;
+      el.scrollTop = el.scrollHeight;
+      this.scrollDirty = false;
+    }
+  }
+
+  /**
+   * Re-fetch the tail of compose logs and re-parse into typed lines.
+   * Called from the `↻` toolbar button.
+   */
+  async refresh(): Promise<void> {
+    const project = this.projectState.activeProject;
+    if (!project) {
+      this.loading.set(false);
+      this.error.set('No active project');
+      return;
+    }
+    this.loading.set(true);
+    try {
+      const raw = await this.tauri.invoke<string>('get_compose_logs', {
+        project,
+        tail: LOGS_TAIL_LINES,
+      });
+      const parsed = raw
+        .split(/\r?\n/)
+        .filter((l) => l.length > 0)
+        .map(parseLogLine);
+      this.lines.set(parsed);
+      this.error.set('');
+      this.scrollDirty = true;
+    } catch (e: unknown) {
+      this.error.set(e instanceof Error ? e.message : String(e));
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  /**
+   * Select a level chip, toggling off back to `'all'` when the active
+   * chip is clicked again.
+   * @param level - The new level filter value.
+   */
+  setLevel(level: LogLevel): void {
+    this.filters.update((f) => ({ ...f, level }));
+  }
+
+  /**
+   * Select a source chip, toggling off back to `'all'` when the active
+   * chip is clicked again.
+   * @param source - The new source filter value.
+   */
+  setSource(source: string): void {
+    this.filters.update((f) => ({ ...f, source }));
+  }
+}

--- a/desktop/src/src/app/logs-view/logs-view.component.ts
+++ b/desktop/src/src/app/logs-view/logs-view.component.ts
@@ -42,7 +42,10 @@ const LEVEL_RE = /^(DEBUG|INFO|WARN|WARNING|ERROR|TRACE)\s+(.*)$/i;
 const CONTAINER_PREFIX_RE = /^speedwave_[^_]+_([^_]+)(?:_\d+)?$/;
 const TRAILING_INDEX_RE = /_\d+$/;
 
-/** Parse a single compose-log line into `LogLine`. Tolerant — never throws. */
+/**
+ * Parse a single compose-log line into `LogLine`. Tolerant — never throws.
+ * @param raw - A single log line as emitted by `nerdctl compose logs`.
+ */
 export function parseLogLine(raw: string): LogLine {
   const trimmed = raw.trim();
   if (!trimmed) {
@@ -63,7 +66,10 @@ export function parseLogLine(raw: string): LogLine {
   return { time, source, level, message };
 }
 
-/** Normalise a raw level token to the small enum used by chips. */
+/**
+ * Normalise a raw level token to the small enum used by chips.
+ * @param raw - Raw level token (e.g. `WARNING`, `TRACE`).
+ */
 function normalizeLevel(raw: string): LogLevel {
   const upper = raw.toUpperCase();
   if (upper === 'ERROR') return 'error';
@@ -72,13 +78,22 @@ function normalizeLevel(raw: string): LogLevel {
   return 'info';
 }
 
-/** Strip the `speedwave_<project>_` prefix from a container name. */
+/**
+ * Strip the `speedwave_<project>_` prefix from a container name.
+ * @param container - Container name as it appears in compose-log prefixes.
+ */
 function stripContainerPrefix(container: string): string {
   const match = CONTAINER_PREFIX_RE.exec(container);
   if (match) return match[1];
   return container.replace(TRAILING_INDEX_RE, '');
 }
 
+/**
+ * Logs view — fetches the compose-log tail and renders filtered, parsed lines.
+ *
+ * Owns the level/source filter chips and auto-scrolls to the bottom whenever a
+ * fresh batch is loaded.
+ */
 @Component({
   selector: 'app-logs-view',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -102,7 +117,12 @@ export class LogsViewComponent implements OnInit, AfterViewChecked {
     const distinct = new Set<string>();
     for (const line of this.lines()) distinct.add(line.source);
     // Filter 'all' from observed sources so the hard-coded chip is never duplicated.
-    return ['all', ...Array.from(distinct).filter((s) => s !== 'all').sort()];
+    return [
+      'all',
+      ...Array.from(distinct)
+        .filter((s) => s !== 'all')
+        .sort(),
+    ];
   });
 
   /** Lines after applying the current filters. */
@@ -163,12 +183,18 @@ export class LogsViewComponent implements OnInit, AfterViewChecked {
     }
   }
 
-  /** Select a level chip. */
+  /**
+   * Select a level chip.
+   * @param level - Level to filter on, or `'all'` to disable the filter.
+   */
   protected setLevel(level: LogLevel): void {
     this.filters.update((f) => ({ ...f, level }));
   }
 
-  /** Select a source chip. */
+  /**
+   * Select a source chip.
+   * @param source - Source to filter on, or `'all'` to disable the filter.
+   */
   protected setSource(source: string): void {
     this.filters.update((f) => ({ ...f, source }));
   }

--- a/desktop/src/src/app/logs-view/logs-view.component.ts
+++ b/desktop/src/src/app/logs-view/logs-view.component.ts
@@ -42,14 +42,7 @@ const LEVEL_RE = /^(DEBUG|INFO|WARN|WARNING|ERROR|TRACE)\s+(.*)$/i;
 const CONTAINER_PREFIX_RE = /^speedwave_[^_]+_([^_]+)(?:_\d+)?$/;
 const TRAILING_INDEX_RE = /_\d+$/;
 
-/**
- * Parse a single compose-log line into `LogLine`.
- *
- * Compose logs look like: `service_1  | [HH:MM:SS.sss] LEVEL  message`.
- * This helper is tolerant — unparsed parts default to `source='log'`,
- * `level='info'`, current wall-clock time. It never throws.
- * @param raw - Raw log line text from the backend.
- */
+/** Parse a single compose-log line into `LogLine`. Tolerant — never throws. */
 export function parseLogLine(raw: string): LogLine {
   const trimmed = raw.trim();
   if (!trimmed) {
@@ -70,10 +63,7 @@ export function parseLogLine(raw: string): LogLine {
   return { time, source, level, message };
 }
 
-/**
- * Normalise a raw level token to the small enum used by chips.
- * @param raw - Level token from a log line, e.g. `INFO`, `WARN`, `ERROR`.
- */
+/** Normalise a raw level token to the small enum used by chips. */
 function normalizeLevel(raw: string): LogLevel {
   const upper = raw.toUpperCase();
   if (upper === 'ERROR') return 'error';
@@ -82,29 +72,13 @@ function normalizeLevel(raw: string): LogLevel {
   return 'info';
 }
 
-/**
- * Strip the `speedwave_<project>_` prefix from a container name so chips
- * and row labels stay short ("redmine" vs "speedwave_test_redmine_1").
- * @param container - Container name as emitted by the runtime.
- */
+/** Strip the `speedwave_<project>_` prefix from a container name. */
 function stripContainerPrefix(container: string): string {
   const match = CONTAINER_PREFIX_RE.exec(container);
   if (match) return match[1];
   return container.replace(TRAILING_INDEX_RE, '');
 }
 
-/**
- * Terminal-minimal logs view.
- *
- * Reads compose logs for the active project, parses each line into
- * timestamp / source / level / message, and renders them with filter
- * chips at the top. Filters combine — selecting `level=error` and
- * `source=redmine` shows only errors from redmine.
- *
- * The list auto-scrolls to bottom whenever new lines arrive and no
- * user filter has been touched this frame (so mid-scroll reading is
- * not interrupted).
- */
 @Component({
   selector: 'app-logs-view',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -161,11 +135,8 @@ export class LogsViewComponent implements OnInit, AfterViewChecked {
     }
   }
 
-  /**
-   * Re-fetch the tail of compose logs and re-parse into typed lines.
-   * Called from the `↻` toolbar button.
-   */
-  async refresh(): Promise<void> {
+  /** Re-fetch the tail of compose logs and re-parse into typed lines. */
+  protected async refresh(): Promise<void> {
     const project = this.projectState.activeProject;
     if (!project) {
       this.loading.set(false);
@@ -192,21 +163,13 @@ export class LogsViewComponent implements OnInit, AfterViewChecked {
     }
   }
 
-  /**
-   * Select a level chip, toggling off back to `'all'` when the active
-   * chip is clicked again.
-   * @param level - The new level filter value.
-   */
-  setLevel(level: LogLevel): void {
+  /** Select a level chip. */
+  protected setLevel(level: LogLevel): void {
     this.filters.update((f) => ({ ...f, level }));
   }
 
-  /**
-   * Select a source chip, toggling off back to `'all'` when the active
-   * chip is clicked again.
-   * @param source - The new source filter value.
-   */
-  setSource(source: string): void {
+  /** Select a source chip. */
+  protected setSource(source: string): void {
     this.filters.update((f) => ({ ...f, source }));
   }
 }

--- a/desktop/src/src/app/logs-view/logs-view.component.ts
+++ b/desktop/src/src/app/logs-view/logs-view.component.ts
@@ -127,7 +127,8 @@ export class LogsViewComponent implements OnInit, AfterViewChecked {
   readonly sources = computed<string[]>(() => {
     const distinct = new Set<string>();
     for (const line of this.lines()) distinct.add(line.source);
-    return ['all', ...Array.from(distinct).sort()];
+    // Filter 'all' from observed sources so the hard-coded chip is never duplicated.
+    return ['all', ...Array.from(distinct).filter((s) => s !== 'all').sort()];
   });
 
   /** Lines after applying the current filters. */

--- a/desktop/src/src/app/shell/shell.component.spec.ts
+++ b/desktop/src/src/app/shell/shell.component.spec.ts
@@ -236,7 +236,7 @@ describe('ShellComponent', () => {
     const nav = fixture.nativeElement.querySelector('[data-testid="app-nav"]');
     const links = Array.from(nav.querySelectorAll('a')) as HTMLAnchorElement[];
     const labels = links.map((a) => a.textContent?.trim());
-    expect(labels).toEqual(['Integrations', 'Plugins', 'Settings']);
+    expect(labels).toEqual(['Integrations', 'Plugins', 'System', 'Logs', 'Settings']);
     expect(labels).not.toContain('Chat');
   });
 
@@ -250,7 +250,7 @@ describe('ShellComponent', () => {
     const nav = fixture.nativeElement.querySelector('[data-testid="app-nav"]');
     const links = Array.from(nav.querySelectorAll('a')) as HTMLAnchorElement[];
     const labels = links.map((a) => a.textContent?.trim());
-    expect(labels).toEqual(['Chat', 'Integrations', 'Plugins', 'Settings']);
+    expect(labels).toEqual(['Chat', 'Integrations', 'Plugins', 'System', 'Logs', 'Settings']);
   });
 
   it('shows Chat nav link when status is error', async () => {

--- a/desktop/src/src/app/shell/shell.component.spec.ts
+++ b/desktop/src/src/app/shell/shell.component.spec.ts
@@ -33,6 +33,8 @@ describe('ShellComponent', () => {
         RouterModule.forRoot([
           { path: 'chat', component: ShellComponent },
           { path: 'settings', component: ShellComponent },
+          { path: 'system', component: ShellComponent },
+          { path: 'logs', component: ShellComponent },
         ]),
       ],
       providers: [{ provide: TauriService, useValue: mockTauri }],

--- a/desktop/src/src/app/shell/shell.component.ts
+++ b/desktop/src/src/app/shell/shell.component.ts
@@ -198,6 +198,8 @@ export class ShellComponent implements OnInit, OnDestroy {
     { id: 'chat', label: 'Chat', route: '/chat' },
     { id: 'integrations', label: 'Integrations', route: '/integrations' },
     { id: 'plugins', label: 'Plugins', route: '/plugins' },
+    { id: 'system', label: 'System', route: '/system' },
+    { id: 'logs', label: 'Logs', route: '/logs' },
     { id: 'settings', label: 'Settings', route: '/settings' },
   ];
 

--- a/desktop/src/src/app/system-view/system-view.component.html
+++ b/desktop/src/src/app/system-view/system-view.component.html
@@ -1,6 +1,6 @@
 <div class="mx-auto max-w-4xl">
   <div class="mb-4 flex items-center justify-between">
-    <h1 class="mono text-[14px] text-sw-text m-0">System health</h1>
+    <h2 class="mono text-[14px] text-sw-text m-0">System health</h2>
     <span class="mono text-[11px] text-sw-text-muted" data-testid="system-refresh-hint">
       auto-refresh 5s
     </span>

--- a/desktop/src/src/app/system-view/system-view.component.html
+++ b/desktop/src/src/app/system-view/system-view.component.html
@@ -90,13 +90,14 @@
                   class="mono text-[11px] text-sw-text-muted hover:text-sw-accent disabled:opacity-50 disabled:cursor-not-allowed"
                   data-testid="system-restart"
                   [disabled]="restarting.has(container.name)"
-                  [attr.aria-label]="'Restart ' + container.name"
+                  aria-label="Restart all project containers"
+                  title="Restarts all project containers (per-container restart not supported)"
                   (click)="restart(container.name)"
                 >
                   @if (restarting.has(container.name)) {
                     restarting…
                   } @else {
-                    restart
+                    restart all
                   }
                 </button>
               </td>
@@ -106,35 +107,34 @@
       </table>
     </div>
 
-    @if (report) {
-      <div
-        class="mt-4 grid grid-cols-1 sm:grid-cols-3 gap-3"
-        data-testid="system-summary"
-      >
-        <div class="rounded ring-1 ring-line bg-bg-1 p-3">
-          <div class="mono text-[10px] uppercase tracking-widest text-ink-mute">vm</div>
-          <div class="mono mt-1 text-[12px] text-sw-text" data-testid="system-vm">
-            {{ report.vm.vm_type }} · {{ report.vm.running ? 'running' : 'stopped' }}
-          </div>
-        </div>
-        <div class="rounded ring-1 ring-line bg-bg-1 p-3">
-          <div class="mono text-[10px] uppercase tracking-widest text-ink-mute">overall</div>
-          <div
-            class="mono mt-1 text-[12px]"
-            [class.text-sw-success]="report.overall_healthy"
-            [class.text-sw-accent]="!report.overall_healthy"
-            data-testid="system-overall"
-          >
-            {{ report.overall_healthy ? 'healthy' : 'degraded' }}
-          </div>
-        </div>
-        <div class="rounded ring-1 ring-line bg-bg-1 p-3">
-          <div class="mono text-[10px] uppercase tracking-widest text-ink-mute">ide_bridge</div>
-          <div class="mono mt-1 text-[12px] text-sw-text-dim" data-testid="system-bridge">
-            {{ report.ide_bridge.running ? 'connected' : 'disconnected' }}
-          </div>
+    <!-- Inside @else if (report && hasContainers) — report is guaranteed non-null here. -->
+    <div
+      class="mt-4 grid grid-cols-1 sm:grid-cols-3 gap-3"
+      data-testid="system-summary"
+    >
+      <div class="rounded ring-1 ring-line bg-bg-1 p-3">
+        <div class="mono text-[10px] uppercase tracking-widest text-ink-mute">vm</div>
+        <div class="mono mt-1 text-[12px] text-sw-text" data-testid="system-vm">
+          {{ report.vm.vm_type }} · {{ report.vm.running ? 'running' : 'stopped' }}
         </div>
       </div>
-    }
+      <div class="rounded ring-1 ring-line bg-bg-1 p-3">
+        <div class="mono text-[10px] uppercase tracking-widest text-ink-mute">overall</div>
+        <div
+          class="mono mt-1 text-[12px]"
+          [class.text-sw-success]="report.overall_healthy"
+          [class.text-sw-accent]="!report.overall_healthy"
+          data-testid="system-overall"
+        >
+          {{ report.overall_healthy ? 'healthy' : 'degraded' }}
+        </div>
+      </div>
+      <div class="rounded ring-1 ring-line bg-bg-1 p-3">
+        <div class="mono text-[10px] uppercase tracking-widest text-ink-mute">ide_bridge</div>
+        <div class="mono mt-1 text-[12px] text-sw-text-dim" data-testid="system-bridge">
+          {{ report.ide_bridge.running ? 'connected' : 'disconnected' }}
+        </div>
+      </div>
+    </div>
   }
 </div>

--- a/desktop/src/src/app/system-view/system-view.component.html
+++ b/desktop/src/src/app/system-view/system-view.component.html
@@ -1,0 +1,140 @@
+<div class="mx-auto max-w-4xl">
+  <div class="mb-4 flex items-center justify-between">
+    <h1 class="mono text-[14px] text-sw-text m-0">System health</h1>
+    <span class="mono text-[11px] text-sw-text-muted" data-testid="system-refresh-hint">
+      auto-refresh 5s
+    </span>
+  </div>
+
+  @if (error) {
+    <div
+      class="mb-4 px-3 py-2 bg-sw-error-bg border border-sw-accent rounded text-sw-accent text-[12px] mono"
+      data-testid="system-error"
+      role="alert"
+    >
+      {{ error }}
+    </div>
+  }
+
+  @if (loading && !report) {
+    <p
+      class="mono text-[12px] text-sw-text-muted py-8 text-center"
+      data-testid="system-loading"
+    >
+      Loading health…
+    </p>
+  } @else if (!hasContainers && !error) {
+    <p
+      class="mono text-[12px] text-sw-text-muted py-8 text-center"
+      data-testid="system-empty"
+    >
+      No containers reported. Start the project to see live status.
+    </p>
+  } @else if (report && hasContainers) {
+    <div
+      class="overflow-hidden rounded ring-1 ring-line"
+      data-testid="system-table-wrapper"
+    >
+      <table class="mono w-full border-collapse" data-testid="system-table">
+        <caption class="sr-only">System containers and health</caption>
+        <thead class="bg-bg-1 text-[10px] uppercase tracking-widest text-ink-mute font-medium">
+          <tr>
+            <th class="px-3 py-2 text-left w-6" scope="col">
+              <span class="sr-only">Status</span>
+            </th>
+            <th class="px-3 py-2 text-left" scope="col">container</th>
+            <th class="px-3 py-2 text-left" scope="col">state</th>
+            <th class="px-3 py-2 text-left" scope="col">healthy</th>
+            <th class="px-3 py-2 text-right" scope="col">
+              <span class="sr-only">actions</span>
+            </th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-line">
+          @for (container of report.containers; track container.name) {
+            <tr data-testid="system-row" class="text-[12px]">
+              <td class="px-3 py-2 align-middle">
+                @if (container.healthy) {
+                  <span
+                    class="text-sw-success"
+                    aria-label="healthy"
+                    data-testid="system-dot-healthy"
+                  >●</span>
+                } @else {
+                  <span
+                    class="text-sw-accent"
+                    aria-label="unhealthy"
+                    data-testid="system-dot-unhealthy"
+                  >○</span>
+                }
+              </td>
+              <td class="px-3 py-2 align-middle text-sw-text" data-testid="system-name">
+                {{ container.name }}
+              </td>
+              <td
+                class="px-3 py-2 align-middle text-sw-teal"
+                data-testid="system-state"
+              >
+                {{ container.status }}
+              </td>
+              <td class="px-3 py-2 align-middle text-sw-text-dim">
+                @if (container.healthy) {
+                  <span data-testid="system-healthy">yes</span>
+                } @else {
+                  <span data-testid="system-healthy">no</span>
+                }
+              </td>
+              <td class="px-3 py-2 align-middle text-right">
+                <button
+                  type="button"
+                  class="mono text-[11px] text-sw-text-muted hover:text-sw-accent disabled:opacity-50 disabled:cursor-not-allowed"
+                  data-testid="system-restart"
+                  [disabled]="restarting.has(container.name)"
+                  [attr.aria-label]="'Restart ' + container.name"
+                  (click)="restart(container.name)"
+                >
+                  @if (restarting.has(container.name)) {
+                    restarting…
+                  } @else {
+                    restart
+                  }
+                </button>
+              </td>
+            </tr>
+          }
+        </tbody>
+      </table>
+    </div>
+
+    @if (report) {
+      <div
+        class="mt-4 grid grid-cols-1 sm:grid-cols-3 gap-3"
+        data-testid="system-summary"
+      >
+        <div class="rounded ring-1 ring-line bg-bg-1 p-3">
+          <div class="mono text-[10px] uppercase tracking-widest text-ink-mute">vm</div>
+          <div class="mono mt-1 text-[12px] text-sw-text" data-testid="system-vm">
+            {{ report.vm.vm_type }} · {{ report.vm.running ? 'running' : 'stopped' }}
+          </div>
+        </div>
+        <div class="rounded ring-1 ring-line bg-bg-1 p-3">
+          <div class="mono text-[10px] uppercase tracking-widest text-ink-mute">overall</div>
+          <div
+            class="mono mt-1 text-[12px]"
+            [class.text-sw-success]="report.overall_healthy"
+            [class.text-sw-accent]="!report.overall_healthy"
+            data-testid="system-overall"
+          >
+            {{ report.overall_healthy ? 'healthy' : 'degraded' }}
+          </div>
+        </div>
+        <div class="rounded ring-1 ring-line bg-bg-1 p-3">
+          <div class="mono text-[10px] uppercase tracking-widest text-ink-mute">ide_bridge</div>
+          <div class="mono mt-1 text-[12px] text-sw-text-dim" data-testid="system-bridge">
+            {{ report.ide_bridge.running ? 'connected' : 'disconnected' }}
+          </div>
+        </div>
+      </div>
+    }
+  }
+</div>

--- a/desktop/src/src/app/system-view/system-view.component.spec.ts
+++ b/desktop/src/src/app/system-view/system-view.component.spec.ts
@@ -236,9 +236,9 @@ describe('SystemViewComponent', () => {
     await component.ngOnInit();
     const baseline = calls.length;
 
-    await component.refresh();
+    await component['refresh']();
     expect(calls.length).toBe(baseline + 1);
-    await component.refresh();
+    await component['refresh']();
     expect(calls.length).toBe(baseline + 2);
   });
 
@@ -256,7 +256,7 @@ describe('SystemViewComponent', () => {
     const btn = fixture.nativeElement.querySelector(
       '[data-testid="system-restart"]'
     ) as HTMLButtonElement;
-    await component.restart('speedwave_test_claude');
+    await component['restart']('speedwave_test_claude');
     fixture.detectChanges();
 
     expect(calls).toContain('recreate_project_containers');
@@ -279,7 +279,7 @@ describe('SystemViewComponent', () => {
     await component.ngOnInit();
     fixture.detectChanges();
 
-    const restartPromise = component.restart('speedwave_test_claude');
+    const restartPromise = component['restart']('speedwave_test_claude');
     fixture.detectChanges();
 
     expect(component.restarting.has('speedwave_test_claude')).toBe(true);

--- a/desktop/src/src/app/system-view/system-view.component.spec.ts
+++ b/desktop/src/src/app/system-view/system-view.component.spec.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SystemViewComponent, SYSTEM_REFRESH_INTERVAL_MS } from './system-view.component';
+import { TauriService } from '../services/tauri.service';
+import { ProjectStateService } from '../services/project-state.service';
+import { MockTauriService } from '../testing/mock-tauri.service';
+import type { HealthReport } from '../models/health';
+
+const MOCK_HEALTHY_REPORT: HealthReport = {
+  containers: [
+    { name: 'speedwave_test_claude', status: 'running', healthy: true },
+    { name: 'speedwave_test_mcp-hub', status: 'running', healthy: true },
+    { name: 'speedwave_test_redmine', status: 'starting', healthy: false },
+  ],
+  vm: { running: true, vm_type: 'lima' },
+  mcp_os: { running: true },
+  ide_bridge: {
+    running: true,
+    port: 4001,
+    ws_url: 'ws://127.0.0.1:4001',
+    detected_ides: [],
+  },
+  overall_healthy: false,
+};
+
+const MOCK_EMPTY_REPORT: HealthReport = {
+  containers: [],
+  vm: { running: false, vm_type: 'lima' },
+  mcp_os: { running: false },
+  ide_bridge: { running: false, port: null, ws_url: null, detected_ides: [] },
+  overall_healthy: false,
+};
+
+describe('SystemViewComponent', () => {
+  let component: SystemViewComponent;
+  let fixture: ComponentFixture<SystemViewComponent>;
+  let mockTauri: MockTauriService;
+  let projectState: ProjectStateService;
+
+  beforeEach(async () => {
+    mockTauri = new MockTauriService();
+    mockTauri.invokeHandler = async (cmd: string) => {
+      if (cmd === 'get_health') return MOCK_HEALTHY_REPORT;
+      return undefined;
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [SystemViewComponent],
+      providers: [{ provide: TauriService, useValue: mockTauri }],
+    }).compileComponents();
+
+    projectState = TestBed.inject(ProjectStateService);
+    projectState.activeProject = 'test';
+
+    fixture = TestBed.createComponent(SystemViewComponent);
+    component = fixture.componentInstance;
+  });
+
+  afterEach(() => {
+    component.ngOnDestroy();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  // -- Happy path: renders a row per container --
+
+  it('renders a row for every container in the health report', async () => {
+    await component.ngOnInit();
+    fixture.detectChanges();
+
+    const rows = fixture.nativeElement.querySelectorAll('[data-testid="system-row"]');
+    expect(rows).toHaveLength(3);
+  });
+
+  it('renders the container name, state, and healthy flag in each row', async () => {
+    await component.ngOnInit();
+    fixture.detectChanges();
+
+    const names = Array.from(
+      fixture.nativeElement.querySelectorAll('[data-testid="system-name"]')
+    ) as HTMLElement[];
+    expect(names.map((n) => n.textContent?.trim())).toEqual([
+      'speedwave_test_claude',
+      'speedwave_test_mcp-hub',
+      'speedwave_test_redmine',
+    ]);
+
+    const states = Array.from(
+      fixture.nativeElement.querySelectorAll('[data-testid="system-state"]')
+    ) as HTMLElement[];
+    expect(states.map((s) => s.textContent?.trim())).toEqual(['running', 'running', 'starting']);
+  });
+
+  it('renders a filled dot for healthy and hollow dot for unhealthy containers', async () => {
+    await component.ngOnInit();
+    fixture.detectChanges();
+
+    const healthy = fixture.nativeElement.querySelectorAll('[data-testid="system-dot-healthy"]');
+    expect(healthy).toHaveLength(2);
+    const unhealthy = fixture.nativeElement.querySelectorAll(
+      '[data-testid="system-dot-unhealthy"]'
+    );
+    expect(unhealthy).toHaveLength(1);
+  });
+
+  it('applies terminal-minimal table classes on the wrapper', async () => {
+    await component.ngOnInit();
+    fixture.detectChanges();
+
+    const wrapper = fixture.nativeElement.querySelector(
+      '[data-testid="system-table-wrapper"]'
+    ) as HTMLElement;
+    expect(wrapper).not.toBeNull();
+    expect(wrapper.className).toContain('overflow-hidden');
+    expect(wrapper.className).toContain('rounded');
+    expect(wrapper.className).toContain('ring-1');
+    expect(wrapper.className).toContain('ring-line');
+
+    const table = fixture.nativeElement.querySelector(
+      '[data-testid="system-table"]'
+    ) as HTMLElement;
+    expect(table.className).toContain('mono');
+    expect(table.className).toContain('border-collapse');
+  });
+
+  it('renders the vm/overall/ide_bridge summary tiles', async () => {
+    await component.ngOnInit();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[data-testid="system-vm"]')?.textContent).toContain(
+      'lima'
+    );
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="system-overall"]')?.textContent?.trim()
+    ).toBe('degraded');
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="system-bridge"]')?.textContent?.trim()
+    ).toBe('connected');
+  });
+
+  // -- ARIA --
+
+  it('includes a visually hidden caption describing the table', async () => {
+    await component.ngOnInit();
+    fixture.detectChanges();
+
+    const caption = fixture.nativeElement.querySelector('caption');
+    expect(caption).not.toBeNull();
+    expect(caption?.textContent?.trim()).toBe('System containers and health');
+    expect(caption?.className).toContain('sr-only');
+  });
+
+  it('adds aria-label on each restart action button', async () => {
+    await component.ngOnInit();
+    fixture.detectChanges();
+
+    const buttons = fixture.nativeElement.querySelectorAll('[data-testid="system-restart"]');
+    expect(buttons[0].getAttribute('aria-label')).toBe('Restart speedwave_test_claude');
+  });
+
+  // -- Edge case: empty containers --
+
+  it('shows an empty hint when health report has zero containers', async () => {
+    mockTauri.invokeHandler = async () => MOCK_EMPTY_REPORT;
+
+    await component.ngOnInit();
+    fixture.detectChanges();
+
+    const hint = fixture.nativeElement.querySelector('[data-testid="system-empty"]');
+    expect(hint).not.toBeNull();
+    expect(hint?.textContent).toContain('No containers');
+    expect(fixture.nativeElement.querySelector('[data-testid="system-table"]')).toBeNull();
+  });
+
+  it('shows an empty-project error when activeProject is null', async () => {
+    projectState.activeProject = null;
+
+    await component.ngOnInit();
+    fixture.detectChanges();
+
+    const error = fixture.nativeElement.querySelector('[data-testid="system-error"]');
+    expect(error).not.toBeNull();
+    expect(error?.textContent).toContain('No active project');
+  });
+
+  // -- Error path --
+
+  it('renders an error block when get_health rejects', async () => {
+    mockTauri.invokeHandler = async () => {
+      throw new Error('health unavailable');
+    };
+
+    await component.ngOnInit();
+    fixture.detectChanges();
+
+    const error = fixture.nativeElement.querySelector('[data-testid="system-error"]');
+    expect(error).not.toBeNull();
+    expect(error?.textContent).toContain('health unavailable');
+    expect(error?.getAttribute('role')).toBe('alert');
+  });
+
+  // -- State transitions --
+
+  it('refresh interval schedules setInterval with the 5 s cadence', async () => {
+    const spy = vi.spyOn(globalThis, 'setInterval');
+    const clearSpy = vi.spyOn(globalThis, 'clearInterval');
+    try {
+      await component.ngOnInit();
+      fixture.detectChanges();
+
+      expect(spy).toHaveBeenCalledOnce();
+      const [, delay] = spy.mock.calls[0];
+      expect(delay).toBe(SYSTEM_REFRESH_INTERVAL_MS);
+
+      // ngOnDestroy clears the interval it created.
+      component.ngOnDestroy();
+      expect(clearSpy).toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+      clearSpy.mockRestore();
+    }
+  });
+
+  it('refresh invoked directly re-fetches health', async () => {
+    const calls: string[] = [];
+    mockTauri.invokeHandler = async (cmd: string) => {
+      calls.push(cmd);
+      return MOCK_HEALTHY_REPORT;
+    };
+
+    await component.ngOnInit();
+    const baseline = calls.length;
+
+    await component.refresh();
+    expect(calls.length).toBe(baseline + 1);
+    await component.refresh();
+    expect(calls.length).toBe(baseline + 2);
+  });
+
+  it('restart button invokes recreate_project_containers then re-fetches health', async () => {
+    const calls: string[] = [];
+    mockTauri.invokeHandler = async (cmd: string) => {
+      calls.push(cmd);
+      if (cmd === 'get_health') return MOCK_HEALTHY_REPORT;
+      return undefined;
+    };
+
+    await component.ngOnInit();
+    fixture.detectChanges();
+
+    const btn = fixture.nativeElement.querySelector(
+      '[data-testid="system-restart"]'
+    ) as HTMLButtonElement;
+    await component.restart('speedwave_test_claude');
+    fixture.detectChanges();
+
+    expect(calls).toContain('recreate_project_containers');
+    expect(calls.filter((c) => c === 'get_health').length).toBeGreaterThanOrEqual(2);
+    expect(btn.disabled).toBe(false); // restored after completion
+  });
+
+  it('disables the restart button while the restart is in flight', async () => {
+    let resolveRestart: (() => void) | null = null;
+    mockTauri.invokeHandler = async (cmd: string) => {
+      if (cmd === 'get_health') return MOCK_HEALTHY_REPORT;
+      if (cmd === 'recreate_project_containers') {
+        return new Promise<void>((resolve) => {
+          resolveRestart = resolve;
+        });
+      }
+      return undefined;
+    };
+
+    await component.ngOnInit();
+    fixture.detectChanges();
+
+    const restartPromise = component.restart('speedwave_test_claude');
+    fixture.detectChanges();
+
+    expect(component.restarting.has('speedwave_test_claude')).toBe(true);
+
+    resolveRestart?.();
+    await restartPromise;
+    fixture.detectChanges();
+
+    expect(component.restarting.has('speedwave_test_claude')).toBe(false);
+  });
+});

--- a/desktop/src/src/app/system-view/system-view.component.spec.ts
+++ b/desktop/src/src/app/system-view/system-view.component.spec.ts
@@ -152,12 +152,15 @@ describe('SystemViewComponent', () => {
     expect(caption?.className).toContain('sr-only');
   });
 
-  it('adds aria-label on each restart action button', async () => {
+  it('adds an aria-label communicating the actual restart-all scope', async () => {
+    // The Tauri command recreates ALL project containers, not just the one
+    // whose row was clicked. The label must communicate the actual scope.
     await component.ngOnInit();
     fixture.detectChanges();
 
     const buttons = fixture.nativeElement.querySelectorAll('[data-testid="system-restart"]');
-    expect(buttons[0].getAttribute('aria-label')).toBe('Restart speedwave_test_claude');
+    expect(buttons[0].getAttribute('aria-label')).toBe('Restart all project containers');
+    expect(buttons[0].textContent?.trim()).toBe('restart all');
   });
 
   // -- Edge case: empty containers --

--- a/desktop/src/src/app/system-view/system-view.component.ts
+++ b/desktop/src/src/app/system-view/system-view.component.ts
@@ -13,14 +13,6 @@ import type { HealthReport } from '../models/health';
 /** How often the system view polls the backend for a fresh health report. */
 export const SYSTEM_REFRESH_INTERVAL_MS = 5000;
 
-/**
- * Terminal-minimal system health view.
- *
- * Polls `get_health` for the active project every 5 s and renders each
- * container as a row in a terminal-style table with a status dot, name,
- * state, healthy flag, and action buttons. Auto-refresh runs only while
- * the component is mounted — `ngOnDestroy` clears the interval.
- */
 @Component({
   selector: 'app-system-view',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -59,7 +51,7 @@ export class SystemViewComponent implements OnInit, OnDestroy {
   }
 
   /** Fetches a fresh health report and updates view state. */
-  async refresh(): Promise<void> {
+  protected async refresh(): Promise<void> {
     const project = this.projectState.activeProject;
     if (!project) {
       this.loading = false;
@@ -79,18 +71,13 @@ export class SystemViewComponent implements OnInit, OnDestroy {
     }
   }
 
-  /**
-   * Recreates all project containers via the existing Tauri command.
-   * The runtime does not expose a per-container restart, so "restart"
-   * here means recreate-all. Runs once and re-fetches health.
-   * @param name - The container name triggered from the row button.
-   */
-  async restart(name: string): Promise<void> {
+  protected async restart(name: string): Promise<void> {
     const project = this.projectState.activeProject;
     if (!project || this.restarting.has(name)) return;
     this.restarting.add(name);
     this.cdr.markForCheck();
     try {
+      // recreate_project_containers restarts all — per-container restart not exposed by runtime
       await this.tauri.invoke('recreate_project_containers', { project });
       await this.refresh();
     } catch (e: unknown) {

--- a/desktop/src/src/app/system-view/system-view.component.ts
+++ b/desktop/src/src/app/system-view/system-view.component.ts
@@ -1,0 +1,108 @@
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  OnDestroy,
+  OnInit,
+  inject,
+} from '@angular/core';
+import { TauriService } from '../services/tauri.service';
+import { ProjectStateService } from '../services/project-state.service';
+import type { HealthReport } from '../models/health';
+
+/** How often the system view polls the backend for a fresh health report. */
+export const SYSTEM_REFRESH_INTERVAL_MS = 5000;
+
+/**
+ * Terminal-minimal system health view.
+ *
+ * Polls `get_health` for the active project every 5 s and renders each
+ * container as a row in a terminal-style table with a status dot, name,
+ * state, healthy flag, and action buttons. Auto-refresh runs only while
+ * the component is mounted — `ngOnDestroy` clears the interval.
+ */
+@Component({
+  selector: 'app-system-view',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './system-view.component.html',
+  host: { class: 'block bg-sw-bg-darkest min-h-screen p-6 text-sw-text' },
+})
+export class SystemViewComponent implements OnInit, OnDestroy {
+  /** Aggregated health report, null until first fetch completes. */
+  report: HealthReport | null = null;
+  /** Error message from the most recent fetch, empty if healthy. */
+  error = '';
+  /** True while the initial fetch is in-flight (hides empty hint). */
+  loading = true;
+  /** Map of container names currently being restarted. */
+  restarting = new Set<string>();
+
+  private refreshTimer: ReturnType<typeof setInterval> | null = null;
+  private readonly tauri = inject(TauriService);
+  private readonly projectState = inject(ProjectStateService);
+  private readonly cdr = inject(ChangeDetectorRef);
+
+  /** Starts the polling cycle and runs an immediate first fetch. */
+  async ngOnInit(): Promise<void> {
+    await this.refresh();
+    this.refreshTimer = setInterval(() => {
+      void this.refresh();
+    }, SYSTEM_REFRESH_INTERVAL_MS);
+  }
+
+  /** Cancels the polling cycle. */
+  ngOnDestroy(): void {
+    if (this.refreshTimer !== null) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+  }
+
+  /** Fetches a fresh health report and updates view state. */
+  async refresh(): Promise<void> {
+    const project = this.projectState.activeProject;
+    if (!project) {
+      this.loading = false;
+      this.report = null;
+      this.error = 'No active project';
+      this.cdr.markForCheck();
+      return;
+    }
+    try {
+      this.report = await this.tauri.invoke<HealthReport>('get_health', { project });
+      this.error = '';
+    } catch (e: unknown) {
+      this.error = e instanceof Error ? e.message : String(e);
+    } finally {
+      this.loading = false;
+      this.cdr.markForCheck();
+    }
+  }
+
+  /**
+   * Recreates all project containers via the existing Tauri command.
+   * The runtime does not expose a per-container restart, so "restart"
+   * here means recreate-all. Runs once and re-fetches health.
+   * @param name - The container name triggered from the row button.
+   */
+  async restart(name: string): Promise<void> {
+    const project = this.projectState.activeProject;
+    if (!project || this.restarting.has(name)) return;
+    this.restarting.add(name);
+    this.cdr.markForCheck();
+    try {
+      await this.tauri.invoke('recreate_project_containers', { project });
+      await this.refresh();
+    } catch (e: unknown) {
+      this.error = e instanceof Error ? e.message : String(e);
+    } finally {
+      this.restarting.delete(name);
+      this.cdr.markForCheck();
+    }
+  }
+
+  /** Whether the health report has at least one container entry. */
+  get hasContainers(): boolean {
+    return this.report !== null && this.report.containers.length > 0;
+  }
+}

--- a/desktop/src/src/app/system-view/system-view.component.ts
+++ b/desktop/src/src/app/system-view/system-view.component.ts
@@ -13,6 +13,13 @@ import type { HealthReport } from '../models/health';
 /** How often the system view polls the backend for a fresh health report. */
 export const SYSTEM_REFRESH_INTERVAL_MS = 5000;
 
+/**
+ * System view — shows aggregated container health and per-container actions.
+ *
+ * Polls `get_system_health` on a fixed cadence and surfaces restart controls
+ * for individual containers; tracks in-flight restarts in a local set so the
+ * UI can disable buttons without round-tripping through the backend.
+ */
 @Component({
   selector: 'app-system-view',
   changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
## Summary

- New \`/system\` route — containers/health table with status dots, mono per design-system Tables spec, auto-refresh.
- New \`/logs\` route — time-prefixed log lines, filter chips by level + source, auto-scroll.
- Wires existing Tauri commands (get_health, get_compose_logs).

## Test plan

- [x] \`make test-angular\`: new specs pass.
- [x] Live UI not exercised — manual smoke-test pending merge.