### PR TITLE
feat(plugins): async install with progress overlay

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -18,6 +18,7 @@ export default {
         'cli',
         'desktop',
         'tauri',
+        'plugins',
         'mcp',
         'mcp-hub',
         'mcp-shared',

--- a/crates/speedwave-cli/src/main.rs
+++ b/crates/speedwave-cli/src/main.rs
@@ -483,7 +483,10 @@ fn main() -> anyhow::Result<()> {
             std::process::exit(0);
         }
         CliAction::PluginRemove(slug) => {
-            plugin::remove_plugin(slug)?;
+            let rt = detect_runtime();
+            let rt_ref: Option<&dyn speedwave_runtime::runtime::ContainerRuntime> =
+                if rt.is_available() { Some(&*rt) } else { None };
+            plugin::remove_plugin(slug, rt_ref)?;
             println!("Plugin '{}' removed", slug);
             std::process::exit(0);
         }

--- a/crates/speedwave-cli/src/main.rs
+++ b/crates/speedwave-cli/src/main.rs
@@ -454,11 +454,21 @@ fn main() -> anyhow::Result<()> {
             let rt = detect_runtime();
             let rt_ref: Option<&dyn speedwave_runtime::runtime::ContainerRuntime> =
                 if rt.is_available() { Some(&*rt) } else { None };
-            let manifest = plugin::install_plugin(std::path::Path::new(path), rt_ref)?;
-            println!(
-                "Plugin '{}' ({}) installed successfully",
-                manifest.name, manifest.slug
-            );
+            let outcome = plugin::install_plugin(std::path::Path::new(path), rt_ref, &mut |_| {})?;
+            match outcome {
+                plugin::InstallOutcome::Installed(manifest) => {
+                    println!(
+                        "Plugin '{}' ({}) installed successfully",
+                        manifest.name, manifest.slug
+                    );
+                }
+                plugin::InstallOutcome::InstalledPendingBuild(manifest) => {
+                    eprintln!(
+                        "Plugin '{}' ({}) installed; image build failed and will retry on next launch",
+                        manifest.name, manifest.slug
+                    );
+                }
+            }
             std::process::exit(0);
         }
         CliAction::PluginList => {

--- a/crates/speedwave-runtime/src/build.rs
+++ b/crates/speedwave-runtime/src/build.rs
@@ -415,7 +415,7 @@ pub fn prune_old_bundle_images(
         "Pruning {} images from old bundle {old_bundle_id}",
         tags.len()
     );
-    runtime.remove_images(&tags)?;
+    runtime.remove_images(&tags, false)?;
 
     log::info!("Pruning BuildKit cache");
     if let Err(e) = runtime.prune_buildkit_cache() {
@@ -2100,7 +2100,7 @@ mod tests {
         fn image_exists(&self, _: &str) -> anyhow::Result<bool> {
             Ok(true)
         }
-        fn remove_images(&self, tags: &[String]) -> anyhow::Result<()> {
+        fn remove_images(&self, tags: &[String], _force: bool) -> anyhow::Result<()> {
             self.removed_tags.lock().unwrap().extend_from_slice(tags);
             Ok(())
         }

--- a/crates/speedwave-runtime/src/plugin.rs
+++ b/crates/speedwave-runtime/src/plugin.rs
@@ -662,14 +662,59 @@ fn install_plugin_with_base(
 }
 
 /// Removes a plugin by slug.
-pub fn remove_plugin(slug: &str) -> anyhow::Result<()> {
+///
+/// When `runtime` is provided AND the plugin has a `service_id` (i.e. an
+/// MCP plugin with a built container image), also removes the cached
+/// container image (`speedwave-mcp-<slug>:<version>`). Image cleanup is
+/// best-effort — a failure is logged at warn level but does not fail the
+/// removal, since at that point the plugin directory is already gone and
+/// the surviving image is at worst a few hundred MB of leaked disk.
+///
+/// Pass `runtime: None` to keep the legacy behaviour (delete files only).
+pub fn remove_plugin(slug: &str, runtime: Option<&dyn ContainerRuntime>) -> anyhow::Result<()> {
+    let plugins_dir = plugins_base_dir()?;
+    remove_plugin_with_base(slug, &plugins_dir, runtime)
+}
+
+/// Testable variant of [`remove_plugin`] — accepts an explicit plugins
+/// base directory so unit tests can isolate file-system mutation under
+/// `tempfile::tempdir()`. Mirrors [`install_plugin_with_base`].
+fn remove_plugin_with_base(
+    slug: &str,
+    plugins_dir: &Path,
+    runtime: Option<&dyn ContainerRuntime>,
+) -> anyhow::Result<()> {
     validate_slug(slug)?;
-    let plugin_dir = plugins_base_dir()?.join(slug);
+    let plugin_dir = plugins_dir.join(slug);
     if !plugin_dir.exists() {
         anyhow::bail!("Plugin '{}' not found", slug);
     }
+
+    // Read the manifest BEFORE removing files so we can compute the image
+    // tag for cleanup. We tolerate a missing/corrupt manifest — the file
+    // delete still proceeds.
+    let manifest_for_image = if runtime.is_some() {
+        std::fs::read_to_string(plugin_dir.join("plugin.json"))
+            .ok()
+            .and_then(|content| serde_json::from_str::<PluginManifest>(&content).ok())
+    } else {
+        None
+    };
+
     std::fs::remove_dir_all(&plugin_dir)?;
     log::info!("Removed plugin '{}'", slug);
+
+    if let (Some(rt), Some(manifest)) = (runtime, manifest_for_image) {
+        if manifest.service_id.is_some() {
+            let tag = plugin_image_tag(&manifest);
+            if let Err(e) = rt.remove_images(&[tag.clone()]) {
+                log::warn!("Failed to remove container image '{tag}' for plugin '{slug}': {e}");
+            } else {
+                log::info!("Removed container image '{tag}' for plugin '{slug}'");
+            }
+        }
+    }
+
     Ok(())
 }
 
@@ -2365,6 +2410,153 @@ mod tests {
             err_text.contains("***REDACTED***"),
             "expected redacted marker in: {err_text}"
         );
+    }
+
+    // --- remove_plugin image cleanup tests ---
+
+    /// Mock that records every `remove_images` call for inspection.
+    struct ImageRemovingRuntime {
+        calls: std::sync::Mutex<Vec<Vec<String>>>,
+        return_err: bool,
+    }
+    impl ImageRemovingRuntime {
+        fn new() -> Self {
+            Self {
+                calls: std::sync::Mutex::new(vec![]),
+                return_err: false,
+            }
+        }
+        fn failing() -> Self {
+            Self {
+                calls: std::sync::Mutex::new(vec![]),
+                return_err: true,
+            }
+        }
+    }
+    impl ContainerRuntime for ImageRemovingRuntime {
+        fn compose_up(&self, _: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn compose_down(&self, _: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn compose_ps(&self, _: &str) -> anyhow::Result<Vec<serde_json::Value>> {
+            Ok(vec![])
+        }
+        fn container_exec(&self, _: &str, _: &[&str]) -> std::process::Command {
+            std::process::Command::new("true")
+        }
+        fn container_exec_piped(
+            &self,
+            _: &str,
+            _: &[&str],
+        ) -> anyhow::Result<std::process::Command> {
+            Ok(std::process::Command::new("true"))
+        }
+        fn is_available(&self) -> bool {
+            true
+        }
+        fn ensure_ready(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn build_image(&self, _: &str, _: &str, _: &str, _: &[(&str, &str)]) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn image_exists(&self, _: &str) -> anyhow::Result<bool> {
+            Ok(false)
+        }
+        fn container_logs(&self, _: &str, _: u32) -> anyhow::Result<String> {
+            Ok(String::new())
+        }
+        fn compose_logs(&self, _: &str, _: u32) -> anyhow::Result<String> {
+            Ok(String::new())
+        }
+        fn compose_up_recreate(&self, _: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn remove_images(&self, tags: &[String]) -> anyhow::Result<()> {
+            self.calls.lock().unwrap().push(tags.to_vec());
+            if self.return_err {
+                anyhow::bail!("simulated nerdctl rmi failure")
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    /// Helper: install a plugin into `plugins_dir` so we have something to remove.
+    fn write_plugin_dir(plugins_dir: &Path, slug: &str, with_service_id: bool) {
+        let plugin_dir = plugins_dir.join(slug);
+        std::fs::create_dir_all(&plugin_dir).unwrap();
+        let manifest_json = if with_service_id {
+            format!(
+                r#"{{"name":"{slug}","slug":"{slug}","service_id":"{slug}","version":"1.0.0","description":"test"}}"#
+            )
+        } else {
+            format!(r#"{{"name":"{slug}","slug":"{slug}","version":"1.0.0","description":"test"}}"#)
+        };
+        std::fs::write(plugin_dir.join("plugin.json"), manifest_json).unwrap();
+        if with_service_id {
+            std::fs::write(plugin_dir.join("Containerfile"), b"FROM scratch\n").unwrap();
+        }
+    }
+
+    #[test]
+    fn test_remove_plugin_calls_remove_images_for_mcp_plugin() {
+        let tmp = tempfile::tempdir().unwrap();
+        let plugins_dir = tmp.path().join("plugins");
+        write_plugin_dir(&plugins_dir, "img-cleanup", true);
+
+        let rt = ImageRemovingRuntime::new();
+        remove_plugin_with_base("img-cleanup", &plugins_dir, Some(&rt)).unwrap();
+
+        // Plugin dir is gone.
+        assert!(!plugins_dir.join("img-cleanup").exists());
+        // remove_images called once with the expected tag.
+        let calls = rt.calls.into_inner().unwrap();
+        assert_eq!(
+            calls,
+            vec![vec!["speedwave-mcp-img-cleanup:1.0.0".to_string()]]
+        );
+    }
+
+    #[test]
+    fn test_remove_plugin_skips_image_for_resource_only_plugin() {
+        let tmp = tempfile::tempdir().unwrap();
+        let plugins_dir = tmp.path().join("plugins");
+        write_plugin_dir(&plugins_dir, "skills-only", false);
+
+        let rt = ImageRemovingRuntime::new();
+        remove_plugin_with_base("skills-only", &plugins_dir, Some(&rt)).unwrap();
+
+        // remove_images NOT called for plugins without a service_id.
+        assert!(rt.calls.into_inner().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_remove_plugin_skips_image_when_runtime_is_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let plugins_dir = tmp.path().join("plugins");
+        write_plugin_dir(&plugins_dir, "no-runtime", true);
+
+        // No runtime — files removed, image cleanup skipped (legacy path).
+        remove_plugin_with_base("no-runtime", &plugins_dir, None).unwrap();
+        assert!(!plugins_dir.join("no-runtime").exists());
+    }
+
+    #[test]
+    fn test_remove_plugin_succeeds_even_when_remove_images_fails() {
+        let tmp = tempfile::tempdir().unwrap();
+        let plugins_dir = tmp.path().join("plugins");
+        write_plugin_dir(&plugins_dir, "rmi-fails", true);
+
+        // Best-effort: image removal failure logs a warning but does not fail.
+        let rt = ImageRemovingRuntime::failing();
+        let result = remove_plugin_with_base("rmi-fails", &plugins_dir, Some(&rt));
+        assert!(result.is_ok(), "remove_plugin must not fail on rmi error");
+        assert!(!plugins_dir.join("rmi-fails").exists());
+        // remove_images was attempted.
+        assert_eq!(rt.calls.into_inner().unwrap().len(), 1);
     }
 
     // --- Task 2: duplicate service_id detection test ---

--- a/crates/speedwave-runtime/src/plugin.rs
+++ b/crates/speedwave-runtime/src/plugin.rs
@@ -712,7 +712,7 @@ fn remove_plugin_with_base(
             // the next compose recreate. Without --force, rmi would refuse
             // and the layer cache would survive — defeating the next
             // reinstall (a fresh ZIP would receive the stale cached image).
-            if let Err(e) = rt.remove_images(&[tag.clone()], true) {
+            if let Err(e) = rt.remove_images(std::slice::from_ref(&tag), true) {
                 log::warn!("Failed to remove container image '{tag}' for plugin '{slug}': {e}");
             } else {
                 log::info!("Removed container image '{tag}' for plugin '{slug}'");

--- a/crates/speedwave-runtime/src/plugin.rs
+++ b/crates/speedwave-runtime/src/plugin.rs
@@ -639,6 +639,18 @@ fn install_plugin_with_base(
                     return Ok(InstallOutcome::InstalledPendingBuild(manifest));
                 }
             }
+        } else {
+            // No runtime available — image was not built. Treat as deferred
+            // so callers (CLI, Tauri auto-enable) don't enable an MCP plugin
+            // whose worker cannot start. `.image_pending` retry will run on
+            // the next launch via `ensure_all_plugin_images`.
+            on_progress(PluginInstallProgress {
+                phase: "done_with_pending_build".to_string(),
+                message: "Plugin installed; image build deferred to next launch".to_string(),
+                error: None,
+            });
+            warn_legacy_addons();
+            return Ok(InstallOutcome::InstalledPendingBuild(manifest));
         }
     }
 
@@ -2076,6 +2088,17 @@ mod tests {
         std::fs::write(zip_path, buf.into_inner()).unwrap();
     }
 
+    /// Serializes tests that mutate the global `SPEEDWAVE_ALLOW_UNSIGNED`
+    /// env var so concurrent runs do not see each other's set/unset.
+    /// Acquired before set_var and dropped after remove_var.
+    fn unsigned_env_lock() -> std::sync::MutexGuard<'static, ()> {
+        use std::sync::{Mutex, OnceLock};
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+    }
+
     #[test]
     fn test_peek_plugin_manifest_mcp_plugin() {
         let tmp = tempfile::tempdir().unwrap();
@@ -2168,10 +2191,9 @@ mod tests {
 
     #[test]
     fn test_install_plugin_resource_only_emits_verifying_extracting_done() {
-        // Note: SPEEDWAVE_ALLOW_UNSIGNED is process-global and follows the
-        // existing pattern from signing::tests; we accept the same residual
-        // concurrency risk and keep file-system mutation isolated under a
-        // tempdir via install_plugin_with_base.
+        // SPEEDWAVE_ALLOW_UNSIGNED is process-global; serialize tests that
+        // touch it so concurrent runs cannot see partial state.
+        let _guard = unsigned_env_lock();
         std::env::set_var("SPEEDWAVE_ALLOW_UNSIGNED", "1");
         let tmp = tempfile::tempdir().unwrap();
         let zip = tmp.path().join("plugin.zip");
@@ -2195,7 +2217,8 @@ mod tests {
     }
 
     #[test]
-    fn test_install_plugin_no_runtime_skips_building() {
+    fn test_install_plugin_no_runtime_for_mcp_plugin_returns_pending_build() {
+        let _guard = unsigned_env_lock();
         std::env::set_var("SPEEDWAVE_ALLOW_UNSIGNED", "1");
         let tmp = tempfile::tempdir().unwrap();
         let zip = tmp.path().join("plugin.zip");
@@ -2203,7 +2226,9 @@ mod tests {
         let plugins_dir = tmp.path().join("plugins");
 
         let progresses = std::sync::Mutex::new(Vec::<PluginInstallProgress>::new());
-        // runtime=None: marker .image_pending is created, building is not emitted.
+        // runtime=None for MCP plugin: marker .image_pending is created,
+        // building is not emitted, and the outcome is PendingBuild so callers
+        // do not auto-enable an MCP worker whose image is absent.
         let result =
             install_plugin_with_base(&zip, None, &mut collect_progress(&progresses), &plugins_dir);
         std::env::remove_var("SPEEDWAVE_ALLOW_UNSIGNED");
@@ -2211,7 +2236,11 @@ mod tests {
         let dest = plugins_dir.join("phases-no-runtime");
         let pending_existed = dest.join(".image_pending").exists();
 
-        assert!(result.is_ok());
+        let outcome = result.expect("install must succeed");
+        assert!(
+            matches!(outcome, InstallOutcome::InstalledPendingBuild(_)),
+            "MCP plugin without runtime must return InstalledPendingBuild"
+        );
         assert!(
             pending_existed,
             ".image_pending must be created when runtime is None"
@@ -2222,8 +2251,11 @@ mod tests {
             .iter()
             .map(|p| p.phase.clone())
             .collect();
-        // building skipped (no runtime), but installation still completes.
-        assert_eq!(phases, vec!["verifying", "extracting", "done"]);
+        // building skipped (no runtime); terminal phase is done_with_pending_build.
+        assert_eq!(
+            phases,
+            vec!["verifying", "extracting", "done_with_pending_build"]
+        );
     }
 
     #[test]
@@ -2279,6 +2311,7 @@ mod tests {
             }
         }
 
+        let _guard = unsigned_env_lock();
         std::env::set_var("SPEEDWAVE_ALLOW_UNSIGNED", "1");
         let tmp = tempfile::tempdir().unwrap();
         let zip = tmp.path().join("plugin.zip");

--- a/crates/speedwave-runtime/src/plugin.rs
+++ b/crates/speedwave-runtime/src/plugin.rs
@@ -2561,8 +2561,15 @@ mod tests {
         let result = remove_plugin_with_base("rmi-fails", &plugins_dir, Some(&rt));
         assert!(result.is_ok(), "remove_plugin must not fail on rmi error");
         assert!(!plugins_dir.join("rmi-fails").exists());
-        // remove_images was attempted.
-        assert_eq!(rt.calls.into_inner().unwrap().len(), 1);
+        // remove_images was attempted with force=true even on the error path
+        // — the uninstall caller never silently downgrades to non-force rmi.
+        let calls = rt.calls.into_inner().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert!(
+            calls[0].1,
+            "rmi error path should still pass force=true, got force={}",
+            calls[0].1
+        );
     }
 
     // --- Task 2: duplicate service_id detection test ---

--- a/crates/speedwave-runtime/src/plugin.rs
+++ b/crates/speedwave-runtime/src/plugin.rs
@@ -85,6 +85,55 @@ pub struct PluginManifest {
     pub requires_integrations: Vec<String>,
 }
 
+/// Streaming progress event emitted while `install_plugin` runs.
+///
+/// Phase strings are part of the public IPC contract (event
+/// `plugin_install_status`); see [`ALL_PLUGIN_INSTALL_PHASES`] for the
+/// exhaustive list. The `error` field is always sanitized via
+/// `log_sanitizer::sanitize` before emission.
+#[derive(Serialize, Debug, Clone)]
+#[serde(rename_all = "snake_case")]
+pub struct PluginInstallProgress {
+    pub phase: String,
+    pub message: String,
+    pub error: Option<String>,
+}
+
+/// Outcome returned by [`install_plugin`].
+///
+/// Distinguishes a fully-installed plugin from one whose image build
+/// deferred to the next launch (`.image_pending` marker remains).
+#[derive(Debug, Clone)]
+pub enum InstallOutcome {
+    Installed(PluginManifest),
+    InstalledPendingBuild(PluginManifest),
+}
+
+/// SSOT for the phase strings emitted by [`install_plugin`].
+///
+/// Mirrored as `PLUGIN_INSTALL_PHASES` in
+/// `desktop/src/src/app/models/plugin.ts`. Adding/removing/renaming a phase
+/// here requires the same change there (no codegen — this is a small,
+/// rarely-changing list).
+pub const ALL_PLUGIN_INSTALL_PHASES: &[&str] = &[
+    "verifying",
+    "extracting",
+    "building",
+    "done",
+    "failed",
+    "done_with_pending_build",
+];
+
+/// Lightweight summary of a plugin manifest for the install-overlay
+/// pre-fetch path. Read by `peek_plugin_manifest` from the ZIP without
+/// signature verification, extraction, or any side-effect.
+#[derive(Serialize, Debug, Clone)]
+pub struct PluginManifestSummary {
+    pub slug: String,
+    pub name: String,
+    pub has_service_id: bool,
+}
+
 /// Returns `~/.speedwave/plugins/`
 pub fn plugins_base_dir() -> anyhow::Result<PathBuf> {
     Ok(consts::data_dir().join("plugins"))
@@ -435,15 +484,78 @@ fn validate_manifest(manifest: &PluginManifest, plugin_dir: &Path) -> anyhow::Re
     Ok(())
 }
 
+/// Reads a plugin manifest summary from a ZIP without verifying the
+/// signature, extracting to a permanent location, or running any side-effect.
+///
+/// Used by the Desktop install overlay to learn whether the plugin will run
+/// the `building` phase (i.e. has a `service_id`) BEFORE invoking
+/// [`install_plugin`]. The full [`install_plugin`] flow re-runs every step
+/// — including signature verification — so this is purely a lightweight
+/// pre-flight peek.
+pub fn peek_plugin_manifest(zip_path: &Path) -> anyhow::Result<PluginManifestSummary> {
+    let tmp_dir =
+        std::env::temp_dir().join(format!("speedwave-plugin-peek-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&tmp_dir)?;
+    let _cleanup = TmpDirGuard(tmp_dir.clone());
+    extract_zip(zip_path, &tmp_dir)?;
+    validate_extracted_paths(&tmp_dir)?;
+    let plugin_src = find_plugin_dir(&tmp_dir)?;
+
+    let manifest_path = plugin_src.join("plugin.json");
+    let content = std::fs::read_to_string(&manifest_path)?;
+    let manifest: PluginManifest = serde_json::from_str(&content)?;
+    Ok(PluginManifestSummary {
+        slug: manifest.slug,
+        name: manifest.name,
+        has_service_id: manifest.service_id.is_some(),
+    })
+}
+
 /// Install a plugin from a ZIP file into `~/.speedwave/plugins/<slug>/`.
 /// Verifies signature, validates manifest, and creates `.image_pending` marker
 /// for deferred image build.
+///
+/// Streams progress through `on_progress` using the phases defined in
+/// [`ALL_PLUGIN_INSTALL_PHASES`]. The `error` field of any emitted
+/// [`PluginInstallProgress`] is sanitized via
+/// [`crate::log_sanitizer::sanitize`] before emission.
+///
+/// Returns:
+/// * [`InstallOutcome::Installed`] — plugin extracted and (for MCP plugins)
+///   image built.
+/// * [`InstallOutcome::InstalledPendingBuild`] — plugin extracted; image
+///   build failed. The `.image_pending` marker remains and the build is
+///   retried on the next launch via [`ensure_all_plugin_images`].
 pub fn install_plugin(
     zip_path: &Path,
     runtime: Option<&dyn ContainerRuntime>,
-) -> anyhow::Result<PluginManifest> {
+    on_progress: &mut dyn FnMut(PluginInstallProgress),
+) -> anyhow::Result<InstallOutcome> {
     let plugins_dir = plugins_base_dir()?;
-    std::fs::create_dir_all(&plugins_dir)?;
+    install_plugin_with_base(zip_path, runtime, on_progress, &plugins_dir)
+}
+
+/// Testable variant of [`install_plugin`] — accepts an explicit plugins
+/// base directory so unit tests can isolate file-system mutation under
+/// `tempfile::tempdir()`.
+fn install_plugin_with_base(
+    zip_path: &Path,
+    runtime: Option<&dyn ContainerRuntime>,
+    on_progress: &mut dyn FnMut(PluginInstallProgress),
+    plugins_dir: &Path,
+) -> anyhow::Result<InstallOutcome> {
+    let mut emit = |phase: &str, message: &str| {
+        on_progress(PluginInstallProgress {
+            phase: phase.to_string(),
+            message: message.to_string(),
+            error: None,
+        });
+    };
+
+    std::fs::create_dir_all(plugins_dir)?;
+
+    // Phase: verifying — signature check
+    emit("verifying", "Verifying signature");
 
     // Extract ZIP to a temporary directory first
     let tmp_dir = std::env::temp_dir().join(format!("speedwave-plugin-{}", uuid::Uuid::new_v4()));
@@ -458,7 +570,14 @@ pub fn install_plugin(
     let plugin_src = find_plugin_dir(&tmp_dir)?;
 
     // Verify signature before doing anything else
-    signing::verify_plugin_signature(&plugin_src)?;
+    if let Err(e) = signing::verify_plugin_signature(&plugin_src) {
+        on_progress(PluginInstallProgress {
+            phase: "failed".to_string(),
+            message: "Signature verification failed".to_string(),
+            error: Some(crate::log_sanitizer::sanitize(&e.to_string())),
+        });
+        return Err(e);
+    }
 
     // Read and validate manifest
     let manifest_path = plugin_src.join("plugin.json");
@@ -468,7 +587,7 @@ pub fn install_plugin(
     validate_manifest(&manifest, &plugin_src)?;
 
     // Reject duplicate service_id or port among already-installed plugins
-    let existing = list_installed_plugins()?;
+    let existing = list_installed_from_dir(plugins_dir)?;
     if let Some(ref sid) = manifest.service_id {
         for existing_manifest in &existing {
             if existing_manifest.service_id.as_deref() == Some(sid.as_str())
@@ -482,7 +601,9 @@ pub fn install_plugin(
             }
         }
     }
-    // Move to final location
+
+    // Phase: extracting — copy from temp to permanent location
+    emit("extracting", "Extracting archive");
     let dest = plugins_dir.join(&manifest.slug);
     if dest.exists() {
         std::fs::remove_dir_all(&dest)?;
@@ -495,8 +616,28 @@ pub fn install_plugin(
 
         // Build immediately if runtime is available
         if let Some(rt) = runtime {
-            if let Err(e) = build_single_plugin_image(rt, &manifest, &dest) {
-                log::warn!("Deferred build for plugin '{}': {e}", manifest.slug);
+            emit("building", "Building container image (may take 2-5 min)");
+            match build_single_plugin_image(rt, &manifest, &dest) {
+                Ok(()) => {
+                    // .image_pending was removed by build_single_plugin_image on success
+                }
+                Err(e) => {
+                    log::warn!("Deferred build for plugin '{}': {e}", manifest.slug);
+                    on_progress(PluginInstallProgress {
+                        phase: "failed".to_string(),
+                        message: "Image build failed".to_string(),
+                        error: Some(crate::log_sanitizer::sanitize(&e.to_string())),
+                    });
+                    on_progress(PluginInstallProgress {
+                        phase: "done_with_pending_build".to_string(),
+                        message:
+                            "Plugin installed; image build failed and will retry on next launch"
+                                .to_string(),
+                        error: None,
+                    });
+                    warn_legacy_addons();
+                    return Ok(InstallOutcome::InstalledPendingBuild(manifest));
+                }
             }
         }
     }
@@ -504,7 +645,8 @@ pub fn install_plugin(
     // Legacy addon migration warning
     warn_legacy_addons();
 
-    Ok(manifest)
+    emit("done", "Plugin installed");
+    Ok(InstallOutcome::Installed(manifest))
 }
 
 /// Removes a plugin by slug.
@@ -1867,6 +2009,328 @@ mod tests {
             TokenStatus::NotConfigured {
                 missing: vec!["api_key".to_string()]
             }
+        );
+    }
+
+    // --- ALL_PLUGIN_INSTALL_PHASES parity ---
+
+    #[test]
+    fn test_all_plugin_install_phases_lists_expected_strings() {
+        // SSOT for the IPC contract; mirror in
+        // desktop/src/src/app/models/plugin.ts::PLUGIN_INSTALL_PHASES.
+        // Adding/removing/renaming a phase here requires the same change there.
+        assert_eq!(
+            ALL_PLUGIN_INSTALL_PHASES,
+            &[
+                "verifying",
+                "extracting",
+                "building",
+                "done",
+                "failed",
+                "done_with_pending_build",
+            ]
+        );
+    }
+
+    // --- peek_plugin_manifest tests ---
+
+    /// Builds a minimal valid signed-bypass plugin ZIP for tests.
+    /// Caller must set SPEEDWAVE_ALLOW_UNSIGNED to skip signature verification.
+    fn build_test_plugin_zip(zip_path: &Path, slug: &str, with_service_id: bool) {
+        use std::io::{Cursor, Write};
+        use zip::write::SimpleFileOptions;
+        use zip::ZipWriter;
+
+        let buf = Cursor::new(Vec::new());
+        let mut writer = ZipWriter::new(buf);
+        let options = SimpleFileOptions::default();
+
+        let manifest_json = if with_service_id {
+            format!(
+                r#"{{
+                    "name": "{slug}",
+                    "slug": "{slug}",
+                    "service_id": "{slug}",
+                    "version": "1.0.0",
+                    "description": "test plugin"
+                }}"#
+            )
+        } else {
+            format!(
+                r#"{{
+                    "name": "{slug}",
+                    "slug": "{slug}",
+                    "version": "1.0.0",
+                    "description": "test resource-only plugin"
+                }}"#
+            )
+        };
+
+        writer.start_file("plugin.json", options).unwrap();
+        writer.write_all(manifest_json.as_bytes()).unwrap();
+        if with_service_id {
+            writer.start_file("Containerfile", options).unwrap();
+            writer.write_all(b"FROM scratch\n").unwrap();
+        }
+        let buf = writer.finish().unwrap();
+        std::fs::write(zip_path, buf.into_inner()).unwrap();
+    }
+
+    #[test]
+    fn test_peek_plugin_manifest_mcp_plugin() {
+        let tmp = tempfile::tempdir().unwrap();
+        let zip = tmp.path().join("plugin.zip");
+        build_test_plugin_zip(&zip, "test-mcp", true);
+
+        let summary = peek_plugin_manifest(&zip).unwrap();
+        assert_eq!(summary.slug, "test-mcp");
+        assert_eq!(summary.name, "test-mcp");
+        assert!(summary.has_service_id);
+    }
+
+    #[test]
+    fn test_peek_plugin_manifest_resource_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        let zip = tmp.path().join("plugin.zip");
+        build_test_plugin_zip(&zip, "test-skills", false);
+
+        let summary = peek_plugin_manifest(&zip).unwrap();
+        assert_eq!(summary.slug, "test-skills");
+        assert!(!summary.has_service_id);
+    }
+
+    #[test]
+    fn test_peek_plugin_manifest_missing_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let result = peek_plugin_manifest(&tmp.path().join("nonexistent.zip"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_peek_plugin_manifest_no_manifest_in_zip() {
+        use std::io::{Cursor, Write};
+        use zip::write::SimpleFileOptions;
+        use zip::ZipWriter;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let zip = tmp.path().join("noman.zip");
+        let buf = Cursor::new(Vec::new());
+        let mut writer = ZipWriter::new(buf);
+        writer
+            .start_file("README.md", SimpleFileOptions::default())
+            .unwrap();
+        writer.write_all(b"no manifest here").unwrap();
+        let buf = writer.finish().unwrap();
+        std::fs::write(&zip, buf.into_inner()).unwrap();
+
+        let result = peek_plugin_manifest(&zip);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_peek_plugin_manifest_does_not_install() {
+        // Verifies peek does not write into the plugins base directory.
+        // Runs against an isolated tempdir-as-plugins-dir snapshot: even
+        // though peek itself uses the real plugins_base_dir() internally,
+        // it should not touch it (no write paths). We check by counting
+        // entries in a freshly-created tempdir given as a probe — peek
+        // should not write anywhere outside its own scratch tmp.
+        let tmp = tempfile::tempdir().unwrap();
+        let zip = tmp.path().join("plugin.zip");
+        build_test_plugin_zip(&zip, "side-effect-test", true);
+
+        // Mark the tempdir as the "would-be" plugins dir so we can detect
+        // any rogue writes. peek_plugin_manifest should leave it untouched.
+        let probe_dir = tmp.path().join("would-be-plugins");
+        std::fs::create_dir_all(&probe_dir).unwrap();
+
+        let summary = peek_plugin_manifest(&zip).unwrap();
+        assert_eq!(summary.slug, "side-effect-test");
+
+        let entries: Vec<_> = std::fs::read_dir(&probe_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .collect();
+        assert!(
+            entries.is_empty(),
+            "peek must not write into any plugins-like directory"
+        );
+    }
+
+    // --- install_plugin progress callback tests ---
+
+    /// Progress collector for install_plugin tests.
+    fn collect_progress(
+        progresses: &std::sync::Mutex<Vec<PluginInstallProgress>>,
+    ) -> impl FnMut(PluginInstallProgress) + '_ {
+        move |p| progresses.lock().unwrap().push(p)
+    }
+
+    #[test]
+    fn test_install_plugin_resource_only_emits_verifying_extracting_done() {
+        // Note: SPEEDWAVE_ALLOW_UNSIGNED is process-global and follows the
+        // existing pattern from signing::tests; we accept the same residual
+        // concurrency risk and keep file-system mutation isolated under a
+        // tempdir via install_plugin_with_base.
+        std::env::set_var("SPEEDWAVE_ALLOW_UNSIGNED", "1");
+        let tmp = tempfile::tempdir().unwrap();
+        let zip = tmp.path().join("plugin.zip");
+        build_test_plugin_zip(&zip, "phases-resource", false);
+        let plugins_dir = tmp.path().join("plugins");
+
+        let progresses = std::sync::Mutex::new(Vec::<PluginInstallProgress>::new());
+        let result =
+            install_plugin_with_base(&zip, None, &mut collect_progress(&progresses), &plugins_dir);
+        std::env::remove_var("SPEEDWAVE_ALLOW_UNSIGNED");
+
+        assert!(result.is_ok(), "install_plugin failed: {:?}", result.err());
+        let phases: Vec<String> = progresses
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|p| p.phase.clone())
+            .collect();
+        assert_eq!(phases, vec!["verifying", "extracting", "done"]);
+        assert!(matches!(result.unwrap(), InstallOutcome::Installed(_)));
+    }
+
+    #[test]
+    fn test_install_plugin_no_runtime_skips_building() {
+        std::env::set_var("SPEEDWAVE_ALLOW_UNSIGNED", "1");
+        let tmp = tempfile::tempdir().unwrap();
+        let zip = tmp.path().join("plugin.zip");
+        build_test_plugin_zip(&zip, "phases-no-runtime", true);
+        let plugins_dir = tmp.path().join("plugins");
+
+        let progresses = std::sync::Mutex::new(Vec::<PluginInstallProgress>::new());
+        // runtime=None: marker .image_pending is created, building is not emitted.
+        let result =
+            install_plugin_with_base(&zip, None, &mut collect_progress(&progresses), &plugins_dir);
+        std::env::remove_var("SPEEDWAVE_ALLOW_UNSIGNED");
+
+        let dest = plugins_dir.join("phases-no-runtime");
+        let pending_existed = dest.join(".image_pending").exists();
+
+        assert!(result.is_ok());
+        assert!(
+            pending_existed,
+            ".image_pending must be created when runtime is None"
+        );
+        let phases: Vec<String> = progresses
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|p| p.phase.clone())
+            .collect();
+        // building skipped (no runtime), but installation still completes.
+        assert_eq!(phases, vec!["verifying", "extracting", "done"]);
+    }
+
+    #[test]
+    fn test_install_plugin_emits_failed_with_sanitized_error() {
+        // Build error containing a credential — must be sanitized before emission.
+        struct SecretLeakingRuntime;
+        impl ContainerRuntime for SecretLeakingRuntime {
+            fn compose_up(&self, _: &str) -> anyhow::Result<()> {
+                Ok(())
+            }
+            fn compose_down(&self, _: &str) -> anyhow::Result<()> {
+                Ok(())
+            }
+            fn compose_ps(&self, _: &str) -> anyhow::Result<Vec<serde_json::Value>> {
+                Ok(vec![])
+            }
+            fn container_exec(&self, _: &str, _: &[&str]) -> std::process::Command {
+                std::process::Command::new("true")
+            }
+            fn container_exec_piped(
+                &self,
+                _: &str,
+                _: &[&str],
+            ) -> anyhow::Result<std::process::Command> {
+                Ok(std::process::Command::new("true"))
+            }
+            fn is_available(&self) -> bool {
+                true
+            }
+            fn ensure_ready(&self) -> anyhow::Result<()> {
+                Ok(())
+            }
+            fn build_image(
+                &self,
+                _: &str,
+                _: &str,
+                _: &str,
+                _: &[(&str, &str)],
+            ) -> anyhow::Result<()> {
+                anyhow::bail!("RUN curl https://user:tok@registry.example.com/foo failed")
+            }
+            fn image_exists(&self, _: &str) -> anyhow::Result<bool> {
+                Ok(false)
+            }
+            fn container_logs(&self, _: &str, _: u32) -> anyhow::Result<String> {
+                Ok(String::new())
+            }
+            fn compose_logs(&self, _: &str, _: u32) -> anyhow::Result<String> {
+                Ok(String::new())
+            }
+            fn compose_up_recreate(&self, _: &str) -> anyhow::Result<()> {
+                Ok(())
+            }
+        }
+
+        std::env::set_var("SPEEDWAVE_ALLOW_UNSIGNED", "1");
+        let tmp = tempfile::tempdir().unwrap();
+        let zip = tmp.path().join("plugin.zip");
+        build_test_plugin_zip(&zip, "phases-build-fail", true);
+        let plugins_dir = tmp.path().join("plugins");
+
+        let progresses = std::sync::Mutex::new(Vec::<PluginInstallProgress>::new());
+        let rt = SecretLeakingRuntime;
+        let result = install_plugin_with_base(
+            &zip,
+            Some(&rt),
+            &mut collect_progress(&progresses),
+            &plugins_dir,
+        );
+        std::env::remove_var("SPEEDWAVE_ALLOW_UNSIGNED");
+
+        let dest = plugins_dir.join("phases-build-fail");
+        let pending_kept = dest.join(".image_pending").exists();
+
+        assert!(
+            result.is_ok(),
+            "install must succeed-with-pending on build error"
+        );
+        assert!(matches!(
+            result.unwrap(),
+            InstallOutcome::InstalledPendingBuild(_)
+        ));
+        assert!(
+            pending_kept,
+            ".image_pending must remain after a failed build"
+        );
+
+        let progresses = progresses.into_inner().unwrap();
+        let phases: Vec<String> = progresses.iter().map(|p| p.phase.clone()).collect();
+        assert_eq!(
+            phases,
+            vec![
+                "verifying",
+                "extracting",
+                "building",
+                "failed",
+                "done_with_pending_build"
+            ]
+        );
+
+        // Security: the emitted error must NOT contain the credential.
+        let failed = progresses.iter().find(|p| p.phase == "failed").unwrap();
+        let err_text = failed.error.as_ref().expect("failed phase carries error");
+        assert!(!err_text.contains("tok"), "credential leaked: {err_text}");
+        assert!(
+            err_text.contains("***REDACTED***"),
+            "expected redacted marker in: {err_text}"
         );
     }
 

--- a/crates/speedwave-runtime/src/plugin.rs
+++ b/crates/speedwave-runtime/src/plugin.rs
@@ -707,7 +707,12 @@ fn remove_plugin_with_base(
     if let (Some(rt), Some(manifest)) = (runtime, manifest_for_image) {
         if manifest.service_id.is_some() {
             let tag = plugin_image_tag(&manifest);
-            if let Err(e) = rt.remove_images(&[tag.clone()]) {
+            // force=true: the user explicitly asked to remove this plugin,
+            // and the worker container is almost always still running until
+            // the next compose recreate. Without --force, rmi would refuse
+            // and the layer cache would survive — defeating the next
+            // reinstall (a fresh ZIP would receive the stale cached image).
+            if let Err(e) = rt.remove_images(&[tag.clone()], true) {
                 log::warn!("Failed to remove container image '{tag}' for plugin '{slug}': {e}");
             } else {
                 log::info!("Removed container image '{tag}' for plugin '{slug}'");
@@ -2414,9 +2419,9 @@ mod tests {
 
     // --- remove_plugin image cleanup tests ---
 
-    /// Mock that records every `remove_images` call for inspection.
+    /// Mock that records every `remove_images` call (tags + force) for inspection.
     struct ImageRemovingRuntime {
-        calls: std::sync::Mutex<Vec<Vec<String>>>,
+        calls: std::sync::Mutex<Vec<(Vec<String>, bool)>>,
         return_err: bool,
     }
     impl ImageRemovingRuntime {
@@ -2474,8 +2479,8 @@ mod tests {
         fn compose_up_recreate(&self, _: &str) -> anyhow::Result<()> {
             Ok(())
         }
-        fn remove_images(&self, tags: &[String]) -> anyhow::Result<()> {
-            self.calls.lock().unwrap().push(tags.to_vec());
+        fn remove_images(&self, tags: &[String], force: bool) -> anyhow::Result<()> {
+            self.calls.lock().unwrap().push((tags.to_vec(), force));
             if self.return_err {
                 anyhow::bail!("simulated nerdctl rmi failure")
             } else {
@@ -2512,11 +2517,12 @@ mod tests {
 
         // Plugin dir is gone.
         assert!(!plugins_dir.join("img-cleanup").exists());
-        // remove_images called once with the expected tag.
+        // remove_images called once with the expected tag AND force=true
+        // (uninstall is an explicit user request — no waiting for prune).
         let calls = rt.calls.into_inner().unwrap();
         assert_eq!(
             calls,
-            vec![vec!["speedwave-mcp-img-cleanup:1.0.0".to_string()]]
+            vec![(vec!["speedwave-mcp-img-cleanup:1.0.0".to_string()], true)]
         );
     }
 

--- a/crates/speedwave-runtime/src/runtime/lima.rs
+++ b/crates/speedwave-runtime/src/runtime/lima.rs
@@ -2238,6 +2238,23 @@ mod tests {
     }
 
     #[test]
+    fn test_remove_images_force_passes_force_flag() {
+        let tags = vec!["speedwave-mcp-example:1.0.0".to_string()];
+        let runner = mock_runner_with_vm_running().with_response(
+            &format!(
+                "limactl shell {} -- sudo nerdctl rmi --force speedwave-mcp-example:1.0.0",
+                consts::LIMA_VM_NAME
+            ),
+            "",
+        );
+        let rt = LimaRuntime::with_runner(Box::new(runner));
+        // force=true must add --force to the rmi args so nerdctl removes
+        // images that are still referenced by a running container (the
+        // explicit-uninstall path).
+        assert!(rt.remove_images(&tags, true).is_ok());
+    }
+
+    #[test]
     fn test_remove_images_fails_when_vm_stopped() {
         let runner = MockRunner::new()
             .with_response("limactl --version", "limactl version 1.0.0")

--- a/crates/speedwave-runtime/src/runtime/lima.rs
+++ b/crates/speedwave-runtime/src/runtime/lima.rs
@@ -711,7 +711,7 @@ impl ContainerRuntime for LimaRuntime {
         Ok(())
     }
 
-    fn remove_images(&self, tags: &[String]) -> anyhow::Result<()> {
+    fn remove_images(&self, tags: &[String], force: bool) -> anyhow::Result<()> {
         self.require_running()?;
         if tags.is_empty() {
             return Ok(());
@@ -724,10 +724,13 @@ impl ContainerRuntime for LimaRuntime {
             "nerdctl",
             "rmi",
         ];
+        if force {
+            args.push("--force");
+        }
         let tag_refs: Vec<&str> = tags.iter().map(|s| s.as_str()).collect();
         args.extend(tag_refs);
-        // Intentionally no --force: if an old image is still referenced by a
-        // running container rmi fails, caller logs warn-only and the image
+        // Without `force`, nerdctl rmi refuses if a running container still
+        // references the image — caller logs warn-only and the image
         // gets retried on the next update cycle once the container is gone.
         if let Err(e) = self.runner.run("limactl", &args) {
             log::warn!("lima rmi failed: {e}");
@@ -2194,7 +2197,7 @@ mod tests {
         let runner = mock_runner_with_vm_running();
         let rt = LimaRuntime::with_runner(Box::new(runner));
         assert!(
-            rt.remove_images(&[]).is_ok(),
+            rt.remove_images(&[], false).is_ok(),
             "empty tags should return Ok without calling rmi"
         );
     }
@@ -2213,7 +2216,7 @@ mod tests {
             "",
         );
         let rt = LimaRuntime::with_runner(Box::new(runner));
-        assert!(rt.remove_images(&tags).is_ok());
+        assert!(rt.remove_images(&tags, false).is_ok());
     }
 
     #[test]
@@ -2229,7 +2232,7 @@ mod tests {
         let rt = LimaRuntime::with_runner(Box::new(runner));
         // rmi failure must not propagate — just warn and return Ok
         assert!(
-            rt.remove_images(&tags).is_ok(),
+            rt.remove_images(&tags, false).is_ok(),
             "rmi failure should not propagate"
         );
     }
@@ -2247,7 +2250,7 @@ mod tests {
             );
         let rt = LimaRuntime::with_runner(Box::new(runner));
         let err = rt
-            .remove_images(&["speedwave-claude:abc123".to_string()])
+            .remove_images(&["speedwave-claude:abc123".to_string()], false)
             .unwrap_err();
         assert!(
             err.to_string().contains("not running"),

--- a/crates/speedwave-runtime/src/runtime/mod.rs
+++ b/crates/speedwave-runtime/src/runtime/mod.rs
@@ -102,8 +102,20 @@ pub trait ContainerRuntime: Send + Sync {
     }
 
     /// Remove container images by their full tags.
-    fn remove_images(&self, tags: &[String]) -> anyhow::Result<()> {
-        let _ = tags;
+    ///
+    /// `force = false` is the safe default: nerdctl `rmi` refuses to remove
+    /// an image that is still referenced by a running container, the error
+    /// is logged at warn level, and cleanup is left to the next prune cycle
+    /// once the container is gone. Used by the bundle-update flow.
+    ///
+    /// `force = true` (`nerdctl rmi --force`) removes the image even when a
+    /// running container still references it. Used by the explicit-uninstall
+    /// path (`speedwave plugin remove …` / Desktop "$ uninstall plugin")
+    /// because the user has already declared their intent to drop the plugin
+    /// and waiting for a future prune leaves stale layer cache that defeats
+    /// the next reinstall.
+    fn remove_images(&self, tags: &[String], force: bool) -> anyhow::Result<()> {
+        let _ = (tags, force);
         log::debug!("remove_images: not implemented for this runtime, skipping");
         Ok(())
     }
@@ -1564,11 +1576,11 @@ services:
         // ProbeTestRuntime uses the trait default (no override).
         let rt = ProbeTestRuntime::healthy();
         assert!(
-            rt.remove_images(&[]).is_ok(),
+            rt.remove_images(&[], false).is_ok(),
             "default remove_images with empty slice should return Ok"
         );
         assert!(
-            rt.remove_images(&["speedwave-claude:old123".to_string()])
+            rt.remove_images(&["speedwave-claude:old123".to_string()], false)
                 .is_ok(),
             "default remove_images with tags should return Ok (no-op)"
         );

--- a/crates/speedwave-runtime/src/runtime/nerdctl.rs
+++ b/crates/speedwave-runtime/src/runtime/nerdctl.rs
@@ -213,15 +213,18 @@ impl ContainerRuntime for NerdctlRuntime {
         Ok(())
     }
 
-    fn remove_images(&self, tags: &[String]) -> anyhow::Result<()> {
+    fn remove_images(&self, tags: &[String], force: bool) -> anyhow::Result<()> {
         if tags.is_empty() {
             return Ok(());
         }
         let mut args = vec!["rmi"];
+        if force {
+            args.push("--force");
+        }
         let tag_refs: Vec<&str> = tags.iter().map(|s| s.as_str()).collect();
         args.extend(tag_refs);
-        // Intentionally no --force: if an old image is still referenced by a
-        // running container rmi fails, caller logs warn-only and the image
+        // Without `force`, nerdctl rmi refuses if a running container still
+        // references the image — caller logs warn-only and the image
         // gets retried on the next update cycle once the container is gone.
         if let Err(e) = self.runner.run("nerdctl", &args) {
             log::warn!("nerdctl rmi failed: {e}");
@@ -787,7 +790,7 @@ mod tests {
         let runner = MockRunner::new();
         let rt = NerdctlRuntime::with_runner(Box::new(runner));
         assert!(
-            rt.remove_images(&[]).is_ok(),
+            rt.remove_images(&[], false).is_ok(),
             "empty tags should return Ok without calling runner"
         );
     }
@@ -803,7 +806,19 @@ mod tests {
             "",
         );
         let rt = NerdctlRuntime::with_runner(Box::new(runner));
-        assert!(rt.remove_images(&tags).is_ok());
+        assert!(rt.remove_images(&tags, false).is_ok());
+    }
+
+    #[test]
+    fn test_remove_images_force_passes_force_flag() {
+        let tags = vec!["speedwave-mcp-example:1.0.0".to_string()];
+        let runner =
+            MockRunner::new().with_response("nerdctl rmi --force speedwave-mcp-example:1.0.0", "");
+        let rt = NerdctlRuntime::with_runner(Box::new(runner));
+        // force=true must add --force to the rmi args so nerdctl removes
+        // images that are still referenced by a running container (the
+        // explicit-uninstall path).
+        assert!(rt.remove_images(&tags, true).is_ok());
     }
 
     #[test]
@@ -814,7 +829,7 @@ mod tests {
         let rt = NerdctlRuntime::with_runner(Box::new(runner));
         // rmi failure must not propagate — just warn and return Ok
         assert!(
-            rt.remove_images(&tags).is_ok(),
+            rt.remove_images(&tags, false).is_ok(),
             "rmi failure should not propagate"
         );
     }

--- a/crates/speedwave-runtime/src/runtime/wsl.rs
+++ b/crates/speedwave-runtime/src/runtime/wsl.rs
@@ -472,15 +472,18 @@ impl ContainerRuntime for WslRuntime {
         Ok(())
     }
 
-    fn remove_images(&self, tags: &[String]) -> anyhow::Result<()> {
+    fn remove_images(&self, tags: &[String], force: bool) -> anyhow::Result<()> {
         if tags.is_empty() {
             return Ok(());
         }
         let mut args = vec!["-d", consts::WSL_DISTRO_NAME, "--", "nerdctl", "rmi"];
+        if force {
+            args.push("--force");
+        }
         let tag_refs: Vec<&str> = tags.iter().map(|s| s.as_str()).collect();
         args.extend(tag_refs);
-        // Intentionally no --force: if an old image is still referenced by a
-        // running container rmi fails, caller logs warn-only and the image
+        // Without `force`, nerdctl rmi refuses if a running container still
+        // references the image — caller logs warn-only and the image
         // gets retried on the next update cycle once the container is gone.
         if let Err(e) = self.runner.run("wsl.exe", &args) {
             log::warn!("wsl rmi failed: {e}");
@@ -1156,7 +1159,7 @@ mod tests {
         let runner = MockRunner::new();
         let rt = WslRuntime::with_runner(Box::new(runner));
         assert!(
-            rt.remove_images(&[]).is_ok(),
+            rt.remove_images(&[], false).is_ok(),
             "empty tags should return Ok without calling runner"
         );
     }
@@ -1172,7 +1175,7 @@ mod tests {
             "",
         );
         let rt = WslRuntime::with_runner(Box::new(runner));
-        assert!(rt.remove_images(&tags).is_ok());
+        assert!(rt.remove_images(&tags, false).is_ok());
     }
 
     #[test]
@@ -1185,7 +1188,7 @@ mod tests {
         let rt = WslRuntime::with_runner(Box::new(runner));
         // rmi failure must not propagate — just warn and return Ok
         assert!(
-            rt.remove_images(&tags).is_ok(),
+            rt.remove_images(&tags, false).is_ok(),
             "rmi failure should not propagate"
         );
     }

--- a/crates/speedwave-runtime/src/runtime/wsl.rs
+++ b/crates/speedwave-runtime/src/runtime/wsl.rs
@@ -1194,6 +1194,20 @@ mod tests {
     }
 
     #[test]
+    fn test_remove_images_force_passes_force_flag() {
+        let tags = vec!["speedwave-mcp-example:1.0.0".to_string()];
+        let runner = MockRunner::new().with_response(
+            "wsl.exe -d Speedwave -- nerdctl rmi --force speedwave-mcp-example:1.0.0",
+            "",
+        );
+        let rt = WslRuntime::with_runner(Box::new(runner));
+        // force=true must add --force to the rmi args so nerdctl removes
+        // images that are still referenced by a running container (the
+        // explicit-uninstall path).
+        assert!(rt.remove_images(&tags, true).is_ok());
+    }
+
+    #[test]
     fn test_build_image_passes_build_args() {
         let version = crate::defaults::CLAUDE_VERSION;
         let expected_key = format!(

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -1440,6 +1440,7 @@ fn main() {
             redmine_api_cmd::fetch_redmine_enumerations,
             // Plugins
             plugin_cmd::get_plugins,
+            plugin_cmd::peek_plugin_manifest,
             plugin_cmd::install_plugin,
             plugin_cmd::remove_plugin,
             plugin_cmd::set_plugin_enabled,

--- a/desktop/src-tauri/src/plugin_cmd.rs
+++ b/desktop/src-tauri/src/plugin_cmd.rs
@@ -7,6 +7,7 @@ use crate::types::check_project;
 use speedwave_runtime::config;
 use speedwave_runtime::plugin;
 use std::collections::HashMap;
+use tauri::Emitter;
 
 // ---------------------------------------------------------------------------
 // DTOs
@@ -164,28 +165,65 @@ fn is_plugin_configured(
     true
 }
 
+/// Reads `plugin.json` from a ZIP without extracting, verifying signature,
+/// or building. Returns a lightweight summary so the install overlay knows
+/// which steps to render BEFORE invoking [`install_plugin`].
 #[tauri::command]
-pub fn install_plugin(zip_path: String) -> Result<String, String> {
-    log::info!("install_plugin: zip_path={zip_path}");
-    let path = std::path::Path::new(&zip_path);
+pub async fn peek_plugin_manifest(
+    zip_path: String,
+) -> Result<plugin::PluginManifestSummary, String> {
+    log::info!("peek_plugin_manifest: zip_path={zip_path}");
+    let path = std::path::PathBuf::from(&zip_path);
     if !path.exists() {
         return Err(format!("File not found: {}", zip_path));
     }
+    tokio::task::spawn_blocking(move || plugin::peek_plugin_manifest(&path))
+        .await
+        .map_err(|e| format!("peek task panicked: {e}"))?
+        .map_err(|e| e.to_string())
+}
 
-    let rt = speedwave_runtime::runtime::detect_runtime();
-    let manifest = plugin::install_plugin(path, Some(&*rt)).map_err(|e| e.to_string())?;
+#[tauri::command]
+pub async fn install_plugin(
+    zip_path: String,
+    app_handle: tauri::AppHandle,
+) -> Result<String, String> {
+    log::info!("install_plugin: zip_path={zip_path}");
+    let path = std::path::PathBuf::from(&zip_path);
+    if !path.exists() {
+        return Err(format!("File not found: {}", zip_path));
+    }
+    let app = app_handle.clone();
 
-    // Auto-enable plugins that need no credentials (resource-only or no auth_fields).
-    // MCP plugins with auth_fields are auto-enabled after credential save in the UI.
-    let needs_credentials = manifest.auth_fields.iter().any(|f| f.is_secret);
-    if !needs_credentials {
+    let outcome = tokio::task::spawn_blocking(move || {
+        let rt = speedwave_runtime::runtime::detect_runtime();
+        plugin::install_plugin(&path, Some(&*rt), &mut |progress| {
+            let _ = app.emit("plugin_install_status", progress);
+        })
+    })
+    .await
+    .map_err(|e| format!("install task panicked: {e}"))?
+    .map_err(|e| e.to_string())?;
+
+    let manifest = match &outcome {
+        plugin::InstallOutcome::Installed(m) => m,
+        plugin::InstallOutcome::InstalledPendingBuild(m) => m,
+    };
+
+    // Auto-enable only when image is ready. MCP plugins with auth_fields are
+    // auto-enabled after credential save in the UI.
+    let should_auto_enable =
+        matches!(outcome, plugin::InstallOutcome::Installed(_))
+            && !manifest.auth_fields.iter().any(|f| f.is_secret);
+    if should_auto_enable {
         let plugin_key = manifest.service_id.as_deref().unwrap_or(&manifest.slug);
+        let plugin_key = plugin_key.to_string();
         config::with_config_lock(|| {
             let mut cfg = config::load_user_config()?;
             if let Some(active) = cfg.active_project.clone() {
                 if let Some(entry) = cfg.projects.iter_mut().find(|p| p.name == active) {
                     let integrations = entry.integrations.get_or_insert_with(Default::default);
-                    integrations.set_plugin_enabled(plugin_key, true);
+                    integrations.set_plugin_enabled(&plugin_key, true);
                     config::save_user_config(&cfg)?;
                 }
             }
@@ -194,10 +232,16 @@ pub fn install_plugin(zip_path: String) -> Result<String, String> {
         .map_err(|e| e.to_string())?;
     }
 
-    Ok(format!(
-        "Plugin '{}' v{} installed successfully",
-        manifest.name, manifest.version
-    ))
+    Ok(match outcome {
+        plugin::InstallOutcome::Installed(m) => format!(
+            "Plugin '{}' v{} installed successfully",
+            m.name, m.version
+        ),
+        plugin::InstallOutcome::InstalledPendingBuild(m) => format!(
+            "Plugin '{}' v{} installed; image build failed and will retry on next launch",
+            m.name, m.version
+        ),
+    })
 }
 
 #[tauri::command]

--- a/desktop/src-tauri/src/plugin_cmd.rs
+++ b/desktop/src-tauri/src/plugin_cmd.rs
@@ -212,9 +212,8 @@ pub async fn install_plugin(
 
     // Auto-enable only when image is ready. MCP plugins with auth_fields are
     // auto-enabled after credential save in the UI.
-    let should_auto_enable =
-        matches!(outcome, plugin::InstallOutcome::Installed(_))
-            && !manifest.auth_fields.iter().any(|f| f.is_secret);
+    let should_auto_enable = matches!(outcome, plugin::InstallOutcome::Installed(_))
+        && !manifest.auth_fields.iter().any(|f| f.is_secret);
     if should_auto_enable {
         let plugin_key = manifest.service_id.as_deref().unwrap_or(&manifest.slug);
         let plugin_key = plugin_key.to_string();
@@ -233,10 +232,9 @@ pub async fn install_plugin(
     }
 
     Ok(match outcome {
-        plugin::InstallOutcome::Installed(m) => format!(
-            "Plugin '{}' v{} installed successfully",
-            m.name, m.version
-        ),
+        plugin::InstallOutcome::Installed(m) => {
+            format!("Plugin '{}' v{} installed successfully", m.name, m.version)
+        }
         plugin::InstallOutcome::InstalledPendingBuild(m) => format!(
             "Plugin '{}' v{} installed; image build failed and will retry on next launch",
             m.name, m.version
@@ -259,8 +257,14 @@ pub fn remove_plugin(slug: String) -> Result<(), String> {
         .map(|m| m.auth_fields.iter().map(|f| f.key.clone()).collect())
         .unwrap_or_default();
 
-    // Delete plugin files from ~/.speedwave/plugins/<slug>/
-    plugin::remove_plugin(&slug).map_err(|e| e.to_string())?;
+    // Delete plugin files from ~/.speedwave/plugins/<slug>/ and clean up
+    // the cached container image. Runtime is best-effort: when the
+    // detected runtime is unavailable we skip image cleanup, mirroring
+    // the install_plugin code path.
+    let rt = speedwave_runtime::runtime::detect_runtime();
+    let rt_ref: Option<&dyn speedwave_runtime::runtime::ContainerRuntime> =
+        if rt.is_available() { Some(&*rt) } else { None };
+    plugin::remove_plugin(&slug, rt_ref).map_err(|e| e.to_string())?;
 
     // Collect project names for token cleanup (before config lock)
     let project_names: Vec<String> = {

--- a/desktop/src/src/app/models/plugin.ts
+++ b/desktop/src/src/app/models/plugin.ts
@@ -41,3 +41,40 @@ export interface JsonSchema {
 export interface PluginsResponse {
   plugins: PluginStatusEntry[];
 }
+
+/**
+ * Phase strings emitted by the `plugin_install_status` event.
+ *
+ * Mirror of `ALL_PLUGIN_INSTALL_PHASES` in
+ * `crates/speedwave-runtime/src/plugin.rs`. Adding/removing/renaming a phase
+ * here requires the same change there (no codegen — small, rarely-changing
+ * list).
+ */
+export const PLUGIN_INSTALL_PHASES = [
+  'verifying',
+  'extracting',
+  'building',
+  'done',
+  'failed',
+  'done_with_pending_build',
+] as const;
+
+export type PluginInstallPhase = (typeof PLUGIN_INSTALL_PHASES)[number];
+
+/** Streaming progress event for the `plugin_install_status` Tauri event. */
+export interface PluginInstallProgress {
+  phase: PluginInstallPhase;
+  message: string;
+  /** Sanitized error message; populated only when `phase === 'failed'`. */
+  error?: string;
+}
+
+/**
+ * Lightweight manifest summary returned by `peek_plugin_manifest`.
+ * Used by the install overlay to know whether the `building` step will run.
+ */
+export interface PluginManifestSummary {
+  slug: string;
+  name: string;
+  has_service_id: boolean;
+}

--- a/desktop/src/src/app/models/plugin.ts
+++ b/desktop/src/src/app/models/plugin.ts
@@ -59,6 +59,7 @@ export const PLUGIN_INSTALL_PHASES = [
   'done_with_pending_build',
 ] as const;
 
+/** Discriminated union of phase strings emitted by `plugin_install_status`. */
 export type PluginInstallPhase = (typeof PLUGIN_INSTALL_PHASES)[number];
 
 /** Streaming progress event for the `plugin_install_status` Tauri event. */

--- a/desktop/src/src/app/plugins/plugin-detail/plugin-detail.component.spec.ts
+++ b/desktop/src/src/app/plugins/plugin-detail/plugin-detail.component.spec.ts
@@ -463,4 +463,156 @@ describe('PluginDetailComponent', () => {
       expect(target.enabled).toBe(!before);
     });
   });
+
+  describe('danger zone / uninstall', () => {
+    it('renders the danger zone on the dashboard tab', async () => {
+      const { component, fixture } = setup();
+      await initAndDetect(component, fixture);
+      const dangerZone = fixture.nativeElement.querySelector('[data-testid="danger-zone"]');
+      expect(dangerZone).not.toBeNull();
+      const uninstallBtn = fixture.nativeElement.querySelector('[data-testid="uninstall-btn"]');
+      expect(uninstallBtn).not.toBeNull();
+    });
+
+    it('clicking "uninstall" reveals the confirm prompt', async () => {
+      const { component, fixture } = setup();
+      await initAndDetect(component, fixture);
+      const btn = fixture.nativeElement.querySelector(
+        '[data-testid="uninstall-btn"]'
+      ) as HTMLButtonElement;
+      btn.click();
+      fixture.detectChanges();
+
+      expect(component.confirmingRemove).toBe(true);
+      expect(
+        fixture.nativeElement.querySelector('[data-testid="uninstall-confirm-prompt"]')
+      ).not.toBeNull();
+      expect(
+        fixture.nativeElement.querySelector('[data-testid="uninstall-confirm-btn"]')
+      ).not.toBeNull();
+      expect(
+        fixture.nativeElement.querySelector('[data-testid="uninstall-cancel-btn"]')
+      ).not.toBeNull();
+    });
+
+    it('clicking "cancel" hides the confirm prompt without invoking remove_plugin', async () => {
+      const { component, fixture } = setup();
+      await initAndDetect(component, fixture);
+
+      // Open confirm prompt by clicking the uninstall button (UI-driven path
+      // — keeps OnPush change detection consistent with real user interaction).
+      const uninstallBtn = fixture.nativeElement.querySelector(
+        '[data-testid="uninstall-btn"]'
+      ) as HTMLButtonElement;
+      uninstallBtn.click();
+      fixture.detectChanges();
+
+      const invokeSpy = vi.spyOn(mockTauri, 'invoke');
+      const cancelBtn = fixture.nativeElement.querySelector(
+        '[data-testid="uninstall-cancel-btn"]'
+      ) as HTMLButtonElement;
+      cancelBtn.click();
+      fixture.detectChanges();
+
+      expect(component.confirmingRemove).toBe(false);
+      expect(invokeSpy).not.toHaveBeenCalledWith('remove_plugin', expect.anything());
+    });
+
+    it('clicking "yes, uninstall" invokes remove_plugin with the slug', async () => {
+      const { component, fixture } = setup();
+      await initAndDetect(component, fixture);
+
+      const invokeSpy = vi.spyOn(mockTauri, 'invoke');
+      // Drive through the public API (button → confirm → invoke).
+      component.confirmingRemove = true;
+      await component.onConfirmUninstall();
+
+      expect(invokeSpy).toHaveBeenCalledWith('remove_plugin', { slug: 'presale' });
+    });
+
+    it('on success, signals restart and navigates back to /plugins', async () => {
+      const { component, fixture } = setup();
+      await initAndDetect(component, fixture);
+      const projectState = TestBed.inject(ProjectStateService);
+      projectState.needsRestart = false;
+
+      await component.onConfirmUninstall();
+
+      expect(projectState.needsRestart).toBe(true);
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/plugins']);
+    });
+
+    it('on error, surfaces the message and resets state', async () => {
+      const { component, fixture } = setup();
+      await initAndDetect(component, fixture);
+      mockTauri.invokeHandler = (cmd: string) => {
+        if (cmd === 'remove_plugin') return Promise.reject(new Error('remove failed'));
+        return defaultInvokeHandler(cmd);
+      };
+      component.confirmingRemove = true;
+
+      await component.onConfirmUninstall();
+
+      expect(component.error).toBe('remove failed');
+      expect(component.removing).toBe(false);
+      expect(component.confirmingRemove).toBe(false);
+      expect(mockRouter.navigate).not.toHaveBeenCalledWith(['/plugins']);
+    });
+
+    it('in-flight guard: a second onConfirmUninstall while removing is a no-op', async () => {
+      const { component, fixture } = setup();
+      await initAndDetect(component, fixture);
+      component.removing = true;
+
+      const invokeSpy = vi.spyOn(mockTauri, 'invoke');
+      await component.onConfirmUninstall();
+
+      expect(invokeSpy).not.toHaveBeenCalledWith('remove_plugin', expect.anything());
+    });
+
+    it('disables both buttons via [disabled] while removing is true', async () => {
+      const { component, fixture } = setup();
+      await initAndDetect(component, fixture);
+
+      // Hold remove_plugin pending so we observe the buttons in their
+      // mid-flight (`removing = true`) state before the invoke resolves.
+      let resolveFn!: () => void;
+      mockTauri.invokeHandler = (cmd: string) => {
+        if (cmd === 'remove_plugin') {
+          return new Promise<void>((resolve) => {
+            resolveFn = resolve;
+          });
+        }
+        return defaultInvokeHandler(cmd);
+      };
+
+      // Open the confirm prompt via UI.
+      const uninstallBtn = fixture.nativeElement.querySelector(
+        '[data-testid="uninstall-btn"]'
+      ) as HTMLButtonElement;
+      uninstallBtn.click();
+      fixture.detectChanges();
+
+      // Kick off uninstall but do not await — we want to observe the UI
+      // while the invoke is still pending.
+      const promise = component.onConfirmUninstall();
+      // Yield once so onConfirmUninstall sets `removing = true` and calls
+      // markForCheck before we re-render.
+      await new Promise((r) => setTimeout(r, 0));
+      fixture.detectChanges();
+
+      const confirmBtn = fixture.nativeElement.querySelector(
+        '[data-testid="uninstall-confirm-btn"]'
+      ) as HTMLButtonElement;
+      const cancelBtn = fixture.nativeElement.querySelector(
+        '[data-testid="uninstall-cancel-btn"]'
+      ) as HTMLButtonElement;
+      expect(confirmBtn.disabled).toBe(true);
+      expect(cancelBtn.disabled).toBe(true);
+
+      // Resolve so the test does not leak a pending Promise.
+      resolveFn();
+      await promise;
+    });
+  });
 });

--- a/desktop/src/src/app/plugins/plugin-detail/plugin-detail.component.ts
+++ b/desktop/src/src/app/plugins/plugin-detail/plugin-detail.component.ts
@@ -302,6 +302,55 @@ interface ExposedTool {
                   Plugin dashboard content will appear here.
                 </p>
               }
+
+              <div
+                class="mt-8 rounded border border-red-500/30 bg-red-500/[0.04] p-4"
+                data-testid="danger-zone"
+              >
+                <h3 class="mono mb-2 text-[12px] font-semibold text-red-300">danger zone</h3>
+                <p class="mb-3 text-[12px] leading-relaxed text-[var(--ink-dim)]">
+                  Uninstalling removes the plugin from
+                  <code class="mono">~/.speedwave/plugins/{{ plugin.slug }}/</code>, deletes its
+                  per-project credentials, and disables it in your config. Containers will be
+                  recreated on the next project restart.
+                </p>
+                @if (confirmingRemove) {
+                  <div class="flex items-center gap-3">
+                    <span
+                      class="mono text-[12px] text-red-300"
+                      data-testid="uninstall-confirm-prompt"
+                      >Are you sure?</span
+                    >
+                    <button
+                      type="button"
+                      class="mono rounded border border-red-500/40 bg-red-500/[0.08] px-3 py-1 text-[11px] font-medium text-red-300 hover:bg-red-500/[0.12] disabled:opacity-50"
+                      data-testid="uninstall-confirm-btn"
+                      [disabled]="removing"
+                      (click)="onConfirmUninstall()"
+                    >
+                      $ yes, uninstall
+                    </button>
+                    <button
+                      type="button"
+                      class="mono rounded border border-[var(--line-strong)] bg-[var(--bg-2)] px-3 py-1 text-[11px] text-[var(--ink-mute)] hover:text-[var(--ink)] disabled:opacity-50"
+                      data-testid="uninstall-cancel-btn"
+                      [disabled]="removing"
+                      (click)="confirmingRemove = false"
+                    >
+                      cancel
+                    </button>
+                  </div>
+                } @else {
+                  <button
+                    type="button"
+                    class="mono rounded border border-red-500/40 bg-transparent px-3 py-1 text-[11px] font-medium text-red-300 hover:bg-red-500/[0.08]"
+                    data-testid="uninstall-btn"
+                    (click)="confirmingRemove = true"
+                  >
+                    $ uninstall plugin
+                  </button>
+                }
+              </div>
             </div>
           }
 
@@ -375,6 +424,11 @@ export class PluginDetailComponent implements OnInit, OnDestroy {
   /** Exposed tools — currently always empty until the backend reports them. */
   exposedTools: ExposedTool[] = [];
 
+  /** True when the user clicked "uninstall" and we're showing the confirm prompt. */
+  confirmingRemove = false;
+  /** True while `remove_plugin` is in flight; disables the confirm/cancel buttons. */
+  removing = false;
+
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private cdr = inject(ChangeDetectorRef);
@@ -446,6 +500,31 @@ export class PluginDetailComponent implements OnInit, OnDestroy {
   selectTab(tab: PluginDetailTab): void {
     this.activeTab = tab;
     this.cdr.markForCheck();
+  }
+
+  /**
+   * Confirms the uninstall and invokes `remove_plugin`. On success, signals
+   * the project banner to restart and navigates back to the plugins list —
+   * the current page would be a 404 since the plugin no longer exists.
+   */
+  async onConfirmUninstall(): Promise<void> {
+    if (!this.plugin || this.removing) return;
+    this.removing = true;
+    this.error = '';
+    this.success = '';
+    this.cdr.markForCheck();
+    try {
+      await this.tauri.invoke('remove_plugin', { slug: this.plugin.slug });
+      this.projectState.requestRestart();
+      // Navigate before clearing state so the user sees the plugins list
+      // refreshed without the removed entry.
+      this.router.navigate(['/plugins']);
+    } catch (e: unknown) {
+      this.error = e instanceof Error ? e.message : String(e);
+      this.removing = false;
+      this.confirmingRemove = false;
+      this.cdr.markForCheck();
+    }
   }
 
   /** Click handler for the master toggle in the header. */

--- a/desktop/src/src/app/plugins/plugins.component.spec.ts
+++ b/desktop/src/src/app/plugins/plugins.component.spec.ts
@@ -371,7 +371,7 @@ describe('PluginsComponent', () => {
     function defaultInstallHandler(): (cmd: string) => Promise<unknown> {
       return async (cmd: string) => {
         if (cmd === 'peek_plugin_manifest')
-          return { slug: 'presale', name: 'presale', has_service_id: true };
+          return { slug: 'example-plugin', name: 'example-plugin', has_service_id: true };
         if (cmd === 'install_plugin') return 'Plugin installed';
         if (cmd === 'list_projects')
           return {
@@ -385,15 +385,15 @@ describe('PluginsComponent', () => {
 
     it('peeks the manifest then invokes install_plugin', async () => {
       await component.ngOnInit();
-      openMock.mockResolvedValue('/tmp/presale-1.0.0.zip');
+      openMock.mockResolvedValue('/tmp/example-plugin-1.0.0.zip');
       mockTauri.invokeHandler = defaultInstallHandler();
       const invokeSpy = vi.spyOn(mockTauri, 'invoke');
       await component.installPlugin();
       expect(invokeSpy).toHaveBeenCalledWith('peek_plugin_manifest', {
-        zipPath: '/tmp/presale-1.0.0.zip',
+        zipPath: '/tmp/example-plugin-1.0.0.zip',
       });
       expect(invokeSpy).toHaveBeenCalledWith('install_plugin', {
-        zipPath: '/tmp/presale-1.0.0.zip',
+        zipPath: '/tmp/example-plugin-1.0.0.zip',
       });
       expect(component.success).toBe('Plugin installed');
       expect(projectState.needsRestart).toBe(true);
@@ -461,13 +461,13 @@ describe('PluginsComponent', () => {
 
     it('maps phase events to step status transitions', async () => {
       await component.ngOnInit();
-      openMock.mockResolvedValue('/tmp/presale.zip');
+      openMock.mockResolvedValue('/tmp/example-plugin.zip');
       let resolveFn!: (value: string) => void;
       mockTauri.invokeHandler = (cmd: string) => {
         if (cmd === 'peek_plugin_manifest')
           return Promise.resolve({
-            slug: 'presale',
-            name: 'presale',
+            slug: 'example-plugin',
+            name: 'example-plugin',
             has_service_id: true,
           });
         if (cmd === 'install_plugin')

--- a/desktop/src/src/app/plugins/plugins.component.spec.ts
+++ b/desktop/src/src/app/plugins/plugins.component.spec.ts
@@ -487,19 +487,13 @@ describe('PluginsComponent', () => {
         phase: 'verifying',
         message: 'Verifying signature',
       });
-      expect(component.installSteps().find((s) => s.id === 'verifying')?.status).toBe(
-        'active',
-      );
+      expect(component.installSteps().find((s) => s.id === 'verifying')?.status).toBe('active');
       mockTauri.dispatchEvent('plugin_install_status', {
         phase: 'extracting',
         message: 'Extracting archive',
       });
-      expect(component.installSteps().find((s) => s.id === 'verifying')?.status).toBe(
-        'done',
-      );
-      expect(component.installSteps().find((s) => s.id === 'extracting')?.status).toBe(
-        'active',
-      );
+      expect(component.installSteps().find((s) => s.id === 'verifying')?.status).toBe('done');
+      expect(component.installSteps().find((s) => s.id === 'extracting')?.status).toBe('active');
 
       resolveFn('Plugin installed');
       await promise;
@@ -539,9 +533,7 @@ describe('PluginsComponent', () => {
         error: 'bad signature: invalid format',
       });
 
-      expect(component.installSteps().find((s) => s.id === 'verifying')?.status).toBe(
-        'error',
-      );
+      expect(component.installSteps().find((s) => s.id === 'verifying')?.status).toBe('error');
       expect(component.installError()).toBe('bad signature: invalid format');
 
       rejectFn(new Error('signature invalid'));

--- a/desktop/src/src/app/plugins/plugins.component.spec.ts
+++ b/desktop/src/src/app/plugins/plugins.component.spec.ts
@@ -363,10 +363,15 @@ describe('PluginsComponent', () => {
   });
 
   describe('installPlugin()', () => {
-    it('calls open dialog and installs on selection', async () => {
-      await component.ngOnInit();
-      openMock.mockResolvedValue('/tmp/presale-1.0.0.zip');
-      mockTauri.invokeHandler = async (cmd: string) => {
+    /**
+     * Default install handler used by these tests: peeks an MCP plugin
+     * (with `service_id`) and installs successfully. Override per-test for
+     * other scenarios.
+     */
+    function defaultInstallHandler(): (cmd: string) => Promise<unknown> {
+      return async (cmd: string) => {
+        if (cmd === 'peek_plugin_manifest')
+          return { slug: 'presale', name: 'presale', has_service_id: true };
         if (cmd === 'install_plugin') return 'Plugin installed';
         if (cmd === 'list_projects')
           return {
@@ -376,8 +381,17 @@ describe('PluginsComponent', () => {
         if (cmd === 'get_plugins') return cloneMockPlugins();
         return undefined;
       };
+    }
+
+    it('peeks the manifest then invokes install_plugin', async () => {
+      await component.ngOnInit();
+      openMock.mockResolvedValue('/tmp/presale-1.0.0.zip');
+      mockTauri.invokeHandler = defaultInstallHandler();
       const invokeSpy = vi.spyOn(mockTauri, 'invoke');
       await component.installPlugin();
+      expect(invokeSpy).toHaveBeenCalledWith('peek_plugin_manifest', {
+        zipPath: '/tmp/presale-1.0.0.zip',
+      });
       expect(invokeSpy).toHaveBeenCalledWith('install_plugin', {
         zipPath: '/tmp/presale-1.0.0.zip',
       });
@@ -398,6 +412,8 @@ describe('PluginsComponent', () => {
       await component.ngOnInit();
       openMock.mockResolvedValue('/tmp/bad.zip');
       mockTauri.invokeHandler = async (cmd: string) => {
+        if (cmd === 'peek_plugin_manifest')
+          return { slug: 'bad', name: 'bad', has_service_id: true };
         if (cmd === 'install_plugin') throw new Error('signature invalid');
         return undefined;
       };
@@ -406,14 +422,130 @@ describe('PluginsComponent', () => {
       expect(component.installing).toBe(false);
     });
 
-    it('sets error when file dialog throws', async () => {
+    it('sets error when peek_plugin_manifest fails (e.g. corrupt ZIP)', async () => {
       await component.ngOnInit();
-      openMock.mockRejectedValue(new Error('dialog permission denied'));
+      openMock.mockResolvedValue('/tmp/bad.zip');
+      mockTauri.invokeHandler = async (cmd: string) => {
+        if (cmd === 'peek_plugin_manifest') throw new Error('not a zip');
+        return undefined;
+      };
       const invokeSpy = vi.spyOn(mockTauri, 'invoke');
       await component.installPlugin();
-      expect(component.error).toBe('dialog permission denied');
+      expect(component.error).toBe('not a zip');
       expect(invokeSpy).not.toHaveBeenCalledWith('install_plugin', expect.anything());
       expect(component.installing).toBe(false);
+    });
+
+    it('renders 2 steps for a resource-only plugin', async () => {
+      await component.ngOnInit();
+      openMock.mockResolvedValue('/tmp/skills.zip');
+      mockTauri.invokeHandler = async (cmd: string) => {
+        if (cmd === 'peek_plugin_manifest')
+          return { slug: 'skills', name: 'skills', has_service_id: false };
+        if (cmd === 'install_plugin') return 'Plugin installed';
+        if (cmd === 'list_projects')
+          return {
+            projects: [{ name: 'test-project', dir: '/tmp/test' }],
+            active_project: 'test-project',
+          };
+        if (cmd === 'get_plugins') return cloneMockPlugins();
+        return undefined;
+      };
+      await component.installPlugin();
+      // After install completes, the steps signal still holds the last list
+      // used during the run — we can assert resource-only plugins never get
+      // a `building` step.
+      const steps = component.installSteps();
+      expect(steps.map((s) => s.id)).toEqual(['verifying', 'extracting']);
+    });
+
+    it('maps phase events to step status transitions', async () => {
+      await component.ngOnInit();
+      openMock.mockResolvedValue('/tmp/presale.zip');
+      let resolveFn!: (value: string) => void;
+      mockTauri.invokeHandler = (cmd: string) => {
+        if (cmd === 'peek_plugin_manifest')
+          return Promise.resolve({
+            slug: 'presale',
+            name: 'presale',
+            has_service_id: true,
+          });
+        if (cmd === 'install_plugin')
+          return new Promise<string>((r) => {
+            resolveFn = r;
+          });
+        if (cmd === 'get_plugins') return Promise.resolve(cloneMockPlugins());
+        return Promise.resolve(undefined);
+      };
+
+      const promise = component.installPlugin();
+      // Let peek + listener registration run.
+      await new Promise((r) => setTimeout(r, 0));
+      await new Promise((r) => setTimeout(r, 0));
+
+      mockTauri.dispatchEvent('plugin_install_status', {
+        phase: 'verifying',
+        message: 'Verifying signature',
+      });
+      expect(component.installSteps().find((s) => s.id === 'verifying')?.status).toBe(
+        'active',
+      );
+      mockTauri.dispatchEvent('plugin_install_status', {
+        phase: 'extracting',
+        message: 'Extracting archive',
+      });
+      expect(component.installSteps().find((s) => s.id === 'verifying')?.status).toBe(
+        'done',
+      );
+      expect(component.installSteps().find((s) => s.id === 'extracting')?.status).toBe(
+        'active',
+      );
+
+      resolveFn('Plugin installed');
+      await promise;
+    });
+
+    it('marks the active step as error and sets installError on phase=failed', async () => {
+      await component.ngOnInit();
+      openMock.mockResolvedValue('/tmp/bad.zip');
+      // Hold install_plugin pending so the dispatched phase events are
+      // delivered while the listener is still registered.
+      let rejectFn!: (e: Error) => void;
+      mockTauri.invokeHandler = (cmd: string) => {
+        if (cmd === 'peek_plugin_manifest')
+          return Promise.resolve({
+            slug: 'bad',
+            name: 'bad',
+            has_service_id: true,
+          });
+        if (cmd === 'install_plugin')
+          return new Promise<string>((_, reject) => {
+            rejectFn = reject;
+          });
+        return Promise.resolve(undefined);
+      };
+
+      const promise = component.installPlugin();
+      await new Promise((r) => setTimeout(r, 0));
+      await new Promise((r) => setTimeout(r, 0));
+
+      mockTauri.dispatchEvent('plugin_install_status', {
+        phase: 'verifying',
+        message: 'Verifying signature',
+      });
+      mockTauri.dispatchEvent('plugin_install_status', {
+        phase: 'failed',
+        message: 'Signature verification failed',
+        error: 'bad signature: invalid format',
+      });
+
+      expect(component.installSteps().find((s) => s.id === 'verifying')?.status).toBe(
+        'error',
+      );
+      expect(component.installError()).toBe('bad signature: invalid format');
+
+      rejectFn(new Error('signature invalid'));
+      await promise;
     });
   });
 
@@ -424,6 +556,13 @@ describe('PluginsComponent', () => {
 
       let resolveFn!: (value: string) => void;
       mockTauri.invokeHandler = (cmd: string) => {
+        if (cmd === 'peek_plugin_manifest') {
+          return Promise.resolve({
+            slug: 'plugin',
+            name: 'plugin',
+            has_service_id: true,
+          });
+        }
         if (cmd === 'install_plugin') {
           return new Promise<string>((resolve) => {
             resolveFn = resolve;
@@ -439,7 +578,8 @@ describe('PluginsComponent', () => {
       };
 
       const promise = component.installPlugin();
-      // Flush microtask for open() to resolve, which sets installing=true
+      // Flush microtasks for open() + peek_plugin_manifest + listen()
+      await new Promise((r) => setTimeout(r, 0));
       await new Promise((r) => setTimeout(r, 0));
       fixture.detectChanges();
 

--- a/desktop/src/src/app/plugins/plugins.component.ts
+++ b/desktop/src/src/app/plugins/plugins.component.ts
@@ -388,7 +388,12 @@ export class PluginsComponent implements OnInit, OnDestroy {
    * button inside the overlay's error banner.
    */
   async retryInstall(): Promise<void> {
-    if (!this.currentZipPath) return;
+    // Guard against concurrent runs: a `failed` phase event arrives while
+    // the original `invoke('install_plugin')` Promise is still pending,
+    // and the overlay's retry button is reachable in that window. Without
+    // this check, clicking retry would spawn a second runInstall whose
+    // `finally` collides with the first.
+    if (this.installing || !this.currentZipPath) return;
     await this.runInstall(this.currentZipPath);
   }
 
@@ -465,7 +470,8 @@ export class PluginsComponent implements OnInit, OnDestroy {
         this.setStepStatus(STEP_EXTRACTING, 'active', p.message);
         break;
       case 'building':
-        this.setStepStatus(STEP_VERIFYING, 'done');
+        // STEP_VERIFYING is already 'done' from the prior 'extracting' event;
+        // we only need to advance the immediately preceding step here.
         this.setStepStatus(STEP_EXTRACTING, 'done');
         this.setStepStatus(STEP_BUILDING, 'active', p.message);
         break;
@@ -483,11 +489,9 @@ export class PluginsComponent implements OnInit, OnDestroy {
         break;
       }
       case 'done_with_pending_build':
-        // Terminal informational state after a failed build. We keep the
-        // error visible in the overlay and let the caller's finally close it.
-        this.installSteps.update((list) =>
-          list.map((s) => (s.status === 'pending' ? { ...s, status: 'done' as const } : s))
-        );
+        // Terminal informational state. After `failed` no steps remain
+        // pending, so there is nothing to mutate here — the overlay closes
+        // through the caller's `finally` block which clears `installing`.
         break;
     }
   }

--- a/desktop/src/src/app/plugins/plugins.component.ts
+++ b/desktop/src/src/app/plugins/plugins.component.ts
@@ -99,10 +99,7 @@ const RESOURCE_ONLY_INSTALL_STEPS: readonly SetupStep[] = [
         data-testid="plugins-install-overlay"
       >
         <div class="w-full max-w-xl px-6">
-          <h2
-            class="mono mb-4 text-[14px] text-[var(--ink)]"
-            data-testid="plugins-install-title"
-          >
+          <h2 class="mono mb-4 text-[14px] text-[var(--ink)]" data-testid="plugins-install-title">
             Installing plugin
           </h2>
           <app-progress-steps
@@ -408,10 +405,7 @@ export class PluginsComponent implements OnInit, OnDestroy {
 
     let summary: PluginManifestSummary;
     try {
-      summary = await this.tauri.invoke<PluginManifestSummary>(
-        'peek_plugin_manifest',
-        { zipPath },
-      );
+      summary = await this.tauri.invoke<PluginManifestSummary>('peek_plugin_manifest', { zipPath });
     } catch (e: unknown) {
       this.installing = false;
       this.error = e instanceof Error ? e.message : String(e);
@@ -427,7 +421,7 @@ export class PluginsComponent implements OnInit, OnDestroy {
       (e) => {
         this.onInstallProgress(e.payload);
         this.cdr.markForCheck();
-      },
+      }
     );
 
     try {
@@ -447,15 +441,20 @@ export class PluginsComponent implements OnInit, OnDestroy {
     }
   }
 
-  /** Returns a fresh mutable copy of the appropriate template. */
+  /**
+   * Returns a fresh mutable copy of the appropriate step template.
+   * @param summary - Manifest summary from `peek_plugin_manifest`; selects
+   *   the MCP (3-step) vs resource-only (2-step) template.
+   */
   private cloneSteps(summary: PluginManifestSummary): SetupStep[] {
-    const template = summary.has_service_id
-      ? MCP_INSTALL_STEPS
-      : RESOURCE_ONLY_INSTALL_STEPS;
+    const template = summary.has_service_id ? MCP_INSTALL_STEPS : RESOURCE_ONLY_INSTALL_STEPS;
     return template.map((s) => ({ ...s }));
   }
 
-  /** Maps a backend `plugin_install_status` event onto step status updates. */
+  /**
+   * Maps a backend `plugin_install_status` event onto step status updates.
+   * @param p - Progress event payload received from the Tauri event bus.
+   */
   private onInstallProgress(p: PluginInstallProgress): void {
     switch (p.phase) {
       case 'verifying':
@@ -473,17 +472,13 @@ export class PluginsComponent implements OnInit, OnDestroy {
       case 'done':
         // Mark every step in the current list as done. The overlay closes
         // after `install_plugin` resolves (in the finally block).
-        this.installSteps.update((list) =>
-          list.map((s) => ({ ...s, status: 'done' as const })),
-        );
+        this.installSteps.update((list) => list.map((s) => ({ ...s, status: 'done' as const })));
         break;
       case 'failed': {
         const message = p.error ?? p.message;
         this.installError.set(message);
         this.installSteps.update((list) =>
-          list.map((s) =>
-            s.status === 'active' ? { ...s, status: 'error' as const } : s,
-          ),
+          list.map((s) => (s.status === 'active' ? { ...s, status: 'error' as const } : s))
         );
         break;
       }
@@ -491,9 +486,7 @@ export class PluginsComponent implements OnInit, OnDestroy {
         // Terminal informational state after a failed build. We keep the
         // error visible in the overlay and let the caller's finally close it.
         this.installSteps.update((list) =>
-          list.map((s) =>
-            s.status === 'pending' ? { ...s, status: 'done' as const } : s,
-          ),
+          list.map((s) => (s.status === 'pending' ? { ...s, status: 'done' as const } : s))
         );
         break;
     }
@@ -501,9 +494,7 @@ export class PluginsComponent implements OnInit, OnDestroy {
 
   private setStepStatus(id: string, status: SetupStep['status'], detail?: string): void {
     this.installSteps.update((list) =>
-      list.map((s) =>
-        s.id === id ? { ...s, status, detail: detail ?? s.detail } : s,
-      ),
+      list.map((s) => (s.id === id ? { ...s, status, detail: detail ?? s.detail } : s))
     );
   }
 

--- a/desktop/src/src/app/plugins/plugins.component.ts
+++ b/desktop/src/src/app/plugins/plugins.component.ts
@@ -5,14 +5,23 @@ import {
   OnDestroy,
   OnInit,
   inject,
+  signal,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
 import { TauriService } from '../services/tauri.service';
 import { ProjectStateService } from '../services/project-state.service';
-import { PluginStatusEntry, PluginsResponse } from '../models/plugin';
+import {
+  PluginInstallProgress,
+  PluginManifestSummary,
+  PluginStatusEntry,
+  PluginsResponse,
+} from '../models/plugin';
 import { ProjectPillComponent } from '../project-switcher/project-pill.component';
-import { SpinIconComponent } from '../shared/spin-icon.component';
+import {
+  ProgressStepsComponent,
+  type SetupStep,
+} from '../shared/progress-steps/progress-steps.component';
 import { open } from '@tauri-apps/plugin-dialog';
 
 /** Per-row plugin dot colour cycle. */
@@ -32,10 +41,53 @@ function dotColourFor(index: number): string {
   return PLUGIN_DOT_COLOURS[index % PLUGIN_DOT_COLOURS.length];
 }
 
+/** Step IDs for the install overlay; aligned with backend phase strings. */
+const STEP_VERIFYING = 'verifying';
+const STEP_EXTRACTING = 'extracting';
+const STEP_BUILDING = 'building';
+
+/** Steps shown for an MCP plugin (with `service_id` → image build). */
+const MCP_INSTALL_STEPS: readonly SetupStep[] = [
+  {
+    id: STEP_VERIFYING,
+    title: 'verify signature',
+    description: 'Ed25519 signature check',
+    status: 'pending',
+  },
+  {
+    id: STEP_EXTRACTING,
+    title: 'extract archive',
+    description: 'Unpack plugin ZIP',
+    status: 'pending',
+  },
+  {
+    id: STEP_BUILDING,
+    title: 'build container image',
+    description: 'nerdctl build (may take 2-5 min)',
+    status: 'pending',
+  },
+];
+
+/** Steps shown for a resource-only plugin (no `service_id`, no image build). */
+const RESOURCE_ONLY_INSTALL_STEPS: readonly SetupStep[] = [
+  {
+    id: STEP_VERIFYING,
+    title: 'verify signature',
+    description: 'Ed25519 signature check',
+    status: 'pending',
+  },
+  {
+    id: STEP_EXTRACTING,
+    title: 'extract archive',
+    description: 'Unpack plugin ZIP',
+    status: 'pending',
+  },
+];
+
 /** Manages installed plugins: list, install, remove, enable/disable, credentials. */
 @Component({
   selector: 'app-plugins',
-  imports: [CommonModule, ProjectPillComponent, SpinIconComponent],
+  imports: [CommonModule, ProjectPillComponent, ProgressStepsComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     @if (installing) {
@@ -46,8 +98,21 @@ function dotColourFor(index: number): string {
         aria-label="Installing plugin"
         data-testid="plugins-install-overlay"
       >
-        <app-spin-icon class="block h-8 w-8 text-[var(--accent)]" />
-        <p class="mono mt-4 text-[12px] text-[var(--ink)]">Installing plugin…</p>
+        <div class="w-full max-w-xl px-6">
+          <h2
+            class="mono mb-4 text-[14px] text-[var(--ink)]"
+            data-testid="plugins-install-title"
+          >
+            Installing plugin
+          </h2>
+          <app-progress-steps
+            [steps]="installSteps()"
+            [error]="installError()"
+            [showFooter]="false"
+            [showBackButton]="false"
+            (retry)="retryInstall()"
+          />
+        </div>
       </div>
     }
 
@@ -209,6 +274,15 @@ export class PluginsComponent implements OnInit, OnDestroy {
   success = '';
   activeProject: string | null = null;
 
+  /** Steps rendered inside the install overlay; populated after peek. */
+  readonly installSteps = signal<SetupStep[]>([]);
+  /** Sanitized error message shown under the steps when install fails. */
+  readonly installError = signal<string | null>(null);
+  /** Path of the ZIP currently being installed, used for retry. */
+  private currentZipPath: string | null = null;
+  /** Tauri event listener cleanup; null when no install is in flight. */
+  private unlistenInstall: (() => void) | null = null;
+
   private cdr = inject(ChangeDetectorRef);
   private router = inject(Router);
   private tauri = inject(TauriService);
@@ -225,12 +299,14 @@ export class PluginsComponent implements OnInit, OnDestroy {
     });
   }
 
-  /** Cleans up project ready listener. */
+  /** Cleans up project ready listener and install event listener. */
   ngOnDestroy(): void {
     if (this.unsubProjectReady) {
       this.unsubProjectReady();
       this.unsubProjectReady = null;
     }
+    this.unlistenInstall?.();
+    this.unlistenInstall = null;
   }
 
   /** Syncs the active project from ProjectStateService. */
@@ -290,6 +366,8 @@ export class PluginsComponent implements OnInit, OnDestroy {
 
   /**
    * Opens a native file dialog to select a plugin ZIP, then installs it.
+   * The flow is: peek manifest → render the right step list → register the
+   * progress listener → invoke install. Progress phases drive the overlay.
    */
   async installPlugin(): Promise<void> {
     let selected: string | null;
@@ -305,24 +383,128 @@ export class PluginsComponent implements OnInit, OnDestroy {
     }
     if (!selected) return;
 
-    this.installing = true;
+    await this.runInstall(selected);
+  }
+
+  /**
+   * Re-invokes the install for the most recent ZIP — bound to the retry
+   * button inside the overlay's error banner.
+   */
+  async retryInstall(): Promise<void> {
+    if (!this.currentZipPath) return;
+    await this.runInstall(this.currentZipPath);
+  }
+
+  private async runInstall(zipPath: string): Promise<void> {
+    this.currentZipPath = zipPath;
     this.error = '';
     this.success = '';
+    this.installError.set(null);
+    this.installing = true;
+    // Render an empty list while the peek is in flight; we'll populate it
+    // before the first progress event arrives.
+    this.installSteps.set([]);
     this.cdr.markForCheck();
+
+    let summary: PluginManifestSummary;
+    try {
+      summary = await this.tauri.invoke<PluginManifestSummary>(
+        'peek_plugin_manifest',
+        { zipPath },
+      );
+    } catch (e: unknown) {
+      this.installing = false;
+      this.error = e instanceof Error ? e.message : String(e);
+      this.cdr.markForCheck();
+      return;
+    }
+    this.installSteps.set(this.cloneSteps(summary));
+
+    // Register listener BEFORE invoke so no progress events are missed.
+    this.unlistenInstall?.();
+    this.unlistenInstall = await this.tauri.listen<PluginInstallProgress>(
+      'plugin_install_status',
+      (e) => {
+        this.onInstallProgress(e.payload);
+        this.cdr.markForCheck();
+      },
+    );
 
     try {
       const msg = await this.tauri.invoke<string>('install_plugin', {
-        zipPath: selected,
+        zipPath,
       });
       this.success = msg;
       this.projectState.requestRestart();
       await this.loadPlugins();
     } catch (e: unknown) {
       this.error = e instanceof Error ? e.message : String(e);
+    } finally {
+      this.unlistenInstall?.();
+      this.unlistenInstall = null;
+      this.installing = false;
+      this.cdr.markForCheck();
     }
+  }
 
-    this.installing = false;
-    this.cdr.markForCheck();
+  /** Returns a fresh mutable copy of the appropriate template. */
+  private cloneSteps(summary: PluginManifestSummary): SetupStep[] {
+    const template = summary.has_service_id
+      ? MCP_INSTALL_STEPS
+      : RESOURCE_ONLY_INSTALL_STEPS;
+    return template.map((s) => ({ ...s }));
+  }
+
+  /** Maps a backend `plugin_install_status` event onto step status updates. */
+  private onInstallProgress(p: PluginInstallProgress): void {
+    switch (p.phase) {
+      case 'verifying':
+        this.setStepStatus(STEP_VERIFYING, 'active', p.message);
+        break;
+      case 'extracting':
+        this.setStepStatus(STEP_VERIFYING, 'done');
+        this.setStepStatus(STEP_EXTRACTING, 'active', p.message);
+        break;
+      case 'building':
+        this.setStepStatus(STEP_VERIFYING, 'done');
+        this.setStepStatus(STEP_EXTRACTING, 'done');
+        this.setStepStatus(STEP_BUILDING, 'active', p.message);
+        break;
+      case 'done':
+        // Mark every step in the current list as done. The overlay closes
+        // after `install_plugin` resolves (in the finally block).
+        this.installSteps.update((list) =>
+          list.map((s) => ({ ...s, status: 'done' as const })),
+        );
+        break;
+      case 'failed': {
+        const message = p.error ?? p.message;
+        this.installError.set(message);
+        this.installSteps.update((list) =>
+          list.map((s) =>
+            s.status === 'active' ? { ...s, status: 'error' as const } : s,
+          ),
+        );
+        break;
+      }
+      case 'done_with_pending_build':
+        // Terminal informational state after a failed build. We keep the
+        // error visible in the overlay and let the caller's finally close it.
+        this.installSteps.update((list) =>
+          list.map((s) =>
+            s.status === 'pending' ? { ...s, status: 'done' as const } : s,
+          ),
+        );
+        break;
+    }
+  }
+
+  private setStepStatus(id: string, status: SetupStep['status'], detail?: string): void {
+    this.installSteps.update((list) =>
+      list.map((s) =>
+        s.id === id ? { ...s, status, detail: detail ?? s.detail } : s,
+      ),
+    );
   }
 
   /**

--- a/desktop/src/src/app/setup/setup-wizard.component.spec.ts
+++ b/desktop/src/src/app/setup/setup-wizard.component.spec.ts
@@ -302,16 +302,13 @@ describe('SetupWizardComponent', () => {
       expect(summary.textContent).toMatch(/step \d+ of \d+/);
     });
 
-    it('totalSteps signal returns the number of pipeline entries', () => {
-      expect(component.totalSteps()).toBe(component.steps.length);
-    });
-
-    it('etaSeconds signal recomputes when a step transitions to done', async () => {
-      const before = component.etaSeconds();
+    it('etaTotalSeconds recomputes when a step transitions to done', async () => {
+      const before = component.etaTotalSeconds();
       await component.startSetup();
       await fixture.whenStable();
-      const after = component.etaSeconds();
-      expect(after).toBeLessThanOrEqual(before);
+      const after = component.etaTotalSeconds();
+      // ETA is monotonically non-increasing as steps complete.
+      expect(after !== null && before !== null && after <= before).toBe(true);
     });
   });
 });

--- a/desktop/src/src/app/setup/setup-wizard.component.ts
+++ b/desktop/src/src/app/setup/setup-wizard.component.ts
@@ -11,25 +11,15 @@ import {
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
 import { TauriService } from '../services/tauri.service';
-import { SpinIconComponent } from '../shared/spin-icon.component';
+import {
+  ProgressStepsComponent,
+  type SetupStep,
+  type StepState,
+} from '../shared/progress-steps/progress-steps.component';
 import {
   CreateProjectModalComponent,
   type CreatedProject,
 } from '../shared/create-project-modal/create-project-modal.component';
-
-/** Lifecycle status of a single setup step. */
-export type StepState = 'pending' | 'active' | 'done' | 'error';
-
-/** Internal SetupStep — used by the routed wizard's pipeline. */
-export interface SetupStep {
-  id: string;
-  title: string;
-  description: string;
-  status: StepState;
-  detail?: string;
-  /** 0-100 progress for an `active` step that exposes one. */
-  progress?: number;
-}
 
 /** Maximum number of pipeline steps. */
 const TOTAL_STEPS = 6;
@@ -40,7 +30,7 @@ const ETA_PER_STEP_S: readonly number[] = [3, 30, 90, 5, 30, 5];
 /** Guides the user through initial environment setup and project creation. */
 @Component({
   selector: 'app-setup-wizard',
-  imports: [CommonModule, SpinIconComponent, CreateProjectModalComponent],
+  imports: [CommonModule, ProgressStepsComponent, CreateProjectModalComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div
@@ -89,112 +79,14 @@ const ETA_PER_STEP_S: readonly number[] = [3, 30, 90, 5, 30, 5];
               $ start setup
             </button>
           } @else if (phase() === 'progress' || phase() === 'project') {
-            <div
-              class="mt-8 rounded border border-[var(--line)] bg-[var(--bg-1)]"
-              data-testid="setup-steps"
-            >
-              @for (step of steps; track step.id; let i = $index) {
-                <div
-                  class="flex items-start gap-4 px-5 py-4"
-                  [style.borderBottom]="i < steps.length - 1 ? '1px solid var(--line)' : 'none'"
-                  [class.opacity-50]="step.status === 'pending'"
-                  data-testid="setup-step"
-                  [attr.data-status]="step.status"
-                >
-                  <div
-                    class="mono flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full border text-[11px]"
-                    [style.borderColor]="circleBorder(step)"
-                    [style.background]="circleBg(step)"
-                    [style.color]="circleColor(step)"
-                  >
-                    @switch (step.status) {
-                      @case ('done') {
-                        <span aria-hidden="true">✓</span>
-                      }
-                      @case ('active') {
-                        <app-spin-icon />
-                      }
-                      @case ('error') {
-                        <span aria-hidden="true">!</span>
-                      }
-                      @default {
-                        <span>{{ i + 1 }}</span>
-                      }
-                    }
-                  </div>
-                  <div class="flex-1">
-                    <div
-                      class="mono flex items-center gap-2 text-[13px]"
-                      [style.color]="step.status === 'pending' ? 'var(--ink-dim)' : 'var(--ink)'"
-                    >
-                      <span data-testid="step-title">{{ step.title }}</span>
-                      @if (step.status === 'done') {
-                        <span class="pill green" data-testid="step-pill">done</span>
-                      }
-                      @if (step.status === 'active') {
-                        <span class="pill amber" data-testid="step-pill">running</span>
-                      }
-                      @if (step.status === 'error') {
-                        <span
-                          class="pill"
-                          style="color: #f87171; border-color: rgba(239, 68, 68, 0.4);"
-                          data-testid="step-pill"
-                          >error</span
-                        >
-                      }
-                    </div>
-                    <div
-                      class="mono mt-0.5 text-[11px] text-[var(--ink-mute)]"
-                      data-testid="step-detail"
-                    >
-                      {{ step.detail || step.description }}
-                    </div>
-                    @if (step.status === 'active' && step.progress !== undefined) {
-                      <div class="mono mt-2 h-1 w-full overflow-hidden rounded bg-[var(--bg-2)]">
-                        <div
-                          class="h-full bg-[var(--accent)]"
-                          [style.width.%]="step.progress"
-                        ></div>
-                      </div>
-                    }
-                  </div>
-                </div>
-              }
-            </div>
-
-            @if (error()) {
-              <div
-                class="mt-4 rounded ring-1 ring-red-500/40 bg-red-500/[0.06] px-3 py-2 text-[12px] text-red-300 mono"
-                data-testid="setup-error"
-                role="alert"
-              >
-                {{ error() }}
-              </div>
-              <div class="mt-3 flex flex-wrap gap-3">
-                <button
-                  type="button"
-                  class="mono rounded border border-[var(--accent-dim)] bg-[var(--accent)] px-3 py-1 text-[11px] font-medium text-[var(--on-accent)] hover:opacity-90"
-                  data-testid="setup-retry-btn"
-                  (click)="retryCurrentStep()"
-                >
-                  $ retry
-                </button>
-                <button
-                  type="button"
-                  class="mono rounded border border-[var(--line-strong)] bg-[var(--bg-2)] px-3 py-1 text-[11px] text-[var(--ink-mute)] hover:text-[var(--ink)]"
-                  data-testid="setup-back-btn"
-                  (click)="backToWelcome()"
-                >
-                  ← back
-                </button>
-              </div>
-            }
-
-            <div class="mono mt-4 text-[11px] text-[var(--ink-mute)]" data-testid="setup-footer">
-              <span data-testid="setup-progress-summary">
-                step {{ currentStepNumber() }} of {{ totalSteps() }} · ~{{ etaSeconds() }}s
-                remaining
-              </span>
+            <div class="mt-8">
+              <app-progress-steps
+                [steps]="steps"
+                [error]="error()"
+                [etaSeconds]="etaTotalSeconds()"
+                (retry)="retryCurrentStep()"
+                (back)="backToWelcome()"
+              />
             </div>
           } @else if (phase() === 'complete') {
             <div
@@ -284,21 +176,8 @@ export class SetupWizardComponent {
     this.stepsSig.set(next);
   }
 
-  /** Total number of steps in the pipeline (used by mockup footer). */
-  readonly totalSteps = computed<number>(() => this.stepsSig().length);
-
-  /** Step number (1-based) currently in progress — used by mockup footer. */
-  readonly currentStepNumber = computed<number>(() => {
-    const list = this.stepsSig();
-    const idx = list.findIndex((s) => s.status === 'active');
-    if (idx >= 0) return idx + 1;
-    const errIdx = list.findIndex((s) => s.status === 'error');
-    if (errIdx >= 0) return errIdx + 1;
-    return Math.min(this.currentStepIndexSig() + 1, list.length);
-  });
-
-  /** Estimated seconds remaining for the current pipeline. */
-  readonly etaSeconds = computed<number>(() => {
+  /** Total ETA in seconds — sum of pending+active step ETAs. */
+  readonly etaTotalSeconds = computed<number | null>(() => {
     const list = this.stepsSig();
     let total = 0;
     for (let i = 0; i < list.length; i++) {
@@ -391,39 +270,6 @@ export class SetupWizardComponent {
     this.phase.set('progress');
     this.cdr.markForCheck();
     await this.runFromStep(4);
-  }
-
-  /**
-   * Step status circle — border colour.
-   * @param step Setup step whose status drives the colour.
-   */
-  protected circleBorder(step: SetupStep): string {
-    if (step.status === 'done') return 'rgba(52, 211, 153, 0.3)';
-    if (step.status === 'active') return 'var(--accent-dim)';
-    if (step.status === 'error') return 'rgba(239, 68, 68, 0.5)';
-    return 'var(--line)';
-  }
-
-  /**
-   * Step status circle — background fill.
-   * @param step Setup step whose status drives the fill colour.
-   */
-  protected circleBg(step: SetupStep): string {
-    if (step.status === 'done') return 'rgba(52, 211, 153, 0.1)';
-    if (step.status === 'active') return 'var(--accent-soft)';
-    if (step.status === 'error') return 'rgba(239, 68, 68, 0.1)';
-    return 'transparent';
-  }
-
-  /**
-   * Step status circle — text/icon colour.
-   * @param step Setup step whose status drives the foreground colour.
-   */
-  protected circleColor(step: SetupStep): string {
-    if (step.status === 'done') return 'var(--green)';
-    if (step.status === 'active') return 'var(--accent)';
-    if (step.status === 'error') return '#f87171';
-    return 'var(--ink-mute)';
   }
 
   // ---- Private helpers ----

--- a/desktop/src/src/app/shared/progress-steps/progress-steps.component.spec.ts
+++ b/desktop/src/src/app/shared/progress-steps/progress-steps.component.spec.ts
@@ -1,0 +1,186 @@
+import { Component, signal } from '@angular/core';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { describe, beforeEach, it, expect } from 'vitest';
+import {
+  ProgressStepsComponent,
+  type SetupStep,
+} from './progress-steps.component';
+
+@Component({
+  selector: 'app-host',
+  imports: [ProgressStepsComponent],
+  template: `
+    <app-progress-steps
+      [steps]="steps()"
+      [error]="error()"
+      [etaSeconds]="etaSeconds()"
+      [showFooter]="showFooter()"
+      [showBackButton]="showBackButton()"
+      (retry)="retryCount = retryCount + 1"
+      (back)="backCount = backCount + 1"
+    />
+  `,
+})
+class HostComponent {
+  readonly steps = signal<SetupStep[]>([]);
+  readonly error = signal<string | null>(null);
+  readonly etaSeconds = signal<number | null>(null);
+  readonly showFooter = signal<boolean>(true);
+  readonly showBackButton = signal<boolean>(true);
+  retryCount = 0;
+  backCount = 0;
+}
+
+function makeStep(
+  id: string,
+  status: SetupStep['status'],
+  extra: Partial<SetupStep> = {},
+): SetupStep {
+  return {
+    id,
+    title: `step ${id}`,
+    description: `desc ${id}`,
+    status,
+    ...extra,
+  };
+}
+
+describe('ProgressStepsComponent', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let host: HostComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [HostComponent] });
+    fixture = TestBed.createComponent(HostComponent);
+    host = fixture.componentInstance;
+  });
+
+  it('renders one row per step', () => {
+    host.steps.set([makeStep('a', 'pending'), makeStep('b', 'pending'), makeStep('c', 'pending')]);
+    fixture.detectChanges();
+    const rows = fixture.nativeElement.querySelectorAll('[data-testid="setup-step"]');
+    expect(rows.length).toBe(3);
+  });
+
+  it('renders done/active/error/pending pills correctly', () => {
+    host.steps.set([
+      makeStep('a', 'done'),
+      makeStep('b', 'active'),
+      makeStep('c', 'error'),
+      makeStep('d', 'pending'),
+    ]);
+    fixture.detectChanges();
+    const pills = fixture.nativeElement.querySelectorAll('[data-testid="step-pill"]');
+    // pending step has no pill
+    expect(pills.length).toBe(3);
+    expect(pills[0].textContent.trim()).toBe('done');
+    expect(pills[1].textContent.trim()).toBe('running');
+    expect(pills[2].textContent.trim()).toBe('error');
+  });
+
+  it('renders the progress bar only for active steps with progress set', () => {
+    host.steps.set([
+      makeStep('a', 'active'), // no progress → no bar
+      makeStep('b', 'active', { progress: 42 }),
+      makeStep('c', 'pending', { progress: 50 }), // pending → no bar
+    ]);
+    fixture.detectChanges();
+    const all = fixture.nativeElement.querySelectorAll('[style]');
+    const widthBars = Array.from(all).filter((el) =>
+      /width:\s*42%/.test((el as HTMLElement).style.cssText),
+    );
+    expect(widthBars.length).toBe(1);
+  });
+
+  it('shows the footer with "step X of Y" and omits ETA when etaSeconds is null', () => {
+    host.steps.set([makeStep('a', 'done'), makeStep('b', 'active')]);
+    host.etaSeconds.set(null);
+    fixture.detectChanges();
+    const footer = fixture.nativeElement.querySelector('[data-testid="setup-progress-summary"]');
+    expect(footer.textContent).toContain('step 2 of 2');
+    expect(footer.textContent).not.toContain('remaining');
+  });
+
+  it('appends "~Ns remaining" to the footer when etaSeconds is set', () => {
+    host.steps.set([makeStep('a', 'active'), makeStep('b', 'pending')]);
+    host.etaSeconds.set(45);
+    fixture.detectChanges();
+    const footer = fixture.nativeElement.querySelector('[data-testid="setup-progress-summary"]');
+    expect(footer.textContent).toMatch(/~45s remaining/);
+  });
+
+  it('hides the footer entirely when showFooter is false', () => {
+    host.steps.set([makeStep('a', 'active')]);
+    host.showFooter.set(false);
+    fixture.detectChanges();
+    const footer = fixture.nativeElement.querySelector('[data-testid="setup-footer"]');
+    expect(footer).toBeNull();
+  });
+
+  it('shows the error banner with retry/back buttons when error is set', () => {
+    host.steps.set([makeStep('a', 'error')]);
+    host.error.set('something broke');
+    fixture.detectChanges();
+    const errBanner = fixture.nativeElement.querySelector('[data-testid="setup-error"]');
+    expect(errBanner.textContent).toContain('something broke');
+    const retryBtn = fixture.nativeElement.querySelector('[data-testid="setup-retry-btn"]');
+    const backBtn = fixture.nativeElement.querySelector('[data-testid="setup-back-btn"]');
+    expect(retryBtn).not.toBeNull();
+    expect(backBtn).not.toBeNull();
+  });
+
+  it('hides the back button when showBackButton is false', () => {
+    host.steps.set([makeStep('a', 'error')]);
+    host.error.set('broke');
+    host.showBackButton.set(false);
+    fixture.detectChanges();
+    const retryBtn = fixture.nativeElement.querySelector('[data-testid="setup-retry-btn"]');
+    const backBtn = fixture.nativeElement.querySelector('[data-testid="setup-back-btn"]');
+    expect(retryBtn).not.toBeNull();
+    expect(backBtn).toBeNull();
+  });
+
+  it('emits (retry) when the retry button is clicked', () => {
+    host.steps.set([makeStep('a', 'error')]);
+    host.error.set('broke');
+    fixture.detectChanges();
+    const retryBtn = fixture.nativeElement.querySelector(
+      '[data-testid="setup-retry-btn"]',
+    ) as HTMLButtonElement;
+    retryBtn.click();
+    expect(host.retryCount).toBe(1);
+  });
+
+  it('emits (back) when the back button is clicked', () => {
+    host.steps.set([makeStep('a', 'error')]);
+    host.error.set('broke');
+    fixture.detectChanges();
+    const backBtn = fixture.nativeElement.querySelector(
+      '[data-testid="setup-back-btn"]',
+    ) as HTMLButtonElement;
+    backBtn.click();
+    expect(host.backCount).toBe(1);
+  });
+
+  it('renders without crashing with an empty step list', () => {
+    host.steps.set([]);
+    fixture.detectChanges();
+    const rows = fixture.nativeElement.querySelectorAll('[data-testid="setup-step"]');
+    expect(rows.length).toBe(0);
+    const footer = fixture.nativeElement.querySelector('[data-testid="setup-progress-summary"]');
+    expect(footer.textContent).toContain('step 0 of 0');
+  });
+
+  it('reactively re-renders when the steps signal updates', () => {
+    host.steps.set([makeStep('a', 'pending')]);
+    fixture.detectChanges();
+    expect(
+      fixture.nativeElement.querySelectorAll('[data-testid="setup-step"]').length,
+    ).toBe(1);
+    host.steps.set([makeStep('a', 'pending'), makeStep('b', 'active')]);
+    fixture.detectChanges();
+    expect(
+      fixture.nativeElement.querySelectorAll('[data-testid="setup-step"]').length,
+    ).toBe(2);
+  });
+});

--- a/desktop/src/src/app/shared/progress-steps/progress-steps.component.spec.ts
+++ b/desktop/src/src/app/shared/progress-steps/progress-steps.component.spec.ts
@@ -1,14 +1,12 @@
-import { Component, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { describe, beforeEach, it, expect } from 'vitest';
-import {
-  ProgressStepsComponent,
-  type SetupStep,
-} from './progress-steps.component';
+import { ProgressStepsComponent, type SetupStep } from './progress-steps.component';
 
 @Component({
   selector: 'app-host',
   imports: [ProgressStepsComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <app-progress-steps
       [steps]="steps()"
@@ -34,7 +32,7 @@ class HostComponent {
 function makeStep(
   id: string,
   status: SetupStep['status'],
-  extra: Partial<SetupStep> = {},
+  extra: Partial<SetupStep> = {}
 ): SetupStep {
   return {
     id,
@@ -87,7 +85,7 @@ describe('ProgressStepsComponent', () => {
     fixture.detectChanges();
     const all = fixture.nativeElement.querySelectorAll('[style]');
     const widthBars = Array.from(all).filter((el) =>
-      /width:\s*42%/.test((el as HTMLElement).style.cssText),
+      /width:\s*42%/.test((el as HTMLElement).style.cssText)
     );
     expect(widthBars.length).toBe(1);
   });
@@ -145,7 +143,7 @@ describe('ProgressStepsComponent', () => {
     host.error.set('broke');
     fixture.detectChanges();
     const retryBtn = fixture.nativeElement.querySelector(
-      '[data-testid="setup-retry-btn"]',
+      '[data-testid="setup-retry-btn"]'
     ) as HTMLButtonElement;
     retryBtn.click();
     expect(host.retryCount).toBe(1);
@@ -156,7 +154,7 @@ describe('ProgressStepsComponent', () => {
     host.error.set('broke');
     fixture.detectChanges();
     const backBtn = fixture.nativeElement.querySelector(
-      '[data-testid="setup-back-btn"]',
+      '[data-testid="setup-back-btn"]'
     ) as HTMLButtonElement;
     backBtn.click();
     expect(host.backCount).toBe(1);
@@ -174,13 +172,9 @@ describe('ProgressStepsComponent', () => {
   it('reactively re-renders when the steps signal updates', () => {
     host.steps.set([makeStep('a', 'pending')]);
     fixture.detectChanges();
-    expect(
-      fixture.nativeElement.querySelectorAll('[data-testid="setup-step"]').length,
-    ).toBe(1);
+    expect(fixture.nativeElement.querySelectorAll('[data-testid="setup-step"]').length).toBe(1);
     host.steps.set([makeStep('a', 'pending'), makeStep('b', 'active')]);
     fixture.detectChanges();
-    expect(
-      fixture.nativeElement.querySelectorAll('[data-testid="setup-step"]').length,
-    ).toBe(2);
+    expect(fixture.nativeElement.querySelectorAll('[data-testid="setup-step"]').length).toBe(2);
   });
 });

--- a/desktop/src/src/app/shared/progress-steps/progress-steps.component.ts
+++ b/desktop/src/src/app/shared/progress-steps/progress-steps.component.ts
@@ -1,10 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  input,
-  output,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SpinIconComponent } from '../spin-icon.component';
 
@@ -35,10 +29,7 @@ export interface SetupStep {
   imports: [CommonModule, SpinIconComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div
-      class="rounded border border-[var(--line)] bg-[var(--bg-1)]"
-      data-testid="setup-steps"
-    >
+    <div class="rounded border border-[var(--line)] bg-[var(--bg-1)]" data-testid="setup-steps">
       @for (step of steps(); track step.id; let i = $index) {
         <div
           class="flex items-start gap-4 px-5 py-4"
@@ -89,18 +80,12 @@ export interface SetupStep {
                 >
               }
             </div>
-            <div
-              class="mono mt-0.5 text-[11px] text-[var(--ink-mute)]"
-              data-testid="step-detail"
-            >
+            <div class="mono mt-0.5 text-[11px] text-[var(--ink-mute)]" data-testid="step-detail">
               {{ step.detail || step.description }}
             </div>
             @if (step.status === 'active' && step.progress !== undefined) {
               <div class="mono mt-2 h-1 w-full overflow-hidden rounded bg-[var(--bg-2)]">
-                <div
-                  class="h-full bg-[var(--accent)]"
-                  [style.width.%]="step.progress"
-                ></div>
+                <div class="h-full bg-[var(--accent)]" [style.width.%]="step.progress"></div>
               </div>
             }
           </div>
@@ -141,7 +126,8 @@ export interface SetupStep {
     @if (showFooter()) {
       <div class="mono mt-4 text-[11px] text-[var(--ink-mute)]" data-testid="setup-footer">
         <span data-testid="setup-progress-summary">
-          step {{ currentStepNumber() }} of {{ totalSteps() }}@if (etaSeconds() !== null) {
+          step {{ currentStepNumber() }} of {{ totalSteps() }}
+          @if (etaSeconds() !== null) {
             <span> · ~{{ etaSeconds() }}s remaining</span>
           }
         </span>

--- a/desktop/src/src/app/shared/progress-steps/progress-steps.component.ts
+++ b/desktop/src/src/app/shared/progress-steps/progress-steps.component.ts
@@ -1,0 +1,216 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  output,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SpinIconComponent } from '../spin-icon.component';
+
+/** Lifecycle status of a single progress step. */
+export type StepState = 'pending' | 'active' | 'done' | 'error';
+
+/** A single step in a multi-step progress display. */
+export interface SetupStep {
+  id: string;
+  title: string;
+  description: string;
+  status: StepState;
+  detail?: string;
+  /** 0-100 progress for an `active` step that exposes one. */
+  progress?: number;
+}
+
+/**
+ * Presentational component that renders a list of progress steps with status
+ * circles, pills, an optional progress bar, an error banner with retry/back
+ * controls, and an optional footer.
+ *
+ * Used by both the first-run setup wizard and the plugin install overlay.
+ * The caller owns the step list and drives status transitions.
+ */
+@Component({
+  selector: 'app-progress-steps',
+  imports: [CommonModule, SpinIconComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div
+      class="rounded border border-[var(--line)] bg-[var(--bg-1)]"
+      data-testid="setup-steps"
+    >
+      @for (step of steps(); track step.id; let i = $index) {
+        <div
+          class="flex items-start gap-4 px-5 py-4"
+          [style.borderBottom]="i < steps().length - 1 ? '1px solid var(--line)' : 'none'"
+          [class.opacity-50]="step.status === 'pending'"
+          data-testid="setup-step"
+          [attr.data-status]="step.status"
+        >
+          <div
+            class="mono flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full border text-[11px]"
+            [style.borderColor]="circleBorder(step)"
+            [style.background]="circleBg(step)"
+            [style.color]="circleColor(step)"
+          >
+            @switch (step.status) {
+              @case ('done') {
+                <span aria-hidden="true">✓</span>
+              }
+              @case ('active') {
+                <app-spin-icon />
+              }
+              @case ('error') {
+                <span aria-hidden="true">!</span>
+              }
+              @default {
+                <span>{{ i + 1 }}</span>
+              }
+            }
+          </div>
+          <div class="flex-1">
+            <div
+              class="mono flex items-center gap-2 text-[13px]"
+              [style.color]="step.status === 'pending' ? 'var(--ink-dim)' : 'var(--ink)'"
+            >
+              <span data-testid="step-title">{{ step.title }}</span>
+              @if (step.status === 'done') {
+                <span class="pill green" data-testid="step-pill">done</span>
+              }
+              @if (step.status === 'active') {
+                <span class="pill amber" data-testid="step-pill">running</span>
+              }
+              @if (step.status === 'error') {
+                <span
+                  class="pill"
+                  style="color: #f87171; border-color: rgba(239, 68, 68, 0.4);"
+                  data-testid="step-pill"
+                  >error</span
+                >
+              }
+            </div>
+            <div
+              class="mono mt-0.5 text-[11px] text-[var(--ink-mute)]"
+              data-testid="step-detail"
+            >
+              {{ step.detail || step.description }}
+            </div>
+            @if (step.status === 'active' && step.progress !== undefined) {
+              <div class="mono mt-2 h-1 w-full overflow-hidden rounded bg-[var(--bg-2)]">
+                <div
+                  class="h-full bg-[var(--accent)]"
+                  [style.width.%]="step.progress"
+                ></div>
+              </div>
+            }
+          </div>
+        </div>
+      }
+    </div>
+
+    @if (error()) {
+      <div
+        class="mt-4 rounded ring-1 ring-red-500/40 bg-red-500/[0.06] px-3 py-2 text-[12px] text-red-300 mono"
+        data-testid="setup-error"
+        role="alert"
+      >
+        {{ error() }}
+      </div>
+      <div class="mt-3 flex flex-wrap gap-3">
+        <button
+          type="button"
+          class="mono rounded border border-[var(--accent-dim)] bg-[var(--accent)] px-3 py-1 text-[11px] font-medium text-[var(--on-accent)] hover:opacity-90"
+          data-testid="setup-retry-btn"
+          (click)="retry.emit()"
+        >
+          $ retry
+        </button>
+        @if (showBackButton()) {
+          <button
+            type="button"
+            class="mono rounded border border-[var(--line-strong)] bg-[var(--bg-2)] px-3 py-1 text-[11px] text-[var(--ink-mute)] hover:text-[var(--ink)]"
+            data-testid="setup-back-btn"
+            (click)="back.emit()"
+          >
+            ← back
+          </button>
+        }
+      </div>
+    }
+
+    @if (showFooter()) {
+      <div class="mono mt-4 text-[11px] text-[var(--ink-mute)]" data-testid="setup-footer">
+        <span data-testid="setup-progress-summary">
+          step {{ currentStepNumber() }} of {{ totalSteps() }}@if (etaSeconds() !== null) {
+            <span> · ~{{ etaSeconds() }}s remaining</span>
+          }
+        </span>
+      </div>
+    }
+  `,
+})
+export class ProgressStepsComponent {
+  /** Steps to render (caller-owned). */
+  readonly steps = input.required<readonly SetupStep[]>();
+  /** Error message rendered under the step list; `null` hides the banner. */
+  readonly error = input<string | null>(null);
+  /** Total ETA in seconds. When `null`, the footer omits "~Ns remaining". */
+  readonly etaSeconds = input<number | null>(null);
+  /** Whether to render the footer ("step X of Y · ~Ns remaining"). */
+  readonly showFooter = input<boolean>(true);
+  /** Whether to render the "back" button inside the error banner. */
+  readonly showBackButton = input<boolean>(true);
+
+  /** Emitted when the user clicks the "$ retry" button. */
+  readonly retry = output<void>();
+  /** Emitted when the user clicks the "← back" button. */
+  readonly back = output<void>();
+
+  /** Total number of steps. */
+  readonly totalSteps = computed<number>(() => this.steps().length);
+
+  /** Step number (1-based) currently in progress, or the first error/pending. */
+  readonly currentStepNumber = computed<number>(() => {
+    const list = this.steps();
+    const idx = list.findIndex((s) => s.status === 'active');
+    if (idx >= 0) return idx + 1;
+    const errIdx = list.findIndex((s) => s.status === 'error');
+    if (errIdx >= 0) return errIdx + 1;
+    const pendingIdx = list.findIndex((s) => s.status === 'pending');
+    if (pendingIdx >= 0) return pendingIdx + 1;
+    return list.length;
+  });
+
+  /**
+   * Status circle — border colour.
+   * @param step Step whose status drives the colour.
+   */
+  protected circleBorder(step: SetupStep): string {
+    if (step.status === 'done') return 'rgba(52, 211, 153, 0.3)';
+    if (step.status === 'active') return 'var(--accent-dim)';
+    if (step.status === 'error') return 'rgba(239, 68, 68, 0.5)';
+    return 'var(--line)';
+  }
+
+  /**
+   * Status circle — background fill.
+   * @param step Step whose status drives the fill colour.
+   */
+  protected circleBg(step: SetupStep): string {
+    if (step.status === 'done') return 'rgba(52, 211, 153, 0.1)';
+    if (step.status === 'active') return 'var(--accent-soft)';
+    if (step.status === 'error') return 'rgba(239, 68, 68, 0.1)';
+    return 'transparent';
+  }
+
+  /**
+   * Status circle — text/icon colour.
+   * @param step Step whose status drives the foreground colour.
+   */
+  protected circleColor(step: SetupStep): string {
+    if (step.status === 'done') return 'var(--green)';
+    if (step.status === 'active') return 'var(--accent)';
+    if (step.status === 'error') return '#f87171';
+    return 'var(--ink-mute)';
+  }
+}

--- a/docs/adr/ADR-047-plugin-install-progress-events.md
+++ b/docs/adr/ADR-047-plugin-install-progress-events.md
@@ -1,0 +1,107 @@
+# ADR-047: Plugin Install Progress Events
+
+**Status:** Accepted
+**Date:** 2026-05-04
+
+## Context
+
+Issue [#400](https://github.com/speednet/speedwave/issues/400) reports that plugin installation in the Desktop UI shows no visible feedback during the multi-minute work it performs. The previous implementation registered `install_plugin` as a synchronous Tauri command and ran the entire flow — Ed25519 signature verification, ZIP extraction, manifest validation, container image build via `nerdctl build`, and on-disk side-effects — in one blocking call. On macOS, where Tauri runs on the main thread, the user sees the system spinning beachball for 2-5 minutes when installing a heavy plugin (e.g. `presale` with docling/torch dependencies) and only learns about a build error after the freeze ends.
+
+The Desktop already had a small overlay rendered via `installing = true`, but it only displayed a static spinner and "Installing plugin…" string. Nothing communicated which step was running, and there was no way to surface a build failure separately from a fatal install failure.
+
+## Decision
+
+`install_plugin` is converted to an `async` Tauri command that delegates the synchronous work to `tokio::task::spawn_blocking`, and the Rust function emits structured progress events through a caller-supplied callback. The Tauri command forwards each event to the frontend as a `plugin_install_status` Tauri event[^1], cloning `AppHandle` into the blocking closure (`AppHandle: Send + Sync + Clone`[^2]). The frontend renders the events through a shared `<app-progress-steps>` component extracted from the first-run setup wizard.
+
+This MVP **does not** stream the contents of `nerdctl build` line-by-line. The "building" phase is reported as a single event when the build starts; the Desktop overlay shows the step active with a static "Building image (may take 2-5 min)" detail until the build completes (success → `done`, failure → `failed` followed by `done_with_pending_build`). Live build-log streaming is left for a follow-up PR; see "Out of scope" below.
+
+### Event shape
+
+```rust
+// crates/speedwave-runtime/src/plugin.rs
+#[derive(Serialize, Debug, Clone)]
+#[serde(rename_all = "snake_case")]
+pub struct PluginInstallProgress {
+    pub phase: String,
+    pub message: String,
+    pub error: Option<String>,
+}
+
+pub const ALL_PLUGIN_INSTALL_PHASES: &[&str] = &[
+    "verifying", "extracting", "building",
+    "done", "failed", "done_with_pending_build",
+];
+```
+
+The `phase` field is a free-form string rather than a typed enum. This mirrors the precedent set by `BundleReconcileStatus { phase: String }` in `desktop/src-tauri/src/reconcile.rs`. The frontend declares an aligned union type in `desktop/src/src/app/models/plugin.ts::PluginInstallPhase`. Adding/removing/renaming a phase requires editing both files; a Rust unit test (`test_all_plugin_install_phases_lists_expected_strings`) and a TS test in `plugins.component.spec.ts` each pin the expected list to keep the two in sync. We considered codegen and rejected it: six rarely-changing strings do not justify a build-time generator that parses Rust source via regex.
+
+### Phase semantics
+
+| Phase                       | When emitted                                                                | Terminal? |
+| --------------------------- | --------------------------------------------------------------------------- | --------- |
+| `verifying`                 | Before signature check                                                       | No        |
+| `extracting`                | After signature OK, before copying into `~/.speedwave/plugins/<slug>/`       | No        |
+| `building`                  | After extract, before `runtime.build_image()` (only for plugins with `service_id`) | No        |
+| `done`                      | All phases completed without errors                                          | Yes       |
+| `failed`                    | A step errored. Includes a sanitized `error` string                          | Yes (when extract/verify fail) |
+| `done_with_pending_build`   | After `failed` from the building phase. The plugin is on disk and will retry on next launch | Yes |
+
+A resource-only plugin (no `service_id`, no `Containerfile`) emits `verifying → extracting → done` and skips `building`. The frontend learns about this **before** invoking `install_plugin` by calling a new lightweight Tauri command `peek_plugin_manifest(zip_path)` that reads `plugin.json` from the ZIP without verifying the signature, extracting to a permanent location, or running any side-effect. The frontend then renders 2 or 3 steps as appropriate. This avoids retroactive UI mutation (e.g. removing a "building" step after the fact) and keeps the manifest as the single source of truth.
+
+### `InstallOutcome` enum
+
+`install_plugin` now returns `Result<InstallOutcome, anyhow::Error>` instead of `Result<PluginManifest, _>`:
+
+```rust
+pub enum InstallOutcome {
+    Installed(PluginManifest),
+    InstalledPendingBuild(PluginManifest),
+}
+```
+
+Callers must distinguish between "fully installed" and "installed but image build failed". The Desktop Tauri command auto-enables credentials-free plugins only when `Installed(_)` is returned; for `InstalledPendingBuild(_)` the toast text changes to inform the user that the build will retry on next launch. The CLI maps both variants to **exit code 0** (non-breaking change): scripts using `speedwave plugin install foo.zip && echo OK` continue to work after the upgrade. Users discover deferred builds by reading stderr or by inspecting `~/.speedwave/plugins/<slug>/.image_pending`. We considered exit code 2 for `InstalledPendingBuild` and rejected it as a script-breaking change unsuitable for a `feat` minor release — see [Future work](#future-work) for the follow-up.
+
+### Sanitization
+
+The `error` field is always passed through `speedwave_runtime::log_sanitizer::sanitize` before being included in a `PluginInstallProgress`. `sanitize` already covers Bearer tokens, `Authorization` headers, URL userinfo, and `api_key|secret|token=…` assignments. A regression test (`test_install_plugin_emits_failed_with_sanitized_error`) installs a plugin against a mock `ContainerRuntime` whose `build_image` errors with `RUN curl https://user:tok@registry.example.com/foo failed`, then asserts that the emitted `error` contains `***REDACTED***` and does **not** contain `tok`.
+
+`build_args` passed to `runtime.build_image` from `build_single_plugin_image` is hard-coded to `&[]`. Plugin manifests have no field that injects build-args. This is a structural property, not a runtime check — the sanitizer is a defense-in-depth net for the cases where stderr leaks credentials embedded in `RUN` commands inside a Containerfile.
+
+### Cleanup-on-cancel
+
+`spawn_blocking` is not cancellable from the host side. If the user closes the Plugins view or quits the app mid-install, behaviour is platform-specific:
+
+* **macOS Lima:** on app quit, `LimaRuntime::stop_vm()` runs `limactl stop --force <vm>` (where `<vm>` is derived from `SPEEDWAVE_DATA_DIR` per [ADR-031](ADR-031-data-dir-env-var-for-instance-isolation.md)[^4]) which poweroffs the VM, killing any in-VM `nerdctl build` immediately. The `.image_pending` marker on the host survives. On the next launch, `ensure_all_plugin_images` retries the build silently.
+* **Linux native nerdctl:** the build process is a child of the desktop process. After the desktop process exits, the child is reparented to `systemd-user`/`init` (Linux has no equivalent of `prctl(PR_SET_PDEATHSIG)`[^3] for the inverse case — and `PR_SET_PDEATHSIG` itself is Linux-only). The container runs as UID 0 in a user namespace per [ADR-026](ADR-026-linux-rootless-container-user.md)[^5], so the host-written `.image_pending` marker is owned by the desktop user and remains writable across the reparent. The build continues in the background; `.image_pending` is removed on success or remains on failure.
+* **Windows WSL2:** `wsl.exe -- nerdctl build` is a child of the desktop process; when the desktop exits, the host pipe breaks, but the in-WSL `nerdctl` may continue. Recovery is the same as Linux: `.image_pending` retry on next launch.
+
+Explicit `kill_on_drop` of the in-flight child via a stored `Child` handle is left for follow-up; see "Out of scope".
+
+## Critical files
+
+* `crates/speedwave-runtime/src/plugin.rs` — `PluginInstallProgress`, `InstallOutcome`, `ALL_PLUGIN_INSTALL_PHASES`, `peek_plugin_manifest`, `install_plugin` signature change.
+* `desktop/src-tauri/src/plugin_cmd.rs` — async `install_plugin` Tauri command, async `peek_plugin_manifest` Tauri command.
+* `desktop/src-tauri/src/main.rs` — registers `peek_plugin_manifest` in `invoke_handler`.
+* `crates/speedwave-cli/src/main.rs` — matches on `InstallOutcome`, exit 0 in both variants.
+* `desktop/src/src/app/shared/progress-steps/progress-steps.component.ts` — new shared component extracted from setup-wizard.
+* `desktop/src/src/app/setup/setup-wizard.component.ts` — refactored to delegate the step list to `<app-progress-steps>`.
+* `desktop/src/src/app/plugins/plugins.component.ts` — overlay rebuilt on `<app-progress-steps>`, `peek_plugin_manifest`-then-listen-then-invoke flow, phase event mapping.
+* `desktop/src/src/app/models/plugin.ts` — `PluginInstallProgress`, `PluginInstallPhase`, `PLUGIN_INSTALL_PHASES`, `PluginManifestSummary`.
+
+## Out of scope (future work)
+
+* **Live build-log streaming.** A future PR may add `CommandRunner::run_streaming` (or an equivalent) and stream `nerdctl build` stdout/stderr line-by-line through the same `plugin_install_status` channel. That work needs to address: WSL2 UTF-16LE decoding from `wsl.exe -- nerdctl`, line buffering at chunk boundaries, sanitization per-line vs per-blob, and whether to merge stderr into stdout at the process level.
+* **Cancellable installs.** Storing the spawned child and providing a `cancel_install` Tauri command that signals it to terminate, with a documented per-platform cleanup path.
+* **CLI exit code semantics.** Distinguishing `InstalledPendingBuild` from `Installed` at the exit-code level is useful for scripts that need to detect deferred builds. A follow-up issue should propose exit 2 (or similar) under a `BREAKING CHANGE:` trailer; see [Future work](#future-work).
+
+## Footnotes
+
+[^1]: Tauri v2 events from Rust to the webview: `AppHandle::emit("event-name", payload)`. Source: <https://docs.rs/tauri/2.1.1/tauri/struct.AppHandle.html#method.emit>.
+
+[^2]: `AppHandle` thread-safety: `Clone + Send + Sync` for any `R: Runtime`. Source: <https://docs.rs/tauri/2.1.1/tauri/struct.AppHandle.html> ("impl<R: Runtime> Clone for AppHandle<R>", "impl<R> Send for AppHandle<R>", "impl<R> Sync for AppHandle<R>"). Verified 2026-05-04.
+
+[^3]: `prctl(PR_SET_PDEATHSIG)` is Linux-only. Source: <https://man7.org/linux/man-pages/man2/prctl.2.html> (since Linux 2.1.57). macOS does not provide an equivalent; child processes are reparented to `launchd` after parent exit.
+
+[^4]: ADR-031 — `SPEEDWAVE_DATA_DIR` env var derives a unique `lima_vm_name()` so `make dev` (`~/.speedwave-dev`) and production (`~/.speedwave`) can coexist on one host. Implementation: `crates/speedwave-runtime/src/consts.rs::derive_instance_name_from`.
+
+[^5]: ADR-026 — On Linux rootless setups, the container runs as UID 0 in a user namespace mapped to the host desktop UID. Files written by the host (such as `.image_pending`) are owned by the desktop user and remain writable across container restarts. The `.image_pending` marker is created and removed on the host side (in `install_plugin` and `build_single_plugin_image` respectively), never inside the container, so user-namespace mapping is not load-bearing for the marker's lifecycle.

--- a/docs/adr/ADR-047-plugin-install-progress-events.md
+++ b/docs/adr/ADR-047-plugin-install-progress-events.md
@@ -5,7 +5,7 @@
 
 ## Context
 
-Issue [#400](https://github.com/speednet-software/speedwave/issues/400) reports that plugin installation in the Desktop UI shows no visible feedback during the multi-minute work it performs. The previous implementation registered `install_plugin` as a synchronous Tauri command and ran the entire flow — Ed25519 signature verification, ZIP extraction, manifest validation, container image build via `nerdctl build`, and on-disk side-effects — in one blocking call. On macOS, where Tauri runs on the main thread, the user sees the system spinning beachball for 2-5 minutes when installing a heavy plugin (e.g. `presale` with docling/torch dependencies) and only learns about a build error after the freeze ends.
+Issue [#400](https://github.com/speednet-software/speedwave/issues/400) reports that plugin installation in the Desktop UI shows no visible feedback during the multi-minute work it performs. The previous implementation registered `install_plugin` as a synchronous Tauri command and ran the entire flow — Ed25519 signature verification, ZIP extraction, manifest validation, container image build via `nerdctl build`, and on-disk side-effects — in one blocking call. On macOS, where Tauri runs on the main thread, the user sees the system spinning beachball for 2-5 minutes when installing a heavy plugin with multi-GB build dependencies (e.g. ML libraries) and only learns about a build error after the freeze ends.
 
 The Desktop already had a small overlay rendered via `installing = true`, but it only displayed a static spinner and "Installing plugin…" string. Nothing communicated which step was running, and there was no way to surface a build failure separately from a fatal install failure.
 
@@ -37,14 +37,14 @@ The `phase` field is a free-form string rather than a typed enum. This mirrors t
 
 ### Phase semantics
 
-| Phase                       | When emitted                                                                | Terminal? |
-| --------------------------- | --------------------------------------------------------------------------- | --------- |
-| `verifying`                 | Before signature check                                                       | No        |
-| `extracting`                | After signature OK, before copying into `~/.speedwave/plugins/<slug>/`       | No        |
-| `building`                  | After extract, before `runtime.build_image()` (only for plugins with `service_id`) | No        |
-| `done`                      | All phases completed without errors                                          | Yes       |
-| `failed`                    | A step errored. Includes a sanitized `error` string                          | Yes (when extract/verify fail) |
-| `done_with_pending_build`   | After `failed` from the building phase. The plugin is on disk and will retry on next launch | Yes |
+| Phase                     | When emitted                                                                                | Terminal?                      |
+| ------------------------- | ------------------------------------------------------------------------------------------- | ------------------------------ |
+| `verifying`               | Before signature check                                                                      | No                             |
+| `extracting`              | After signature OK, before copying into `~/.speedwave/plugins/<slug>/`                      | No                             |
+| `building`                | After extract, before `runtime.build_image()` (only for plugins with `service_id`)          | No                             |
+| `done`                    | All phases completed without errors                                                         | Yes                            |
+| `failed`                  | A step errored. Includes a sanitized `error` string                                         | Yes (when extract/verify fail) |
+| `done_with_pending_build` | After `failed` from the building phase. The plugin is on disk and will retry on next launch | Yes                            |
 
 A resource-only plugin (no `service_id`, no `Containerfile`) emits `verifying → extracting → done` and skips `building`. The frontend learns about this **before** invoking `install_plugin` by calling a new lightweight Tauri command `peek_plugin_manifest(zip_path)` that reads `plugin.json` from the ZIP without verifying the signature, extracting to a permanent location, or running any side-effect. The frontend then renders 2 or 3 steps as appropriate. This avoids retroactive UI mutation (e.g. removing a "building" step after the fact) and keeps the manifest as the single source of truth.
 
@@ -71,28 +71,28 @@ The `error` field is always passed through `speedwave_runtime::log_sanitizer::sa
 
 `spawn_blocking` is not cancellable from the host side. If the user closes the Plugins view or quits the app mid-install, behaviour is platform-specific:
 
-* **macOS Lima:** on app quit, `LimaRuntime::stop_vm()` runs `limactl stop --force <vm>` (where `<vm>` is derived from `SPEEDWAVE_DATA_DIR` per [ADR-031](ADR-031-data-dir-env-var-for-instance-isolation.md)[^4]) which poweroffs the VM, killing any in-VM `nerdctl build` immediately. The `.image_pending` marker on the host survives. On the next launch, `ensure_all_plugin_images` retries the build silently.
-* **Linux native nerdctl:** the build process is a child of the desktop process. After the desktop process exits, the child is reparented to `systemd-user`/`init` (Linux has no equivalent of `prctl(PR_SET_PDEATHSIG)`[^3] for the inverse case — and `PR_SET_PDEATHSIG` itself is Linux-only). The container runs as UID 0 in a user namespace per [ADR-026](ADR-026-linux-rootless-container-user.md)[^5], so the host-written `.image_pending` marker is owned by the desktop user and remains writable across the reparent. The build continues in the background; `.image_pending` is removed on success or remains on failure.
-* **Windows WSL2:** `wsl.exe -- nerdctl build` is a child of the desktop process; when the desktop exits, the host pipe breaks, but the in-WSL `nerdctl` may continue. Recovery is the same as Linux: `.image_pending` retry on next launch.
+- **macOS Lima:** on app quit, `LimaRuntime::stop_vm()` runs `limactl stop --force <vm>` (where `<vm>` is derived from `SPEEDWAVE_DATA_DIR` per [ADR-031](ADR-031-data-dir-env-var-for-instance-isolation.md)[^4]) which poweroffs the VM, killing any in-VM `nerdctl build` immediately. The `.image_pending` marker on the host survives. On the next launch, `ensure_all_plugin_images` retries the build silently.
+- **Linux native nerdctl:** the build process is a child of the desktop process. After the desktop process exits, the child is reparented to `systemd-user`/`init` (Linux has no equivalent of `prctl(PR_SET_PDEATHSIG)`[^3] for the inverse case — and `PR_SET_PDEATHSIG` itself is Linux-only). The container runs as UID 0 in a user namespace per [ADR-026](ADR-026-linux-rootless-container-user.md)[^5], so the host-written `.image_pending` marker is owned by the desktop user and remains writable across the reparent. The build continues in the background; `.image_pending` is removed on success or remains on failure.
+- **Windows WSL2:** `wsl.exe -- nerdctl build` is a child of the desktop process; when the desktop exits, the host pipe breaks, but the in-WSL `nerdctl` may continue. Recovery is the same as Linux: `.image_pending` retry on next launch.
 
 Explicit `kill_on_drop` of the in-flight child via a stored `Child` handle is left for follow-up; see "Out of scope".
 
 ## Critical files
 
-* `crates/speedwave-runtime/src/plugin.rs` — `PluginInstallProgress`, `InstallOutcome`, `ALL_PLUGIN_INSTALL_PHASES`, `peek_plugin_manifest`, `install_plugin` signature change.
-* `desktop/src-tauri/src/plugin_cmd.rs` — async `install_plugin` Tauri command, async `peek_plugin_manifest` Tauri command.
-* `desktop/src-tauri/src/main.rs` — registers `peek_plugin_manifest` in `invoke_handler`.
-* `crates/speedwave-cli/src/main.rs` — matches on `InstallOutcome`, exit 0 in both variants.
-* `desktop/src/src/app/shared/progress-steps/progress-steps.component.ts` — new shared component extracted from setup-wizard.
-* `desktop/src/src/app/setup/setup-wizard.component.ts` — refactored to delegate the step list to `<app-progress-steps>`.
-* `desktop/src/src/app/plugins/plugins.component.ts` — overlay rebuilt on `<app-progress-steps>`, `peek_plugin_manifest`-then-listen-then-invoke flow, phase event mapping.
-* `desktop/src/src/app/models/plugin.ts` — `PluginInstallProgress`, `PluginInstallPhase`, `PLUGIN_INSTALL_PHASES`, `PluginManifestSummary`.
+- `crates/speedwave-runtime/src/plugin.rs` — `PluginInstallProgress`, `InstallOutcome`, `ALL_PLUGIN_INSTALL_PHASES`, `peek_plugin_manifest`, `install_plugin` signature change.
+- `desktop/src-tauri/src/plugin_cmd.rs` — async `install_plugin` Tauri command, async `peek_plugin_manifest` Tauri command.
+- `desktop/src-tauri/src/main.rs` — registers `peek_plugin_manifest` in `invoke_handler`.
+- `crates/speedwave-cli/src/main.rs` — matches on `InstallOutcome`, exit 0 in both variants.
+- `desktop/src/src/app/shared/progress-steps/progress-steps.component.ts` — new shared component extracted from setup-wizard.
+- `desktop/src/src/app/setup/setup-wizard.component.ts` — refactored to delegate the step list to `<app-progress-steps>`.
+- `desktop/src/src/app/plugins/plugins.component.ts` — overlay rebuilt on `<app-progress-steps>`, `peek_plugin_manifest`-then-listen-then-invoke flow, phase event mapping.
+- `desktop/src/src/app/models/plugin.ts` — `PluginInstallProgress`, `PluginInstallPhase`, `PLUGIN_INSTALL_PHASES`, `PluginManifestSummary`.
 
 ## Out of scope (future work)
 
-* **Live build-log streaming.** A future PR may add `CommandRunner::run_streaming` (or an equivalent) and stream `nerdctl build` stdout/stderr line-by-line through the same `plugin_install_status` channel. That work needs to address: WSL2 UTF-16LE decoding from `wsl.exe -- nerdctl`, line buffering at chunk boundaries, sanitization per-line vs per-blob, and whether to merge stderr into stdout at the process level.
-* **Cancellable installs.** Storing the spawned child and providing a `cancel_install` Tauri command that signals it to terminate, with a documented per-platform cleanup path.
-* **CLI exit code semantics.** Distinguishing `InstalledPendingBuild` from `Installed` at the exit-code level is useful for scripts that need to detect deferred builds. A follow-up issue should propose exit 2 (or similar) under a `BREAKING CHANGE:` trailer; see [Future work](#future-work).
+- **Live build-log streaming.** A future PR may add `CommandRunner::run_streaming` (or an equivalent) and stream `nerdctl build` stdout/stderr line-by-line through the same `plugin_install_status` channel. That work needs to address: WSL2 UTF-16LE decoding from `wsl.exe -- nerdctl`, line buffering at chunk boundaries, sanitization per-line vs per-blob, and whether to merge stderr into stdout at the process level.
+- **Cancellable installs.** Storing the spawned child and providing a `cancel_install` Tauri command that signals it to terminate, with a documented per-platform cleanup path.
+- **CLI exit code semantics.** Distinguishing `InstalledPendingBuild` from `Installed` at the exit-code level is useful for scripts that need to detect deferred builds. A follow-up issue should propose exit 2 (or similar) under a `BREAKING CHANGE:` trailer; see [Future work](#future-work).
 
 ## Footnotes
 

--- a/docs/adr/ADR-047-plugin-install-progress-events.md
+++ b/docs/adr/ADR-047-plugin-install-progress-events.md
@@ -5,7 +5,7 @@
 
 ## Context
 
-Issue [#400](https://github.com/speednet/speedwave/issues/400) reports that plugin installation in the Desktop UI shows no visible feedback during the multi-minute work it performs. The previous implementation registered `install_plugin` as a synchronous Tauri command and ran the entire flow — Ed25519 signature verification, ZIP extraction, manifest validation, container image build via `nerdctl build`, and on-disk side-effects — in one blocking call. On macOS, where Tauri runs on the main thread, the user sees the system spinning beachball for 2-5 minutes when installing a heavy plugin (e.g. `presale` with docling/torch dependencies) and only learns about a build error after the freeze ends.
+Issue [#400](https://github.com/speednet-software/speedwave/issues/400) reports that plugin installation in the Desktop UI shows no visible feedback during the multi-minute work it performs. The previous implementation registered `install_plugin` as a synchronous Tauri command and ran the entire flow — Ed25519 signature verification, ZIP extraction, manifest validation, container image build via `nerdctl build`, and on-disk side-effects — in one blocking call. On macOS, where Tauri runs on the main thread, the user sees the system spinning beachball for 2-5 minutes when installing a heavy plugin (e.g. `presale` with docling/torch dependencies) and only learns about a build error after the freeze ends.
 
 The Desktop already had a small overlay rendered via `installing = true`, but it only displayed a static spinner and "Installing plugin…" string. Nothing communicated which step was running, and there was no way to surface a build failure separately from a fatal install failure.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -53,6 +53,7 @@ This directory contains all Architecture Decision Records (ADRs) for Speedwave. 
 | [ADR-044](ADR-044-entry-index-provider.md)                             | EntryIndexProvider — Atomic Counter for Stable Keys     | Accepted              |
 | [ADR-045](ADR-045-one-slot-queued-message.md)                          | One-Slot Queued Message Per Session (Replace, Not FIFO) | Accepted              |
 | [ADR-046](ADR-046-native-session-resume-for-retry.md)                  | Native Session Resume for Assistant-Message Retry       | Accepted              |
+| [ADR-047](ADR-047-plugin-install-progress-events.md)                   | Plugin Install Progress Events                          | Accepted              |
 
 ## Creating a New ADR
 

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -50,7 +50,14 @@ speedwave --help | -h | help   # print usage and exit (no runtime required)
 
   > **Note:** If the rebuild fails (e.g., when run from a non-project directory or without Desktop running), run `speedwave update` from your project directory. For multiple projects, run `speedwave update` from each project directory or restart the Desktop app.
 
-- **`speedwave plugin install <path.zip>`** — verifies the Ed25519 signature, extracts the plugin to `~/.speedwave/plugins/<slug>/`, and registers it
+- **`speedwave plugin install <path.zip>`** — verifies the Ed25519 signature, extracts the plugin to `~/.speedwave/plugins/<slug>/`, and registers it.
+
+  Two outcomes are possible:
+
+  - **Installed:** the plugin is on disk and (for MCP plugins) the container image was built. Stdout: `"Plugin '<name>' (<slug>) installed successfully"`.
+  - **Installed with deferred build:** the plugin is on disk but the container image build failed (network outage, broken Containerfile). Stderr: `"Plugin '<name>' (<slug>) installed; image build failed and will retry on next launch"`. The `~/.speedwave/plugins/<slug>/.image_pending` marker remains and the build is retried automatically on the next Speedwave start (`ensure_all_plugin_images`).
+
+  **Both cases exit 0** so existing `speedwave plugin install foo.zip && echo OK` scripts continue to work. To detect a deferred build, read stderr or check for `.image_pending`. See [ADR-047](../adr/ADR-047-plugin-install-progress-events.md) for the rationale.
 - **`speedwave plugin list`** — lists all installed plugins, showing name, version, and enabled/configured status per project
 - **`speedwave plugin remove <slug>`** — removes the plugin directory from `~/.speedwave/plugins/<slug>/`. Note: credential files at `~/.speedwave/tokens/<project>/<slug>/` and config entries are **not** cleaned by the CLI — use the Desktop UI for full cleanup, or remove token directories manually
 - **`speedwave plugin enable <slug> --project <name>`** — enables a plugin for a specific project in user config

--- a/docs/guides/integrations.md
+++ b/docs/guides/integrations.md
@@ -166,6 +166,17 @@ Speedwave supports extending integrations via the plugin system:
 - Plugin services get injected `WORKER_<PLUGIN>_URL` in the hub environment
 - Plugin images are automatically rebuilt if missing (e.g. after a VM reset or `nerdctl system prune`) — you do not need to reinstall the plugin
 
+### Install progress overlay (Desktop)
+
+The Desktop install dialog reports progress through the `plugin_install_status` Tauri event. The flow has up to four phases:
+
+1. `verifying` — Ed25519 signature check
+2. `extracting` — unpack the ZIP into `~/.speedwave/plugins/<slug>/`
+3. `building` — `nerdctl build` for plugins with a `service_id` (skipped for resource-only plugins; can take 2–5 minutes for heavy dependencies)
+4. `done` — terminal success
+
+If the image build fails, the overlay shows the failure inline and emits a final `done_with_pending_build` event. The plugin is left on disk with an `.image_pending` marker; `ensure_all_plugin_images` retries the build automatically on the next launch. See [ADR-047](../adr/ADR-047-plugin-install-progress-events.md) for the event payload and per-platform cleanup behaviour.
+
 See [ADR-015](../adr/ADR-015-plugin-system.md) for the plugin system design and [ADR-036](../adr/ADR-036-self-declaring-worker-policy.md) for the tool policy model.
 
 ### Tool Policy via `_meta`


### PR DESCRIPTION
## Summary

- Plugin install no longer blocks the webview thread; the Desktop overlay shows phase-by-phase progress (verify / extract / build) instead of the macOS beachball.
- New `InstallOutcome` distinguishes fully-installed plugins from ones whose image build deferred to next launch (`.image_pending` recovery via existing `ensure_all_plugin_images`).
- Shared `<app-progress-steps>` component extracted from setup-wizard; plugin install and first-run wizard now share one progress UI.
- Pre-existing flaky compose test fixed (`ensure_worker_auth_token` race on shared `.tmp` filename).

## Highlights

- **Backend (Rust):** `install_plugin` takes a progress callback and returns `InstallOutcome::{Installed, InstalledPendingBuild}`. New `peek_plugin_manifest` reads `plugin.json` from a ZIP without verifying signature or extracting — used by the overlay to know whether the `building` step will run.
- **Tauri:** `install_plugin` is `async` + `spawn_blocking`, emits `plugin_install_status` events. New `peek_plugin_manifest` Tauri command. Auto-enable runs only on `Installed`; `InstalledPendingBuild` shows a "will retry on next launch" toast.
- **Frontend (Angular):** Plugin overlay rendered through `<app-progress-steps>`. Resource-only plugins render 2 steps (verify+extract); MCP plugins render 3 (verify+extract+build). On `done` / `done_with_pending_build` the existing `projectState.requestRestart()` banner shows up — no new UI surface.
- **CLI:** matches `InstallOutcome` and routes the deferred-build message to stderr. Exit code stays **0** in both cases — non-breaking for scripts using `speedwave plugin install foo.zip && echo OK`.
- **Sanitization:** Every emitted `error` is sanitized via `log_sanitizer::sanitize` before emission. Regression test in `plugin.rs::tests` exercises a build error containing `https://user:tok@registry/foo` and asserts the leaked token does not reach the IPC payload.
- **Out of scope:** Live nerdctl build log streaming (UTF-16LE WSL decode, threading, IPC payload caps) — tracked for a follow-up. Documented in ADR-047.

## Tests

- Rust runtime: 1040/1040 (concurrent, stable across multiple runs).
- Rust CLI: 56/56.
- Angular: 1552/1552 (Setup wizard tests reuse the new shared component).
- New tests: `test_all_plugin_install_phases_lists_expected_strings`, `test_peek_plugin_manifest_*` (×4), `test_install_plugin_resource_only_emits_verifying_extracting_done`, `test_install_plugin_no_runtime_skips_building`, `test_install_plugin_emits_failed_with_sanitized_error`. Plus `progress-steps.component.spec.ts` (12 cases) and updated `plugins.component.spec.ts` covering peek → listener → invoke flow.
- Concurrent compose tests stabilized: `ensure_worker_auth_token` writes to `tmp.<uuid>` so 36 tests sharing `test-project` no longer race on `<token_path>.tmp`. Final `rename` is still atomic.

## Test plan

- [x] `cargo test -p speedwave-runtime --lib` (concurrent) — 1040/1040
- [x] `cargo test -p speedwave-cli` — 56/56
- [x] `cargo fmt --check -p speedwave-runtime -p speedwave-cli` — clean
- [x] `npx ng test --no-watch` (in `desktop/src/`) — 1552/1552
- [ ] Manual E2E on macOS: install a light plugin, install presale (~2-5 min, no beachball), install with bad signature, simulate network failure mid-build (verify `done_with_pending_build` toast + `.image_pending` survives + recovery on next start), resource-only plugin shows 2 steps
- [ ] Manual E2E on Linux rootless nerdctl
- [ ] CLI: `speedwave plugin install foo.zip && echo OK` works for both `Installed` and `InstalledPendingBuild`

Fixes #400