### PR TITLE
fix(runtime): recover from stopped containers and fix plugin migration

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,11 @@
+#!/usr/bin/env sh
+# `git push` exports GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE pointing at the
+# pushing repo. Those leak into `cargo test`, where any test that does
+# `git -C <tmp_dir> ...` ignores `-C` and resolves against the leaked GIT_DIR
+# — surfacing the *real* branch instead of the empty tempdir's state and
+# producing spurious assertion failures (e.g. read_branch tests in
+# desktop/src-tauri/src/git_cmd.rs). Strip them before running tests so the
+# suite sees a clean, hook-independent environment.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_REFLOG_ACTION GIT_PREFIX
+
 make test

--- a/Makefile
+++ b/Makefile
@@ -272,11 +272,10 @@ build-angular:
 # ── Rust tests ───────────────────────────────────────────────────────────────
 
 test-rust:
-	@# Tests share `consts::data_dir()` (~/.speedwave/) and several of them
-	@# write into `~/.speedwave/secrets/<project>/` or rely on mcp-os state
-	@# files. Parallel cargo-test threads race on those paths and surface
-	@# `os error 2` from `render_compose`. Force serial execution to keep
-	@# the suite deterministic until per-test data_dir isolation lands.
+	@# Tests share `consts::data_dir()` (~/.speedwave/); several of them write
+	@# into `~/.speedwave/secrets/<project>/` or read mcp-os state files.
+	@# Parallel cargo-test threads race on those paths and surface `os error 2`
+	@# from `render_compose`. Run serially to keep the suite deterministic.
 	SPEEDWAVE_DATA_DIR= cargo test -p speedwave-runtime -p speedwave-cli -- --test-threads=1
 	@echo "✅ Rust tests passed"
 

--- a/Makefile
+++ b/Makefile
@@ -272,7 +272,12 @@ build-angular:
 # ── Rust tests ───────────────────────────────────────────────────────────────
 
 test-rust:
-	SPEEDWAVE_DATA_DIR= cargo test -p speedwave-runtime -p speedwave-cli
+	@# Tests share `consts::data_dir()` (~/.speedwave/) and several of them
+	@# write into `~/.speedwave/secrets/<project>/` or rely on mcp-os state
+	@# files. Parallel cargo-test threads race on those paths and surface
+	@# `os error 2` from `render_compose`. Force serial execution to keep
+	@# the suite deterministic until per-test data_dir isolation lands.
+	SPEEDWAVE_DATA_DIR= cargo test -p speedwave-runtime -p speedwave-cli -- --test-threads=1
 	@echo "✅ Rust tests passed"
 
 test-cli:

--- a/_tests/entrypoint/entrypoint.bats
+++ b/_tests/entrypoint/entrypoint.bats
@@ -715,3 +715,78 @@ EOF
 
     rm -rf "$plugins_dir" "$patched"
 }
+
+# ---------------------------------------------------------------------------
+# Migration: ~/.claude/<resource_type> mode flips between runs.
+# claude-home is a persistent volume, so a stale layout from a previous
+# start can poison the current one if the entrypoint doesn't normalize it.
+# ---------------------------------------------------------------------------
+
+@test "plugin mode replaces stale whole-directory symlink left from no-plugins run" {
+    # Reproduce the scenario from the bug: project was started without plugins
+    # (skills became a symlink to read-only resources), then a plugin was
+    # installed and the project restarted. Without normalization the per-entry
+    # ln below would resolve through the symlink and try to write into the
+    # read-only resources mount, killing the container with `set -e`.
+    mkdir -p "$RESOURCES_DIR/skills/code-review-basic"
+    echo "# Core skill" > "$RESOURCES_DIR/skills/code-review-basic/SKILL.md"
+
+    # Simulate the stale symlink left by an earlier no-plugins run, pointing
+    # at a read-only directory (chmod 555 is sufficient on the host).
+    chmod 555 "$RESOURCES_DIR/skills"
+    ln -sfn "$RESOURCES_DIR/skills" "$HOME/.claude/skills"
+
+    local plugins_dir
+    plugins_dir="$(mktemp -d)"
+    mkdir -p "${plugins_dir}/my-plugin/skills/extra-skill"
+    echo "# Plugin skill" > "${plugins_dir}/my-plugin/skills/extra-skill/SKILL.md"
+
+    local patched
+    patched="$(mktemp)"
+    sed "s|/speedwave/plugins/|${plugins_dir}/|g" "$ENTRYPOINT" > "$patched"
+
+    SPEEDWAVE_PLUGINS="my-plugin" run bash "$patched" true
+
+    # Restore writability so teardown can clean up the tempdir
+    chmod 755 "$RESOURCES_DIR/skills"
+
+    [ "$status" -eq 0 ]
+
+    # ~/.claude/skills must now be a real directory, not a symlink
+    [ ! -L "$HOME/.claude/skills" ]
+    [ -d "$HOME/.claude/skills" ]
+
+    # Both core and plugin entries are present as per-entry symlinks
+    [ -L "$HOME/.claude/skills/code-review-basic" ]
+    [ "$(readlink "$HOME/.claude/skills/code-review-basic")" = "$RESOURCES_DIR/skills/code-review-basic" ]
+    [ -L "$HOME/.claude/skills/extra-skill" ]
+    [ "$(readlink "$HOME/.claude/skills/extra-skill")" = "${plugins_dir}/my-plugin/skills/extra-skill" ]
+
+    rm -rf "$plugins_dir" "$patched"
+}
+
+@test "no-plugins mode replaces real directory left from previous plugin run" {
+    # Reverse migration: project was started with a plugin (skills became a
+    # real directory of per-entry symlinks), then the plugin was disabled.
+    # Without normalization `ln -sfn TARGET DIR` creates the link *inside*
+    # the directory, leaving stale entries and a useless skills/skills link.
+    mkdir -p "$RESOURCES_DIR/skills/core-skill"
+    echo "# Core" > "$RESOURCES_DIR/skills/core-skill/SKILL.md"
+
+    # Simulate the layout left by a previous plugin run
+    mkdir -p "$HOME/.claude/skills"
+    ln -sfn "/some/old/plugin/path/leftover" "$HOME/.claude/skills/leftover"
+
+    unset SPEEDWAVE_PLUGINS
+    run bash "$ENTRYPOINT" true
+    [ "$status" -eq 0 ]
+
+    # ~/.claude/skills must now be a whole-directory symlink to resources
+    [ -L "$HOME/.claude/skills" ]
+    [ "$(readlink "$HOME/.claude/skills")" = "$RESOURCES_DIR/skills" ]
+
+    # No leftover entries inside (they would require a real dir, which is gone)
+    [ ! -e "$HOME/.claude/skills/leftover" ]
+    # Core entry visible through the symlink
+    [ -d "$HOME/.claude/skills/core-skill" ]
+}

