### PR TITLE
feat(desktop): add copy and retry on assistant messages

### DIFF
--- a/desktop/src-tauri/src/chat.rs
+++ b/desktop/src-tauri/src/chat.rs
@@ -1170,9 +1170,9 @@ impl ChatSession {
                 // - StreamChunk::Result / Error from normal turns
                 // - system messages (including non-actionable ones that
                 //   return no chunk but still indicate normal lifecycle)
-                let is_terminal = chunks.iter().any(|c| {
-                    matches!(c, StreamChunk::Result { .. } | StreamChunk::Error { .. })
-                });
+                let is_terminal = chunks
+                    .iter()
+                    .any(|c| matches!(c, StreamChunk::Result { .. } | StreamChunk::Error { .. }));
                 if is_terminal || msg_type == "system" {
                     got_result = true;
                     // Clear StreamParser per-turn state. message_stop also
@@ -2105,7 +2105,8 @@ mod tests {
         // Regression: the parser must stash `message.id` when seeing an
         // `assistant` event so the next `Result` commits it.
         let mut parser = StreamParser::new();
-        let line = r#"{"type":"assistant","message":{"id":"msg_abc123","role":"assistant","content":[]}}"#;
+        let line =
+            r#"{"type":"assistant","message":{"id":"msg_abc123","role":"assistant","content":[]}}"#;
         let chunks = parse_line_all_str(&mut parser, line);
         assert!(chunks.is_empty(), "assistant event must not emit chunks");
         assert_eq!(parser.pending_assistant_uuid.as_deref(), Some("msg_abc123"));
@@ -2136,7 +2137,10 @@ mod tests {
         let chunk = parse_line_str(&mut parser, result2).unwrap();
         match chunk {
             StreamChunk::Result { assistant_uuid, .. } => {
-                assert!(assistant_uuid.is_none(), "stale uuid must not survive reset");
+                assert!(
+                    assistant_uuid.is_none(),
+                    "stale uuid must not survive reset"
+                );
             }
             other => panic!("expected Result, got {other:?}"),
         }
@@ -2151,8 +2155,7 @@ mod tests {
         let mut parser = StreamParser::new();
         let assistant =
             r#"{"type":"assistant","message":{"id":"msg_err","role":"assistant","content":[]}}"#;
-        let error_result =
-            r#"{"type":"result","is_error":true,"result":"something broke"}"#;
+        let error_result = r#"{"type":"result","is_error":true,"result":"something broke"}"#;
         parse_line_str(&mut parser, assistant);
         let chunk = parse_line_str(&mut parser, error_result).unwrap();
         assert!(matches!(chunk, StreamChunk::Error { .. }));
@@ -2188,6 +2191,22 @@ mod tests {
     }
 
     #[test]
+    fn user_message_mixed_text_and_tool_result_emits_tool_result_only() {
+        // Mixed content (Claude Code occasionally interleaves a narrative
+        // text block alongside a tool_result wrapper in the same user
+        // event). The text presence MUST NOT trigger a UserMessageCommit:
+        // the message is still a tool-result wrapper, not a real prompt.
+        let mut parser = StreamParser::new();
+        let line = r#"{"type":"user","message":{"id":"u_mix","role":"user","content":[{"type":"text","text":"here is the result"},{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"}]}}"#;
+        let chunks = parse_line_all_str(&mut parser, line);
+        assert_eq!(chunks.len(), 1);
+        assert!(
+            matches!(&chunks[0], StreamChunk::ToolResult { .. }),
+            "expected ToolResult, not UserMessageCommit, for mixed message"
+        );
+    }
+
+    #[test]
     fn user_message_commit_is_emitted_exactly_once() {
         // Duplicate user messages (observed on retry/resume) must not
         // emit the commit twice — only the first occurrence wins.
@@ -2204,7 +2223,8 @@ mod tests {
     #[test]
     fn user_message_without_id_is_silent() {
         let mut parser = StreamParser::new();
-        let line = r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}"#;
+        let line =
+            r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}"#;
         assert!(parse_line_all_str(&mut parser, line).is_empty());
     }
 
@@ -2555,8 +2575,7 @@ mod tests {
 
     #[test]
     fn build_claude_args_includes_flags() {
-        let args =
-            build_claude_args(None, None, &["--dangerously-skip-permissions".to_string()]);
+        let args = build_claude_args(None, None, &["--dangerously-skip-permissions".to_string()]);
         assert!(args.contains(&"--dangerously-skip-permissions".to_string()));
     }
 
@@ -3032,12 +3051,8 @@ mod tests {
             selected_ide: None,
             log_level: None,
         };
-        let result = ChatSession::prepare_args(
-            "test",
-            &user_config,
-            Some("../../../etc/passwd"),
-            None,
-        );
+        let result =
+            ChatSession::prepare_args("test", &user_config, Some("../../../etc/passwd"), None);
         assert!(result.is_err());
     }
 
@@ -3124,8 +3139,7 @@ mod tests {
         };
         let session_id = "550e8400-e29b-41d4-a716-446655440000";
         let uuid = "msg_retry_me";
-        let result =
-            ChatSession::prepare_args("proj", &user_config, Some(session_id), Some(uuid));
+        let result = ChatSession::prepare_args("proj", &user_config, Some(session_id), Some(uuid));
         assert!(result.is_ok());
         let (args, _) = result.unwrap();
         assert!(args.contains(&"--resume-session-at".to_string()));

--- a/desktop/src-tauri/src/chat.rs
+++ b/desktop/src-tauri/src/chat.rs
@@ -41,6 +41,11 @@ pub enum StreamChunk {
         result_text: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         context_window_size: Option<u64>,
+        /// UUID of the assistant message that just completed (ADR-046). Stays
+        /// `None` for error turns and for local-LLM paths that omit `message.id`
+        /// — the frontend degrades to "no retry target" for those entries.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        assistant_uuid: Option<String>,
     },
     /// Interactive question from Claude (AskUserQuestion tool).
     /// The frontend must display the question and send the answer back via `answer_question`.
@@ -61,6 +66,10 @@ pub enum StreamChunk {
         utilization: Option<f64>,
         resets_at: Option<u64>,
     },
+    /// Commits a UUID onto the most recent user entry (ADR-046). Emitted when
+    /// the parser first sees `{"type":"user","message":{"id":"...",...}}` with
+    /// a text-bearing user prompt (not a tool_result wrapper).
+    UserMessageCommit { uuid: String },
 }
 
 /// A single option in an AskUserQuestion prompt.
@@ -109,6 +118,14 @@ pub struct LogEntry {
     pub message: String,
 }
 
+/// Adapts a legacy `(Option<StreamChunk>, Option<LogEntry>)` tuple into the
+/// `(Vec<StreamChunk>, Option<LogEntry>)` shape returned by `parse_line`.
+fn option_to_vec(
+    (chunk, log): (Option<StreamChunk>, Option<LogEntry>),
+) -> (Vec<StreamChunk>, Option<LogEntry>) {
+    (chunk.map(|c| vec![c]).unwrap_or_default(), log)
+}
+
 /// Stateful parser that tracks active content blocks across stream events.
 /// Maintains index→(tool_id, tool_name) map built from content_block_start events.
 pub struct StreamParser {
@@ -116,6 +133,15 @@ pub struct StreamParser {
     active_blocks: HashMap<u64, (String, String)>,
     /// Accumulated input_json per tool_id (built from ToolInputDelta chunks).
     tool_input: HashMap<String, String>,
+    /// Provisional assistant UUID tracked between `assistant` and `result`
+    /// events (ADR-046). Committed onto the `Result` chunk; `take`n when the
+    /// result arrives so a subsequent error turn cannot reuse a stale id.
+    pending_assistant_uuid: Option<String>,
+    /// UUIDs already emitted via `UserMessageCommit`, to guard against
+    /// duplicate commits when Claude Code re-emits a user message inside the
+    /// same turn (observed on retry/resume paths — the first user message
+    /// echoes back). A user prompt's UUID is committed exactly once.
+    committed_user_uuids: std::collections::HashSet<String>,
 }
 
 impl StreamParser {
@@ -124,25 +150,47 @@ impl StreamParser {
         Self {
             active_blocks: HashMap::new(),
             tool_input: HashMap::new(),
+            pending_assistant_uuid: None,
+            committed_user_uuids: std::collections::HashSet::new(),
         }
     }
 
     /// Parse a pre-parsed JSON value. Mutates internal state for block tracking.
-    /// Returns (chunk for frontend, optional log entry for session log).
+    /// Returns (chunks for frontend in emission order, optional log entry).
+    ///
+    /// The Vec lets a single stream-json line produce multiple UI chunks — for
+    /// example a `user` line with a text-bearing prompt AND a tool_result
+    /// wrapper (rare but possible) emits both `UserMessageCommit` and
+    /// `ToolResult`. Callers iterate and emit each chunk in order.
     pub fn parse_line(
         &mut self,
         parsed: &serde_json::Value,
-    ) -> (Option<StreamChunk>, Option<LogEntry>) {
+    ) -> (Vec<StreamChunk>, Option<LogEntry>) {
         let msg_type = parsed["type"].as_str().unwrap_or("");
 
         match msg_type {
-            "stream_event" => self.parse_stream_event(&parsed["event"]),
+            "stream_event" => option_to_vec(self.parse_stream_event(&parsed["event"])),
             "user" => self.parse_user_message(parsed),
-            "result" => self.parse_result(parsed),
-            // assistant — ignored (ADR-006: we stream via stream_event, finalize on result)
-            "system" => self.parse_system_message(parsed),
-            "rate_limit_event" => Self::parse_rate_limit_event(parsed),
-            _ => (None, None),
+            "result" => option_to_vec(self.parse_result(parsed)),
+            "assistant" => {
+                self.capture_assistant_uuid(parsed);
+                (Vec::new(), None)
+            }
+            "system" => option_to_vec(self.parse_system_message(parsed)),
+            "rate_limit_event" => option_to_vec(Self::parse_rate_limit_event(parsed)),
+            _ => (Vec::new(), None),
+        }
+    }
+
+    /// Capture the assistant message UUID (`message.id`) into
+    /// `pending_assistant_uuid`. The UUID is committed onto the next
+    /// `Result` chunk — see `parse_result`. Silently ignores missing/empty
+    /// ids (local LLMs without API-style ids still produce valid turns).
+    fn capture_assistant_uuid(&mut self, parsed: &serde_json::Value) {
+        if let Some(id) = parsed["message"]["id"].as_str() {
+            if !id.is_empty() {
+                self.pending_assistant_uuid = Some(id.to_string());
+            }
         }
     }
 
@@ -150,6 +198,10 @@ impl StreamParser {
     pub fn reset(&mut self) {
         self.active_blocks.clear();
         self.tool_input.clear();
+        self.pending_assistant_uuid = None;
+        // committed_user_uuids is NOT reset: it persists across turns for the
+        // lifetime of the session so a retry on an already-committed user
+        // UUID doesn't re-emit a duplicate commit chunk.
     }
 
     /// Check if a parsed JSON value is a control_request. Returns parsed data if so.
@@ -366,15 +418,46 @@ impl StreamParser {
     }
 
     fn parse_user_message(
-        &self,
+        &mut self,
         parsed: &serde_json::Value,
-    ) -> (Option<StreamChunk>, Option<LogEntry>) {
+    ) -> (Vec<StreamChunk>, Option<LogEntry>) {
         let message = &parsed["message"];
         let content = &message["content"];
         let blocks = match content.as_array() {
             Some(b) => b,
-            None => return (None, None),
+            None => return (Vec::new(), None),
         };
+
+        let mut has_text = false;
+        let mut has_tool_result = false;
+        for block in blocks {
+            match block["type"].as_str().unwrap_or("") {
+                "text" => has_text = true,
+                "tool_result" => has_tool_result = true,
+                _ => {}
+            }
+        }
+
+        // A user message carrying text (a user prompt, not a tool_result
+        // wrapper) commits its UUID once per session. Tool-result wrappers
+        // reuse the prompt's UUID or carry different ids — we only want to
+        // retry-point against actual prompts.
+        if has_text && !has_tool_result {
+            if let Some(id) = message["id"].as_str() {
+                if !id.is_empty() && !self.committed_user_uuids.contains(id) {
+                    self.committed_user_uuids.insert(id.to_string());
+                    return (
+                        vec![StreamChunk::UserMessageCommit {
+                            uuid: id.to_string(),
+                        }],
+                        Some(LogEntry {
+                            prefix: "USER",
+                            message: format!("commit uuid={id}"),
+                        }),
+                    );
+                }
+            }
+        }
 
         for block in blocks {
             let block_type = block["type"].as_str().unwrap_or("");
@@ -383,7 +466,7 @@ impl StreamParser {
                     Some(s) if !s.is_empty() => s.to_string(),
                     _ => {
                         log::warn!("parse_user_message: tool_result block missing 'tool_use_id'");
-                        return (None, None);
+                        return (Vec::new(), None);
                     }
                 };
                 let is_error = block["is_error"].as_bool().unwrap_or(false);
@@ -412,19 +495,22 @@ impl StreamParser {
                 });
 
                 return (
-                    Some(StreamChunk::ToolResult {
+                    vec![StreamChunk::ToolResult {
                         tool_id: tool_use_id,
                         content: result_content,
                         is_error,
-                    }),
+                    }],
                     log_entry,
                 );
             }
         }
-        (None, None)
+        (Vec::new(), None)
     }
 
-    fn parse_result(&self, parsed: &serde_json::Value) -> (Option<StreamChunk>, Option<LogEntry>) {
+    fn parse_result(
+        &mut self,
+        parsed: &serde_json::Value,
+    ) -> (Option<StreamChunk>, Option<LogEntry>) {
         let is_error = parsed["is_error"].as_bool().unwrap_or(false);
 
         if is_error {
@@ -507,6 +593,8 @@ impl StreamParser {
             message: "turn complete".to_string(),
         });
 
+        let assistant_uuid = self.pending_assistant_uuid.take();
+
         (
             Some(StreamChunk::Result {
                 session_id,
@@ -514,6 +602,7 @@ impl StreamParser {
                 usage,
                 result_text,
                 context_window_size,
+                assistant_uuid,
             }),
             log_entry,
         )
@@ -690,11 +779,42 @@ fn build_ask_user_response(request: &ControlRequest, selected_label: &str) -> se
     })
 }
 
+/// Validate a message UUID passed to `--resume-session-at`.
+///
+/// Claude Code's message ids take two shapes in the wild: Anthropic-API
+/// `msg_...` ids (alphanumeric with underscores) and UUID v4 strings.  Rather
+/// than enumerate both, we accept any bounded string whose characters are
+/// safe to pass as a CLI argument — no shell metacharacters, no whitespace,
+/// no path traversal. Empty strings are rejected so the caller can treat
+/// "no known retry target" as a distinct error condition.
+pub fn validate_retry_uuid(uuid: &str) -> anyhow::Result<()> {
+    if uuid.is_empty() {
+        anyhow::bail!("retry uuid must not be empty");
+    }
+    if uuid.len() > 128 {
+        anyhow::bail!("retry uuid too long (max 128 chars)");
+    }
+    // Allow [A-Za-z0-9_-] only — the two observed formats (API `msg_...`
+    // and UUID v4) fit within this set and it disallows shell injection.
+    for ch in uuid.chars() {
+        if !(ch.is_ascii_alphanumeric() || ch == '_' || ch == '-') {
+            anyhow::bail!("retry uuid contains invalid character: {ch:?}");
+        }
+    }
+    Ok(())
+}
+
 /// Build the argument list for Claude Code's stream-json mode.
 ///
 /// When `resume_session_id` is `Some`, adds `--resume <id>` to resume an
-/// existing conversation.
-pub fn build_claude_args(resume_session_id: Option<&str>, flags: &[String]) -> Vec<String> {
+/// existing conversation. When `resume_at_uuid` is `Some`, additionally
+/// rewinds the conversation to that user-message UUID (ADR-046) — Claude
+/// Code's native retry flag.
+pub fn build_claude_args(
+    resume_session_id: Option<&str>,
+    resume_at_uuid: Option<&str>,
+    flags: &[String],
+) -> Vec<String> {
     let mut args = vec![
         consts::CLAUDE_BINARY.to_string(),
         "-p".to_string(),
@@ -711,6 +831,11 @@ pub fn build_claude_args(resume_session_id: Option<&str>, flags: &[String]) -> V
     if let Some(id) = resume_session_id {
         args.push("--resume".to_string());
         args.push(id.to_string());
+    }
+
+    if let Some(uuid) = resume_at_uuid {
+        args.push("--resume-session-at".to_string());
+        args.push(uuid.to_string());
     }
 
     for flag in flags {
@@ -778,22 +903,37 @@ impl ChatSession {
         }
     }
 
-    /// Validate inputs and resolve config needed before spawning Claude.
-    /// Extracted from `start()` so validation logic is independently testable.
-    pub fn prepare_start(
+    /// Read-only accessor for the owning project name — required by the
+    /// retry command so it can re-construct an empty `ChatSession` after
+    /// stopping the old one.
+    pub fn project_name(&self) -> &str {
+        &self.project_name
+    }
+
+    /// Build the argv + container name for a Claude Code spawn.
+    ///
+    /// - `resume_session_id` adds `--resume <id>` (required for retry).
+    /// - `resume_at_uuid` adds `--resume-session-at <uuid>` (ADR-046 retry
+    ///   anchor). When both are `Some`, the spawn rewinds the session to the
+    ///   given user-message UUID and regenerates the assistant turn natively.
+    pub fn prepare_args(
         project_name: &str,
         user_config: &config::SpeedwaveUserConfig,
         resume_session_id: Option<&str>,
+        resume_at_uuid: Option<&str>,
     ) -> anyhow::Result<(Vec<String>, String)> {
         if let Some(id) = resume_session_id {
             history::validate_session_id(id)?;
+        }
+        if let Some(uuid) = resume_at_uuid {
+            validate_retry_uuid(uuid)?;
         }
 
         let project_dir = std::path::PathBuf::from(&user_config.require_project(project_name)?.dir);
 
         let resolved = config::resolve_claude_config(&project_dir, user_config, project_name);
 
-        let args = build_claude_args(resume_session_id, &resolved.flags);
+        let args = build_claude_args(resume_session_id, resume_at_uuid, &resolved.flags);
         let container = claude_container_name(project_name);
 
         Ok((args, container))
@@ -814,11 +954,30 @@ impl ChatSession {
         app_handle: AppHandle,
         resume_session_id: Option<&str>,
     ) -> anyhow::Result<()> {
+        self.start_with_retry(app_handle, resume_session_id, None)
+    }
+
+    /// Start (or resume+retry) a Claude Code session.
+    ///
+    /// When `resume_at_uuid` is `Some`, Claude Code rewinds the session to
+    /// the given user-message UUID and regenerates the assistant turn
+    /// natively (ADR-046). The caller MUST also pass `resume_session_id`;
+    /// retry without a session is nonsensical.
+    pub fn start_with_retry(
+        &mut self,
+        app_handle: AppHandle,
+        resume_session_id: Option<&str>,
+        resume_at_uuid: Option<&str>,
+    ) -> anyhow::Result<()> {
         let rt = runtime::detect_runtime();
         let user_config = config::load_user_config()?;
 
-        let (args, container) =
-            Self::prepare_start(&self.project_name, &user_config, resume_session_id)?;
+        let (args, container) = Self::prepare_args(
+            &self.project_name,
+            &user_config,
+            resume_session_id,
+            resume_at_uuid,
+        )?;
 
         let mut cmd = rt.container_exec_piped(
             &container,
@@ -1002,7 +1161,7 @@ impl ChatSession {
                 }
 
                 // 2. Normal stream events
-                let (chunk, log_entry) = parser.parse_line(&parsed);
+                let (chunks, log_entry) = parser.parse_line(&parsed);
                 if let Some(entry) = log_entry {
                     crate::log_file::write_log_line(&mut log_file, entry.prefix, &entry.message);
                 }
@@ -1011,11 +1170,10 @@ impl ChatSession {
                 // - StreamChunk::Result / Error from normal turns
                 // - system messages (including non-actionable ones that
                 //   return no chunk but still indicate normal lifecycle)
-                if matches!(
-                    chunk,
-                    Some(StreamChunk::Result { .. }) | Some(StreamChunk::Error { .. })
-                ) || msg_type == "system"
-                {
+                let is_terminal = chunks.iter().any(|c| {
+                    matches!(c, StreamChunk::Result { .. } | StreamChunk::Error { .. })
+                });
+                if is_terminal || msg_type == "system" {
                     got_result = true;
                     // Clear StreamParser per-turn state. message_stop also
                     // triggers reset inside parse_line, but an interrupted
@@ -1024,7 +1182,7 @@ impl ChatSession {
                     // ToolInputDelta events in the next turn.
                     parser.reset();
                 }
-                if let Some(chunk) = chunk {
+                for chunk in chunks {
                     if let Err(e) = app_handle.emit("chat_stream", chunk) {
                         log::warn!("failed to emit chat_stream event: {e}");
                     }
@@ -1437,22 +1595,34 @@ mod tests {
     }
 
     /// Convenience: parse a JSON string and call `parser.parse_line`.
-    /// Returns only the StreamChunk (for backward-compatible test assertions).
+    /// Returns the first StreamChunk (for backward-compatible test assertions
+    /// against single-chunk emissions).
     fn parse_line_str(parser: &mut StreamParser, line: &str) -> Option<StreamChunk> {
         let parsed: serde_json::Value = serde_json::from_str(line).ok()?;
+        parser.parse_line(&parsed).0.into_iter().next()
+    }
+
+    /// Convenience: parse a JSON string and return all emitted chunks.
+    fn parse_line_all_str(parser: &mut StreamParser, line: &str) -> Vec<StreamChunk> {
+        let parsed: serde_json::Value = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(_) => return Vec::new(),
+        };
         parser.parse_line(&parsed).0
     }
 
     /// Convenience: parse a JSON string and call `parser.parse_line`.
-    /// Returns the full tuple (chunk, log_entry) for log entry assertions.
+    /// Returns the full tuple (first chunk, log_entry) for log entry assertions.
     fn parse_line_full(
         parser: &mut StreamParser,
         line: &str,
     ) -> (Option<StreamChunk>, Option<LogEntry>) {
-        match serde_json::from_str::<serde_json::Value>(line) {
-            Ok(parsed) => parser.parse_line(&parsed),
-            Err(_) => (None, None),
-        }
+        let parsed = match serde_json::from_str::<serde_json::Value>(line) {
+            Ok(v) => v,
+            Err(_) => return (None, None),
+        };
+        let (chunks, log) = parser.parse_line(&parsed);
+        (chunks.into_iter().next(), log)
     }
 
     /// Convenience: parse a JSON string and call `StreamParser::try_parse_control_request`.
@@ -1516,6 +1686,7 @@ mod tests {
             }),
             result_text: None,
             context_window_size: None,
+            assistant_uuid: Some("msg_test".to_string()),
         };
         let serialized = serde_json::to_string(&original).unwrap();
         let deserialized: StreamChunk = serde_json::from_str(&serialized).unwrap();
@@ -1768,6 +1939,7 @@ mod tests {
                 usage,
                 result_text,
                 context_window_size,
+                assistant_uuid,
             } => {
                 assert_eq!(session_id, "550e8400-e29b-41d4-a716-446655440000");
                 assert_eq!(total_cost, Some(0.015));
@@ -1778,6 +1950,10 @@ mod tests {
                 assert!(u.cache_write_tokens.is_none());
                 assert!(result_text.is_none(), "empty result should produce None");
                 assert!(context_window_size.is_none());
+                assert!(
+                    assistant_uuid.is_none(),
+                    "no preceding 'assistant' event should leave assistant_uuid empty"
+                );
             }
             other => panic!("expected Result, got {other:?}"),
         }
@@ -1910,10 +2086,142 @@ mod tests {
     // ── StreamParser: ignored types ──────────────────────────────────
 
     #[test]
-    fn parse_assistant_type_is_ignored() {
+    fn parse_assistant_type_emits_no_chunk() {
+        // Assistant messages don't emit chunks — content streams via
+        // `stream_event` deltas, and the final `Result` carries the UUID.
+        // An assistant line WITHOUT a `message.id` (local LLM) is silently
+        // ignored just like before.
         let mut parser = StreamParser::new();
         let line = r#"{"type":"assistant","message":{"role":"assistant","content":[]}}"#;
         assert!(parse_line_str(&mut parser, line).is_none());
+        assert!(
+            parser.pending_assistant_uuid.is_none(),
+            "missing message.id must leave pending_assistant_uuid empty"
+        );
+    }
+
+    #[test]
+    fn parse_assistant_with_id_captures_pending_uuid() {
+        // Regression: the parser must stash `message.id` when seeing an
+        // `assistant` event so the next `Result` commits it.
+        let mut parser = StreamParser::new();
+        let line = r#"{"type":"assistant","message":{"id":"msg_abc123","role":"assistant","content":[]}}"#;
+        let chunks = parse_line_all_str(&mut parser, line);
+        assert!(chunks.is_empty(), "assistant event must not emit chunks");
+        assert_eq!(parser.pending_assistant_uuid.as_deref(), Some("msg_abc123"));
+    }
+
+    #[test]
+    fn result_commits_pending_assistant_uuid_and_clears_it() {
+        // The assistant UUID seen before a Result commits ONTO that Result
+        // (ADR-046: atomic commit on turn completion) and is cleared so the
+        // next turn doesn't recycle a stale id.
+        let mut parser = StreamParser::new();
+        let assistant =
+            r#"{"type":"assistant","message":{"id":"msg_turn1","role":"assistant","content":[]}}"#;
+        let result = r#"{"type":"result","session_id":"550e8400-e29b-41d4-a716-446655440000","total_cost_usd":0.01,"usage":{"input_tokens":1,"output_tokens":1},"is_error":false,"result":""}"#;
+
+        parse_line_str(&mut parser, assistant);
+        let chunk = parse_line_str(&mut parser, result).unwrap();
+        match chunk {
+            StreamChunk::Result { assistant_uuid, .. } => {
+                assert_eq!(assistant_uuid.as_deref(), Some("msg_turn1"));
+            }
+            other => panic!("expected Result, got {other:?}"),
+        }
+
+        // Fresh turn: Result with no preceding assistant must have None.
+        parser.reset();
+        let result2 = r#"{"type":"result","session_id":"550e8400-e29b-41d4-a716-446655440000","total_cost_usd":0.01,"is_error":false,"result":""}"#;
+        let chunk = parse_line_str(&mut parser, result2).unwrap();
+        match chunk {
+            StreamChunk::Result { assistant_uuid, .. } => {
+                assert!(assistant_uuid.is_none(), "stale uuid must not survive reset");
+            }
+            other => panic!("expected Result, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn assistant_uuid_does_not_leak_into_error_result() {
+        // An error turn also `take`s the pending UUID so a subsequent
+        // successful turn that arrives without its own `assistant` event
+        // (an edge protocol) cannot be mislabeled with the errored turn's
+        // identity.
+        let mut parser = StreamParser::new();
+        let assistant =
+            r#"{"type":"assistant","message":{"id":"msg_err","role":"assistant","content":[]}}"#;
+        let error_result =
+            r#"{"type":"result","is_error":true,"result":"something broke"}"#;
+        parse_line_str(&mut parser, assistant);
+        let chunk = parse_line_str(&mut parser, error_result).unwrap();
+        assert!(matches!(chunk, StreamChunk::Error { .. }));
+        // pending_assistant_uuid stays set here because `parse_result`
+        // short-circuits on `is_error=true`; the stdout-reader loop calls
+        // `parser.reset()` after every terminal chunk which clears it. The
+        // reset() is exercised explicitly to prove the clear happens.
+        parser.reset();
+        assert!(parser.pending_assistant_uuid.is_none());
+    }
+
+    #[test]
+    fn user_message_with_text_and_id_emits_user_message_commit() {
+        let mut parser = StreamParser::new();
+        let line = r#"{"type":"user","message":{"id":"u_hello","role":"user","content":[{"type":"text","text":"hello"}]}}"#;
+        let chunks = parse_line_all_str(&mut parser, line);
+        assert_eq!(chunks.len(), 1);
+        match &chunks[0] {
+            StreamChunk::UserMessageCommit { uuid } => assert_eq!(uuid, "u_hello"),
+            other => panic!("expected UserMessageCommit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn user_message_tool_result_does_not_emit_commit() {
+        // Tool-result wrappers carry a user role but must NOT commit a
+        // retry-point UUID — they're not real user prompts.
+        let mut parser = StreamParser::new();
+        let line = r#"{"type":"user","message":{"id":"u_tr","role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"}]}}"#;
+        let chunks = parse_line_all_str(&mut parser, line);
+        assert_eq!(chunks.len(), 1);
+        assert!(matches!(&chunks[0], StreamChunk::ToolResult { .. }));
+    }
+
+    #[test]
+    fn user_message_commit_is_emitted_exactly_once() {
+        // Duplicate user messages (observed on retry/resume) must not
+        // emit the commit twice — only the first occurrence wins.
+        let mut parser = StreamParser::new();
+        let line = r#"{"type":"user","message":{"id":"u_once","role":"user","content":[{"type":"text","text":"hi"}]}}"#;
+        assert_eq!(parse_line_all_str(&mut parser, line).len(), 1);
+        assert_eq!(
+            parse_line_all_str(&mut parser, line).len(),
+            0,
+            "second occurrence of same user UUID must not re-emit"
+        );
+    }
+
+    #[test]
+    fn user_message_without_id_is_silent() {
+        let mut parser = StreamParser::new();
+        let line = r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}"#;
+        assert!(parse_line_all_str(&mut parser, line).is_empty());
+    }
+
+    #[test]
+    fn user_message_commit_survives_reset() {
+        // Across a turn boundary (reset), a previously-committed user UUID
+        // must stay in the dedup set — otherwise the re-echoed prompt on a
+        // resume would commit a second time.
+        let mut parser = StreamParser::new();
+        let line = r#"{"type":"user","message":{"id":"u_persist","role":"user","content":[{"type":"text","text":"hi"}]}}"#;
+        assert_eq!(parse_line_all_str(&mut parser, line).len(), 1);
+        parser.reset();
+        assert_eq!(
+            parse_line_all_str(&mut parser, line).len(),
+            0,
+            "reset must not clear committed_user_uuids"
+        );
     }
 
     #[test]
@@ -2075,7 +2383,8 @@ mod tests {
         let mut parser = StreamParser::new();
         let line = r#"{"type":"rate_limit_event","rate_limit_info":{"status":"allowed_warning","utilization":73.5,"resets_at":1738425600}}"#;
         let parsed: serde_json::Value = serde_json::from_str(line).unwrap();
-        let (chunk, log_entry) = parser.parse_line(&parsed);
+        let (chunks, log_entry) = parser.parse_line(&parsed);
+        let chunk = chunks.into_iter().next();
         match chunk {
             Some(StreamChunk::RateLimit {
                 status,
@@ -2098,7 +2407,8 @@ mod tests {
         let mut parser = StreamParser::new();
         let line = r#"{"type":"rate_limit_event","rate_limit_info":{"status":"allowed"}}"#;
         let parsed: serde_json::Value = serde_json::from_str(line).unwrap();
-        let (chunk, _) = parser.parse_line(&parsed);
+        let (chunks, _) = parser.parse_line(&parsed);
+        let chunk = chunks.into_iter().next();
         match chunk {
             Some(StreamChunk::RateLimit {
                 status,
@@ -2118,7 +2428,8 @@ mod tests {
         let mut parser = StreamParser::new();
         let line = r#"{"type":"rate_limit_event","rate_limit_info":{"status":"rejected","utilization":100.0,"resets_at":1738430000}}"#;
         let parsed: serde_json::Value = serde_json::from_str(line).unwrap();
-        let (chunk, _) = parser.parse_line(&parsed);
+        let (chunks, _) = parser.parse_line(&parsed);
+        let chunk = chunks.into_iter().next();
         match chunk {
             Some(StreamChunk::RateLimit {
                 status,
@@ -2210,24 +2521,42 @@ mod tests {
 
     #[test]
     fn build_claude_args_without_resume() {
-        let args = build_claude_args(None, &[]);
+        let args = build_claude_args(None, None, &[]);
         assert!(args.contains(&consts::CLAUDE_BINARY.to_string()));
         assert!(args.contains(&"-p".to_string()));
         assert!(!args.contains(&"--resume".to_string()));
+        assert!(!args.contains(&"--resume-session-at".to_string()));
         assert!(args.contains(&"--permission-prompt-tool".to_string()));
     }
 
     #[test]
     fn build_claude_args_with_resume() {
         let id = "550e8400-e29b-41d4-a716-446655440000";
-        let args = build_claude_args(Some(id), &[]);
+        let args = build_claude_args(Some(id), None, &[]);
         let resume_pos = args.iter().position(|a| a == "--resume").unwrap();
         assert_eq!(args[resume_pos + 1], id);
+        assert!(!args.contains(&"--resume-session-at".to_string()));
+    }
+
+    #[test]
+    fn build_claude_args_with_resume_and_uuid() {
+        // ADR-046: retry uses `--resume <session>` + `--resume-session-at <uuid>`.
+        let session = "550e8400-e29b-41d4-a716-446655440000";
+        let uuid = "msg_retry_anchor";
+        let args = build_claude_args(Some(session), Some(uuid), &[]);
+        let resume_pos = args.iter().position(|a| a == "--resume").unwrap();
+        assert_eq!(args[resume_pos + 1], session);
+        let at_pos = args
+            .iter()
+            .position(|a| a == "--resume-session-at")
+            .expect("--resume-session-at must be present");
+        assert_eq!(args[at_pos + 1], uuid);
     }
 
     #[test]
     fn build_claude_args_includes_flags() {
-        let args = build_claude_args(None, &["--dangerously-skip-permissions".to_string()]);
+        let args =
+            build_claude_args(None, None, &["--dangerously-skip-permissions".to_string()]);
         assert!(args.contains(&"--dangerously-skip-permissions".to_string()));
     }
 
@@ -2660,7 +2989,7 @@ mod tests {
 
     #[test]
     fn build_claude_args_includes_permission_prompt_tool() {
-        let args = build_claude_args(None, &[]);
+        let args = build_claude_args(None, None, &[]);
         let pos = args
             .iter()
             .position(|a| a == "--permission-prompt-tool")
@@ -2670,17 +2999,17 @@ mod tests {
 
     // ── Control request fixture test ────────────────────────────────
 
-    // ── prepare_start tests ─────────────────────────────────────────
+    // ── prepare_args tests ──────────────────────────────────────────
 
     #[test]
-    fn prepare_start_fails_when_project_not_in_config() {
+    fn prepare_args_fails_when_project_not_in_config() {
         let user_config = config::SpeedwaveUserConfig {
             projects: vec![],
             active_project: None,
             selected_ide: None,
             log_level: None,
         };
-        let result = ChatSession::prepare_start("nonexistent", &user_config, None);
+        let result = ChatSession::prepare_args("nonexistent", &user_config, None, None);
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
         assert!(
@@ -2690,7 +3019,7 @@ mod tests {
     }
 
     #[test]
-    fn prepare_start_fails_with_invalid_resume_session_id() {
+    fn prepare_args_fails_with_invalid_resume_session_id() {
         let user_config = config::SpeedwaveUserConfig {
             projects: vec![config::ProjectUserEntry {
                 name: "test".to_string(),
@@ -2703,12 +3032,40 @@ mod tests {
             selected_ide: None,
             log_level: None,
         };
-        let result = ChatSession::prepare_start("test", &user_config, Some("../../../etc/passwd"));
+        let result = ChatSession::prepare_args(
+            "test",
+            &user_config,
+            Some("../../../etc/passwd"),
+            None,
+        );
         assert!(result.is_err());
     }
 
     #[test]
-    fn prepare_start_succeeds_with_valid_project() {
+    fn prepare_args_fails_with_malformed_retry_uuid() {
+        let user_config = config::SpeedwaveUserConfig {
+            projects: vec![config::ProjectUserEntry {
+                name: "test".to_string(),
+                dir: "/tmp/test".to_string(),
+                claude: None,
+                integrations: None,
+                plugin_settings: None,
+            }],
+            active_project: None,
+            selected_ide: None,
+            log_level: None,
+        };
+        let result = ChatSession::prepare_args(
+            "test",
+            &user_config,
+            Some("550e8400-e29b-41d4-a716-446655440000"),
+            Some("$(rm -rf /)"),
+        );
+        assert!(result.is_err(), "shell-injection uuid must be rejected");
+    }
+
+    #[test]
+    fn prepare_args_succeeds_with_valid_project() {
         let user_config = config::SpeedwaveUserConfig {
             projects: vec![config::ProjectUserEntry {
                 name: "myproject".to_string(),
@@ -2721,7 +3078,7 @@ mod tests {
             selected_ide: None,
             log_level: None,
         };
-        let result = ChatSession::prepare_start("myproject", &user_config, None);
+        let result = ChatSession::prepare_args("myproject", &user_config, None, None);
         assert!(result.is_ok());
         let (args, container) = result.unwrap();
         assert!(args.contains(&"-p".to_string()));
@@ -2729,7 +3086,7 @@ mod tests {
     }
 
     #[test]
-    fn prepare_start_with_resume_includes_resume_flag() {
+    fn prepare_args_with_resume_includes_resume_flag() {
         let user_config = config::SpeedwaveUserConfig {
             projects: vec![config::ProjectUserEntry {
                 name: "proj".to_string(),
@@ -2743,11 +3100,79 @@ mod tests {
             log_level: None,
         };
         let session_id = "550e8400-e29b-41d4-a716-446655440000";
-        let result = ChatSession::prepare_start("proj", &user_config, Some(session_id));
+        let result = ChatSession::prepare_args("proj", &user_config, Some(session_id), None);
         assert!(result.is_ok());
         let (args, _container) = result.unwrap();
         assert!(args.contains(&"--resume".to_string()));
         assert!(args.contains(&session_id.to_string()));
+        assert!(!args.contains(&"--resume-session-at".to_string()));
+    }
+
+    #[test]
+    fn prepare_args_with_retry_uuid_includes_resume_session_at_flag() {
+        let user_config = config::SpeedwaveUserConfig {
+            projects: vec![config::ProjectUserEntry {
+                name: "proj".to_string(),
+                dir: "/tmp/proj".to_string(),
+                claude: None,
+                integrations: None,
+                plugin_settings: None,
+            }],
+            active_project: None,
+            selected_ide: None,
+            log_level: None,
+        };
+        let session_id = "550e8400-e29b-41d4-a716-446655440000";
+        let uuid = "msg_retry_me";
+        let result =
+            ChatSession::prepare_args("proj", &user_config, Some(session_id), Some(uuid));
+        assert!(result.is_ok());
+        let (args, _) = result.unwrap();
+        assert!(args.contains(&"--resume-session-at".to_string()));
+        assert!(args.contains(&uuid.to_string()));
+    }
+
+    // ── validate_retry_uuid ──────────────────────────────────────────
+
+    #[test]
+    fn validate_retry_uuid_accepts_api_msg_ids() {
+        assert!(validate_retry_uuid("msg_01ABCdef_123").is_ok());
+    }
+
+    #[test]
+    fn validate_retry_uuid_accepts_uuid_v4() {
+        assert!(validate_retry_uuid("550e8400-e29b-41d4-a716-446655440000").is_ok());
+    }
+
+    #[test]
+    fn validate_retry_uuid_rejects_empty() {
+        assert!(validate_retry_uuid("").is_err());
+    }
+
+    #[test]
+    fn validate_retry_uuid_rejects_shell_metachars() {
+        for bad in ["a;b", "a b", "a|b", "`id`", "a$b", "a&b", "a'b", "a\"b"] {
+            assert!(
+                validate_retry_uuid(bad).is_err(),
+                "must reject shell-injection uuid: {bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_retry_uuid_rejects_path_traversal() {
+        for bad in ["../x", "a/b", "a\\b"] {
+            assert!(
+                validate_retry_uuid(bad).is_err(),
+                "must reject path-traversal uuid: {bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_retry_uuid_rejects_overlong() {
+        let too_long = "a".repeat(129);
+        assert!(validate_retry_uuid(&too_long).is_err());
     }
 
     // ── Silent failure prevention tests ──────────────────────────────
@@ -2931,6 +3356,7 @@ mod tests {
             usage: None,
             result_text: None,
             context_window_size: None,
+            assistant_uuid: None,
         };
         let json = serde_json::to_string(&chunk).unwrap();
         assert!(
@@ -2940,6 +3366,10 @@ mod tests {
         assert!(
             !json.contains("context_window_size"),
             "context_window_size should be absent when None, got: {json}"
+        );
+        assert!(
+            !json.contains("assistant_uuid"),
+            "assistant_uuid should be absent when None, got: {json}"
         );
     }
 
@@ -2951,6 +3381,7 @@ mod tests {
             usage: None,
             result_text: None,
             context_window_size: Some(1_000_000),
+            assistant_uuid: None,
         };
         let json = serde_json::to_string(&chunk).unwrap();
         assert!(

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -27,6 +27,7 @@ mod oauth_cmd;
 mod plugin_cmd;
 mod reconcile;
 mod redmine_api_cmd;
+mod retry_cmd;
 mod setup_wizard;
 mod tray;
 mod types;
@@ -1360,6 +1361,7 @@ fn main() {
             send_message,
             answer_question,
             stop_chat,
+            retry_cmd::retry_last_turn,
             // Chat history
             list_conversations,
             get_conversation,

--- a/desktop/src-tauri/src/retry_cmd.rs
+++ b/desktop/src-tauri/src/retry_cmd.rs
@@ -44,8 +44,6 @@ pub enum RetryError {
     PendingAssistant,
     /// The given session id is not known or malformed.
     SessionNotFound,
-    /// Another turn is currently streaming — retry would race with it.
-    Streaming,
     /// Spawning Claude Code with `--resume-session-at` failed.
     ResumeFailed(String),
 }
@@ -56,7 +54,6 @@ impl std::fmt::Display for RetryError {
             Self::NoAssistantTurn => write!(f, "no assistant turn to retry"),
             Self::PendingAssistant => write!(f, "last assistant turn is still streaming"),
             Self::SessionNotFound => write!(f, "session id not found or invalid"),
-            Self::Streaming => write!(f, "another turn is currently streaming"),
             Self::ResumeFailed(msg) => write!(f, "failed to spawn resume: {msg}"),
         }
     }
@@ -157,17 +154,6 @@ pub async fn retry_last_turn(
     })
     .await
     .map_err(|e| RetryError::ResumeFailed(format!("join error: {e}")))?
-}
-
-/// Helper used by the Tauri command's driver to read the project name out of
-/// a locked `ChatSession`. Defined as a free function on `ChatSession` via a
-/// dedicated accessor in `chat.rs`.
-///
-/// Exposed as a test hook: the trait `SessionDriver` remains the preferred
-/// test seam for new code.
-#[allow(dead_code)]
-pub(crate) fn _project_name_for_driver(arc: &Arc<Mutex<ChatSession>>) -> Option<String> {
-    arc.lock().ok().map(|g| g.project_name().to_string())
 }
 
 #[cfg(test)]
@@ -302,7 +288,7 @@ mod tests {
 
     #[test]
     fn retry_error_round_trips() {
-        let original = RetryError::Streaming;
+        let original = RetryError::PendingAssistant;
         let json = serde_json::to_string(&original).unwrap();
         let decoded: RetryError = serde_json::from_str(&json).unwrap();
         assert_eq!(decoded, original);

--- a/desktop/src-tauri/src/retry_cmd.rs
+++ b/desktop/src-tauri/src/retry_cmd.rs
@@ -17,13 +17,6 @@
 //! Errors are serialised as a tagged `RetryError` enum so the frontend can
 //! react (disable the button, show a banner, prompt re-auth, …) without
 //! string-matching error messages.
-//!
-//! The `PendingAssistant` variant is reserved for when the state-tree
-//! backbone from Unit 2 has merged — at that point the backend verifies the
-//! last assistant entry is `Committed` before spawning. Until then, the
-//! frontend's `canRetry` signal guards against retrying a pending assistant.
-
-use std::sync::{Arc, Mutex};
 
 use serde::{Deserialize, Serialize};
 use tauri::AppHandle;
@@ -40,8 +33,6 @@ use crate::history::validate_session_id;
 pub enum RetryError {
     /// The conversation has no assistant turn yet — retry is meaningless.
     NoAssistantTurn,
-    /// The latest assistant entry is still streaming (pending Result).
-    PendingAssistant,
     /// The given session id is not known or malformed.
     SessionNotFound,
     /// Spawning Claude Code with `--resume-session-at` failed.
@@ -52,7 +43,6 @@ impl std::fmt::Display for RetryError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::NoAssistantTurn => write!(f, "no assistant turn to retry"),
-            Self::PendingAssistant => write!(f, "last assistant turn is still streaming"),
             Self::SessionNotFound => write!(f, "session id not found or invalid"),
             Self::ResumeFailed(msg) => write!(f, "failed to spawn resume: {msg}"),
         }
@@ -183,11 +173,7 @@ mod tests {
                 None => Ok(()),
             }
         }
-        fn start_with_retry(
-            &mut self,
-            session_id: &str,
-            user_uuid: &str,
-        ) -> Result<(), String> {
+        fn start_with_retry(&mut self, session_id: &str, user_uuid: &str) -> Result<(), String> {
             self.start_calls
                 .push((session_id.to_string(), user_uuid.to_string()));
             match &self.start_err {
@@ -221,7 +207,10 @@ mod tests {
         let mut drv = MockDriver::default();
         let r = retry_last_turn_inner("not-a-uuid", VALID_UUID, &mut drv);
         assert_eq!(r, Err(RetryError::SessionNotFound));
-        assert_eq!(drv.stop_calls, 0, "stop must not be called on invalid input");
+        assert_eq!(
+            drv.stop_calls, 0,
+            "stop must not be called on invalid input"
+        );
         assert!(drv.start_calls.is_empty());
     }
 
@@ -263,7 +252,10 @@ mod tests {
         let r = retry_last_turn_inner(VALID_SESSION, VALID_UUID, &mut drv);
         assert!(matches!(r, Err(RetryError::ResumeFailed(m)) if m.contains("stop boom")));
         assert_eq!(drv.stop_calls, 1);
-        assert!(drv.start_calls.is_empty(), "start must not run after stop failure");
+        assert!(
+            drv.start_calls.is_empty(),
+            "start must not run after stop failure"
+        );
     }
 
     #[test]
@@ -273,9 +265,7 @@ mod tests {
             ..Default::default()
         };
         let r = retry_last_turn_inner(VALID_SESSION, VALID_UUID, &mut drv);
-        assert!(
-            matches!(r, Err(RetryError::ResumeFailed(m)) if m.contains("nerdctl exec failed"))
-        );
+        assert!(matches!(r, Err(RetryError::ResumeFailed(m)) if m.contains("nerdctl exec failed")));
         assert_eq!(drv.stop_calls, 1);
         assert_eq!(drv.start_calls.len(), 1);
     }
@@ -293,10 +283,18 @@ mod tests {
 
     #[test]
     fn retry_error_round_trips() {
-        let original = RetryError::PendingAssistant;
-        let json = serde_json::to_string(&original).unwrap();
-        let decoded: RetryError = serde_json::from_str(&json).unwrap();
-        assert_eq!(decoded, original);
+        // Round-trip every variant to prove the serde tag/content layout is
+        // stable for the frontend kind-matching.
+        let cases = [
+            RetryError::NoAssistantTurn,
+            RetryError::SessionNotFound,
+            RetryError::ResumeFailed("boom".into()),
+        ];
+        for original in cases {
+            let json = serde_json::to_string(&original).unwrap();
+            let decoded: RetryError = serde_json::from_str(&json).unwrap();
+            assert_eq!(decoded, original);
+        }
     }
 
     // ── State invariant: file checksum ──────────────────────────────

--- a/desktop/src-tauri/src/retry_cmd.rs
+++ b/desktop/src-tauri/src/retry_cmd.rs
@@ -1,0 +1,329 @@
+//! Tauri command — retry the last assistant turn via Claude Code's native
+//! `--resume-session-at` flag (ADR-046).
+//!
+//! The frontend owns the conversation state-tree (until Unit 2's patch-based
+//! backbone lands) and passes the retry anchor explicitly: the current
+//! `session_id` and the UUID of the user prompt to rewind to. The backend
+//! does not mutate the session JSONL file — Claude Code's native resume
+//! handles the trim-and-regenerate atomically.
+//!
+//! Flow:
+//! 1. Validate the session id and user UUID.
+//! 2. Swap the live `ChatSession` out of its mutex so `stop()` runs without
+//!    starving other commands.
+//! 3. Stop the old session (kills the child, drains reader threads).
+//! 4. Start a new session with `--resume <session> --resume-session-at <uuid>`.
+//!
+//! Errors are serialised as a tagged `RetryError` enum so the frontend can
+//! react (disable the button, show a banner, prompt re-auth, …) without
+//! string-matching error messages.
+//!
+//! The `PendingAssistant` variant is reserved for when the state-tree
+//! backbone from Unit 2 has merged — at that point the backend verifies the
+//! last assistant entry is `Committed` before spawning. Until then, the
+//! frontend's `canRetry` signal guards against retrying a pending assistant.
+
+use std::sync::{Arc, Mutex};
+
+use serde::{Deserialize, Serialize};
+use tauri::AppHandle;
+
+use crate::chat::{validate_retry_uuid, ChatSession, SharedChatSession};
+use crate::history::validate_session_id;
+
+/// Errors surfaced to the frontend from `retry_last_turn`.
+///
+/// Serialised as a tagged enum (`{ "kind": "NoAssistantTurn" }` etc.) so the
+/// frontend can match on the kind field without inspecting messages.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(tag = "kind", content = "message")]
+pub enum RetryError {
+    /// The conversation has no assistant turn yet — retry is meaningless.
+    NoAssistantTurn,
+    /// The latest assistant entry is still streaming (pending Result).
+    PendingAssistant,
+    /// The given session id is not known or malformed.
+    SessionNotFound,
+    /// Another turn is currently streaming — retry would race with it.
+    Streaming,
+    /// Spawning Claude Code with `--resume-session-at` failed.
+    ResumeFailed(String),
+}
+
+impl std::fmt::Display for RetryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoAssistantTurn => write!(f, "no assistant turn to retry"),
+            Self::PendingAssistant => write!(f, "last assistant turn is still streaming"),
+            Self::SessionNotFound => write!(f, "session id not found or invalid"),
+            Self::Streaming => write!(f, "another turn is currently streaming"),
+            Self::ResumeFailed(msg) => write!(f, "failed to spawn resume: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for RetryError {}
+
+/// Pure core of `retry_last_turn` — does not touch Tauri types.
+///
+/// Extracted so unit tests can exercise the validation/stop/spawn sequence
+/// against a mocked `ChatSession` layer via the `SessionDriver` trait below.
+pub(crate) fn retry_last_turn_inner(
+    session_id: &str,
+    user_uuid: &str,
+    driver: &mut dyn SessionDriver,
+) -> Result<(), RetryError> {
+    if validate_session_id(session_id).is_err() {
+        return Err(RetryError::SessionNotFound);
+    }
+    if validate_retry_uuid(user_uuid).is_err() {
+        return Err(RetryError::NoAssistantTurn);
+    }
+
+    driver.stop().map_err(RetryError::ResumeFailed)?;
+    driver
+        .start_with_retry(session_id, user_uuid)
+        .map_err(RetryError::ResumeFailed)?;
+    Ok(())
+}
+
+/// Driver abstraction over the session lifecycle, for tests.
+pub(crate) trait SessionDriver {
+    fn stop(&mut self) -> Result<(), String>;
+    fn start_with_retry(&mut self, session_id: &str, user_uuid: &str) -> Result<(), String>;
+}
+
+/// Real driver backed by [`ChatSession`]. Swaps the session out of its mutex
+/// so `stop()` (which can block on reader-thread drain) does not starve
+/// `send_message` and friends.
+struct ChatSessionDriver<'a> {
+    session_arc: SharedChatSession,
+    project_name: Option<String>,
+    app_handle: &'a AppHandle,
+}
+
+impl SessionDriver for ChatSessionDriver<'_> {
+    fn stop(&mut self) -> Result<(), String> {
+        let mut old = {
+            let mut guard = self
+                .session_arc
+                .lock()
+                .map_err(|e| format!("session lock poisoned: {e}"))?;
+            let project_name = guard.project_name().to_string();
+            self.project_name = Some(project_name.clone());
+            std::mem::replace(&mut *guard, ChatSession::new(&project_name))
+        };
+        old.stop().map_err(|e| e.to_string())?;
+        drop(old);
+        Ok(())
+    }
+
+    fn start_with_retry(&mut self, session_id: &str, user_uuid: &str) -> Result<(), String> {
+        let mut session = self
+            .session_arc
+            .lock()
+            .map_err(|e| format!("session lock poisoned: {e}"))?;
+        session
+            .start_with_retry(self.app_handle.clone(), Some(session_id), Some(user_uuid))
+            .map_err(|e| e.to_string())
+    }
+}
+
+/// Tauri command — retry the last assistant turn in the active session.
+///
+/// The frontend passes the `session_id` of the current conversation and
+/// `user_uuid` of the user message to rewind to (ADR-046). On success, a
+/// fresh Claude Code spawn starts streaming a replacement turn via the
+/// usual `chat_stream` event channel.
+#[tauri::command]
+pub async fn retry_last_turn(
+    session_id: String,
+    user_uuid: String,
+    app_handle: AppHandle,
+    state: tauri::State<'_, SharedChatSession>,
+) -> Result<(), RetryError> {
+    log::info!(
+        "retry_last_turn: session={session_id} user_uuid_len={}",
+        user_uuid.len()
+    );
+    let session_arc = state.inner().clone();
+    tokio::task::spawn_blocking(move || {
+        let mut driver = ChatSessionDriver {
+            session_arc,
+            project_name: None,
+            app_handle: &app_handle,
+        };
+        retry_last_turn_inner(&session_id, &user_uuid, &mut driver)
+    })
+    .await
+    .map_err(|e| RetryError::ResumeFailed(format!("join error: {e}")))?
+}
+
+/// Helper used by the Tauri command's driver to read the project name out of
+/// a locked `ChatSession`. Defined as a free function on `ChatSession` via a
+/// dedicated accessor in `chat.rs`.
+///
+/// Exposed as a test hook: the trait `SessionDriver` remains the preferred
+/// test seam for new code.
+#[allow(dead_code)]
+pub(crate) fn _project_name_for_driver(arc: &Arc<Mutex<ChatSession>>) -> Option<String> {
+    arc.lock().ok().map(|g| g.project_name().to_string())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    /// Canned driver that records calls for assertion.
+    #[derive(Default)]
+    struct MockDriver {
+        stop_calls: u32,
+        start_calls: Vec<(String, String)>,
+        stop_err: Option<String>,
+        start_err: Option<String>,
+    }
+
+    impl SessionDriver for MockDriver {
+        fn stop(&mut self) -> Result<(), String> {
+            self.stop_calls += 1;
+            match &self.stop_err {
+                Some(e) => Err(e.clone()),
+                None => Ok(()),
+            }
+        }
+        fn start_with_retry(
+            &mut self,
+            session_id: &str,
+            user_uuid: &str,
+        ) -> Result<(), String> {
+            self.start_calls
+                .push((session_id.to_string(), user_uuid.to_string()));
+            match &self.start_err {
+                Some(e) => Err(e.clone()),
+                None => Ok(()),
+            }
+        }
+    }
+
+    const VALID_SESSION: &str = "550e8400-e29b-41d4-a716-446655440000";
+    const VALID_UUID: &str = "msg_01ABCdef";
+
+    // ── Happy path ──────────────────────────────────────────────────
+
+    #[test]
+    fn retry_happy_path_stops_then_starts_with_retry() {
+        let mut drv = MockDriver::default();
+        let r = retry_last_turn_inner(VALID_SESSION, VALID_UUID, &mut drv);
+        assert!(r.is_ok(), "expected Ok, got {r:?}");
+        assert_eq!(drv.stop_calls, 1);
+        assert_eq!(
+            drv.start_calls,
+            vec![(VALID_SESSION.to_string(), VALID_UUID.to_string())]
+        );
+    }
+
+    // ── Error paths ─────────────────────────────────────────────────
+
+    #[test]
+    fn retry_with_invalid_session_returns_session_not_found() {
+        let mut drv = MockDriver::default();
+        let r = retry_last_turn_inner("not-a-uuid", VALID_UUID, &mut drv);
+        assert_eq!(r, Err(RetryError::SessionNotFound));
+        assert_eq!(drv.stop_calls, 0, "stop must not be called on invalid input");
+        assert!(drv.start_calls.is_empty());
+    }
+
+    #[test]
+    fn retry_with_empty_session_returns_session_not_found() {
+        let mut drv = MockDriver::default();
+        let r = retry_last_turn_inner("", VALID_UUID, &mut drv);
+        assert_eq!(r, Err(RetryError::SessionNotFound));
+        assert_eq!(drv.stop_calls, 0);
+    }
+
+    #[test]
+    fn retry_with_empty_uuid_returns_no_assistant_turn() {
+        // An empty UUID in this architecture means the frontend tried to
+        // retry without a committed user UUID — which the `canRetry` signal
+        // should have prevented, but we belt-and-brace it on the backend.
+        let mut drv = MockDriver::default();
+        let r = retry_last_turn_inner(VALID_SESSION, "", &mut drv);
+        assert_eq!(r, Err(RetryError::NoAssistantTurn));
+        assert_eq!(drv.stop_calls, 0);
+    }
+
+    #[test]
+    fn retry_with_malformed_uuid_returns_no_assistant_turn() {
+        let mut drv = MockDriver::default();
+        let r = retry_last_turn_inner(VALID_SESSION, "foo; rm -rf /", &mut drv);
+        assert_eq!(r, Err(RetryError::NoAssistantTurn));
+        assert_eq!(drv.stop_calls, 0);
+    }
+
+    #[test]
+    fn retry_stop_failure_returns_resume_failed_without_start() {
+        // If stop fails we MUST NOT proceed to start — otherwise the old
+        // child could race stdout with the new one.
+        let mut drv = MockDriver {
+            stop_err: Some("stop boom".to_string()),
+            ..Default::default()
+        };
+        let r = retry_last_turn_inner(VALID_SESSION, VALID_UUID, &mut drv);
+        assert!(matches!(r, Err(RetryError::ResumeFailed(m)) if m.contains("stop boom")));
+        assert_eq!(drv.stop_calls, 1);
+        assert!(drv.start_calls.is_empty(), "start must not run after stop failure");
+    }
+
+    #[test]
+    fn retry_start_failure_propagates_resume_failed() {
+        let mut drv = MockDriver {
+            start_err: Some("nerdctl exec failed".to_string()),
+            ..Default::default()
+        };
+        let r = retry_last_turn_inner(VALID_SESSION, VALID_UUID, &mut drv);
+        assert!(
+            matches!(r, Err(RetryError::ResumeFailed(m)) if m.contains("nerdctl exec failed"))
+        );
+        assert_eq!(drv.stop_calls, 1);
+        assert_eq!(drv.start_calls.len(), 1);
+    }
+
+    // ── RetryError serialisation ────────────────────────────────────
+
+    #[test]
+    fn retry_error_serialises_as_tagged_kind() {
+        let v = serde_json::to_value(RetryError::NoAssistantTurn).unwrap();
+        assert_eq!(v["kind"], "NoAssistantTurn");
+        let v = serde_json::to_value(RetryError::ResumeFailed("bad".into())).unwrap();
+        assert_eq!(v["kind"], "ResumeFailed");
+        assert_eq!(v["message"], "bad");
+    }
+
+    #[test]
+    fn retry_error_round_trips() {
+        let original = RetryError::Streaming;
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: RetryError = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, original);
+    }
+
+    // ── State invariant: file checksum ──────────────────────────────
+
+    #[test]
+    fn retry_does_not_open_session_jsonl_in_mock_driver() {
+        // The mock driver never touches disk. This test documents the
+        // contract: retry_last_turn_inner does NOT interact with the
+        // session JSONL file directly — file mutation is delegated to
+        // Claude Code's native `--resume-session-at` flag (ADR-046).
+        //
+        // An E2E test in `desktop-e2e/` checksums the file before/after
+        // and asserts equality against the pre-retry state. This unit
+        // test stands as a type-level guard against future changes that
+        // might sneak in fs::File::open calls.
+        let mut drv = MockDriver::default();
+        let r = retry_last_turn_inner(VALID_SESSION, VALID_UUID, &mut drv);
+        assert!(r.is_ok());
+        assert_eq!(drv.stop_calls, 1);
+    }
+}

--- a/desktop/src-tauri/src/retry_cmd.rs
+++ b/desktop/src-tauri/src/retry_cmd.rs
@@ -139,8 +139,13 @@ pub async fn retry_last_turn(
     app_handle: AppHandle,
     state: tauri::State<'_, SharedChatSession>,
 ) -> Result<(), RetryError> {
+    // Log only a short prefix of the session id to address CodeQL
+    // 'cleartext-logging': the desktop log file is readable by any
+    // process running as the same user, so a full UUID lets a co-resident
+    // process resume an arbitrary session.
     log::info!(
-        "retry_last_turn: session={session_id} user_uuid_len={}",
+        "retry_last_turn: session_prefix={} user_uuid_len={}",
+        &session_id[..8.min(session_id.len())],
         user_uuid.len()
     );
     let session_arc = state.inner().clone();

--- a/desktop/src/src/app/chat/chat.component.html
+++ b/desktop/src/src/app/chat/chat.component.html
@@ -73,6 +73,7 @@
           [messages]="chat.messages"
           [currentBlocks]="chat.currentBlocks"
           [isStreaming]="chat.isStreaming"
+          [lastAssistantIndex]="lastAssistantIndex"
           (questionAnswered)="onQuestionAnswered($event)"
         />
         <app-session-stats [stats]="chat.sessionStats" />

--- a/desktop/src/src/app/chat/chat.component.spec.ts
+++ b/desktop/src/src/app/chat/chat.component.spec.ts
@@ -1119,4 +1119,59 @@ describe('ChatComponent', () => {
       expect(spy).not.toHaveBeenCalled();
     });
   });
+
+  // ── isLastAssistant: O(1) cached lookup ────────────────────────────────────
+
+  describe('isLastAssistant', () => {
+    it('returns false when there are no messages', () => {
+      chatState.loadMessages([]);
+      expect(component.isLastAssistant(0)).toBe(false);
+    });
+
+    it('returns true for the most recent assistant message', () => {
+      chatState.loadMessages([
+        { role: 'user', blocks: [{ type: 'text', content: 'hi' }], timestamp: 1 },
+        { role: 'assistant', blocks: [{ type: 'text', content: 'A1' }], timestamp: 2 },
+        { role: 'user', blocks: [{ type: 'text', content: 'next' }], timestamp: 3 },
+        { role: 'assistant', blocks: [{ type: 'text', content: 'A2' }], timestamp: 4 },
+      ]);
+      expect(component.isLastAssistant(3)).toBe(true);
+      expect(component.isLastAssistant(1)).toBe(false);
+    });
+
+    it('returns false for non-assistant rows even at the tail', () => {
+      chatState.loadMessages([
+        { role: 'assistant', blocks: [{ type: 'text', content: 'A1' }], timestamp: 1 },
+        { role: 'user', blocks: [{ type: 'text', content: 'after' }], timestamp: 2 },
+      ]);
+      expect(component.isLastAssistant(0)).toBe(true);
+      expect(component.isLastAssistant(1)).toBe(false);
+    });
+
+    it('returns false for every row when no assistant message exists', () => {
+      chatState.loadMessages([
+        { role: 'user', blocks: [{ type: 'text', content: 'q1' }], timestamp: 1 },
+        { role: 'user', blocks: [{ type: 'text', content: 'q2' }], timestamp: 2 },
+      ]);
+      expect(component.isLastAssistant(0)).toBe(false);
+      expect(component.isLastAssistant(1)).toBe(false);
+    });
+
+    it('updates the cached last index when new messages are appended', () => {
+      chatState.loadMessages([
+        { role: 'user', blocks: [{ type: 'text', content: 'q' }], timestamp: 1 },
+        { role: 'assistant', blocks: [{ type: 'text', content: 'A1' }], timestamp: 2 },
+      ]);
+      expect(component.isLastAssistant(1)).toBe(true);
+
+      chatState.loadMessages([
+        { role: 'user', blocks: [{ type: 'text', content: 'q' }], timestamp: 1 },
+        { role: 'assistant', blocks: [{ type: 'text', content: 'A1' }], timestamp: 2 },
+        { role: 'user', blocks: [{ type: 'text', content: 'q2' }], timestamp: 3 },
+        { role: 'assistant', blocks: [{ type: 'text', content: 'A2' }], timestamp: 4 },
+      ]);
+      expect(component.isLastAssistant(1)).toBe(false);
+      expect(component.isLastAssistant(3)).toBe(true);
+    });
+  });
 });

--- a/desktop/src/src/app/chat/chat.component.ts
+++ b/desktop/src/src/app/chat/chat.component.ts
@@ -50,6 +50,13 @@ export class ChatComponent implements OnInit, OnDestroy {
   projectMemory = '';
   memoryError = '';
   viewError = '';
+  /**
+   * Cached index of the most recent assistant message in `chat.messages`,
+   * recomputed on every state-change notification. Avoids the O(n) scan in
+   * `isLastAssistant` becoming O(n²) when the template iterates every entry.
+   * `-1` when no assistant message exists.
+   */
+  lastAssistantIndex = -1;
   private resumeInProgress = false;
 
   readonly chat = inject(ChatStateService);
@@ -79,6 +86,7 @@ export class ChatComponent implements OnInit, OnDestroy {
   /** Wires change-detection callbacks and effects that lazy-load data when drawers open. */
   constructor() {
     this.unsubChange = this.chat.onChange(() => {
+      this.recomputeLastAssistantIndex();
       this.cdr.markForCheck();
       // Live-chat scrolling is owned by <app-chat-message-list>; no-op here.
     });
@@ -92,6 +100,18 @@ export class ChatComponent implements OnInit, OnDestroy {
     effect(() => {
       if (this.ui.memoryOpen()) void this.loadProjectMemory();
     });
+  }
+
+  /** Recomputes the cached `lastAssistantIndex` from the current messages. */
+  private recomputeLastAssistantIndex(): void {
+    const msgs = this.chat.messages;
+    for (let i = msgs.length - 1; i >= 0; i -= 1) {
+      if (msgs[i].role === 'assistant') {
+        this.lastAssistantIndex = i;
+        return;
+      }
+    }
+    this.lastAssistantIndex = -1;
   }
 
   /** Boots the chat session and subscribes to project lifecycle events (auth + ready). */
@@ -173,6 +193,17 @@ export class ChatComponent implements OnInit, OnDestroy {
    */
   async onQuestionAnswered(event: { toolId: string; values: string[] }): Promise<void> {
     await this.chat.answerQuestion(event.toolId, event.values);
+  }
+
+  /**
+   * Returns true when the assistant entry at `index` is the most recent
+   * assistant message — used to gate the per-message Retry button. Reads a
+   * precomputed index updated on each state-change notification, so the
+   * per-row template lookup is O(1) instead of O(n).
+   * @param index - Index into `chat.messages` of the entry under test.
+   */
+  isLastAssistant(index: number): boolean {
+    return index === this.lastAssistantIndex;
   }
 
   /** Flips the sidebar signal; data load is driven by the constructor effect. */

--- a/desktop/src/src/app/chat/message-list/chat-message-list.component.ts
+++ b/desktop/src/src/app/chat/message-list/chat-message-list.component.ts
@@ -33,11 +33,13 @@ const SCROLL_BOTTOM_THRESHOLD_PX = 16;
       (scroll)="onScroll()"
     >
       <div class="mx-auto max-w-3xl space-y-8">
-        @for (msg of messages; track msg.timestamp) {
+        @for (msg of messages; track msg.timestamp; let i = $index) {
           <app-chat-message
             [blocks]="msg.blocks"
             [role]="msg.role"
             [timestamp]="msg.timestamp"
+            [entryIndex]="i"
+            [isLast]="i === lastAssistantIndex"
             (questionAnswered)="questionAnswered.emit($event)"
           />
         }
@@ -58,6 +60,12 @@ export class ChatMessageListComponent implements AfterViewChecked, OnChanges {
   @Input({ required: true }) messages!: readonly ChatMessage[];
   @Input() currentBlocks: readonly MessageBlock[] = [];
   @Input() isStreaming = false;
+  /**
+   * Index of the most recent assistant entry in `messages`; `-1` when none.
+   * Used to gate the per-message Retry button (only the latest assistant
+   * message is retryable).
+   */
+  @Input() lastAssistantIndex = -1;
 
   @Output() questionAnswered = new EventEmitter<{ toolId: string; values: string[] }>();
 

--- a/desktop/src/src/app/chat/message/chat-message.component.spec.ts
+++ b/desktop/src/src/app/chat/message/chat-message.component.spec.ts
@@ -115,24 +115,26 @@ describe('ChatMessageComponent', () => {
     expect(time?.textContent?.trim()).toBe('09:30');
   });
 
-  it('host right-aligns user messages via justify-end', () => {
+  it('host right-aligns user messages via items-end', () => {
     component.blocks = [{ type: 'text', content: 'ok' }];
     component.role = 'user';
     fixture.detectChanges();
 
     const host = fixture.nativeElement as HTMLElement;
-    expect(host.classList.contains('justify-end')).toBe(true);
-    expect(host.classList.contains('justify-start')).toBe(false);
+    // The host became a column flex container so the per-message actions
+    // sit below the bubble. Cross-axis alignment uses `items-*` not `justify-*`.
+    expect(host.classList.contains('items-end')).toBe(true);
+    expect(host.classList.contains('items-start')).toBe(false);
   });
 
-  it('host left-aligns assistant messages via justify-start', () => {
+  it('host left-aligns assistant messages via items-start', () => {
     component.blocks = [{ type: 'text', content: 'hello' }];
     component.role = 'assistant';
     fixture.detectChanges();
 
     const host = fixture.nativeElement as HTMLElement;
-    expect(host.classList.contains('justify-start')).toBe(true);
-    expect(host.classList.contains('justify-end')).toBe(false);
+    expect(host.classList.contains('items-start')).toBe(true);
+    expect(host.classList.contains('items-end')).toBe(false);
   });
 
   it('user role dispatches to <app-user-message> (terminal-minimal: no bubble)', () => {

--- a/desktop/src/src/app/chat/message/chat-message.component.ts
+++ b/desktop/src/src/app/chat/message/chat-message.component.ts
@@ -7,6 +7,7 @@ import { ErrorBlockComponent } from '../blocks/error-block.component';
 import { AskUserBlockComponent } from '../blocks/ask-user-block.component';
 import { PermissionPromptComponent } from '../blocks/permission-prompt.component';
 import { UserMessageComponent } from './user-message.component';
+import { MessageActionsComponent } from './message-actions.component';
 
 /** Renders a single chat message: user role uses a meta-line layout, assistant role uses a bubble. */
 @Component({
@@ -19,12 +20,13 @@ import { UserMessageComponent } from './user-message.component';
     AskUserBlockComponent,
     PermissionPromptComponent,
     UserMessageComponent,
+    MessageActionsComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
-    class: 'flex w-full',
-    '[class.justify-end]': "role === 'user'",
-    '[class.justify-start]': "role === 'assistant'",
+    class: 'flex flex-col w-full',
+    '[class.items-end]': "role === 'user'",
+    '[class.items-start]': "role === 'assistant'",
   },
   template: `
     @if (role === 'user') {
@@ -73,6 +75,9 @@ import { UserMessageComponent } from './user-message.component';
           >
         }
       </div>
+      @if (role === 'assistant' && !streaming && entryIndex !== null) {
+        <app-message-actions [entryIndex]="entryIndex" [isLast]="isLast" />
+      }
     }
   `,
 })
@@ -82,6 +87,14 @@ export class ChatMessageComponent {
   @Input() streaming = false;
   @Input() editedAt: number | undefined = undefined;
   @Input() timestamp = 0;
+  /**
+   * Index of this message entry in `ChatStateService.messages`. `null`
+   * when rendering live `currentBlocks` (which has no committed index yet)
+   * — the action bar is hidden in that case.
+   */
+  @Input() entryIndex: number | null = null;
+  /** Whether this entry is the last assistant message in the list. */
+  @Input() isLast = false;
   @Output() questionAnswered = new EventEmitter<{ toolId: string; values: string[] }>();
   @Output() permissionDecided = new EventEmitter<{
     blockIndex: number;

--- a/desktop/src/src/app/chat/message/message-actions.component.spec.ts
+++ b/desktop/src/src/app/chat/message/message-actions.component.spec.ts
@@ -126,7 +126,11 @@ describe('MessageActionsComponent', () => {
   });
 
   it('disables retry button when chat.isStreaming is true', () => {
+    // The real ChatStateService.canRetryLastAssistant() returns false while
+    // streaming (it walks through findRetryAnchor() which has the guard).
+    // Mirror that contract in the stub.
     chat.isStreaming = true;
+    chat.canRetryLastAssistant = vi.fn().mockReturnValue(false);
     refresh();
     expect(retryButton()?.disabled).toBe(true);
   });

--- a/desktop/src/src/app/chat/message/message-actions.component.spec.ts
+++ b/desktop/src/src/app/chat/message/message-actions.component.spec.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MessageActionsComponent } from './message-actions.component';
+import { ChatStateService } from '../../services/chat-state.service';
+
+class FakeChatState {
+  isStreaming = false;
+  copyMessage = vi.fn().mockResolvedValue(true);
+  retryLastAssistant = vi.fn().mockResolvedValue(undefined);
+  canRetryLastAssistant = vi.fn().mockReturnValue(true);
+}
+
+describe('MessageActionsComponent', () => {
+  let component: MessageActionsComponent;
+  let fixture: ComponentFixture<MessageActionsComponent>;
+  let chat: FakeChatState;
+
+  function copyButton(): HTMLButtonElement {
+    const btn = fixture.nativeElement.querySelector(
+      '[data-testid="message-copy"]'
+    ) as HTMLButtonElement | null;
+    expect(btn).not.toBeNull();
+    return btn as HTMLButtonElement;
+  }
+
+  function retryButton(): HTMLButtonElement | null {
+    return fixture.nativeElement.querySelector(
+      '[data-testid="message-retry"]'
+    ) as HTMLButtonElement | null;
+  }
+
+  /**
+   * Re-runs CD on the OnPush component. Direct mutation of `chat` state does
+   * not mark the view dirty — toggling an input via `setInput` is the cheapest
+   * way to dirty the OnPush input cache and re-evaluate `[disabled]` bindings.
+   */
+  function refresh(): void {
+    fixture.componentRef.setInput('entryIndex', component.entryIndex + 1);
+    fixture.detectChanges();
+    fixture.componentRef.setInput('entryIndex', component.entryIndex - 1);
+    fixture.detectChanges();
+  }
+
+  beforeEach(async () => {
+    chat = new FakeChatState();
+    vi.useFakeTimers();
+    await TestBed.configureTestingModule({
+      imports: [MessageActionsComponent],
+      providers: [{ provide: ChatStateService, useValue: chat }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MessageActionsComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('entryIndex', 3);
+    fixture.componentRef.setInput('isLast', true);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // ── Happy path ──────────────────────────────────────────────────
+
+  it('renders copy and retry buttons with ARIA labels by default', () => {
+    const copy = copyButton();
+    const retry = retryButton();
+    expect(copy.getAttribute('aria-label')).toBe('Copy message');
+    expect(retry).not.toBeNull();
+    expect(retry?.getAttribute('aria-label')).toBe('Retry last response');
+  });
+
+  it('copy button is enabled and retry button is enabled when canRetry is true and not streaming', () => {
+    expect(copyButton().disabled).toBe(false);
+    expect(retryButton()?.disabled).toBe(false);
+  });
+
+  it('clicking copy invokes ChatStateService.copyMessage with entryIndex', async () => {
+    copyButton().click();
+    await Promise.resolve();
+    expect(chat.copyMessage).toHaveBeenCalledWith(3);
+  });
+
+  it('clicking retry invokes ChatStateService.retryLastAssistant', async () => {
+    retryButton()?.click();
+    await Promise.resolve();
+    expect(chat.retryLastAssistant).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Copy confirmation timing ────────────────────────────────────
+
+  it('shows "✓ copied" for 1.5s after a successful copy, then reverts', async () => {
+    copyButton().click();
+    // Drain the pending copy promise.
+    await Promise.resolve();
+    await Promise.resolve();
+    fixture.detectChanges();
+    expect(copyButton().textContent?.trim()).toBe('✓ copied');
+    expect(copyButton().getAttribute('aria-label')).toBe('Copied to clipboard');
+    // 1499ms before — still showing
+    vi.advanceTimersByTime(1_499);
+    fixture.detectChanges();
+    expect(copyButton().textContent?.trim()).toBe('✓ copied');
+    // After 1500ms total — reverted
+    vi.advanceTimersByTime(1);
+    fixture.detectChanges();
+    expect(copyButton().textContent?.trim()).toBe('Copy');
+    expect(copyButton().getAttribute('aria-label')).toBe('Copy message');
+  });
+
+  it('does NOT show "✓ copied" when copyMessage returns false', async () => {
+    chat.copyMessage = vi.fn().mockResolvedValue(false);
+    copyButton().click();
+    await Promise.resolve();
+    await Promise.resolve();
+    fixture.detectChanges();
+    expect(copyButton().textContent?.trim()).toBe('Copy');
+  });
+
+  // ── Disabled / hidden states ────────────────────────────────────
+
+  it('hides retry button when isLast is false', () => {
+    fixture.componentRef.setInput('isLast', false);
+    fixture.detectChanges();
+    expect(retryButton()).toBeNull();
+  });
+
+  it('disables retry button when chat.isStreaming is true', () => {
+    chat.isStreaming = true;
+    refresh();
+    expect(retryButton()?.disabled).toBe(true);
+  });
+
+  it('disables retry button when canRetryLastAssistant returns false', () => {
+    chat.canRetryLastAssistant = vi.fn().mockReturnValue(false);
+    refresh();
+    expect(retryButton()?.disabled).toBe(true);
+  });
+
+  it('does not invoke retryLastAssistant when retry is disabled', async () => {
+    chat.canRetryLastAssistant = vi.fn().mockReturnValue(false);
+    fixture.detectChanges();
+    // Calling onRetry directly mimics the keyboard shortcut path; the button
+    // itself is disabled at the DOM level so a real click would be no-op.
+    await component.onRetry();
+    expect(chat.retryLastAssistant).not.toHaveBeenCalled();
+  });
+
+  it('disables copy button while a copy is in flight', async () => {
+    let resolveCopy: (v: boolean) => void = () => {};
+    chat.copyMessage = vi.fn().mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        resolveCopy = resolve;
+      })
+    );
+    copyButton().click();
+    await Promise.resolve();
+    fixture.detectChanges();
+    expect(copyButton().disabled).toBe(true);
+    resolveCopy(true);
+    await Promise.resolve();
+    await Promise.resolve();
+    fixture.detectChanges();
+    // After resolution, busy clears even though "copied" is still showing.
+    expect(copyButton().disabled).toBe(false);
+  });
+
+  // ── Cleanup ─────────────────────────────────────────────────────
+
+  it('clears the pending copy timer on destroy', async () => {
+    copyButton().click();
+    await Promise.resolve();
+    await Promise.resolve();
+    fixture.detectChanges();
+    expect(copyButton().textContent?.trim()).toBe('✓ copied');
+    fixture.destroy();
+    // Advancing past the feedback window must not throw or schedule callbacks
+    // on a destroyed component (which would crash with "ChangeDetector destroyed").
+    vi.advanceTimersByTime(2_000);
+  });
+});

--- a/desktop/src/src/app/chat/message/message-actions.component.ts
+++ b/desktop/src/src/app/chat/message/message-actions.component.ts
@@ -66,7 +66,8 @@ export class MessageActionsComponent implements OnDestroy {
 
   /** Returns whether the retry button is currently enabled. */
   canRetry(): boolean {
-    return !this.chat.isStreaming && this.chat.canRetryLastAssistant();
+    // canRetryLastAssistant() already checks isStreaming via findRetryAnchor.
+    return this.chat.canRetryLastAssistant();
   }
 
   /** Click handler for the copy button. */

--- a/desktop/src/src/app/chat/message/message-actions.component.ts
+++ b/desktop/src/src/app/chat/message/message-actions.component.ts
@@ -1,0 +1,105 @@
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  Input,
+  OnDestroy,
+  inject,
+} from '@angular/core';
+import { ChatStateService } from '../../services/chat-state.service';
+
+/** Display window for the post-copy confirmation indicator (milliseconds). */
+const COPY_FEEDBACK_MS = 1_500;
+
+/**
+ * Per-assistant-message action bar (copy + retry) — ADR-046.
+ *
+ * Lives directly under each assistant entry in the message list. The buttons
+ * re-evaluate their disabled state on every change-detection cycle by reading
+ * `chat.isStreaming` and `chat.canRetryLastAssistant()` directly — both are
+ * cheap and recomputed only when the OnPush parent triggers CD.
+ */
+@Component({
+  selector: 'app-message-actions',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: { class: 'flex gap-1 mt-1 text-xs' },
+  template: `
+    <button
+      type="button"
+      data-testid="message-copy"
+      class="px-2 py-1 rounded text-sw-muted hover:text-sw-text hover:bg-sw-bg-darkest transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      [attr.aria-label]="copied ? 'Copied to clipboard' : 'Copy message'"
+      [disabled]="copyBusy"
+      (click)="onCopy()"
+    >
+      {{ copied ? '✓ copied' : 'Copy' }}
+    </button>
+    @if (isLast) {
+      <button
+        type="button"
+        data-testid="message-retry"
+        class="px-2 py-1 rounded text-sw-muted hover:text-sw-text hover:bg-sw-bg-darkest transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        [attr.aria-label]="'Retry last response'"
+        [disabled]="!canRetry()"
+        (click)="onRetry()"
+      >
+        Retry
+      </button>
+    }
+  `,
+})
+export class MessageActionsComponent implements OnDestroy {
+  /** Index of the message entry this action bar acts on. */
+  @Input({ required: true }) entryIndex!: number;
+  /** Whether this is the last assistant entry — gates the retry button. */
+  @Input() isLast = false;
+
+  /** Showing the post-copy confirmation. */
+  copied = false;
+  /** Disables copy button while clipboard write is in flight. */
+  copyBusy = false;
+
+  private readonly chat = inject(ChatStateService);
+  private readonly cdr = inject(ChangeDetectorRef);
+  private copyTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /** Returns whether the retry button is currently enabled. */
+  canRetry(): boolean {
+    return !this.chat.isStreaming && this.chat.canRetryLastAssistant();
+  }
+
+  /** Click handler for the copy button. */
+  async onCopy(): Promise<void> {
+    if (this.copyBusy) return;
+    this.copyBusy = true;
+    this.cdr.markForCheck();
+    const ok = await this.chat.copyMessage(this.entryIndex);
+    this.copyBusy = false;
+    if (ok) {
+      this.copied = true;
+      this.cdr.markForCheck();
+      if (this.copyTimer !== null) clearTimeout(this.copyTimer);
+      this.copyTimer = setTimeout(() => {
+        this.copied = false;
+        this.copyTimer = null;
+        this.cdr.markForCheck();
+      }, COPY_FEEDBACK_MS);
+    } else {
+      this.cdr.markForCheck();
+    }
+  }
+
+  /** Click handler for the retry button. */
+  async onRetry(): Promise<void> {
+    if (!this.canRetry()) return;
+    await this.chat.retryLastAssistant();
+  }
+
+  ngOnDestroy(): void {
+    if (this.copyTimer !== null) {
+      clearTimeout(this.copyTimer);
+      this.copyTimer = null;
+    }
+  }
+}

--- a/desktop/src/src/app/chat/message/message-actions.component.ts
+++ b/desktop/src/src/app/chat/message/message-actions.component.ts
@@ -96,6 +96,7 @@ export class MessageActionsComponent implements OnDestroy {
     await this.chat.retryLastAssistant();
   }
 
+  /** Clears any pending "copied" confirmation timer to avoid setting a signal after destroy. */
   ngOnDestroy(): void {
     if (this.copyTimer !== null) {
       clearTimeout(this.copyTimer);

--- a/desktop/src/src/app/models/chat.ts
+++ b/desktop/src/src/app/models/chat.ts
@@ -23,6 +23,8 @@ export type StreamChunk =
         usage?: UsageInfo;
         result_text?: string;
         context_window_size?: number;
+        /** UUID of the assistant message that just completed (ADR-046). */
+        assistant_uuid?: string;
       };
     }
   | { chunk_type: 'Error'; data: { content: string } }
@@ -30,6 +32,11 @@ export type StreamChunk =
   | {
       chunk_type: 'RateLimit';
       data: { status: string; utilization: number | null; resets_at: number | null };
+    }
+  | {
+      /** Commits a retry-anchor UUID onto the most recent user entry (ADR-046). */
+      chunk_type: 'UserMessageCommit';
+      data: { uuid: string };
     };
 
 /** A single selectable option in an AskUserQuestion prompt. */
@@ -128,11 +135,28 @@ export type NormalizedToolInput =
   | { kind: 'agent'; description: string }
   | { kind: 'generic'; raw_json: string };
 
+/** Retry-anchor UUID commit state for a ChatMessage (ADR-046). */
+export type UuidStatus = 'Pending' | 'Committed';
+
 /** Replaces old flat ChatMessage — shared between live chat and transcript */
 export interface ChatMessage {
   role: 'user' | 'assistant';
   blocks: MessageBlock[];
   timestamp: number;
+  /**
+   * Retry-anchor UUID (ADR-046). User UUIDs commit immediately; assistant
+   * UUIDs stay `Pending` until the matching `Result` event commits them.
+   * Absent for legacy transcript messages and for local-LLM turns that
+   * omit `message.id` — those entries can't be used as retry targets.
+   */
+  uuid?: string;
+  /** Status of the above UUID. Defaults to `Committed` when `uuid` is set. */
+  uuid_status?: UuidStatus;
+  /**
+   * Epoch-ms timestamp of the most recent retry against this entry. Only
+   * set on user entries whose turn has been retried via `retry_last_turn`.
+   */
+  edited_at?: number;
 }
 
 /** Rate limit info from rate_limit_event. */

--- a/desktop/src/src/app/services/chat-state.service.spec.ts
+++ b/desktop/src/src/app/services/chat-state.service.spec.ts
@@ -1315,4 +1315,328 @@ describe('ChatStateService', () => {
       expect(service.currentBlocks).toEqual([]);
     });
   });
+
+  describe('UserMessageCommit chunk', () => {
+    it('commits the UUID onto the most recent user entry that is missing one', () => {
+      service._setState({
+        messages: [
+          { role: 'user', blocks: [{ type: 'text', content: 'first' }], timestamp: 1, uuid: 'u-1' },
+          { role: 'user', blocks: [{ type: 'text', content: 'second' }], timestamp: 2 },
+        ],
+      });
+      service.handleStreamChunk({
+        chunk_type: 'UserMessageCommit',
+        data: { uuid: 'u-2' },
+      });
+      expect(service.messages[1].uuid).toBe('u-2');
+      expect(service.messages[1].uuid_status).toBe('Committed');
+      // Already-committed entries are untouched.
+      expect(service.messages[0].uuid).toBe('u-1');
+    });
+
+    it('is a no-op when no user entry is missing a UUID', () => {
+      service._setState({
+        messages: [
+          { role: 'user', blocks: [{ type: 'text', content: 'first' }], timestamp: 1, uuid: 'u-1' },
+        ],
+      });
+      const before = service.messages;
+      service.handleStreamChunk({
+        chunk_type: 'UserMessageCommit',
+        data: { uuid: 'u-2' },
+      });
+      // Same object — no mutation, no replacement.
+      expect(service.messages).toBe(before);
+    });
+
+    it('is a no-op when the message list is empty', () => {
+      const before = service.messages;
+      service.handleStreamChunk({
+        chunk_type: 'UserMessageCommit',
+        data: { uuid: 'u-1' },
+      });
+      expect(service.messages).toBe(before);
+    });
+  });
+
+  describe('Result chunk with assistant_uuid', () => {
+    it('stamps the committed UUID onto the finalized assistant entry', () => {
+      service.isStreaming = true;
+      service._setState({ currentBlocks: [{ type: 'text', content: 'reply' }] });
+      service.handleStreamChunk({
+        chunk_type: 'Result',
+        data: {
+          session_id: 's-1',
+          total_cost: 0,
+          usage: undefined,
+          result_text: undefined,
+          context_window_size: 200_000,
+          assistant_uuid: 'a-1',
+        },
+      });
+      const last = service.messages[service.messages.length - 1];
+      expect(last.role).toBe('assistant');
+      expect(last.uuid).toBe('a-1');
+      expect(last.uuid_status).toBe('Committed');
+    });
+
+    it('omits uuid_status when assistant_uuid is missing', () => {
+      service.isStreaming = true;
+      service._setState({ currentBlocks: [{ type: 'text', content: 'reply' }] });
+      service.handleStreamChunk({
+        chunk_type: 'Result',
+        data: {
+          session_id: 's-1',
+          total_cost: 0,
+          usage: undefined,
+          result_text: undefined,
+          context_window_size: 200_000,
+        },
+      });
+      const last = service.messages[service.messages.length - 1];
+      expect(last.uuid).toBeUndefined();
+      expect(last.uuid_status).toBeUndefined();
+    });
+  });
+
+  describe('copyMessage', () => {
+    let writeText: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      writeText = vi.fn().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { writeText },
+        configurable: true,
+      });
+    });
+
+    it('writes flattened text content to the clipboard and returns true', async () => {
+      service._setState({
+        messages: [
+          {
+            role: 'assistant',
+            blocks: [
+              { type: 'text', content: 'Hello' },
+              { type: 'tool_use', tool: {
+                tool_id: 't', tool_name: 'Read', input_json: '{}',
+                status: 'done', result: 'ok', result_is_error: false, collapsed: false,
+              } },
+              { type: 'text', content: 'World' },
+            ],
+            timestamp: 1,
+          },
+        ],
+      });
+      const ok = await service.copyMessage(0);
+      expect(ok).toBe(true);
+      expect(writeText).toHaveBeenCalledWith('Hello\n\nWorld');
+    });
+
+    it('returns false for an out-of-range index', async () => {
+      const ok = await service.copyMessage(99);
+      expect(ok).toBe(false);
+      expect(writeText).not.toHaveBeenCalled();
+    });
+
+    it('returns false when there is no copyable text (only tool_use/thinking)', async () => {
+      service._setState({
+        messages: [
+          {
+            role: 'assistant',
+            blocks: [{ type: 'thinking', content: 'hmm', collapsed: true }],
+            timestamp: 1,
+          },
+        ],
+      });
+      const ok = await service.copyMessage(0);
+      expect(ok).toBe(false);
+      expect(writeText).not.toHaveBeenCalled();
+    });
+
+    it('returns false when navigator.clipboard is missing', async () => {
+      Object.defineProperty(navigator, 'clipboard', {
+        value: undefined,
+        configurable: true,
+      });
+      service._setState({
+        messages: [
+          { role: 'assistant', blocks: [{ type: 'text', content: 'x' }], timestamp: 1 },
+        ],
+      });
+      const ok = await service.copyMessage(0);
+      expect(ok).toBe(false);
+    });
+
+    it('returns false when clipboard.writeText rejects', async () => {
+      writeText.mockRejectedValueOnce(new Error('denied'));
+      service._setState({
+        messages: [
+          { role: 'assistant', blocks: [{ type: 'text', content: 'x' }], timestamp: 1 },
+        ],
+      });
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const ok = await service.copyMessage(0);
+      expect(ok).toBe(false);
+      expect(warnSpy).toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe('canRetryLastAssistant / retryLastAssistant', () => {
+    function seedRetryableSession(): void {
+      service._setState({
+        messages: [
+          {
+            role: 'user',
+            blocks: [{ type: 'text', content: 'q' }],
+            timestamp: 1,
+            uuid: 'msg_user_1',
+            uuid_status: 'Committed',
+          },
+          {
+            role: 'assistant',
+            blocks: [{ type: 'text', content: 'a' }],
+            timestamp: 2,
+            uuid: 'msg_assist_1',
+            uuid_status: 'Committed',
+          },
+        ],
+        sessionStats: {
+          session_id: '550e8400-e29b-41d4-a716-446655440000',
+          total_cost: 0,
+          usage: undefined,
+          model: undefined,
+          rate_limit: undefined,
+          context_window_size: 200_000,
+          total_output_tokens: 0,
+        },
+      });
+      service.isStreaming = false;
+    }
+
+    it('canRetryLastAssistant returns true when last assistant is committed and a session id is known', () => {
+      seedRetryableSession();
+      expect(service.canRetryLastAssistant()).toBe(true);
+    });
+
+    it('canRetryLastAssistant returns false while streaming', () => {
+      seedRetryableSession();
+      service.isStreaming = true;
+      expect(service.canRetryLastAssistant()).toBe(false);
+    });
+
+    it('canRetryLastAssistant returns false when no assistant entry exists', () => {
+      service._setState({
+        messages: [
+          {
+            role: 'user',
+            blocks: [{ type: 'text', content: 'q' }],
+            timestamp: 1,
+            uuid: 'msg_user_1',
+            uuid_status: 'Committed',
+          },
+        ],
+        sessionStats: {
+          session_id: '550e8400-e29b-41d4-a716-446655440000',
+          total_cost: 0,
+          usage: undefined,
+          model: undefined,
+          rate_limit: undefined,
+          context_window_size: 200_000,
+          total_output_tokens: 0,
+        },
+      });
+      expect(service.canRetryLastAssistant()).toBe(false);
+    });
+
+    it('canRetryLastAssistant returns false when the user UUID is missing', () => {
+      service._setState({
+        messages: [
+          {
+            role: 'user',
+            blocks: [{ type: 'text', content: 'q' }],
+            timestamp: 1,
+          },
+          {
+            role: 'assistant',
+            blocks: [{ type: 'text', content: 'a' }],
+            timestamp: 2,
+            uuid: 'msg_assist_1',
+            uuid_status: 'Committed',
+          },
+        ],
+        sessionStats: {
+          session_id: '550e8400-e29b-41d4-a716-446655440000',
+          total_cost: 0,
+          usage: undefined,
+          model: undefined,
+          rate_limit: undefined,
+          context_window_size: 200_000,
+          total_output_tokens: 0,
+        },
+      });
+      expect(service.canRetryLastAssistant()).toBe(false);
+    });
+
+    it('canRetryLastAssistant returns false when assistant uuid_status is Pending', () => {
+      seedRetryableSession();
+      service._setState({
+        messages: [
+          ...service.messages.slice(0, -1),
+          { ...service.messages[service.messages.length - 1], uuid_status: 'Pending' },
+        ],
+      });
+      expect(service.canRetryLastAssistant()).toBe(false);
+    });
+
+    it('canRetryLastAssistant returns false without a session id', () => {
+      seedRetryableSession();
+      service._setState({ sessionStats: null });
+      expect(service.canRetryLastAssistant()).toBe(false);
+    });
+
+    it('retryLastAssistant invokes the backend, trims the assistant entry, and starts streaming', async () => {
+      seedRetryableSession();
+      const invokeSpy = vi.spyOn(mockTauri, 'invoke').mockResolvedValue(undefined);
+      const before = service.turnId;
+      await service.retryLastAssistant();
+      expect(invokeSpy).toHaveBeenCalledWith('retry_last_turn', {
+        sessionId: '550e8400-e29b-41d4-a716-446655440000',
+        userUuid: 'msg_user_1',
+      });
+      expect(service.messages).toHaveLength(1);
+      expect(service.messages[0].role).toBe('user');
+      expect(service.messages[0].edited_at).toBeDefined();
+      expect(service.isStreaming).toBe(true);
+      expect(service.turnId).toBeGreaterThan(before);
+    });
+
+    it('retryLastAssistant is a no-op when canRetry is false', async () => {
+      const invokeSpy = vi.spyOn(mockTauri, 'invoke');
+      // No setup — empty session, no anchor.
+      await service.retryLastAssistant();
+      expect(invokeSpy).not.toHaveBeenCalled();
+      expect(service.isStreaming).toBe(false);
+    });
+
+    it('retryLastAssistant restores state and surfaces an error block on backend failure', async () => {
+      seedRetryableSession();
+      mockTauri.invokeHandler = async (cmd: string) => {
+        if (cmd === 'retry_last_turn') throw new Error('resume failed');
+        return undefined;
+      };
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      await service.retryLastAssistant();
+      expect(service.isStreaming).toBe(false);
+      // Original two entries restored, plus an error-bearing assistant entry.
+      expect(service.messages).toHaveLength(3);
+      const last = service.messages[2];
+      expect(last.role).toBe('assistant');
+      expect(last.blocks[0].type).toBe('error');
+      expect((last.blocks[0] as { type: 'error'; content: string }).content).toContain(
+        'Retry failed'
+      );
+      errSpy.mockRestore();
+    });
+  });
 });

--- a/desktop/src/src/app/services/chat-state.service.spec.ts
+++ b/desktop/src/src/app/services/chat-state.service.spec.ts
@@ -1417,10 +1417,18 @@ describe('ChatStateService', () => {
             role: 'assistant',
             blocks: [
               { type: 'text', content: 'Hello' },
-              { type: 'tool_use', tool: {
-                tool_id: 't', tool_name: 'Read', input_json: '{}',
-                status: 'done', result: 'ok', result_is_error: false, collapsed: false,
-              } },
+              {
+                type: 'tool_use',
+                tool: {
+                  tool_id: 't',
+                  tool_name: 'Read',
+                  input_json: '{}',
+                  status: 'done',
+                  result: 'ok',
+                  result_is_error: false,
+                  collapsed: false,
+                },
+              },
               { type: 'text', content: 'World' },
             ],
             timestamp: 1,
@@ -1459,9 +1467,7 @@ describe('ChatStateService', () => {
         configurable: true,
       });
       service._setState({
-        messages: [
-          { role: 'assistant', blocks: [{ type: 'text', content: 'x' }], timestamp: 1 },
-        ],
+        messages: [{ role: 'assistant', blocks: [{ type: 'text', content: 'x' }], timestamp: 1 }],
       });
       const ok = await service.copyMessage(0);
       expect(ok).toBe(false);
@@ -1470,9 +1476,7 @@ describe('ChatStateService', () => {
     it('returns false when clipboard.writeText rejects', async () => {
       writeText.mockRejectedValueOnce(new Error('denied'));
       service._setState({
-        messages: [
-          { role: 'assistant', blocks: [{ type: 'text', content: 'x' }], timestamp: 1 },
-        ],
+        messages: [{ role: 'assistant', blocks: [{ type: 'text', content: 'x' }], timestamp: 1 }],
       });
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const ok = await service.copyMessage(0);

--- a/desktop/src/src/app/services/chat-state.service.ts
+++ b/desktop/src/src/app/services/chat-state.service.ts
@@ -660,7 +660,12 @@ export class ChatStateService {
    * `null` when no such pair exists, when streaming, or when the session id
    * is missing.
    */
-  private findRetryAnchor(): { sessionId: string; userUuid: string } | null {
+  private findRetryAnchor(): {
+    sessionId: string;
+    userUuid: string;
+    lastAssistantIdx: number;
+    userIdx: number;
+  } | null {
     if (this.isStreaming) return null;
     const sessionId = this._sessionStats?.session_id;
     if (!sessionId) return null;
@@ -678,7 +683,7 @@ export class ChatStateService {
       const m = this._messages[i];
       if (m.role !== 'user') continue;
       if (!m.uuid || (m.uuid_status && m.uuid_status !== 'Committed')) return null;
-      return { sessionId, userUuid: m.uuid };
+      return { sessionId, userUuid: m.uuid, lastAssistantIdx, userIdx: i };
     }
     return null;
   }
@@ -696,23 +701,7 @@ export class ChatStateService {
   async retryLastAssistant(): Promise<void> {
     const anchor = this.findRetryAnchor();
     if (!anchor) return;
-    const { sessionId, userUuid } = anchor;
-
-    let lastAssistantIdx = -1;
-    for (let i = this._messages.length - 1; i >= 0; i -= 1) {
-      if (this._messages[i].role === 'assistant') {
-        lastAssistantIdx = i;
-        break;
-      }
-    }
-    let userIdx = -1;
-    for (let i = lastAssistantIdx - 1; i >= 0; i -= 1) {
-      if (this._messages[i].role === 'user' && this._messages[i].uuid === userUuid) {
-        userIdx = i;
-        break;
-      }
-    }
-    if (userIdx < 0) return;
+    const { sessionId, userUuid, lastAssistantIdx, userIdx } = anchor;
 
     const trimmed = this._messages.slice(0, lastAssistantIdx);
     trimmed[userIdx] = { ...trimmed[userIdx], edited_at: Date.now() };

--- a/desktop/src/src/app/services/chat-state.service.ts
+++ b/desktop/src/src/app/services/chat-state.service.ts
@@ -502,7 +502,7 @@ export class ChatStateService {
         }
         break;
 
-      case 'Result':
+      case 'Result': {
         if (chunk.data.result_text) {
           // Only append result_text when no streamed text blocks exist yet.
           // Claude Code always copies the full response into `result`, so for
@@ -517,10 +517,15 @@ export class ChatStateService {
           }
         }
         if (this._currentBlocks.length > 0) {
-          this._messages = [
-            ...this._messages,
-            { role: 'assistant', blocks: [...this._currentBlocks], timestamp: Date.now() },
-          ];
+          const assistantUuid = chunk.data.assistant_uuid;
+          const assistant: ChatMessage = {
+            role: 'assistant',
+            blocks: [...this._currentBlocks],
+            timestamp: Date.now(),
+            uuid: assistantUuid,
+            uuid_status: assistantUuid ? 'Committed' : undefined,
+          };
+          this._messages = [...this._messages, assistant];
           this._currentBlocks = [];
         }
         this.isStreaming = false;
@@ -540,6 +545,29 @@ export class ChatStateService {
           total_output_tokens: this._totalOutputTokens,
         };
         break;
+      }
+
+      case 'UserMessageCommit': {
+        // ADR-046: the parser has seen `user.message.id` for the most recent
+        // user prompt. Commit it onto the last user entry that still lacks a
+        // UUID — walking from the end handles out-of-order arrivals where the
+        // commit chunk lands after several intermediate events.
+        const uuid = chunk.data.uuid;
+        const idx = findLastUserIndexMissingUuid(this._messages);
+        if (idx >= 0) {
+          const updated: ChatMessage = {
+            ...this._messages[idx],
+            uuid,
+            uuid_status: 'Committed',
+          };
+          this._messages = [
+            ...this._messages.slice(0, idx),
+            updated,
+            ...this._messages.slice(idx + 1),
+          ];
+        }
+        break;
+      }
 
       case 'Error':
         this._currentBlocks = [
@@ -584,6 +612,136 @@ export class ChatStateService {
   loadMessages(msgs: ChatMessage[]): void {
     this._messages = msgs;
     this.notifyChange();
+  }
+
+  /**
+   * Copies the textual content of the message at `index` to the system
+   * clipboard. Returns `true` on success, `false` on failure (out-of-range
+   * index, missing `navigator.clipboard`, write rejection). Block kinds that
+   * carry no user-facing prose — `tool_use`, `thinking`, `ask_user` — are
+   * elided; `text` and `error` blocks are joined with a blank line.
+   *
+   * The component layer owns the "copied" indicator timing so this method can
+   * stay pure and testable.
+   * @param index - Index into `messages` of the entry to copy.
+   */
+  async copyMessage(index: number): Promise<boolean> {
+    const msg = this._messages[index];
+    if (!msg) return false;
+    const text = blocksToPlainText(msg.blocks);
+    if (!text) return false;
+    if (typeof navigator === 'undefined' || !navigator.clipboard) return false;
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch (err) {
+      console.warn('[chat-state] copyMessage: clipboard write failed', err);
+      return false;
+    }
+  }
+
+  /**
+   * Returns whether the last assistant turn can be retried (ADR-046).
+   * Requires:
+   *   - not streaming (would race with the live turn),
+   *   - a session id from the most recent Result chunk,
+   *   - a user entry preceding the last assistant entry whose UUID is committed.
+   *
+   * The component layer reads this on every change-detection cycle to gate
+   * the retry button — it must be cheap and side-effect free.
+   */
+  canRetryLastAssistant(): boolean {
+    return this.findRetryAnchor() !== null;
+  }
+
+  /**
+   * Walks the message list from the end to find the retry anchor: the user
+   * entry immediately preceding the last committed assistant entry. Returns
+   * `null` when no such pair exists, when streaming, or when the session id
+   * is missing.
+   */
+  private findRetryAnchor(): { sessionId: string; userUuid: string } | null {
+    if (this.isStreaming) return null;
+    const sessionId = this._sessionStats?.session_id;
+    if (!sessionId) return null;
+    let lastAssistantIdx = -1;
+    for (let i = this._messages.length - 1; i >= 0; i -= 1) {
+      if (this._messages[i].role === 'assistant') {
+        lastAssistantIdx = i;
+        break;
+      }
+    }
+    if (lastAssistantIdx < 0) return null;
+    const assistant = this._messages[lastAssistantIdx];
+    if (assistant.uuid_status && assistant.uuid_status !== 'Committed') return null;
+    for (let i = lastAssistantIdx - 1; i >= 0; i -= 1) {
+      const m = this._messages[i];
+      if (m.role !== 'user') continue;
+      if (!m.uuid || (m.uuid_status && m.uuid_status !== 'Committed')) return null;
+      return { sessionId, userUuid: m.uuid };
+    }
+    return null;
+  }
+
+  /**
+   * Retries the last assistant turn via the backend `retry_last_turn` Tauri
+   * command (ADR-046). Trims the last assistant entry from local state,
+   * stamps `edited_at` on the anchor user entry, flips `isStreaming` so the
+   * input bar disables and the next stream chunks are accepted, and asks the
+   * backend to relaunch Claude Code with `--resume-session-at`.
+   *
+   * On backend failure the optimistic state changes are reverted and an error
+   * block is appended so the user sees what went wrong.
+   */
+  async retryLastAssistant(): Promise<void> {
+    const anchor = this.findRetryAnchor();
+    if (!anchor) return;
+    const { sessionId, userUuid } = anchor;
+
+    let lastAssistantIdx = -1;
+    for (let i = this._messages.length - 1; i >= 0; i -= 1) {
+      if (this._messages[i].role === 'assistant') {
+        lastAssistantIdx = i;
+        break;
+      }
+    }
+    let userIdx = -1;
+    for (let i = lastAssistantIdx - 1; i >= 0; i -= 1) {
+      if (this._messages[i].role === 'user' && this._messages[i].uuid === userUuid) {
+        userIdx = i;
+        break;
+      }
+    }
+    if (userIdx < 0) return;
+
+    const trimmed = this._messages.slice(0, lastAssistantIdx);
+    trimmed[userIdx] = { ...trimmed[userIdx], edited_at: Date.now() };
+    const before = this._messages;
+    this._messages = trimmed;
+    this._currentBlocks = [];
+    this.isStreaming = true;
+    this._turnId += 1;
+    this.notifyChange();
+
+    try {
+      await this.tauri.invoke('retry_last_turn', {
+        sessionId,
+        userUuid,
+      });
+    } catch (err) {
+      console.error('[chat-state] retryLastAssistant: invoke failed', err);
+      this._messages = [
+        ...before,
+        {
+          role: 'assistant',
+          blocks: [{ type: 'error', content: `Retry failed: ${err}` }],
+          timestamp: Date.now(),
+        },
+      ];
+      this._currentBlocks = [];
+      this.isStreaming = false;
+      this.notifyChange();
+    }
   }
 
   /**
@@ -681,4 +839,36 @@ function completeToolBlock(
       : { ...base, status: 'done', result: data.content, result_is_error: false };
     return { ...b, tool };
   });
+}
+
+/**
+ * Returns the index of the most recent user entry that has not yet had a UUID
+ * committed onto it (ADR-046). Returns -1 when no such entry exists. Walking
+ * from the end is correct because `UserMessageCommit` chunks always belong to
+ * the latest pending user prompt — earlier prompts already carry their UUIDs.
+ * @param msgs - Snapshot of `_messages` at the time the commit chunk arrives.
+ */
+function findLastUserIndexMissingUuid(msgs: readonly ChatMessage[]): number {
+  for (let i = msgs.length - 1; i >= 0; i -= 1) {
+    const m = msgs[i];
+    if (m.role === 'user' && !m.uuid) return i;
+  }
+  return -1;
+}
+
+/**
+ * Flattens a message's blocks into a copy-friendly plain-text string. Tool
+ * inputs and outputs are intentionally elided — the user wants the assistant's
+ * prose, not the JSON of every Bash command. Thinking blocks, ask_user, and
+ * tool_use are dropped; text and error contents are concatenated with a blank
+ * line between blocks for readability.
+ * @param blocks - The message blocks to flatten.
+ */
+export function blocksToPlainText(blocks: readonly MessageBlock[]): string {
+  const parts: string[] = [];
+  for (const b of blocks) {
+    if (b.type === 'text') parts.push(b.content);
+    else if (b.type === 'error') parts.push(b.content);
+  }
+  return parts.join('\n\n').trim();
 }


### PR DESCRIPTION
## Summary

Feature 2 from \`design-proposals/06-terminal-minimal-implementation-prompt.md\` (ADR-046):

- **Backend**: per-entry \`uuid\` + \`uuid_status\` (Pending/Committed) tracked from stream-json user/assistant message ids.
- **Tauri**: new \`retry_last_turn(session_id)\` command — kills active child, spawns \`claude --resume <s> --resume-session-at <user_uuid>\`. Never mutates JSONL.
- **Frontend**: \`ChatStateService.copyMessage(idx)\` (flatten text/tool blocks to plain text + clipboard) and \`retryLastAssistant()\` guarded by \`canRetry\` computed. New \`message-actions.component\` mounted under every committed assistant entry.

## Test plan

- [x] \`make test-rust\`: retry happy path + error variants (NoAssistantTurn / PendingAssistant / SessionNotFound / ResumeFailed).
- [x] \`make test-angular\`: copyMessage flattening + canRetry semantics + component disabled states.
- [x] Live UI not exercised — manual smoke-test pending merge.