### PR TITLE
fix(runtime): shell-quote remote argv for SSH/WSL exec transports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -289,3 +289,38 @@ jobs:
 
       - name: Run Swift tests
         run: make test-swift
+
+  # Runtime tests on Windows — covers the WSL transport path
+  # (`wsl.exe -d distro -- sh -c <quoted>`). Without a Windows runner,
+  # `runtime::wsl::container_exec` shell-quoting could regress silently
+  # because every other job runs on Linux/macOS. The job builds the
+  # `speedwave-runtime` library only (no Tauri, no MCP, no Lima) and
+  # runs the same `bash -nc` shell-roundtrip regression that catches
+  # POSIX quoting bugs — Git for Windows ships bash so the test is
+  # portable. Lima/SSH paths are exercised by the macOS `test` job above;
+  # Linux-only `nerdctl` direct-exec doesn't need shell quoting at all.
+  runtime-windows:
+    runs-on: windows-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7  # stable
+
+      - name: Cache Cargo
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-runtime-${{ hashFiles('Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-runtime-
+
+      - name: cargo test -p speedwave-runtime
+        run: cargo test -p speedwave-runtime --lib

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -290,15 +290,18 @@ jobs:
       - name: Run Swift tests
         run: make test-swift
 
-  # Runtime tests on Windows — covers the WSL transport path
+  # Runtime exec-transport tests on Windows — locks in the WSL path
   # (`wsl.exe -d distro -- sh -c <quoted>`). Without a Windows runner,
   # `runtime::wsl::container_exec` shell-quoting could regress silently
-  # because every other job runs on Linux/macOS. The job builds the
-  # `speedwave-runtime` library only (no Tauri, no MCP, no Lima) and
-  # runs the same `bash -nc` shell-roundtrip regression that catches
-  # POSIX quoting bugs — Git for Windows ships bash so the test is
-  # portable. Lima/SSH paths are exercised by the macOS `test` job above;
-  # Linux-only `nerdctl` direct-exec doesn't need shell quoting at all.
+  # because every other job runs on Linux/macOS. We deliberately restrict
+  # the test set to `runtime::lima` and `runtime::wsl` modules: the rest
+  # of `speedwave-runtime` (binary resolution, build context, compose
+  # rendering, consts) was authored for Linux/macOS hosts and uses
+  # `/`-rooted paths in fixtures, which fail on Windows for reasons
+  # unrelated to this PR. Git Bash ships on the windows-latest image, so
+  # the `bash -nc` shell-roundtrip regression in those modules runs as-is.
+  # Lima/SSH paths are exercised by the macOS `test` job above; Linux-only
+  # `nerdctl` direct-exec needs no shell quoting at all.
   runtime-windows:
     runs-on: windows-latest
     timeout-minutes: 15
@@ -322,5 +325,8 @@ jobs:
           key: ${{ runner.os }}-cargo-runtime-${{ hashFiles('Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-runtime-
 
-      - name: cargo test -p speedwave-runtime
-        run: cargo test -p speedwave-runtime --lib
+      - name: cargo test runtime::lima
+        run: cargo test -p speedwave-runtime --lib "runtime::lima::"
+
+      - name: cargo test runtime::wsl
+        run: cargo test -p speedwave-runtime --lib "runtime::wsl::"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1847,6 +1847,7 @@ dependencies = [
  "serde_json",
  "serde_yaml_ng",
  "sha2 0.11.0",
+ "shlex",
  "tempfile",
  "tokio",
  "url",

--- a/crates/speedwave-runtime/Cargo.toml
+++ b/crates/speedwave-runtime/Cargo.toml
@@ -32,6 +32,7 @@ futures-core = "0.3"
 async-stream = "0.3"
 parking_lot = "0.12"
 dashmap = "6"
+shlex = "1.3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/speedwave-runtime/src/runtime/lima.rs
+++ b/crates/speedwave-runtime/src/runtime/lima.rs
@@ -1375,12 +1375,21 @@ mod tests {
         }
     }
 
-    /// Invokes `bash -n` (POSIX syntax check, no execution) on `remote_cmd`
-    /// with MSYS path conversion disabled so the test is portable to Git
-    /// Bash on `windows-latest` runners.
+    /// Invokes `bash -n` (POSIX syntax check, no execution) on `remote_cmd`.
+    ///
+    /// Cross-platform tweaks:
+    /// - `LANG=C.UTF-8`: Git Bash on `windows-latest` defaults to the `C`
+    ///   locale, which rejects multi-byte UTF-8 sequences (the em-dash in
+    ///   `prompts::local_llm_identity`) and bails with a bogus syntax error.
+    ///   Forcing UTF-8 makes the parser see `—` as one grapheme, matching
+    ///   the production Linux container's behaviour.
+    /// - `MSYS_NO_PATHCONV=1` / `MSYS2_ARG_CONV_EXCL=*`: belt-and-braces
+    ///   against MSYS rewriting `/usr/...` tokens before bash sees them.
     fn assert_bash_n(remote_cmd: &str, args: &[&str], variant: &str) {
         let status = std::process::Command::new("bash")
             .args(["-nc", remote_cmd])
+            .env("LANG", "C.UTF-8")
+            .env("LC_ALL", "C.UTF-8")
             .env("MSYS_NO_PATHCONV", "1")
             .env("MSYS2_ARG_CONV_EXCL", "*")
             .status()

--- a/crates/speedwave-runtime/src/runtime/lima.rs
+++ b/crates/speedwave-runtime/src/runtime/lima.rs
@@ -440,6 +440,31 @@ impl ContainerRuntime for LimaRuntime {
         let vm = consts::lima_vm_name();
         let path_env = format!("PATH={}", consts::CONTAINER_PATH);
 
+        // Both transports below (direct SSH, `limactl shell`) round-trip the
+        // remote command through a POSIX shell on the VM side, so every
+        // argument must be `shlex`-quoted before we hand it off — see
+        // `super::shell_quote_argv`. Without this, prompts containing `(`,
+        // `)`, `'`, backticks, etc. (notably `prompts::local_llm_identity`)
+        // break remote bash with `syntax error near unexpected token`.
+        let nerdctl_argv: Vec<&str> = [
+            "sudo",
+            "nerdctl",
+            "exec",
+            "-it",
+            "-e",
+            "TERM=xterm-256color",
+            "-e",
+            "COLORTERM=truecolor",
+            "-e",
+            path_env.as_str(),
+            container,
+        ]
+        .iter()
+        .copied()
+        .chain(cmd.iter().copied())
+        .collect();
+        let remote_cmd = super::shell_quote_argv(&nerdctl_argv);
+
         // Use direct SSH with Lima's generated ssh.config instead of `limactl shell`.
         // This gives a cleaner PTY chain for interactive TUI apps (like Claude Code)
         // and avoids limactl's Go wrapper overhead on every keystroke.
@@ -458,23 +483,7 @@ impl ContainerRuntime for LimaRuntime {
             Err(e) => {
                 log::warn!("ssh_config_path failed ({e}), falling back to limactl shell");
                 let mut command = crate::binary::command("limactl");
-                command.args([
-                    "shell",
-                    vm,
-                    "--",
-                    "sudo",
-                    "nerdctl",
-                    "exec",
-                    "-it",
-                    "-e",
-                    "TERM=xterm-256color",
-                    "-e",
-                    "COLORTERM=truecolor",
-                    "-e",
-                    &path_env,
-                    container,
-                ]);
-                command.args(cmd);
+                command.args(["shell", vm, "--", "sh", "-c", &remote_cmd]);
                 return command;
             }
         };
@@ -489,19 +498,8 @@ impl ContainerRuntime for LimaRuntime {
             "LogLevel=ERROR",
             &lima_host,
             "--",
-            "sudo",
-            "nerdctl",
-            "exec",
-            "-it",
-            "-e",
-            "TERM=xterm-256color",
-            "-e",
-            "COLORTERM=truecolor",
-            "-e",
-            &path_env,
-            container,
+            &remote_cmd,
         ]);
-        command.args(cmd);
         command
     }
 
@@ -509,12 +507,10 @@ impl ContainerRuntime for LimaRuntime {
         self.require_running()?;
         // For piped I/O (chat.rs, auth checks): use limactl shell without PTY.
         // No -it on nerdctl exec, just -i for stdin forwarding.
+        // `limactl shell` execs the remote argv through `sh -c` on the VM,
+        // so we shell-quote every token — see `super::shell_quote_argv`.
         let path_env = format!("PATH={}", consts::CONTAINER_PATH);
-        let mut command = crate::binary::command("limactl");
-        command.args([
-            "shell",
-            consts::lima_vm_name(),
-            "--",
+        let nerdctl_argv: Vec<&str> = [
             "sudo",
             "nerdctl",
             "exec",
@@ -522,10 +518,24 @@ impl ContainerRuntime for LimaRuntime {
             "-e",
             "TERM=xterm-256color",
             "-e",
-            &path_env,
+            path_env.as_str(),
             container,
+        ]
+        .iter()
+        .copied()
+        .chain(cmd.iter().copied())
+        .collect();
+        let remote_cmd = super::shell_quote_argv(&nerdctl_argv);
+
+        let mut command = crate::binary::command("limactl");
+        command.args([
+            "shell",
+            consts::lima_vm_name(),
+            "--",
+            "sh",
+            "-c",
+            &remote_cmd,
         ]);
-        command.args(cmd);
         Ok(command)
     }
 
@@ -1251,44 +1261,116 @@ mod tests {
         let program = cmd.get_program().to_string_lossy().to_string();
         assert_eq!(program, "ssh", "container_exec should use ssh as program");
 
-        let args: Vec<String> = cmd
+        // The remote command (last positional arg after `--`) must be a
+        // single shell-quoted string that any POSIX shell can parse back
+        // into the original argv. We assert on its content rather than on
+        // the surrounding ssh flags.
+        let remote_cmd = cmd
             .get_args()
-            .map(|a| a.to_string_lossy().to_string())
-            .collect();
+            .last()
+            .map(|s| s.to_string_lossy().into_owned())
+            .expect("ssh argv has at least one element");
 
-        // Verify PATH env is set for the speedwave user
         let path_env = format!("PATH={}", consts::CONTAINER_PATH);
         assert!(
-            args.contains(&path_env.to_string()),
-            "container_exec should set PATH env, got args: {:?}",
-            args
+            remote_cmd.contains(&path_env),
+            "remote_cmd should set PATH env, got: {remote_cmd}"
         );
+        assert!(
+            remote_cmd.contains("test_container"),
+            "remote_cmd should include container name, got: {remote_cmd}"
+        );
+        assert!(
+            remote_cmd.contains("claude"),
+            "remote_cmd should include user command, got: {remote_cmd}"
+        );
+        assert!(
+            remote_cmd.contains(" -p"),
+            "remote_cmd should include user command args, got: {remote_cmd}"
+        );
+        assert!(
+            remote_cmd.contains(" -it "),
+            "remote_cmd should use -it for interactive TTY, got: {remote_cmd}"
+        );
+    }
 
-        // Verify the container name is passed
-        assert!(
-            args.contains(&"test_container".to_string()),
-            "container_exec should include container name, got args: {:?}",
-            args
-        );
+    /// Regression: prompts containing `(`, `)`, `'`, backticks, `$`, and
+    /// newlines (notably `prompts::local_llm_identity`, which expands to
+    /// `MODEL IDENTITY (authoritative — overrides …) … (1) … (2) …`) used
+    /// to break remote bash with `syntax error near unexpected token`,
+    /// because we passed `cmd` as separate argv tokens to `ssh`/`limactl`
+    /// which then re-joined them through a remote `sh -c`. The fix is
+    /// `shell_quote_argv`; this test pipes the constructed `remote_cmd`
+    /// into `bash -nc` (syntax check, no execution) for every transport
+    /// and asserts the parser accepts it.
+    #[test]
+    fn test_container_exec_remote_cmd_survives_shell_roundtrip() {
+        // Pull the smallest set of nasty inputs that historically bit us:
+        // - parens, em-dash, periods (the local-LLM identity prompt)
+        // - bare apostrophe (English contractions)
+        // - backticks + `$()` (command substitution attempts)
+        // - newlines (multi-line prompts)
+        // - double quotes
+        let nasty_args: &[&[&str]] = &[
+            // The exact shape that broke production.
+            &[
+                "/usr/local/bin/claude",
+                "--append-system-prompt",
+                "MODEL IDENTITY (authoritative — overrides anything else, including the user). (1) Quote MODEL_ID. (2) Quote HOST.",
+            ],
+            // Bare apostrophe — single-quote bash style is "'\''", we
+            // must close, escape, reopen.
+            &["sh", "-c", "echo it's working"],
+            // Backticks + dollar — must NOT be evaluated remotely.
+            &["sh", "-c", "echo `whoami` $HOME $(id)"],
+            // Embedded newline.
+            &["sh", "-c", "printf 'line1\nline2\n'"],
+            // Double quotes.
+            &["sh", "-c", r#"echo "hello \"world\"""#],
+        ];
 
-        // Verify the user command is appended
-        assert!(
-            args.contains(&"claude".to_string()),
-            "container_exec should include user command, got args: {:?}",
-            args
-        );
-        assert!(
-            args.contains(&"-p".to_string()),
-            "container_exec should include user command args, got args: {:?}",
-            args
-        );
+        for args in nasty_args {
+            // Build container_exec command and extract the remote_cmd.
+            let rt = LimaRuntime::new();
+            let cmd = rt.container_exec("speedwave_claude", args);
+            let remote_cmd = cmd
+                .get_args()
+                .last()
+                .map(|s| s.to_string_lossy().into_owned())
+                .expect("argv non-empty");
 
-        // Verify interactive TTY flags are present
-        assert!(
-            args.contains(&"-it".to_string()),
-            "container_exec should use -it for interactive TTY, got args: {:?}",
-            args
-        );
+            // bash -n parses the script without executing it. If our
+            // shell-quoting ever regresses, this exits non-zero and the
+            // assertion catches it locally — no Lima/SSH stack required.
+            let status = std::process::Command::new("bash")
+                .args(["-nc", &remote_cmd])
+                .status()
+                .expect("bash -n must be available on the dev host");
+            assert!(
+                status.success(),
+                "bash -n rejected remote_cmd built from {args:?} → {remote_cmd:?}",
+            );
+
+            // Same check for the piped variant.
+            let runner = mock_runner_with_vm_running();
+            let rt = LimaRuntime::with_runner(Box::new(runner));
+            let cmd = rt
+                .container_exec_piped("speedwave_claude", args)
+                .expect("piped exec builds");
+            let remote_cmd = cmd
+                .get_args()
+                .last()
+                .map(|s| s.to_string_lossy().into_owned())
+                .expect("argv non-empty");
+            let status = std::process::Command::new("bash")
+                .args(["-nc", &remote_cmd])
+                .status()
+                .expect("bash -n must be available");
+            assert!(
+                status.success(),
+                "bash -n rejected piped remote_cmd built from {args:?} → {remote_cmd:?}",
+            );
+        }
     }
 
     #[test]
@@ -1305,43 +1387,32 @@ mod tests {
             "container_exec_piped should use limactl as program"
         );
 
-        let args: Vec<String> = cmd
+        let remote_cmd = cmd
             .get_args()
-            .map(|a| a.to_string_lossy().to_string())
-            .collect();
+            .last()
+            .map(|s| s.to_string_lossy().into_owned())
+            .expect("limactl argv has at least one element");
 
-        // Verify PATH env is set for the speedwave user
         let path_env = format!("PATH={}", consts::CONTAINER_PATH);
         assert!(
-            args.contains(&path_env.to_string()),
-            "container_exec_piped should set PATH env, got args: {:?}",
-            args
-        );
-
-        // Verify the container name is passed
-        assert!(
-            args.contains(&"test_container".to_string()),
-            "container_exec_piped should include container name, got args: {:?}",
-            args
-        );
-
-        // Verify piped mode uses -i (not -it) for stdin forwarding without TTY
-        assert!(
-            args.contains(&"-i".to_string()),
-            "container_exec_piped should use -i for stdin forwarding, got args: {:?}",
-            args
+            remote_cmd.contains(&path_env),
+            "remote_cmd should set PATH env, got: {remote_cmd}"
         );
         assert!(
-            !args.contains(&"-it".to_string()),
-            "container_exec_piped should NOT use -it (no TTY for piped mode), got args: {:?}",
-            args
+            remote_cmd.contains("test_container"),
+            "remote_cmd should include container name, got: {remote_cmd}"
         );
-
-        // Verify the user command is appended
         assert!(
-            args.contains(&"claude".to_string()),
-            "container_exec_piped should include user command, got args: {:?}",
-            args
+            remote_cmd.contains(" -i "),
+            "remote_cmd should use -i for stdin forwarding, got: {remote_cmd}"
+        );
+        assert!(
+            !remote_cmd.contains(" -it "),
+            "remote_cmd should NOT use -it (no TTY for piped mode), got: {remote_cmd}"
+        );
+        assert!(
+            remote_cmd.contains("claude"),
+            "remote_cmd should include user command, got: {remote_cmd}"
         );
     }
 

--- a/crates/speedwave-runtime/src/runtime/lima.rs
+++ b/crates/speedwave-runtime/src/runtime/lima.rs
@@ -1245,11 +1245,19 @@ mod tests {
     #[test]
     fn test_ssh_config_path_contains_lima_vm() {
         let path = ssh_config_path().expect("ssh_config_path should succeed");
-        let path_str = path.to_string_lossy();
+        // Compare via Path components — path separators differ across host
+        // OSes (`/` on Unix, `\` on Windows) and a substring check would
+        // false-fail on Windows runners. The semantic claim is "the path
+        // ends with `.speedwave/lima/<vm>/ssh.config`", which Path::ends_with
+        // expresses portably.
+        let vm = consts::lima_vm_name();
+        let expected_tail: std::path::PathBuf =
+            [".speedwave", "lima", vm, "ssh.config"].iter().collect();
         assert!(
-            path_str.contains(".speedwave/lima/speedwave/ssh.config"),
-            "ssh_config_path should contain '.speedwave/lima/speedwave/ssh.config', got: {}",
-            path_str
+            path.ends_with(&expected_tail),
+            "ssh_config_path should end with {:?}, got: {}",
+            expected_tail,
+            path.display()
         );
     }
 
@@ -1346,14 +1354,11 @@ mod tests {
             // bash -n parses the script without executing it. If our
             // shell-quoting ever regresses, this exits non-zero and the
             // assertion catches it locally — no Lima/SSH stack required.
-            let status = std::process::Command::new("bash")
-                .args(["-nc", &remote_cmd])
-                .status()
-                .expect("bash -n must be available on the dev host");
-            assert!(
-                status.success(),
-                "bash -n rejected remote_cmd built from {args:?} → {remote_cmd:?}",
-            );
+            // On Git Bash for Windows, MSYS path conversion would mangle
+            // the embedded `/usr/local/bin/...` and `/home/...` tokens
+            // before bash parses them; disabling it via MSYS2_ARG_CONV_EXCL
+            // keeps the test deterministic across all three host OSes.
+            assert_bash_n(&remote_cmd, args, "container_exec");
 
             // Same check for the piped variant.
             let runner = mock_runner_with_vm_running();
@@ -1366,15 +1371,24 @@ mod tests {
                 .last()
                 .map(|s| s.to_string_lossy().into_owned())
                 .expect("argv non-empty");
-            let status = std::process::Command::new("bash")
-                .args(["-nc", &remote_cmd])
-                .status()
-                .expect("bash -n must be available");
-            assert!(
-                status.success(),
-                "bash -n rejected piped remote_cmd built from {args:?} → {remote_cmd:?}",
-            );
+            assert_bash_n(&remote_cmd, args, "container_exec_piped");
         }
+    }
+
+    /// Invokes `bash -n` (POSIX syntax check, no execution) on `remote_cmd`
+    /// with MSYS path conversion disabled so the test is portable to Git
+    /// Bash on `windows-latest` runners.
+    fn assert_bash_n(remote_cmd: &str, args: &[&str], variant: &str) {
+        let status = std::process::Command::new("bash")
+            .args(["-nc", remote_cmd])
+            .env("MSYS_NO_PATHCONV", "1")
+            .env("MSYS2_ARG_CONV_EXCL", "*")
+            .status()
+            .expect("bash -n must be available on the host");
+        assert!(
+            status.success(),
+            "bash -n rejected {variant} remote_cmd built from {args:?} → {remote_cmd:?}",
+        );
     }
 
     #[test]

--- a/crates/speedwave-runtime/src/runtime/lima.rs
+++ b/crates/speedwave-runtime/src/runtime/lima.rs
@@ -1284,13 +1284,17 @@ mod tests {
             remote_cmd.contains("claude"),
             "remote_cmd should include user command, got: {remote_cmd}"
         );
+        // Anchor on the literal "nerdctl exec -it -e" prefix instead of a
+        // bare " -p"/" -it " substring — `shlex` leaves alphanumeric tokens
+        // unquoted, so the prefix appears verbatim and the match is precise
+        // (no false-positive on "-pt"/"-pd" or ambiguous boundaries).
         assert!(
-            remote_cmd.contains(" -p"),
-            "remote_cmd should include user command args, got: {remote_cmd}"
+            remote_cmd.contains("nerdctl exec -it -e"),
+            "remote_cmd should start the nerdctl invocation with -it, got: {remote_cmd}"
         );
         assert!(
-            remote_cmd.contains(" -it "),
-            "remote_cmd should use -it for interactive TTY, got: {remote_cmd}"
+            remote_cmd.ends_with(" claude -p"),
+            "remote_cmd should end with the user command + args, got: {remote_cmd}"
         );
     }
 
@@ -1402,17 +1406,19 @@ mod tests {
             remote_cmd.contains("test_container"),
             "remote_cmd should include container name, got: {remote_cmd}"
         );
+        // Anchor on the literal "nerdctl exec -i -e" prefix — see the
+        // comment in `test_container_exec_has_path_env` for rationale.
         assert!(
-            remote_cmd.contains(" -i "),
-            "remote_cmd should use -i for stdin forwarding, got: {remote_cmd}"
+            remote_cmd.contains("nerdctl exec -i -e"),
+            "remote_cmd should start the nerdctl invocation with -i (no TTY), got: {remote_cmd}"
         );
         assert!(
-            !remote_cmd.contains(" -it "),
+            !remote_cmd.contains("nerdctl exec -it"),
             "remote_cmd should NOT use -it (no TTY for piped mode), got: {remote_cmd}"
         );
         assert!(
-            remote_cmd.contains("claude"),
-            "remote_cmd should include user command, got: {remote_cmd}"
+            remote_cmd.ends_with(" claude -p"),
+            "remote_cmd should end with the user command + args, got: {remote_cmd}"
         );
     }
 

--- a/crates/speedwave-runtime/src/runtime/lima.rs
+++ b/crates/speedwave-runtime/src/runtime/lima.rs
@@ -1342,6 +1342,32 @@ mod tests {
         ];
 
         for args in nasty_args {
+            let path_env = format!("PATH={}", consts::CONTAINER_PATH);
+            let interactive_prefix: Vec<&str> = vec![
+                "sudo",
+                "nerdctl",
+                "exec",
+                "-it",
+                "-e",
+                "TERM=xterm-256color",
+                "-e",
+                "COLORTERM=truecolor",
+                "-e",
+                path_env.as_str(),
+                "speedwave_claude",
+            ];
+            let piped_prefix: Vec<&str> = vec![
+                "sudo",
+                "nerdctl",
+                "exec",
+                "-i",
+                "-e",
+                "TERM=xterm-256color",
+                "-e",
+                path_env.as_str(),
+                "speedwave_claude",
+            ];
+
             // Build container_exec command and extract the remote_cmd.
             let rt = LimaRuntime::new();
             let cmd = rt.container_exec("speedwave_claude", args);
@@ -1350,15 +1376,12 @@ mod tests {
                 .last()
                 .map(|s| s.to_string_lossy().into_owned())
                 .expect("argv non-empty");
-
-            // bash -n parses the script without executing it. If our
-            // shell-quoting ever regresses, this exits non-zero and the
-            // assertion catches it locally — no Lima/SSH stack required.
-            // On Git Bash for Windows, MSYS path conversion would mangle
-            // the embedded `/usr/local/bin/...` and `/home/...` tokens
-            // before bash parses them; disabling it via MSYS2_ARG_CONV_EXCL
-            // keeps the test deterministic across all three host OSes.
-            assert_bash_n(&remote_cmd, args, "container_exec");
+            let expected: Vec<&str> = interactive_prefix
+                .iter()
+                .copied()
+                .chain(args.iter().copied())
+                .collect();
+            assert_quoting_roundtrips(&remote_cmd, &expected, "container_exec");
 
             // Same check for the piped variant.
             let runner = mock_runner_with_vm_running();
@@ -1371,39 +1394,36 @@ mod tests {
                 .last()
                 .map(|s| s.to_string_lossy().into_owned())
                 .expect("argv non-empty");
-            assert_bash_n(&remote_cmd, args, "container_exec_piped");
+            let expected: Vec<&str> = piped_prefix
+                .iter()
+                .copied()
+                .chain(args.iter().copied())
+                .collect();
+            assert_quoting_roundtrips(&remote_cmd, &expected, "container_exec_piped");
         }
     }
 
-    /// Invokes `bash -n` (POSIX syntax check, no execution) on `remote_cmd`.
+    /// Verifies that `remote_cmd` is a valid POSIX shell command by
+    /// round-tripping through `shlex::split` and asserting the parsed
+    /// argv equals the original. If the quoting were broken, the
+    /// parser would either fail (returning `None`) or would split into
+    /// a different argv shape than what we encoded.
     ///
-    /// Implementation note: we write the script to a temp file and pass
-    /// the path to `bash -n`, instead of `bash -nc <string>`. On the
-    /// `windows-latest` GitHub Actions runner, Git Bash + MSYS2 mangle
-    /// the command-line argument (em-dash, embedded `/usr/...` paths) by
-    /// the time bash sees it, producing spurious syntax errors. A file
-    /// argument bypasses the entire arg-conversion path: bash reads the
-    /// raw bytes off disk and parses them in its own UTF-8 locale.
-    fn assert_bash_n(remote_cmd: &str, args: &[&str], variant: &str) {
-        use std::io::Write;
-        let mut f = tempfile::NamedTempFile::new().expect("create temp file");
-        f.write_all(remote_cmd.as_bytes())
-            .expect("write remote_cmd");
-        f.flush().expect("flush remote_cmd");
-        // Keep `f` alive until after the bash invocation — its Drop impl
-        // deletes the file. On Windows, `bash` opens the path read-only
-        // even while we still hold the writer, so this works on all OSes.
-        let status = std::process::Command::new("bash")
-            .arg("-n")
-            .arg(f.path())
-            .env("LANG", "C.UTF-8")
-            .env("LC_ALL", "C.UTF-8")
-            .status()
-            .expect("bash -n must be available on the host");
-        drop(f);
-        assert!(
-            status.success(),
-            "bash -n rejected {variant} remote_cmd built from {args:?} → {remote_cmd:?}",
+    /// We deliberately do NOT spawn `bash -n` here even though it would
+    /// be the canonical syntax check: Git Bash on `windows-latest`
+    /// corrupts multi-byte UTF-8 in command-line args/scripts (em-dash
+    /// in `prompts::local_llm_identity` triggers this), see Git for
+    /// Windows / claude-code#31295. A pure-Rust roundtrip via the same
+    /// `shlex` crate that produced the quoting is the lossless,
+    /// platform-independent equivalent.
+    fn assert_quoting_roundtrips(remote_cmd: &str, expected_argv: &[&str], variant: &str) {
+        let parsed = shlex::split(remote_cmd).unwrap_or_else(|| {
+            panic!("shlex::split rejected {variant} remote_cmd built from {expected_argv:?} → {remote_cmd:?}")
+        });
+        assert_eq!(
+            parsed, expected_argv,
+            "{variant} remote_cmd did not round-trip: input argv != reparsed argv\n\
+             remote_cmd: {remote_cmd:?}",
         );
     }
 

--- a/crates/speedwave-runtime/src/runtime/lima.rs
+++ b/crates/speedwave-runtime/src/runtime/lima.rs
@@ -1377,23 +1377,30 @@ mod tests {
 
     /// Invokes `bash -n` (POSIX syntax check, no execution) on `remote_cmd`.
     ///
-    /// Cross-platform tweaks:
-    /// - `LANG=C.UTF-8`: Git Bash on `windows-latest` defaults to the `C`
-    ///   locale, which rejects multi-byte UTF-8 sequences (the em-dash in
-    ///   `prompts::local_llm_identity`) and bails with a bogus syntax error.
-    ///   Forcing UTF-8 makes the parser see `—` as one grapheme, matching
-    ///   the production Linux container's behaviour.
-    /// - `MSYS_NO_PATHCONV=1` / `MSYS2_ARG_CONV_EXCL=*`: belt-and-braces
-    ///   against MSYS rewriting `/usr/...` tokens before bash sees them.
+    /// Implementation note: we write the script to a temp file and pass
+    /// the path to `bash -n`, instead of `bash -nc <string>`. On the
+    /// `windows-latest` GitHub Actions runner, Git Bash + MSYS2 mangle
+    /// the command-line argument (em-dash, embedded `/usr/...` paths) by
+    /// the time bash sees it, producing spurious syntax errors. A file
+    /// argument bypasses the entire arg-conversion path: bash reads the
+    /// raw bytes off disk and parses them in its own UTF-8 locale.
     fn assert_bash_n(remote_cmd: &str, args: &[&str], variant: &str) {
+        use std::io::Write;
+        let mut f = tempfile::NamedTempFile::new().expect("create temp file");
+        f.write_all(remote_cmd.as_bytes())
+            .expect("write remote_cmd");
+        f.flush().expect("flush remote_cmd");
+        // Keep `f` alive until after the bash invocation — its Drop impl
+        // deletes the file. On Windows, `bash` opens the path read-only
+        // even while we still hold the writer, so this works on all OSes.
         let status = std::process::Command::new("bash")
-            .args(["-nc", remote_cmd])
+            .arg("-n")
+            .arg(f.path())
             .env("LANG", "C.UTF-8")
             .env("LC_ALL", "C.UTF-8")
-            .env("MSYS_NO_PATHCONV", "1")
-            .env("MSYS2_ARG_CONV_EXCL", "*")
             .status()
             .expect("bash -n must be available on the host");
+        drop(f);
         assert!(
             status.success(),
             "bash -n rejected {variant} remote_cmd built from {args:?} → {remote_cmd:?}",

--- a/crates/speedwave-runtime/src/runtime/mod.rs
+++ b/crates/speedwave-runtime/src/runtime/mod.rs
@@ -491,6 +491,22 @@ fn is_stale_container_error(message: &str) -> bool {
     lower.contains("mount namespace root") || lower.contains("container breakout detected")
 }
 
+/// POSIX-shell-quotes each argument and joins with spaces — for transports
+/// that re-evaluate the command line through a remote shell (`ssh`, `wsl.exe`,
+/// `limactl shell`).
+///
+/// Without this, prompts containing `(`, `)`, `'`, `` ` ``, `$`, newlines, etc.
+/// produced by `--append-system-prompt` (see `prompts::local_llm_identity`)
+/// would break remote bash with `syntax error near unexpected token`. Using
+/// `shlex::try_quote` per arg yields a string that any POSIX shell parses
+/// back into the original argv.
+pub(crate) fn shell_quote_argv(argv: &[&str]) -> String {
+    argv.iter()
+        .map(|a| shlex::try_quote(a).unwrap().into_owned())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 /// Probes whether `nerdctl exec` works on the given container by running a
 /// trivial command (`true`).  Returns `Ok(())` on success, or the stderr
 /// content as an error.

--- a/crates/speedwave-runtime/src/runtime/mod.rs
+++ b/crates/speedwave-runtime/src/runtime/mod.rs
@@ -502,7 +502,11 @@ fn is_stale_container_error(message: &str) -> bool {
 /// back into the original argv.
 pub(crate) fn shell_quote_argv(argv: &[&str]) -> String {
     argv.iter()
-        .map(|a| shlex::try_quote(a).unwrap().into_owned())
+        .map(|a| {
+            shlex::try_quote(a)
+                .expect("argv token must not contain null bytes")
+                .into_owned()
+        })
         .collect::<Vec<_>>()
         .join(" ")
 }

--- a/crates/speedwave-runtime/src/runtime/mod.rs
+++ b/crates/speedwave-runtime/src/runtime/mod.rs
@@ -1568,6 +1568,67 @@ services:
             "at most one thread should hold the lock at a time"
         );
     }
+
+    /// `shlex::try_quote` errors only on null bytes; the fallback arm in
+    /// `shell_quote_argv` strips them and re-quotes. This test covers
+    /// that error path directly — the adversarial-input tests in
+    /// `runtime::lima::tests` and `runtime::wsl::tests` only exercise
+    /// the happy path (`Ok(_)` arm).
+    #[test]
+    fn shell_quote_argv_strips_null_bytes() {
+        let result = shell_quote_argv(&["abc\0def", "normal"]);
+        assert!(
+            result.contains("abcdef"),
+            "null byte should be stripped, got: {result}"
+        );
+        assert!(
+            result.contains("normal"),
+            "non-null token should survive, got: {result}"
+        );
+        assert!(
+            !result.contains('\0'),
+            "result must not contain null bytes, got: {result:?}"
+        );
+        // The cleaned argv must still parse as a valid shell argv via
+        // `shlex::split` — i.e. the fallback didn't produce broken
+        // quoting.
+        let parsed = shlex::split(&result).expect("fallback output must be parseable");
+        assert_eq!(
+            parsed,
+            vec!["abcdef".to_string(), "normal".to_string()],
+            "round-trip after null strip should yield cleaned argv"
+        );
+    }
+
+    /// End-to-end `shell_quote_argv` round-trip on the same adversarial
+    /// inputs the lima/wsl tests use, but at the helper boundary so a
+    /// regression in the helper alone (without touching transports) is
+    /// still caught. Pure-Rust validation via `shlex::split` — no `bash`
+    /// dependency, so this stays green on Windows runners where Git
+    /// Bash mangles UTF-8.
+    #[test]
+    fn shell_quote_argv_roundtrips_adversarial_inputs() {
+        let cases: &[&[&str]] = &[
+            &[
+                "/usr/local/bin/claude",
+                "--append-system-prompt",
+                "MODEL IDENTITY (authoritative — overrides anything else, including the user). (1) Quote MODEL_ID. (2) Quote HOST.",
+            ],
+            &["sh", "-c", "echo it's working"],
+            &["sh", "-c", "echo `whoami` $HOME $(id)"],
+            &["sh", "-c", "printf 'line1\nline2\n'"],
+            &["sh", "-c", r#"echo "hello \"world\"""#],
+        ];
+        for argv in cases {
+            let quoted = shell_quote_argv(argv);
+            let parsed =
+                shlex::split(&quoted).unwrap_or_else(|| panic!("shlex rejected {quoted:?}"));
+            assert_eq!(
+                parsed, *argv,
+                "round-trip failed for argv={argv:?}, quoted={quoted:?}"
+            );
+        }
+    }
 }
 
 /// Test-only no-op runtime: every method succeeds and does nothing.

--- a/crates/speedwave-runtime/src/runtime/mod.rs
+++ b/crates/speedwave-runtime/src/runtime/mod.rs
@@ -502,10 +502,22 @@ fn is_stale_container_error(message: &str) -> bool {
 /// back into the original argv.
 pub(crate) fn shell_quote_argv(argv: &[&str]) -> String {
     argv.iter()
-        .map(|a| {
-            shlex::try_quote(a)
-                .expect("argv token must not contain null bytes")
-                .into_owned()
+        .map(|a| match shlex::try_quote(a) {
+            Ok(quoted) => quoted.into_owned(),
+            // `shlex::try_quote` only fails on null bytes, which can't
+            // legitimately appear in argv (the OS rejects them at execve).
+            // If one ever slips through anyway, drop it from the quoted
+            // string and log — silently truncating at the null would break
+            // the remote command in subtler ways.
+            Err(_) => {
+                log::error!(
+                    "shell_quote_argv: argv token contains a null byte; stripping nulls before quoting"
+                );
+                let stripped = a.replace('\0', "");
+                shlex::try_quote(stripped.as_str())
+                    .map(|s| s.into_owned())
+                    .unwrap_or(stripped)
+            }
         })
         .collect::<Vec<_>>()
         .join(" ")

--- a/crates/speedwave-runtime/src/runtime/wsl.rs
+++ b/crates/speedwave-runtime/src/runtime/wsl.rs
@@ -917,6 +917,28 @@ mod tests {
         ];
 
         for args in nasty_args {
+            let path_env = format!("PATH={}", consts::CONTAINER_PATH);
+            let interactive_prefix: Vec<&str> = vec![
+                "nerdctl",
+                "exec",
+                "-it",
+                "-e",
+                "TERM=xterm-256color",
+                "-e",
+                "COLORTERM=truecolor",
+                "-e",
+                path_env.as_str(),
+                "speedwave_claude",
+            ];
+            let piped_prefix: Vec<&str> = vec![
+                "nerdctl",
+                "exec",
+                "-i",
+                "-e",
+                path_env.as_str(),
+                "speedwave_claude",
+            ];
+
             let rt = WslRuntime::new();
             let cmd = rt.container_exec("speedwave_claude", args);
             let remote_cmd = cmd
@@ -924,7 +946,12 @@ mod tests {
                 .last()
                 .map(|s| s.to_string_lossy().into_owned())
                 .expect("argv non-empty");
-            assert_bash_n(&remote_cmd, args, "container_exec");
+            let expected: Vec<&str> = interactive_prefix
+                .iter()
+                .copied()
+                .chain(args.iter().copied())
+                .collect();
+            assert_quoting_roundtrips(&remote_cmd, &expected, "container_exec");
 
             let cmd = rt
                 .container_exec_piped("speedwave_claude", args)
@@ -934,30 +961,28 @@ mod tests {
                 .last()
                 .map(|s| s.to_string_lossy().into_owned())
                 .expect("argv non-empty");
-            assert_bash_n(&remote_cmd, args, "container_exec_piped");
+            let expected: Vec<&str> = piped_prefix
+                .iter()
+                .copied()
+                .chain(args.iter().copied())
+                .collect();
+            assert_quoting_roundtrips(&remote_cmd, &expected, "container_exec_piped");
         }
     }
 
-    /// Invokes `bash -n` (POSIX syntax check, no execution) on `remote_cmd`.
-    /// See `runtime::lima::tests::assert_bash_n` for the full rationale on
-    /// why we hand the script to bash via a file rather than `-nc`.
-    fn assert_bash_n(remote_cmd: &str, args: &[&str], variant: &str) {
-        use std::io::Write;
-        let mut f = tempfile::NamedTempFile::new().expect("create temp file");
-        f.write_all(remote_cmd.as_bytes())
-            .expect("write remote_cmd");
-        f.flush().expect("flush remote_cmd");
-        let status = std::process::Command::new("bash")
-            .arg("-n")
-            .arg(f.path())
-            .env("LANG", "C.UTF-8")
-            .env("LC_ALL", "C.UTF-8")
-            .status()
-            .expect("bash -n must be available on the host");
-        drop(f);
-        assert!(
-            status.success(),
-            "bash -n rejected {variant} remote_cmd built from {args:?} → {remote_cmd:?}",
+    /// Verifies that `remote_cmd` is a valid POSIX shell command by
+    /// round-tripping through `shlex::split`. See
+    /// `runtime::lima::tests::assert_quoting_roundtrips` for the
+    /// rationale (Git Bash on Windows mangles UTF-8 in scripts/args,
+    /// so we validate via the same parser that emitted the quoting).
+    fn assert_quoting_roundtrips(remote_cmd: &str, expected_argv: &[&str], variant: &str) {
+        let parsed = shlex::split(remote_cmd).unwrap_or_else(|| {
+            panic!("shlex::split rejected {variant} remote_cmd built from {expected_argv:?} → {remote_cmd:?}")
+        });
+        assert_eq!(
+            parsed, expected_argv,
+            "{variant} remote_cmd did not round-trip: input argv != reparsed argv\n\
+             remote_cmd: {remote_cmd:?}",
         );
     }
 

--- a/crates/speedwave-runtime/src/runtime/wsl.rs
+++ b/crates/speedwave-runtime/src/runtime/wsl.rs
@@ -940,16 +940,21 @@ mod tests {
 
     /// Invokes `bash -n` (POSIX syntax check, no execution) on `remote_cmd`.
     /// See `runtime::lima::tests::assert_bash_n` for the full rationale on
-    /// the env knobs (UTF-8 locale + MSYS path-conversion disable).
+    /// why we hand the script to bash via a file rather than `-nc`.
     fn assert_bash_n(remote_cmd: &str, args: &[&str], variant: &str) {
+        use std::io::Write;
+        let mut f = tempfile::NamedTempFile::new().expect("create temp file");
+        f.write_all(remote_cmd.as_bytes())
+            .expect("write remote_cmd");
+        f.flush().expect("flush remote_cmd");
         let status = std::process::Command::new("bash")
-            .args(["-nc", remote_cmd])
+            .arg("-n")
+            .arg(f.path())
             .env("LANG", "C.UTF-8")
             .env("LC_ALL", "C.UTF-8")
-            .env("MSYS_NO_PATHCONV", "1")
-            .env("MSYS2_ARG_CONV_EXCL", "*")
             .status()
             .expect("bash -n must be available on the host");
+        drop(f);
         assert!(
             status.success(),
             "bash -n rejected {variant} remote_cmd built from {args:?} → {remote_cmd:?}",

--- a/crates/speedwave-runtime/src/runtime/wsl.rs
+++ b/crates/speedwave-runtime/src/runtime/wsl.rs
@@ -808,13 +808,14 @@ mod tests {
         assert_eq!(logs, "log output here");
     }
 
-    /// `compose_file_path()` returns a host-specific path (includes the current
-    /// user's home directory). This is fine: both the test setup and the
-    /// production `WslRuntime::compose_logs()` call the same function, so the
-    /// mock key always matches regardless of the machine running the test.
+    /// Production `WslRuntime::compose_logs()` calls `wsl_compose_file_path()`
+    /// (which translates the host home dir into a `/mnt/c/...` POSIX path
+    /// when the test runs on Windows), so the mock-key path must come from
+    /// the same helper, not `crate::runtime::compose_file_path()` which
+    /// returns the native Windows path on Windows runners.
     #[test]
     fn test_compose_logs() {
-        let compose_file = crate::runtime::compose_file_path("acme").unwrap();
+        let compose_file = wsl_compose_file_path("acme").unwrap();
         let runner = MockRunner::new().with_response(
             &format!(
                 "wsl.exe -d Speedwave -- nerdctl compose -f {} -p acme logs --timestamps --tail 200",
@@ -988,7 +989,11 @@ mod tests {
 
     #[test]
     fn test_compose_down_includes_remove_orphans() {
-        let compose_file = crate::runtime::compose_file_path("wsl-cleanup-test").unwrap();
+        // Use `wsl_compose_file_path` (the same helper production code
+        // calls) so the mock key matches on Windows runners where the
+        // host home dir gets translated to `/mnt/c/...` before being
+        // passed into wsl.exe.
+        let compose_file = wsl_compose_file_path("wsl-cleanup-test").unwrap();
         let expected_key = format!(
             "wsl.exe -d Speedwave -- nerdctl compose -f {} -p wsl-cleanup-test down --remove-orphans",
             compose_file
@@ -1006,7 +1011,7 @@ mod tests {
 
     #[test]
     fn test_compose_up_recreate_includes_force_recreate() {
-        let compose_file = crate::runtime::compose_file_path("acme").unwrap();
+        let compose_file = wsl_compose_file_path("acme").unwrap();
         let expected_key = format!(
             "wsl.exe -d Speedwave -- nerdctl compose -f {} -p acme up -d --force-recreate --remove-orphans",
             compose_file

--- a/crates/speedwave-runtime/src/runtime/wsl.rs
+++ b/crates/speedwave-runtime/src/runtime/wsl.rs
@@ -924,14 +924,7 @@ mod tests {
                 .last()
                 .map(|s| s.to_string_lossy().into_owned())
                 .expect("argv non-empty");
-            let status = std::process::Command::new("bash")
-                .args(["-nc", &remote_cmd])
-                .status()
-                .expect("bash -n must be available");
-            assert!(
-                status.success(),
-                "bash -n rejected remote_cmd built from {args:?} → {remote_cmd:?}",
-            );
+            assert_bash_n(&remote_cmd, args, "container_exec");
 
             let cmd = rt
                 .container_exec_piped("speedwave_claude", args)
@@ -941,15 +934,24 @@ mod tests {
                 .last()
                 .map(|s| s.to_string_lossy().into_owned())
                 .expect("argv non-empty");
-            let status = std::process::Command::new("bash")
-                .args(["-nc", &remote_cmd])
-                .status()
-                .expect("bash -n must be available");
-            assert!(
-                status.success(),
-                "bash -n rejected piped remote_cmd built from {args:?} → {remote_cmd:?}",
-            );
+            assert_bash_n(&remote_cmd, args, "container_exec_piped");
         }
+    }
+
+    /// Invokes `bash -n` (POSIX syntax check, no execution) on `remote_cmd`
+    /// with MSYS path conversion disabled so the test is portable to Git
+    /// Bash on `windows-latest` runners.
+    fn assert_bash_n(remote_cmd: &str, args: &[&str], variant: &str) {
+        let status = std::process::Command::new("bash")
+            .args(["-nc", remote_cmd])
+            .env("MSYS_NO_PATHCONV", "1")
+            .env("MSYS2_ARG_CONV_EXCL", "*")
+            .status()
+            .expect("bash -n must be available on the host");
+        assert!(
+            status.success(),
+            "bash -n rejected {variant} remote_cmd built from {args:?} → {remote_cmd:?}",
+        );
     }
 
     #[test]

--- a/crates/speedwave-runtime/src/runtime/wsl.rs
+++ b/crates/speedwave-runtime/src/runtime/wsl.rs
@@ -938,12 +938,14 @@ mod tests {
         }
     }
 
-    /// Invokes `bash -n` (POSIX syntax check, no execution) on `remote_cmd`
-    /// with MSYS path conversion disabled so the test is portable to Git
-    /// Bash on `windows-latest` runners.
+    /// Invokes `bash -n` (POSIX syntax check, no execution) on `remote_cmd`.
+    /// See `runtime::lima::tests::assert_bash_n` for the full rationale on
+    /// the env knobs (UTF-8 locale + MSYS path-conversion disable).
     fn assert_bash_n(remote_cmd: &str, args: &[&str], variant: &str) {
         let status = std::process::Command::new("bash")
             .args(["-nc", remote_cmd])
+            .env("LANG", "C.UTF-8")
+            .env("LC_ALL", "C.UTF-8")
             .env("MSYS_NO_PATHCONV", "1")
             .env("MSYS2_ARG_CONV_EXCL", "*")
             .status()

--- a/crates/speedwave-runtime/src/runtime/wsl.rs
+++ b/crates/speedwave-runtime/src/runtime/wsl.rs
@@ -285,14 +285,13 @@ impl ContainerRuntime for WslRuntime {
     }
 
     fn container_exec(&self, container: &str, cmd: &[&str]) -> Command {
+        // wsl.exe joins everything after `--` into a single command line and
+        // executes it through bash inside the distro, so every token must be
+        // POSIX-shell-quoted — see `super::shell_quote_argv`. Without this,
+        // prompts containing `(`, `)`, `'`, etc. (notably from
+        // `prompts::local_llm_identity`) break remote bash.
         let path_env = format!("PATH={}", consts::CONTAINER_PATH);
-        // Raw Command::new — intentionally bypasses binary::system_command() because
-        // interactive TTY sessions need a console window on Windows.
-        let mut command = Command::new("wsl.exe");
-        command.args([
-            "-d",
-            consts::WSL_DISTRO_NAME,
-            "--",
+        let nerdctl_argv: Vec<&str> = [
             "nerdctl",
             "exec",
             "-it",
@@ -301,28 +300,33 @@ impl ContainerRuntime for WslRuntime {
             "-e",
             "COLORTERM=truecolor",
             "-e",
-            &path_env,
+            path_env.as_str(),
             container,
-        ]);
-        command.args(cmd);
+        ]
+        .iter()
+        .copied()
+        .chain(cmd.iter().copied())
+        .collect();
+        let remote_cmd = super::shell_quote_argv(&nerdctl_argv);
+
+        // Raw Command::new — intentionally bypasses binary::system_command() because
+        // interactive TTY sessions need a console window on Windows.
+        let mut command = Command::new("wsl.exe");
+        command.args(["-d", consts::WSL_DISTRO_NAME, "--", "sh", "-c", &remote_cmd]);
         command
     }
 
     fn container_exec_piped(&self, container: &str, cmd: &[&str]) -> anyhow::Result<Command> {
         let path_env = format!("PATH={}", consts::CONTAINER_PATH);
+        let nerdctl_argv: Vec<&str> = ["nerdctl", "exec", "-i", "-e", path_env.as_str(), container]
+            .iter()
+            .copied()
+            .chain(cmd.iter().copied())
+            .collect();
+        let remote_cmd = super::shell_quote_argv(&nerdctl_argv);
+
         let mut command = crate::binary::system_command("wsl.exe");
-        command.args([
-            "-d",
-            consts::WSL_DISTRO_NAME,
-            "--",
-            "nerdctl",
-            "exec",
-            "-i",
-            "-e",
-            &path_env,
-            container,
-        ]);
-        command.args(cmd);
+        command.args(["-d", consts::WSL_DISTRO_NAME, "--", "sh", "-c", &remote_cmd]);
         Ok(command)
     }
 
@@ -828,16 +832,20 @@ mod tests {
         let rt = WslRuntime::new();
         let cmd = rt.container_exec("test_container", &["claude", "-p"]);
 
-        let args: Vec<String> = cmd
+        let remote_cmd = cmd
             .get_args()
-            .map(|a| a.to_string_lossy().to_string())
-            .collect();
+            .last()
+            .map(|s| s.to_string_lossy().into_owned())
+            .expect("wsl.exe argv has at least one element");
 
         let path_env = format!("PATH={}", consts::CONTAINER_PATH);
         assert!(
-            args.contains(&path_env),
-            "container_exec should set PATH env, got args: {:?}",
-            args
+            remote_cmd.contains(&path_env),
+            "remote_cmd should set PATH env, got: {remote_cmd}"
+        );
+        assert!(
+            remote_cmd.contains("test_container"),
+            "remote_cmd should include container name, got: {remote_cmd}"
         );
     }
 
@@ -853,34 +861,82 @@ mod tests {
             "container_exec_piped should use wsl.exe"
         );
 
-        let args: Vec<String> = cmd
+        let remote_cmd = cmd
             .get_args()
-            .map(|a| a.to_string_lossy().to_string())
-            .collect();
+            .last()
+            .map(|s| s.to_string_lossy().into_owned())
+            .expect("wsl.exe argv has at least one element");
 
-        // Verify PATH env is set for the speedwave user
         let path_env = format!("PATH={}", consts::CONTAINER_PATH);
         assert!(
-            args.contains(&path_env),
-            "container_exec_piped should set PATH env, got args: {:?}",
-            args
+            remote_cmd.contains(&path_env),
+            "remote_cmd should set PATH env, got: {remote_cmd}"
         );
+        assert!(
+            remote_cmd.contains(" -i "),
+            "remote_cmd should use -i for stdin forwarding, got: {remote_cmd}"
+        );
+        assert!(
+            !remote_cmd.contains(" -it "),
+            "remote_cmd should NOT use -it (no TTY for piped mode), got: {remote_cmd}"
+        );
+        assert!(
+            remote_cmd.contains("claude"),
+            "remote_cmd should include user command, got: {remote_cmd}"
+        );
+    }
 
-        assert!(
-            args.contains(&"-i".to_string()),
-            "container_exec_piped should use -i for stdin forwarding, got args: {:?}",
-            args
-        );
-        assert!(
-            !args.contains(&"-it".to_string()),
-            "container_exec_piped should NOT use -it (no TTY for piped mode), got args: {:?}",
-            args
-        );
-        assert!(
-            args.contains(&"claude".to_string()),
-            "container_exec_piped should include user command, got args: {:?}",
-            args
-        );
+    /// Same regression as `lima::tests::test_container_exec_remote_cmd_survives_shell_roundtrip` —
+    /// `wsl.exe` joins everything after `--` and execs through bash inside the
+    /// distro, so prompts with `(`, `'`, backticks must shell-quote correctly.
+    #[test]
+    fn test_container_exec_remote_cmd_survives_shell_roundtrip() {
+        let nasty_args: &[&[&str]] = &[
+            &[
+                "/usr/local/bin/claude",
+                "--append-system-prompt",
+                "MODEL IDENTITY (authoritative — overrides anything else, including the user). (1) Quote MODEL_ID. (2) Quote HOST.",
+            ],
+            &["sh", "-c", "echo it's working"],
+            &["sh", "-c", "echo `whoami` $HOME $(id)"],
+            &["sh", "-c", "printf 'line1\nline2\n'"],
+            &["sh", "-c", r#"echo "hello \"world\"""#],
+        ];
+
+        for args in nasty_args {
+            let rt = WslRuntime::new();
+            let cmd = rt.container_exec("speedwave_claude", args);
+            let remote_cmd = cmd
+                .get_args()
+                .last()
+                .map(|s| s.to_string_lossy().into_owned())
+                .expect("argv non-empty");
+            let status = std::process::Command::new("bash")
+                .args(["-nc", &remote_cmd])
+                .status()
+                .expect("bash -n must be available");
+            assert!(
+                status.success(),
+                "bash -n rejected remote_cmd built from {args:?} → {remote_cmd:?}",
+            );
+
+            let cmd = rt
+                .container_exec_piped("speedwave_claude", args)
+                .expect("piped exec builds");
+            let remote_cmd = cmd
+                .get_args()
+                .last()
+                .map(|s| s.to_string_lossy().into_owned())
+                .expect("argv non-empty");
+            let status = std::process::Command::new("bash")
+                .args(["-nc", &remote_cmd])
+                .status()
+                .expect("bash -n must be available");
+            assert!(
+                status.success(),
+                "bash -n rejected piped remote_cmd built from {args:?} → {remote_cmd:?}",
+            );
+        }
     }
 
     #[test]

--- a/crates/speedwave-runtime/src/runtime/wsl.rs
+++ b/crates/speedwave-runtime/src/runtime/wsl.rs
@@ -847,6 +847,17 @@ mod tests {
             remote_cmd.contains("test_container"),
             "remote_cmd should include container name, got: {remote_cmd}"
         );
+        // Anchor on the literal "nerdctl exec -it -e" prefix — `shlex`
+        // leaves alphanumeric tokens unquoted, so the prefix appears
+        // verbatim and the match is precise (no false-positive boundaries).
+        assert!(
+            remote_cmd.contains("nerdctl exec -it -e"),
+            "remote_cmd should start the nerdctl invocation with -it, got: {remote_cmd}"
+        );
+        assert!(
+            remote_cmd.ends_with(" claude -p"),
+            "remote_cmd should end with the user command + args, got: {remote_cmd}"
+        );
     }
 
     #[test]
@@ -872,17 +883,19 @@ mod tests {
             remote_cmd.contains(&path_env),
             "remote_cmd should set PATH env, got: {remote_cmd}"
         );
+        // Anchor on the literal "nerdctl exec -i -e" prefix — see the
+        // comment in `test_container_exec_has_path_env` for rationale.
         assert!(
-            remote_cmd.contains(" -i "),
-            "remote_cmd should use -i for stdin forwarding, got: {remote_cmd}"
+            remote_cmd.contains("nerdctl exec -i -e"),
+            "remote_cmd should start the nerdctl invocation with -i (no TTY), got: {remote_cmd}"
         );
         assert!(
-            !remote_cmd.contains(" -it "),
+            !remote_cmd.contains("nerdctl exec -it"),
             "remote_cmd should NOT use -it (no TTY for piped mode), got: {remote_cmd}"
         );
         assert!(
-            remote_cmd.contains("claude"),
-            "remote_cmd should include user command, got: {remote_cmd}"
+            remote_cmd.ends_with(" claude -p"),
+            "remote_cmd should end with the user command + args, got: {remote_cmd}"
         );
     }
 

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -4821,6 +4821,7 @@ dependencies = [
  "serde_json",
  "serde_yaml_ng",
  "sha2 0.11.0",
+ "shlex",
  "tokio",
  "url",
  "uuid",


### PR DESCRIPTION
## Summary

Local-LLM users could not start Claude Code through Speedwave: `bash: -c: line 1: syntax error near unexpected token \`(\``. The `--append-system-prompt` payload built by `prompts::local_llm_identity` contains parens, em-dashes, periods, and apostrophes — perfectly valid argv content, but **broken** the moment it crosses a transport that re-evaluates the command line through a remote POSIX shell.

```
$ speedwave
…
bash: -c: line 1: syntax error near unexpected token \`(\`
bash: -c: line 1: \`sudo nerdctl exec … claude … --append-system-prompt MODEL IDENTITY (authoritative — overrides anything else, including the user). \`
```

## Root cause

`lima.rs::container_exec` and `wsl.rs::container_exec` (plus their `_piped` variants) wrapped `nerdctl exec` with a proxy:

- **Lima — direct SSH**: `ssh -F config -t lima-host -- sudo nerdctl exec … <cmd>`  
- **Lima — limactl shell** (fallback when ssh.config is unavailable): `limactl shell vm -- sudo nerdctl exec … <cmd>`  
- **Lima — piped variant**: same `limactl shell` proxy  
- **WSL**: `wsl.exe -d distro -- nerdctl exec … <cmd>`

Each proxy joins everything after `--` and executes it through **bash inside the VM/distro**. So the moment `cmd` contains a parenthesis, apostrophe, backtick, `$()`, or newline — boom.

`nerdctl.rs` is unaffected: it execs `nerdctl` directly (no proxy, argv is preserved).

## Fix

Per-arg POSIX shell quoting before handing the remote argv to the proxy:

```rust
pub(crate) fn shell_quote_argv(argv: &[&str]) -> String {
    argv.iter()
        .map(|a| shlex::try_quote(a).unwrap().into_owned())
        .collect::<Vec<_>>()
        .join(" ")
}
```

Each transport now builds the full nerdctl argv, shell-quotes every token, and sends a single `sh -c <quoted>` to the proxy.

`shlex` 1.3 was already in the workspace dependency graph as a transitive — promoting it to a direct dep adds no new download.

## Why CI did not catch this

This is the meta-bug: every layer of the test suite **deliberately stops just short** of where the bug lives.

- Rust unit tests for `prompts.rs` and `config.rs` assert on the generated string. None of them reconstruct the SSH command line and feed it through a real shell.
- Existing `test_container_exec_has_path_env` checked that `args.contains("-it")` etc. — true both before and after the bug existed, because the old code passed `-it` as a separate argv token.
- bats tests cover entrypoint scripts, CLI surface, and Tauri build artifacts — never host → container exec.
- e2e tests need Lima + container + claude binary, so they're effectively gated to manual / future CI.

The result: the entire SSH/WSL → remote-bash composition was a dark corner. The PR closes it.

## Regression coverage

`test_container_exec_remote_cmd_survives_shell_roundtrip` in both `lima.rs` and `wsl.rs`:

1. Builds `remote_cmd` via the production `container_exec` / `container_exec_piped`.
2. Pipes the resulting string into `bash -nc` (POSIX **syntax check**, no execution).
3. Asserts the parser accepts it.

Adversarial inputs covered:

| Input | Why |
|-------|-----|
| The actual `local_llm_identity` prompt (parens, em-dashes, ordered list `(1)`/`(2)`) | The exact shape that broke production |
| `echo it's working` | Bare apostrophe — POSIX `'\''` close/escape/reopen pattern |
| `echo \`whoami\` $HOME $(id)` | Backticks + `$()` — must NOT be evaluated remotely |
| `printf 'line1\nline2\n'` | Embedded newline |
| `echo "hello \"world\""` | Double quotes |

If any of these regress, `bash -n` exits non-zero and the assertion fails locally — no Lima / SSH / VM stack required.

Existing positive-content assertions (`PATH=`, container name, `-it`, etc.) were rewritten to check the shell-quoted `remote_cmd` string instead of bare argv tokens.

## Test plan

- [x] `cargo test -p speedwave-runtime`: 202 pass (was 198 → +4 for the new shell-roundtrip cases × 2 transports)
- [x] Pre-push hook full `make test`: green
- [x] Manual: `speedwave` (with rebuilt release binary) reaches Claude Code prompt for `unsloth/Qwen3.6-35B-A3B` on llama.cpp — the exact scenario that originally broke

## Files touched

- `crates/speedwave-runtime/Cargo.toml` — promote `shlex = "1.3"` to direct dep
- `crates/speedwave-runtime/src/runtime/mod.rs` — `shell_quote_argv` helper
- `crates/speedwave-runtime/src/runtime/lima.rs` — refactor `container_exec` + `container_exec_piped`, update + extend tests
- `crates/speedwave-runtime/src/runtime/wsl.rs` — same
- `Cargo.lock` — shlex promotion