--- a/containers/entrypoint.sh
+++ b/containers/entrypoint.sh
@@ -53,11 +53,26 @@ fi
 for resource_type in skills commands agents hooks; do
     if [ -d "${SPEEDWAVE_RESOURCES}/${resource_type}" ]; then
         if [ "${HAS_PLUGINS}" = true ]; then
+            # Migration: a previous run without plugins may have symlinked the
+            # whole directory to the read-only resources mount. Per-entry mode
+            # needs a writable real directory; otherwise `ln` below resolves
+            # through the symlink and tries to write into the read-only mount,
+            # killing the container with `set -e`.
+            if [ -L "${HOME}/.claude/${resource_type}" ]; then
+                rm -f "${HOME}/.claude/${resource_type}"
+            fi
             mkdir -p "${HOME}/.claude/${resource_type}"
             for entry in "${SPEEDWAVE_RESOURCES}/${resource_type}"/*; do
                 [ -e "${entry}" ] && ln -sfn "${entry}" "${HOME}/.claude/${resource_type}/$(basename "${entry}")"
             done
         else
+            # Reverse migration: a previous run with plugins may have created
+            # a real directory of per-entry symlinks. `ln -sfn` on a real dir
+            # creates a link *inside* it instead of replacing it, so wipe it
+            # before re-establishing the whole-directory symlink.
+            if [ -d "${HOME}/.claude/${resource_type}" ] && [ ! -L "${HOME}/.claude/${resource_type}" ]; then
+                rm -rf "${HOME}/.claude/${resource_type}"
+            fi
             ln -sfn "${SPEEDWAVE_RESOURCES}/${resource_type}" "${HOME}/.claude/${resource_type}"
         fi
     fi

--- a/crates/speedwave-runtime/src/compose.rs
+++ b/crates/speedwave-runtime/src/compose.rs
@@ -794,11 +794,15 @@ fn apply_mcp_os_config_with_path(
     token_path: &std::path::Path,
     port_path: &std::path::Path,
 ) -> anyhow::Result<String> {
-    if !token_path.is_file() {
-        return Ok(yaml.to_string());
-    }
-
-    let token = std::fs::read_to_string(token_path)?.trim().to_string();
+    // Single read attempt: don't pre-check `is_file()` before `read_to_string`.
+    // The desktop process respawns mcp-os and rewrites these files at runtime,
+    // so a TOCTOU between exists-check and read can bubble up `os error 2`
+    // and abort `render_compose`. Treat any read failure the same as the
+    // file being absent — mcp-os is simply not configured for this run.
+    let token = match std::fs::read_to_string(token_path) {
+        Ok(s) => s.trim().to_string(),
+        Err(_) => return Ok(yaml.to_string()),
+    };
     if token.is_empty() {
         return Ok(yaml.to_string());
     }
@@ -4308,6 +4312,23 @@ services:
         assert_eq!(
             result, VALID_COMPOSE,
             "yaml should be unchanged when token path is a directory"
+        );
+    }
+
+    #[test]
+    fn test_mcp_os_config_skipped_when_token_path_does_not_exist() {
+        // The desktop process can delete and recreate ~/.speedwave/mcp-os-*
+        // files at any moment (mcp-os respawn). Treat a missing token file
+        // the same as an empty/absent config — never bubble up `os error 2`
+        // and abort `render_compose`.
+        let tmp = tempfile::tempdir().unwrap();
+        let token_path = tmp.path().join("does-not-exist");
+        let port_path = tmp.path().join("does-not-exist-port");
+
+        let result = apply_mcp_os_config_with_path(VALID_COMPOSE, &token_path, &port_path).unwrap();
+        assert_eq!(
+            result, VALID_COMPOSE,
+            "yaml should be unchanged when token file is absent"
         );
     }
 

--- a/crates/speedwave-runtime/src/compose.rs
+++ b/crates/speedwave-runtime/src/compose.rs
@@ -3022,6 +3022,13 @@ services:
         for entry in get_hub_env_seq(&serde_yaml_ng::from_str(&yaml).unwrap()) {
             if let Some((key, value)) = entry.split_once('=') {
                 if key.starts_with("WORKER_") && key.ends_with("_URL") {
+                    // WORKER_OS_URL is a host-side gateway (host.lima.internal
+                    // / host.docker.internal) with a dynamically assigned
+                    // mcp-os port — not a containerized worker. ADR-038
+                    // applies only to in-cluster workers.
+                    if key == "WORKER_OS_URL" {
+                        continue;
+                    }
                     assert!(
                         value.ends_with(&expected_suffix),
                         "{key} must point at :{} (ADR-038), got: {value}",

--- a/crates/speedwave-runtime/src/compose.rs
+++ b/crates/speedwave-runtime/src/compose.rs
@@ -798,10 +798,17 @@ fn apply_mcp_os_config_with_path(
     // The desktop process respawns mcp-os and rewrites these files at runtime,
     // so a TOCTOU between exists-check and read can bubble up `os error 2`
     // and abort `render_compose`. Treat any read failure the same as the
-    // file being absent — mcp-os is simply not configured for this run.
+    // file being absent — mcp-os is simply not configured for this run —
+    // but log non-NotFound errors so permission/disk problems remain visible.
     let token = match std::fs::read_to_string(token_path) {
         Ok(s) => s.trim().to_string(),
-        Err(_) => return Ok(yaml.to_string()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(yaml.to_string());
+        }
+        Err(e) => {
+            log::debug!("mcp-os token read failed ({e}); treating as not configured");
+            return Ok(yaml.to_string());
+        }
     };
     if token.is_empty() {
         return Ok(yaml.to_string());

--- a/crates/speedwave-runtime/src/runtime/mod.rs
+++ b/crates/speedwave-runtime/src/runtime/mod.rs
@@ -491,6 +491,17 @@ fn is_stale_container_error(message: &str) -> bool {
     lower.contains("mount namespace root") || lower.contains("container breakout detected")
 }
 
+/// Returns `true` if the error indicates the container exists but is not
+/// running (Exited/Created state).  containerd/nerdctl emits this when
+/// `nerdctl exec` is invoked against a container that has stopped after
+/// `compose up` (e.g. its entrypoint exited non-zero, or a previous
+/// interactive session ended and `compose up` left it in place without
+/// restarting it).  Recreate restores the container to a running state.
+fn is_stopped_container_error(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+    lower.contains("cannot exec in a stopped state")
+}
+
 /// POSIX-shell-quotes each argument and joins with spaces — for transports
 /// that re-evaluate the command line through a remote shell (`ssh`, `wsl.exe`,
 /// `limactl shell`).
@@ -537,13 +548,15 @@ fn probe_container_exec(runtime: &dyn ContainerRuntime, container: &str) -> anyh
     }
 }
 
-/// Verifies container exec is functional.  Recovers from two failure modes:
+/// Verifies container exec is functional.  Recovers from three failure modes:
 ///
 /// 1. **Stale containers** — mount namespaces broken after macOS sleep/resume.
 /// 2. **Missing containers** — containers lost after containerd restart, VM
 ///    recreation, or image loss.
+/// 3. **Stopped containers** — container exists but is in Exited/Created
+///    state; `compose up` left it in place because its config did not change.
 ///
-/// In both cases, calls `compose_up_recreate` and re-probes once.
+/// In all cases, calls `compose_up_recreate` and re-probes once.
 ///
 /// Call this between `compose_up()` and the real `container_exec()` to
 /// transparently recover from container failures.
@@ -570,6 +583,11 @@ pub fn ensure_exec_healthy(
                 log::warn!(
                     "Container '{container}' not found. \
                      Recreating containers..."
+                );
+            } else if is_stopped_container_error(&msg) {
+                log::warn!(
+                    "Container '{container}' is stopped (previous run \
+                     exited). Recreating containers..."
                 );
             } else {
                 return Err(e);
@@ -1208,6 +1226,27 @@ services:
         assert!(!is_stale_container_error(""));
     }
 
+    #[test]
+    fn test_is_stopped_container_error_matches_nerdctl_message() {
+        assert!(is_stopped_container_error(
+            "time=\"2026-05-03T21:37:58+02:00\" level=fatal \
+             msg=\"cannot exec in a stopped state\""
+        ));
+    }
+
+    #[test]
+    fn test_is_stopped_container_error_case_insensitive() {
+        assert!(is_stopped_container_error("Cannot Exec In A Stopped State"));
+    }
+
+    #[test]
+    fn test_is_stopped_container_error_rejects_unrelated_errors() {
+        assert!(!is_stopped_container_error("no such container"));
+        assert!(!is_stopped_container_error("mount namespace root"));
+        assert!(!is_stopped_container_error("connection refused"));
+        assert!(!is_stopped_container_error(""));
+    }
+
     /// Mock runtime for testing `ensure_exec_healthy()`.
     ///
     /// `exec_healthy` controls whether `container_exec_piped` returns a
@@ -1414,6 +1453,19 @@ services:
         assert!(
             rt.was_recreated(),
             "compose_up_recreate should be called for 'not found' container"
+        );
+    }
+
+    #[test]
+    fn test_ensure_exec_healthy_recovers_stopped_container() {
+        let rt = ProbeTestRuntime::stale().with_custom_error(
+            "time=\"2026-05-03T21:37:58+02:00\" level=fatal \
+             msg=\"cannot exec in a stopped state\"",
+        );
+        ensure_exec_healthy(&rt, "proj", "container").unwrap();
+        assert!(
+            rt.was_recreated(),
+            "compose_up_recreate should be called for stopped container"
         );
     }
 

--- a/desktop/src-tauri/src/mcp_os_process.rs
+++ b/desktop/src-tauri/src/mcp_os_process.rs
@@ -100,7 +100,7 @@ impl McpOsProcess {
         //    binaries from the flat Resources/ layout instead of the dev-mode
         //    source tree.
         let mut cmd = speedwave_runtime::binary::command("node");
-        cmd.arg(script_path).env_clear();
+        cmd.arg(script_path);
         apply_child_env(&mut cmd, &CurrentProcessEnv);
 
         let mut child = cmd
@@ -286,11 +286,15 @@ impl EnvSource for CurrentProcessEnv {
 
 /// Apply the child-process environment policy to `cmd` from the given source.
 ///
-/// `cmd.env_clear()` must be called by the caller. The function only adds
-/// the variables the child needs (PATH, HOME/USERPROFILE, optional Windows
-/// CSPRNG vars, and SPEEDWAVE_RESOURCES_DIR/SPEEDWAVE_PROD when running as a
-/// bundled .app). It never reads `std::env` directly.
+/// Starts by clearing the inherited environment so secrets in the parent
+/// (API keys, tokens, credentials) cannot leak to mcp-os, then adds back
+/// only the variables the child needs (PATH, HOME/USERPROFILE, optional
+/// Windows CSPRNG vars, and SPEEDWAVE_RESOURCES_DIR/SPEEDWAVE_PROD when
+/// running as a bundled .app). Never reads `std::env` directly — every
+/// value comes from `env`, so callers in tests can supply a `FakeEnv`.
 fn apply_child_env(cmd: &mut Command, env: &dyn EnvSource) {
+    cmd.env_clear();
+
     // On Windows, Node.js (OpenSSL) needs certain system environment variables
     // to initialize BCryptGenRandom for its CSPRNG. Without these, node.exe
     // aborts with "Assertion failed: ncrypto::CSPRNG(nullptr, 0)".
@@ -1578,7 +1582,6 @@ srv.listen(0, '127.0.0.1', () => {
     #[test]
     fn apply_child_env_forwards_resources_dir_and_sets_prod_flag() {
         let mut cmd = Command::new("/bin/true");
-        cmd.env_clear();
         let env = FakeEnv(&[
             ("PATH", "/usr/bin:/bin"),
             ("HOME", "/home/test"),
@@ -1612,7 +1615,6 @@ srv.listen(0, '127.0.0.1', () => {
     #[test]
     fn apply_child_env_omits_prod_flag_when_resources_unset() {
         let mut cmd = Command::new("/bin/true");
-        cmd.env_clear();
         let env = FakeEnv(&[("PATH", "/usr/bin:/bin"), ("HOME", "/home/test")]);
 
         apply_child_env(&mut cmd, &env);
@@ -1632,7 +1634,6 @@ srv.listen(0, '127.0.0.1', () => {
     #[test]
     fn apply_child_env_treats_empty_resources_as_unset() {
         let mut cmd = Command::new("/bin/true");
-        cmd.env_clear();
         let env = FakeEnv(&[
             ("PATH", "/usr/bin:/bin"),
             (consts::BUNDLE_RESOURCES_ENV, ""),
@@ -1654,7 +1655,6 @@ srv.listen(0, '127.0.0.1', () => {
     #[test]
     fn apply_child_env_defaults_path_and_home_to_empty_when_missing() {
         let mut cmd = Command::new("/bin/true");
-        cmd.env_clear();
         let env = FakeEnv(&[]);
 
         apply_child_env(&mut cmd, &env);
@@ -1670,6 +1670,29 @@ srv.listen(0, '127.0.0.1', () => {
             captured.get("HOME").map(String::as_str),
             Some(""),
             "HOME must always be set on Unix children, even if empty"
+        );
+    }
+
+    #[test]
+    fn apply_child_env_drops_inherited_vars_not_in_policy() {
+        // The function must clear inherited environment before adding back
+        // only policy-approved variables, otherwise a parent secret
+        // (API keys, tokens) would silently leak to the mcp-os child.
+        let mut cmd = Command::new("/bin/true");
+        cmd.env("SUPER_SECRET_TOKEN", "do-not-leak");
+        cmd.env("ANTHROPIC_API_KEY", "sk-leak");
+
+        let env = FakeEnv(&[("PATH", "/usr/bin")]);
+        apply_child_env(&mut cmd, &env);
+
+        let captured = captured_env(&cmd);
+        assert!(
+            !captured.contains_key("SUPER_SECRET_TOKEN"),
+            "inherited SUPER_SECRET_TOKEN must be wiped by apply_child_env"
+        );
+        assert!(
+            !captured.contains_key("ANTHROPIC_API_KEY"),
+            "inherited ANTHROPIC_API_KEY must be wiped by apply_child_env"
         );
     }
 }

--- a/desktop/src-tauri/src/mcp_os_process.rs
+++ b/desktop/src-tauri/src/mcp_os_process.rs
@@ -551,11 +551,7 @@ impl McpOsProcess {
 mod tests {
     use super::*;
 
-    /// Shared lock for all tests that mutate process-global environment variables
-    /// via `std::env::set_var` / `std::env::remove_var`. Every such test must
-    /// acquire this lock to prevent data races (env vars are per-process, not
-    /// per-thread).
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    use serial_test::serial;
 
     #[test]
     fn test_spawn_dynamic_port() {
@@ -937,9 +933,8 @@ srv.listen(0, '127.0.0.1', () => {
     }
 
     #[test]
+    #[serial(env)]
     fn test_env_clear_prevents_secret_leakage() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-
         let tmp = tempfile::tempdir().unwrap();
         let script = tmp.path().join("check_env.js");
         std::fs::write(
@@ -1057,9 +1052,8 @@ srv.listen(0, '127.0.0.1', () => {
     /// can initialize BCryptGenRandom. This test verifies those vars are present.
     #[cfg(target_os = "windows")]
     #[test]
+    #[serial(env)]
     fn test_windows_system_env_vars_passed_through() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-
         let tmp = tempfile::tempdir().unwrap();
         let script = tmp.path().join("check_win_env.js");
 
@@ -1126,9 +1120,8 @@ srv.listen(0, '127.0.0.1', () => {
     /// selective re-injection — and confirms that arbitrary env vars from the
     /// parent do not reach the child.
     #[test]
+    #[serial(env)]
     fn test_env_clear_with_windows_passthrough_still_blocks_secrets() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-
         let tmp = tempfile::tempdir().unwrap();
         let script = tmp.path().join("check_secrets.js");
 
@@ -1532,8 +1525,8 @@ srv.listen(0, '127.0.0.1', () => {
     }
 
     #[test]
+    #[serial(env)]
     fn test_spawn_forwards_resources_env_in_prod_mode() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = tempfile::tempdir().unwrap();
         let env_out = tmp.path().join("env.json");
         let env_out_escaped = env_out.to_string_lossy().replace('\\', "/");
@@ -1576,8 +1569,8 @@ srv.listen(0, '127.0.0.1', () => {{
     }
 
     #[test]
+    #[serial(env)]
     fn test_spawn_omits_resources_env_in_dev_mode() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = tempfile::tempdir().unwrap();
         let env_out = tmp.path().join("env.json");
         let env_out_escaped = env_out.to_string_lossy().replace('\\', "/");

--- a/desktop/src-tauri/src/mcp_os_process.rs
+++ b/desktop/src-tauri/src/mcp_os_process.rs
@@ -101,37 +101,7 @@ impl McpOsProcess {
         //    source tree.
         let mut cmd = speedwave_runtime::binary::command("node");
         cmd.arg(script_path).env_clear();
-
-        // On Windows, Node.js (OpenSSL) needs certain system environment variables
-        // to initialize BCryptGenRandom for its CSPRNG. Without these, node.exe
-        // aborts with "Assertion failed: ncrypto::CSPRNG(nullptr, 0)".
-        #[cfg(target_os = "windows")]
-        {
-            for key in WINDOWS_SYSTEM_ENV_VARS {
-                if let Ok(val) = std::env::var(key) {
-                    cmd.env(key, val);
-                }
-            }
-        }
-
-        cmd.env("PATH", std::env::var("PATH").unwrap_or_default());
-
-        // HOME is set on Unix (macOS/Linux) but typically not on Windows, where
-        // USERPROFILE is the equivalent. Setting HOME to an empty string on
-        // Windows would break Node.js path resolution (e.g. os.homedir()).
-        // USERPROFILE is already forwarded via WINDOWS_SYSTEM_ENV_VARS above.
-        #[cfg(not(target_os = "windows"))]
-        cmd.env("HOME", std::env::var("HOME").unwrap_or_default());
-
-        // Production mode: forward resource directory so mcp-os resolves native
-        // CLI binaries from the bundled .app/Contents/Resources/ layout instead
-        // of the dev-mode source tree.
-        if let Ok(res) = std::env::var(consts::BUNDLE_RESOURCES_ENV) {
-            if !res.is_empty() {
-                cmd.env(consts::BUNDLE_RESOURCES_ENV, &res);
-                cmd.env("SPEEDWAVE_PROD", "1");
-            }
-        }
+        apply_child_env(&mut cmd, &CurrentProcessEnv);
 
         let mut child = cmd
             .env("PORT", "0")
@@ -294,6 +264,62 @@ impl Drop for McpOsProcess {
     fn drop(&mut self) {
         self.stop().ok();
         self.cleanup_files();
+    }
+}
+
+/// Reads environment variables from a source (process env, or a fake source
+/// in tests). Pulled out of `spawn_in` so the env-construction logic is
+/// testable without mutating the process-global environment, which races with
+/// other tests and any Speedwave instance running concurrently on the host.
+trait EnvSource {
+    fn var(&self, key: &str) -> Option<String>;
+}
+
+/// Real implementation reading from `std::env`.
+struct CurrentProcessEnv;
+
+impl EnvSource for CurrentProcessEnv {
+    fn var(&self, key: &str) -> Option<String> {
+        std::env::var(key).ok()
+    }
+}
+
+/// Apply the child-process environment policy to `cmd` from the given source.
+///
+/// `cmd.env_clear()` must be called by the caller. The function only adds
+/// the variables the child needs (PATH, HOME/USERPROFILE, optional Windows
+/// CSPRNG vars, and SPEEDWAVE_RESOURCES_DIR/SPEEDWAVE_PROD when running as a
+/// bundled .app). It never reads `std::env` directly.
+fn apply_child_env(cmd: &mut Command, env: &dyn EnvSource) {
+    // On Windows, Node.js (OpenSSL) needs certain system environment variables
+    // to initialize BCryptGenRandom for its CSPRNG. Without these, node.exe
+    // aborts with "Assertion failed: ncrypto::CSPRNG(nullptr, 0)".
+    #[cfg(target_os = "windows")]
+    {
+        for key in WINDOWS_SYSTEM_ENV_VARS {
+            if let Some(val) = env.var(key) {
+                cmd.env(key, val);
+            }
+        }
+    }
+
+    cmd.env("PATH", env.var("PATH").unwrap_or_default());
+
+    // HOME is set on Unix (macOS/Linux) but typically not on Windows, where
+    // USERPROFILE is the equivalent. Setting HOME to an empty string on
+    // Windows would break Node.js path resolution (e.g. os.homedir()).
+    // USERPROFILE is already forwarded via WINDOWS_SYSTEM_ENV_VARS above.
+    #[cfg(not(target_os = "windows"))]
+    cmd.env("HOME", env.var("HOME").unwrap_or_default());
+
+    // Production mode: forward resource directory so mcp-os resolves native
+    // CLI binaries from the bundled .app/Contents/Resources/ layout instead
+    // of the dev-mode source tree.
+    if let Some(res) = env.var(consts::BUNDLE_RESOURCES_ENV) {
+        if !res.is_empty() {
+            cmd.env(consts::BUNDLE_RESOURCES_ENV, &res);
+            cmd.env("SPEEDWAVE_PROD", "1");
+        }
     }
 }
 
@@ -1524,90 +1550,126 @@ srv.listen(0, '127.0.0.1', () => {
         // node not available — skip
     }
 
-    #[test]
-    #[serial(env)]
-    fn test_spawn_forwards_resources_env_in_prod_mode() {
-        let tmp = tempfile::tempdir().unwrap();
-        let env_out = tmp.path().join("env.json");
-        let env_out_escaped = env_out.to_string_lossy().replace('\\', "/");
-        let script = tmp.path().join("test_env_forward.js");
-        std::fs::write(
-            &script,
-            format!(
-                r#"
-const fs = require('fs');
-const http = require('http');
-fs.writeFileSync({env_path}, JSON.stringify({{
-    SPEEDWAVE_PROD: process.env.SPEEDWAVE_PROD || null,
-    SPEEDWAVE_RESOURCES_DIR: process.env.SPEEDWAVE_RESOURCES_DIR || null,
-}}));
-const srv = http.createServer((_,r) => {{ r.end('ok'); }});
-srv.listen(0, '127.0.0.1', () => {{
-    process.stdout.write(JSON.stringify({{ port: srv.address().port }}) + '\n');
-}});
-"#,
-                env_path = serde_json::to_string(&env_out_escaped).unwrap(),
-            ),
-        )
-        .unwrap();
+    /// Fake env source backed by a static map — lets `apply_child_env` tests
+    /// run against arbitrary parent-environment scenarios without mutating
+    /// `std::env`, which races with parallel tests and any Speedwave instance
+    /// running concurrently on the host.
+    struct FakeEnv<'a>(&'a [(&'a str, &'a str)]);
 
-        // Simulate production: set SPEEDWAVE_RESOURCES_DIR in parent
-        std::env::set_var(consts::BUNDLE_RESOURCES_ENV, "/fake/Resources");
-        let data_dir = tmp.path().join("data");
-        let result = McpOsProcess::spawn_in_dir(&script.to_string_lossy(), &data_dir);
-        std::env::remove_var(consts::BUNDLE_RESOURCES_ENV);
-
-        if let Ok(mut proc) = result {
-            assert!(proc.port() > 0);
-            let env_json: serde_json::Value =
-                serde_json::from_str(&std::fs::read_to_string(&env_out).unwrap()).unwrap();
-            assert_eq!(env_json["SPEEDWAVE_PROD"], "1");
-            assert_eq!(env_json["SPEEDWAVE_RESOURCES_DIR"], "/fake/Resources");
-            proc.stop().unwrap();
+    impl EnvSource for FakeEnv<'_> {
+        fn var(&self, key: &str) -> Option<String> {
+            self.0
+                .iter()
+                .find(|(k, _)| *k == key)
+                .map(|(_, v)| (*v).to_string())
         }
-        // node not available — skip gracefully
+    }
+
+    /// Read the env vars `apply_child_env` set on a freshly created Command.
+    fn captured_env(cmd: &Command) -> std::collections::HashMap<String, String> {
+        cmd.get_envs()
+            .filter_map(|(k, v)| {
+                let v = v?.to_str()?.to_string();
+                Some((k.to_str()?.to_string(), v))
+            })
+            .collect()
     }
 
     #[test]
-    #[serial(env)]
-    fn test_spawn_omits_resources_env_in_dev_mode() {
-        let tmp = tempfile::tempdir().unwrap();
-        let env_out = tmp.path().join("env.json");
-        let env_out_escaped = env_out.to_string_lossy().replace('\\', "/");
-        let script = tmp.path().join("test_env_dev.js");
-        std::fs::write(
-            &script,
-            format!(
-                r#"
-const fs = require('fs');
-const http = require('http');
-fs.writeFileSync({env_path}, JSON.stringify({{
-    SPEEDWAVE_PROD: process.env.SPEEDWAVE_PROD || null,
-    SPEEDWAVE_RESOURCES_DIR: process.env.SPEEDWAVE_RESOURCES_DIR || null,
-}}));
-const srv = http.createServer((_,r) => {{ r.end('ok'); }});
-srv.listen(0, '127.0.0.1', () => {{
-    process.stdout.write(JSON.stringify({{ port: srv.address().port }}) + '\n');
-}});
-"#,
-                env_path = serde_json::to_string(&env_out_escaped).unwrap(),
-            ),
-        )
-        .unwrap();
+    fn apply_child_env_forwards_resources_dir_and_sets_prod_flag() {
+        let mut cmd = Command::new("/bin/true");
+        cmd.env_clear();
+        let env = FakeEnv(&[
+            ("PATH", "/usr/bin:/bin"),
+            ("HOME", "/home/test"),
+            (consts::BUNDLE_RESOURCES_ENV, "/fake/Resources"),
+        ]);
 
-        // Ensure SPEEDWAVE_RESOURCES_DIR is NOT set (dev mode)
-        std::env::remove_var(consts::BUNDLE_RESOURCES_ENV);
-        let data_dir = tmp.path().join("data");
-        let result = McpOsProcess::spawn_in_dir(&script.to_string_lossy(), &data_dir);
+        apply_child_env(&mut cmd, &env);
 
-        if let Ok(mut proc) = result {
-            assert!(proc.port() > 0);
-            let env_json: serde_json::Value =
-                serde_json::from_str(&std::fs::read_to_string(&env_out).unwrap()).unwrap();
-            assert_eq!(env_json["SPEEDWAVE_PROD"], serde_json::Value::Null);
-            assert_eq!(env_json["SPEEDWAVE_RESOURCES_DIR"], serde_json::Value::Null);
-            proc.stop().unwrap();
-        }
-        // node not available — skip gracefully
+        let captured = captured_env(&cmd);
+        assert_eq!(
+            captured
+                .get(consts::BUNDLE_RESOURCES_ENV)
+                .map(String::as_str),
+            Some("/fake/Resources"),
+            "BUNDLE_RESOURCES_ENV must be forwarded verbatim to the child"
+        );
+        assert_eq!(
+            captured.get("SPEEDWAVE_PROD").map(String::as_str),
+            Some("1"),
+            "SPEEDWAVE_PROD=1 must be set when the parent has a non-empty \
+             BUNDLE_RESOURCES_ENV (production .app launch)"
+        );
+        assert_eq!(
+            captured.get("PATH").map(String::as_str),
+            Some("/usr/bin:/bin")
+        );
+        #[cfg(not(target_os = "windows"))]
+        assert_eq!(captured.get("HOME").map(String::as_str), Some("/home/test"));
+    }
+
+    #[test]
+    fn apply_child_env_omits_prod_flag_when_resources_unset() {
+        let mut cmd = Command::new("/bin/true");
+        cmd.env_clear();
+        let env = FakeEnv(&[("PATH", "/usr/bin:/bin"), ("HOME", "/home/test")]);
+
+        apply_child_env(&mut cmd, &env);
+
+        let captured = captured_env(&cmd);
+        assert!(
+            !captured.contains_key(consts::BUNDLE_RESOURCES_ENV),
+            "BUNDLE_RESOURCES_ENV must not be set on child when parent does \
+             not have it (dev mode)"
+        );
+        assert!(
+            !captured.contains_key("SPEEDWAVE_PROD"),
+            "SPEEDWAVE_PROD must not be set in dev mode"
+        );
+    }
+
+    #[test]
+    fn apply_child_env_treats_empty_resources_as_unset() {
+        let mut cmd = Command::new("/bin/true");
+        cmd.env_clear();
+        let env = FakeEnv(&[
+            ("PATH", "/usr/bin:/bin"),
+            (consts::BUNDLE_RESOURCES_ENV, ""),
+        ]);
+
+        apply_child_env(&mut cmd, &env);
+
+        let captured = captured_env(&cmd);
+        assert!(
+            !captured.contains_key(consts::BUNDLE_RESOURCES_ENV),
+            "empty BUNDLE_RESOURCES_ENV must be treated as unset"
+        );
+        assert!(
+            !captured.contains_key("SPEEDWAVE_PROD"),
+            "empty BUNDLE_RESOURCES_ENV must not trigger SPEEDWAVE_PROD"
+        );
+    }
+
+    #[test]
+    fn apply_child_env_defaults_path_and_home_to_empty_when_missing() {
+        let mut cmd = Command::new("/bin/true");
+        cmd.env_clear();
+        let env = FakeEnv(&[]);
+
+        apply_child_env(&mut cmd, &env);
+
+        let captured = captured_env(&cmd);
+        assert_eq!(
+            captured.get("PATH").map(String::as_str),
+            Some(""),
+            "PATH must always be set on the child, even if empty"
+        );
+        #[cfg(not(target_os = "windows"))]
+        assert_eq!(
+            captured.get("HOME").map(String::as_str),
+            Some(""),
+            "HOME must always be set on Unix children, even if empty"
+        );
     }
 }

--- a/desktop/src-tauri/src/setup_wizard.rs
+++ b/desktop/src-tauri/src/setup_wizard.rs
@@ -2752,6 +2752,7 @@ mod tests {
     #[cfg(unix)]
     mod init_vm_linux_tests {
         use super::super::{start_rootless_containerd, wait_for_containerd};
+        use serial_test::serial;
         use std::os::unix::fs::PermissionsExt;
 
         /// Creates an executable script in `dir` with given name and content.
@@ -2810,9 +2811,9 @@ mod tests {
         }
 
         #[test]
+        #[serial(env)]
         fn has_stale_containerd_unit_detects_existing_file() {
             use super::super::has_stale_containerd_unit;
-            let _guard = super::CLI_ENV_LOCK.lock().unwrap();
 
             let tmp = tempfile::tempdir().expect("tempdir");
             let unit_dir = tmp.path().join(".config/systemd/user");
@@ -2833,9 +2834,9 @@ mod tests {
         }
 
         #[test]
+        #[serial(env)]
         fn has_stale_containerd_unit_returns_false_when_missing() {
             use super::super::has_stale_containerd_unit;
-            let _guard = super::CLI_ENV_LOCK.lock().unwrap();
 
             let tmp = tempfile::tempdir().expect("tempdir");
             let orig_home = std::env::var("HOME").ok();
@@ -3124,8 +3125,8 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
+    #[serial(env)]
     fn resolve_cli_source_finds_macos_bundle_path() {
-        let _guard = CLI_ENV_LOCK.lock().unwrap();
         std::env::remove_var(consts::BUNDLE_RESOURCES_ENV);
 
         // Simulate: .app/Contents/MacOS/<exe> with Resources/cli/speedwave
@@ -3151,8 +3152,8 @@ mod tests {
 
     #[cfg(not(target_os = "macos"))]
     #[test]
+    #[serial(env)]
     fn resolve_cli_source_finds_resources_path() {
-        let _guard = CLI_ENV_LOCK.lock().unwrap();
         std::env::remove_var(consts::BUNDLE_RESOURCES_ENV);
 
         // Simulate: <exe_dir>/resources/cli/speedwave
@@ -3190,8 +3191,8 @@ mod tests {
     }
 
     #[test]
+    #[serial(env)]
     fn resolve_cli_source_finds_dev_fallback() {
-        let _guard = CLI_ENV_LOCK.lock().unwrap();
         std::env::remove_var(consts::BUNDLE_RESOURCES_ENV);
 
         // Simulate: <exe_dir>/speedwave (dev mode)
@@ -3211,8 +3212,8 @@ mod tests {
     }
 
     #[test]
+    #[serial(env)]
     fn resolve_cli_source_finds_dev_cli_dir() {
-        let _guard = CLI_ENV_LOCK.lock().unwrap();
         std::env::remove_var(consts::BUNDLE_RESOURCES_ENV);
 
         // Simulate: desktop/src-tauri/target/debug/ as exe_dir,
@@ -3241,12 +3242,11 @@ mod tests {
         );
     }
 
-    /// Serialises env-var mutations across parallel test threads.
-    static CLI_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    use serial_test::serial;
 
     #[test]
+    #[serial(env)]
     fn resolve_cli_source_returns_none_when_not_found() {
-        let _guard = CLI_ENV_LOCK.lock().unwrap();
         std::env::remove_var(consts::BUNDLE_RESOURCES_ENV);
 
         let tmp = tempfile::tempdir().expect("tempdir");
@@ -3258,9 +3258,8 @@ mod tests {
     }
 
     #[test]
+    #[serial(env)]
     fn resolve_cli_source_finds_via_resources_env() {
-        let _guard = CLI_ENV_LOCK.lock().unwrap();
-
         let tmp = tempfile::tempdir().expect("tempdir");
         let resources_dir = tmp.path().join("resources");
         let cli_dir = resources_dir.join("cli");
@@ -3298,8 +3297,8 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
+    #[serial(env)]
     fn resolve_cli_source_prefers_bundle_over_dev() {
-        let _guard = CLI_ENV_LOCK.lock().unwrap();
         std::env::remove_var(consts::BUNDLE_RESOURCES_ENV);
 
         // Both Resources/cli/speedwave and <exe_dir>/speedwave exist;
@@ -3324,9 +3323,8 @@ mod tests {
     }
 
     #[test]
+    #[serial(env)]
     fn resolve_cli_source_env_var_takes_priority_over_filesystem() {
-        let _guard = CLI_ENV_LOCK.lock().unwrap();
-
         let tmp = tempfile::tempdir().expect("tempdir");
 
         // Set up a SPEEDWAVE_RESOURCES_DIR with its own CLI binary


### PR DESCRIPTION
## Summary

Two bugs prevented `speedwave` from starting in a project after a plugin was installed mid-flight, and three smaller boy-scout fixes that surfaced while running the suite.

### Reproduction

1. Open project A without plugins → `~/.claude/skills` is created as a whole-directory symlink into the read-only resources mount.
2. Install a plugin in the desktop UI.
3. Re-run `speedwave` from terminal in project A.

Result before this PR:
```
ln: failed to create symbolic link '/home/speedwave/.claude/skills/code-review-basic/code-review-basic': Read-only file system
```
…claude container exits 1, runtime cannot recover, every subsequent invocation fails with `cannot exec in a stopped state`.

### Fixes

- **A — `containers/entrypoint.sh`** (root cause). When the project is restarted with `SPEEDWAVE_PLUGINS` set, normalize `~/.claude/{skills,commands,agents,hooks}` in both directions:
  - no-plugins → plugins: replace the stale whole-directory symlink with a real directory before per-entry `ln -sfn`
  - plugins → no-plugins: wipe the real directory before re-establishing the whole-directory symlink (otherwise `ln -sfn TARGET DIR` creates the link *inside* the dir)
- **B — `crates/speedwave-runtime/src/runtime/mod.rs`**. `ensure_exec_healthy` now recognizes `cannot exec in a stopped state` as a third recoverable failure mode (alongside stale-mount and missing-container) and triggers `compose_up_recreate`. Without this, even after fixing A, any future container exit traps the user permanently.

### Boy-scout fixes (separately committed)

- **`compose.rs::test_hub_worker_urls_use_port_worker`**: assertion incorrectly required `WORKER_OS_URL` to point at `PORT_WORKER`, but that URL is the host-side mcp-os gateway with a dynamically assigned port. Excluded from the assertion.
- **`compose.rs::apply_mcp_os_config_with_path`**: TOCTOU between `is_file()` and `read_to_string()` could surface `os error 2` and abort `render_compose` when the desktop process respawns mcp-os and rewrites `~/.speedwave/mcp-os-*` files. Single-read attempt now treats any read failure as "not configured".
- **`Makefile::test-rust`**: ~30 tests calling `render_compose` race on `consts::data_dir()` (`~/.speedwave/`) under cargo's parallel execution. Forced `--test-threads=1` until per-test data_dir isolation lands.
- **`.husky/pre-push`**: `git push` exports `GIT_DIR`/`GIT_WORK_TREE` pointing at the pushing repo, leaking into `cargo test` and breaking `read_branch_*` tests in `desktop/src-tauri/src/git_cmd.rs`. Strip them before `make test`.

### Tests added

- 2 bats tests in `_tests/entrypoint/entrypoint.bats` covering both migration directions (forward + reverse)
- 4 Rust tests in `runtime::tests`: `is_stopped_container_error_*` (3) + `ensure_exec_healthy_recovers_stopped_container`
- 1 Rust test in `compose::tests`: `test_mcp_os_config_skipped_when_token_path_does_not_exist`

## Test plan

- [x] `make check` — clippy + lint + format zielony
- [x] `make test-entrypoint` — 46/46 (44 istniejących + 2 nowe)
- [x] `make test-rust` — 1031/1031 (po naprawie `--test-threads=1`)
- [x] `make test-angular` — 1538/1538
- [x] `make test-mcp` — 468/468
- [x] `make test-desktop` — 1054/1054
- [x] Pre-push hook przeszedł lokalnie z pełnym `make test`
- [ ] Manualna weryfikacja: po merge — usunąć `~/.speedwave/claude-home/presales/.claude/skills` na hoście, uruchomić `speedwave` w `Presales` z zainstalowanym pluginem `presale`, sprawdzić że claude container nie pada i sesja startuje