### PR TITLE
chore(runtime): bump Claude Code 2.1.104 → 2.1.121

### DIFF
--- a/containers/claude-resources/system-prompts/local-llm.md
+++ b/containers/claude-resources/system-prompts/local-llm.md
@@ -10,12 +10,10 @@ When you need to do something with the world (read a file, browse a page, query 
 
 The Speedwave MCP hub exposes these core tools to you:
 
-- **Bash** — run a shell command inside the container. Use for file listing, git, build/test commands, quick inspections. Prefer dedicated tools (Read/Edit/Grep/Glob) when one fits.
+- **Bash** — run a shell command inside the container. Use for file listing, git, build/test commands, quick inspections, finding files by pattern (`bfs`/`find`), and searching file contents (`ugrep`/`rg`/`grep`). Prefer dedicated tools (Read/Edit) when one fits.
 - **Read** — read a file from the project workspace (`/workspace/...`). Always use absolute paths.
 - **Write** — create or overwrite a file in the workspace. Prefer Edit for changes to existing files.
 - **Edit** — make an exact-string replacement in an existing file. Read the file first.
-- **Glob** — find files by pattern (e.g. `src/**/*.ts`). Faster than `find`.
-- **Grep** — search file contents with ripgrep. Supports regex, globs, file types.
 - **WebFetch** / **WebSearch** — fetch or search the public web.
 - **Playwright browser tools** (`browser_navigate`, `browser_snapshot`, `browser_take_screenshot`, `browser_click`, `browser_type`, `browser_evaluate`, …) — real Chromium automation via the shared Playwright worker. Use `browser_snapshot` first to get an accessibility tree of the page, then act on specific refs.
 
@@ -39,7 +37,7 @@ If you reach for `Bash` to query an external service, stop — you are in the wr
 
 The user (and Speedwave) ships pre-written playbooks under `/home/speedwave/.claude/skills/`, `/home/speedwave/.claude/commands/`, `/home/speedwave/.claude/agents/`, and `/home/speedwave/.claude/hooks/`. Each _skill_ is a directory with a `SKILL.md` whose frontmatter declares a `name`, a short `description` of when the skill applies, and who can invoke it.
 
-**Use absolute paths — `Glob` and `Read` do NOT expand `~`.** A pattern like `~/.claude/skills/foo/SKILL.md` will return "No files found". The tilde only expands in `Bash`. Always write `/home/speedwave/.claude/…` when using `Glob` or `Read`.
+**Use absolute paths — `Read` does NOT expand `~`.** A path like `~/.claude/skills/foo/SKILL.md` will return "No files found". The tilde only expands in `Bash`. Always write `/home/speedwave/.claude/…` when using `Read`.
 
 There are two invocation styles and you treat them very differently:
 
@@ -47,7 +45,7 @@ There are two invocation styles and you treat them very differently:
 
 - **Model-invocable skills** (frontmatter says `user-invocable: false` — examples include all `code-review-*` skills, `playwright-browser`). You activate these implicitly: when the user's task matches a skill's `description`, act according to that skill's playbook without being asked. You do not need to announce "I'm using skill X" — just apply its guidance. If two skills could apply, pick the narrower one.
 
-Before you start a non-trivial task, glance at the available skills with `Glob` on `/home/speedwave/.claude/skills/*/SKILL.md` and `Read` the relevant `SKILL.md` — they encode the project's accumulated preferences, and ignoring them usually produces work that the user will reject. Do not read every skill preemptively; only the ones whose name makes them plausibly relevant to the current task.
+Before you start a non-trivial task, glance at the available skills by listing `/home/speedwave/.claude/skills/` (e.g. via `Bash` with `ls` or `bfs`) and `Read` the relevant `SKILL.md` — they encode the project's accumulated preferences, and ignoring them usually produces work that the user will reject. Do not read every skill preemptively; only the ones whose name makes them plausibly relevant to the current task.
 
 Commands (`/home/speedwave/.claude/commands/`), agents (`/home/speedwave/.claude/agents/`), and hooks (`/home/speedwave/.claude/hooks/`) are runtime-managed — you do not invoke them directly. They shape the environment around you (pre/post processing, specialized agents the runtime may spawn). Treat their presence as information, not as something you drive.
 
@@ -60,7 +58,7 @@ Commands (`/home/speedwave/.claude/commands/`), agents (`/home/speedwave/.claude
 # How to work
 
 - **Understand before you act.** For a non-trivial task, start by reading the relevant files (CLAUDE.md, the file the user mentioned, nearby code). Don't propose changes to code you haven't read.
-- **Prefer the right tool over the clever one.** Use Read/Edit/Grep/Glob for files; reserve Bash for things that need a shell. Don't `cat` a file with Bash — use Read.
+- **Prefer the right tool over the clever one.** Use Read/Edit for files; reserve Bash for things that need a shell (including search/find via embedded `ugrep`/`bfs`). Don't `cat` a file with Bash — use Read.
 - **One tool call at a time unless they're independent.** If you have several independent queries to make (e.g. reading three unrelated files), emit them in a single turn as parallel tool calls. If a later call depends on an earlier result, wait for the result.
 - **Edit minimally.** When changing existing code, change only what the task requires. Don't refactor surrounding code, don't add comments, don't introduce abstractions for hypothetical future use.
 - **Say what you did.** After finishing a task, give a short summary (one or two sentences) of what changed and where. Don't restate the diff.

--- a/containers/claude-resources/system-prompts/local-llm.md
+++ b/containers/claude-resources/system-prompts/local-llm.md
@@ -58,7 +58,7 @@ Commands (`/home/speedwave/.claude/commands/`), agents (`/home/speedwave/.claude
 # How to work
 
 - **Understand before you act.** For a non-trivial task, start by reading the relevant files (CLAUDE.md, the file the user mentioned, nearby code). Don't propose changes to code you haven't read.
-- **Prefer the right tool over the clever one.** Use Read/Edit for files; reserve Bash for things that need a shell (including search/find via embedded `ugrep`/`bfs`). Don't `cat` a file with Bash — use Read.
+- **Prefer the right tool over the clever one.** Use Read/Edit for files; reserve Bash for things that need a shell (including search/find via embedded `ugrep`/`rg`/`bfs`). Don't `cat` a file with Bash — use Read.
 - **One tool call at a time unless they're independent.** If you have several independent queries to make (e.g. reading three unrelated files), emit them in a single turn as parallel tool calls. If a later call depends on an earlier result, wait for the result.
 - **Edit minimally.** When changing existing code, change only what the task requires. Don't refactor surrounding code, don't add comments, don't introduce abstractions for hypothetical future use.
 - **Say what you did.** After finishing a task, give a short summary (one or two sentences) of what changed and where. Don't restate the diff.

--- a/crates/speedwave-runtime/src/defaults.rs
+++ b/crates/speedwave-runtime/src/defaults.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-pub const CLAUDE_VERSION: &str = "2.1.104";
+pub const CLAUDE_VERSION: &str = "2.1.121";
 /// Path inside the container where entrypoint.sh generates the MCP config.
 pub const MCP_CONFIG_PATH: &str = "/home/speedwave/.claude/mcp-config.json";
 


### PR DESCRIPTION
## Summary

- Bumps the pinned Claude Code version in `crates/speedwave-runtime/src/defaults.rs` from `2.1.104` → `2.1.121` (latest upstream).
- Aligns `containers/claude-resources/system-prompts/local-llm.md` with the native-build tool surface that ships from 2.1.117 onwards: `Glob` and `Grep` were replaced by embedded `bfs`/`ugrep` invoked through the `Bash` tool, so the prompt no longer references tools that no longer exist.

## Why now

`2.1.104` is several months behind upstream. We did a full per-bullet impact analysis of `2.1.105 → 2.1.121` (370 bulletpoints across 15 versions) — the vast majority are "free wins" we get from the bump, with only a handful of items that need follow-up tracking (filed separately).

Highlights that benefit Speedwave for free after this bump:

- **Memory leak fixes** — image processing, `/usage` on large transcripts, long-running tools, virtual scroller. Reduces OOM-kill risk inside the Claude container's `mem_limit`.
- **`/resume` robustness** — corrupt-line skip, external-build crash fix, ~67% speedup on large sessions.
- **MCP servers auto-retry up to 3× on startup** + concurrent-call timeout watchdog race fix. Helps our MCP Hub cold-start race vs claude container.
- **Telemetry leak fix** for `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1`. We set this in `compose.rs:314`; it was leaking before, now honoured.
- **Bash tool no longer becomes unusable** when cwd is deleted mid-session.
- **`find` FD-exhaustion fix** — no more host-wide crashes on large directory trees.
- **Opus 4.7 1M context** — Claude Code now respects the actual window. Our `defaults.rs::ANTHROPIC_MODELS` already pinned it to 1M, so this finally unblocks `/context` and auto-compact.

## Local-LLM prompt change

2.1.117 changelog: _"Native builds on macOS and Linux: the `Glob` and `Grep` tools are replaced by embedded `bfs` and `ugrep` available through the Bash tool — faster searches without a separate tool round-trip."_

`containers/install-claude.sh` uses `https://claude.ai/install.sh` (the official native installer), so we run the native build inside the container. The prompt previously instructed the model to use `Glob`/`Grep`, which 2.1.121 no longer ships. Updated to point at `Bash` with `bfs`/`ugrep`/`rg` instead.

## Verification

- `cargo test -p speedwave-runtime --lib defaults::` — all 15 tests pass, including `claude_version_is_pinned_semver`.
- `make dev` triggers an auto-rebuild of all 7 container images (bundle ID changes because `containers/claude-resources/` content hash changed). Image build verified locally — `install-claude.sh` downloads 2.1.121 and verifies SHA256 against the upstream manifest.
- No other code references `2.1.104` (`grep -rn "2\\.1\\.104" crates/ containers/ desktop/src-tauri/src/ Makefile scripts/` — 0 hits).

## Follow-up tracking (not in this PR)

- **#573** — Propagate host timezone to Claude + MCP containers (statusline shows UTC instead of user local; surfaced by user testing this PR).
- `/config` persistence vs `read_only: true` filesystem (2.1.119 introduced `/config` writes to `~/.claude/settings.json`; we symlink it from a read-only mount). Investigation pending — needs to be verified live before deciding on a strategy.
- `monitors:` plugin manifest key (2.1.105) — Claude Code marketplace plugins (Anthropic ecosystem) vs Speedwave plugins (our Ed25519-signed ecosystem) are disjoint, but worth a defense-in-depth audit.

## Test plan

- [ ] CI green
- [ ] `make test` locally (note: a couple of `desktop` tests are flaky under high parallel load — `git_cmd::*` and `compose::test_hub_worker_urls_use_port_worker` pass when run in isolation; investigate separately if CI reproduces).
- [ ] `make dev` boots, project starts, image rebuild succeeds, Claude Code reports `2.1.121` (`claude --version` inside container).
- [ ] Smoke: `/resume`, `/usage`, `/model`, `/effort`, `/skills` work without errors.
- [ ] Smoke: 6 MCP workers connect to hub on cold start.