### PR TITLE
fix(desktop): strip pointer-style markdown links from memory panel

### DIFF
--- a/crates/speedwave-runtime/src/compose.rs
+++ b/crates/speedwave-runtime/src/compose.rs
@@ -612,8 +612,11 @@ fn ensure_worker_auth_token(
         uuid::Uuid::new_v4().to_string()
     };
 
-    // Atomic write with 0o600 permissions (pattern from update.rs)
-    let tmp_path = token_path.with_extension("tmp");
+    // Atomic write with 0o600 permissions (pattern from update.rs).
+    // Use a unique suffix to avoid collisions when multiple callers write
+    // the same token file concurrently (e.g., parallel tests or processes).
+    let tmp_name = format!("{}.{}.tmp", token_file_name, uuid::Uuid::new_v4());
+    let tmp_path = secrets_dir.join(&tmp_name);
     std::fs::write(&tmp_path, &token)?;
     #[cfg(unix)]
     {
@@ -3011,8 +3014,9 @@ services:
         }
     }
 
-    /// ADR-038: every WORKER_*_URL entry in mcp-hub environment must point at
-    /// `:{PORT_WORKER}`.
+    /// ADR-038: every container-to-container WORKER_*_URL in mcp-hub must point
+    /// at `:{PORT_WORKER}`. `WORKER_OS_URL` is exempt: mcp-os runs on the host
+    /// and uses a dynamic port allocated by the OS, not PORT_WORKER.
     #[test]
     fn test_hub_worker_urls_use_port_worker() {
         let config = ResolvedClaudeConfig {

--- a/desktop/src/src/app/chat/memory-panel/memory-panel.component.spec.ts
+++ b/desktop/src/src/app/chat/memory-panel/memory-panel.component.spec.ts
@@ -128,15 +128,17 @@ describe('MemoryPanelComponent', () => {
       expect(pill!.textContent!.trim()).toBe('3 entries');
     });
 
-    it('falls back to the markdown renderer when no sections are parsed', () => {
+    it('renders raw markdown as plain text when no canonical sections are parsed', () => {
       host.open = true;
       host.markdown = '# Hello\n\nWorld';
       fixture.detectChanges();
       const body = q('[data-testid="memory-panel-body"]');
       expect(body).not.toBeNull();
-      expect(body!.querySelector('app-text-block')).not.toBeNull();
-      expect(body!.textContent).toContain('Hello');
-      expect(body!.textContent).toContain('World');
+      expect(q('app-text-block')).toBeNull();
+      const fallback = q('[data-testid="memory-panel-fallback"]');
+      expect(fallback).not.toBeNull();
+      expect(fallback!.textContent).toContain('# Hello');
+      expect(fallback!.textContent).toContain('World');
     });
 
     it('shows empty placeholder when markdown is empty string', () => {
@@ -186,7 +188,10 @@ describe('MemoryPanelComponent', () => {
       fixture.detectChanges();
 
       expect(q('[data-testid="memory-panel-error"]')).toBeNull();
-      expect(q('app-text-block')).not.toBeNull();
+      // Fallback branch now renders plain text, not <app-text-block>.
+      expect(q('app-text-block')).toBeNull();
+      expect(q('[data-testid="memory-panel-fallback"]')).not.toBeNull();
+      expect(q('[data-testid="memory-panel-fallback"]')!.textContent).toContain('# Recovered');
     });
 
     it('renders empty placeholder when both markdown and error are empty', () => {
@@ -197,6 +202,82 @@ describe('MemoryPanelComponent', () => {
 
       expect(q('[data-testid="memory-panel-error"]')).toBeNull();
       expect(q('[data-testid="memory-panel-empty"]')).not.toBeNull();
+    });
+  });
+
+  describe('link safety (no markdown rendering)', () => {
+    it('does not render anchors for relative markdown links (the white-screen regression)', () => {
+      host.open = true;
+      host.markdown =
+        '- [feedback_no_hardcoded_paths.md](feedback_no_hardcoded_paths.md) — Never put absolute user paths in committed files';
+      fixture.detectChanges();
+      const body = q('[data-testid="memory-panel-body"]');
+      expect(body).not.toBeNull();
+      expect(body!.querySelector('a')).toBeNull();
+      // Pointer-style links are stripped: only the description survives so the
+      // panel shows what the user wrote, not the implementation file name.
+      expect(body!.textContent).not.toContain('feedback_no_hardcoded_paths.md');
+      expect(body!.textContent).toContain('Never put absolute user paths');
+    });
+
+    it('does not render anchors for absolute http links inside MEMORY.md', () => {
+      host.open = true;
+      host.markdown = 'See [docs](https://example.com/docs) for more.';
+      fixture.detectChanges();
+      const body = q('[data-testid="memory-panel-body"]');
+      expect(body).not.toBeNull();
+      expect(body!.querySelector('a')).toBeNull();
+      // Inline link collapses to its visible text; URL is dropped.
+      expect(body!.textContent).toContain('See docs for more.');
+      expect(body!.textContent).not.toContain('https://example.com');
+    });
+
+    it('strips pointer-style links in the unstructured fallback (no canonical headers)', () => {
+      // Regression for MEMORY.md files that are just a bullet list of
+      // pointer entries (no `## ...` headers), which land in the fallback
+      // branch rather than parsed sections. Each entry must collapse to its
+      // description so neither the bracketed title nor the file name leak
+      // into the rendered drawer.
+      host.open = true;
+      host.markdown = [
+        '- [foo entry](foo.md) — first description',
+        '- [bar entry](bar.md) — second description',
+      ].join('\n');
+      fixture.detectChanges();
+      const fallback = q('[data-testid="memory-panel-fallback"]');
+      expect(fallback).not.toBeNull();
+      expect(fallback!.querySelector('a')).toBeNull();
+      expect(fallback!.textContent).toContain('first description');
+      expect(fallback!.textContent).toContain('second description');
+      expect(fallback!.textContent).not.toContain('foo.md');
+      expect(fallback!.textContent).not.toContain('bar.md');
+      expect(fallback!.textContent).not.toContain('[foo entry]');
+      expect(fallback!.textContent).not.toContain('[bar entry]');
+    });
+
+    it('does not render anchors when MEMORY.md mixes canonical sections with link entries', () => {
+      host.open = true;
+      host.markdown = '## Feedback\n\n- [a.md](a.md) one\n- [b.md](b.md) two';
+      fixture.detectChanges();
+      const body = q('[data-testid="memory-panel-body"]');
+      expect(body).not.toBeNull();
+      expect(body!.querySelector('a')).toBeNull();
+      // Pointer-style links collapse to their description (the file name is
+      // dropped). The test verifies both that no anchor is rendered AND that
+      // the user-visible text survives the strip.
+      expect(body!.textContent).not.toContain('[a.md](a.md)');
+      expect(body!.textContent).not.toContain('[b.md](b.md)');
+      expect(body!.textContent).toContain('one');
+      expect(body!.textContent).toContain('two');
+    });
+
+    it('does not render anchors when MEMORY.md fallback contains a javascript: scheme', () => {
+      host.open = true;
+      host.markdown = '[click](javascript:alert(1))';
+      fixture.detectChanges();
+      const body = q('[data-testid="memory-panel-body"]');
+      expect(body).not.toBeNull();
+      expect(body!.querySelector('a')).toBeNull();
     });
   });
 });
@@ -230,5 +311,50 @@ describe('parseSections', () => {
     expect(out).toHaveLength(1);
     expect(out[0].body).toContain('- bullet one');
     expect(out[0].body).toContain('closing line.');
+  });
+
+  it('strips pointer-style markdown links so only the description remains', () => {
+    const md = [
+      '## User',
+      '',
+      '- [foo entry](foo.md) — first description',
+      '- [bar entry](bar.md) — second description',
+    ].join('\n');
+    const out = parseSections(md);
+    expect(out).toHaveLength(1);
+    expect(out[0].body).toBe(['- first description', '- second description'].join('\n'));
+    expect(out[0].body).not.toContain('[');
+    expect(out[0].body).not.toContain('foo.md');
+    expect(out[0].body).not.toContain('bar.md');
+  });
+
+  it('handles em-dash, en-dash, and hyphen separators between link and description', () => {
+    const md = [
+      '## Feedback',
+      '',
+      '- [a](a.md) — em-dash desc',
+      '- [b](b.md) – en-dash desc',
+      '- [c](c.md) - hyphen desc',
+    ].join('\n');
+    const out = parseSections(md);
+    expect(out[0].body).toBe(['- em-dash desc', '- en-dash desc', '- hyphen desc'].join('\n'));
+  });
+
+  it('keeps the bullet when a pointer entry has no description', () => {
+    const md = '## Project\n\n- [orphan](orphan.md)';
+    const out = parseSections(md);
+    expect(out[0].body).toBe('-');
+  });
+
+  it('inlines bare markdown links inside a sentence with their visible text', () => {
+    const md = '## Reference\n\nSee [the docs](https://example.com) for more.';
+    const out = parseSections(md);
+    expect(out[0].body).toBe('See the docs for more.');
+  });
+
+  it('passes through plain bullet lines unchanged when no links are present', () => {
+    const md = '## User\n\n- plain note one\n- plain note two';
+    const out = parseSections(md);
+    expect(out[0].body).toBe('- plain note one\n- plain note two');
   });
 });

--- a/desktop/src/src/app/chat/memory-panel/memory-panel.component.spec.ts
+++ b/desktop/src/src/app/chat/memory-panel/memory-panel.component.spec.ts
@@ -188,7 +188,6 @@ describe('MemoryPanelComponent', () => {
       fixture.detectChanges();
 
       expect(q('[data-testid="memory-panel-error"]')).toBeNull();
-      // Fallback branch now renders plain text, not <app-text-block>.
       expect(q('app-text-block')).toBeNull();
       expect(q('[data-testid="memory-panel-fallback"]')).not.toBeNull();
       expect(q('[data-testid="memory-panel-fallback"]')!.textContent).toContain('# Recovered');
@@ -214,8 +213,6 @@ describe('MemoryPanelComponent', () => {
       const body = q('[data-testid="memory-panel-body"]');
       expect(body).not.toBeNull();
       expect(body!.querySelector('a')).toBeNull();
-      // Pointer-style links are stripped: only the description survives so the
-      // panel shows what the user wrote, not the implementation file name.
       expect(body!.textContent).not.toContain('feedback_no_hardcoded_paths.md');
       expect(body!.textContent).toContain('Never put absolute user paths');
     });
@@ -227,17 +224,12 @@ describe('MemoryPanelComponent', () => {
       const body = q('[data-testid="memory-panel-body"]');
       expect(body).not.toBeNull();
       expect(body!.querySelector('a')).toBeNull();
-      // Inline link collapses to its visible text; URL is dropped.
       expect(body!.textContent).toContain('See docs for more.');
       expect(body!.textContent).not.toContain('https://example.com');
     });
 
     it('strips pointer-style links in the unstructured fallback (no canonical headers)', () => {
-      // Regression for MEMORY.md files that are just a bullet list of
-      // pointer entries (no `## ...` headers), which land in the fallback
-      // branch rather than parsed sections. Each entry must collapse to its
-      // description so neither the bracketed title nor the file name leak
-      // into the rendered drawer.
+      // No `## ...` headers — entries land in the fallback branch.
       host.open = true;
       host.markdown = [
         '- [foo entry](foo.md) — first description',
@@ -262,9 +254,6 @@ describe('MemoryPanelComponent', () => {
       const body = q('[data-testid="memory-panel-body"]');
       expect(body).not.toBeNull();
       expect(body!.querySelector('a')).toBeNull();
-      // Pointer-style links collapse to their description (the file name is
-      // dropped). The test verifies both that no anchor is rendered AND that
-      // the user-visible text survives the strip.
       expect(body!.textContent).not.toContain('[a.md](a.md)');
       expect(body!.textContent).not.toContain('[b.md](b.md)');
       expect(body!.textContent).toContain('one');

--- a/desktop/src/src/app/chat/memory-panel/memory-panel.component.ts
+++ b/desktop/src/src/app/chat/memory-panel/memory-panel.component.ts
@@ -16,7 +16,6 @@ import {
 } from '@angular/core';
 import { filter } from 'rxjs/operators';
 import { IconComponent } from '../../shared/icon.component';
-import { TextBlockComponent } from '../blocks/text-block.component';
 
 /**
  * Left overlay drawer that surfaces the active project's CLAUDE.md.
@@ -29,15 +28,17 @@ import { TextBlockComponent } from '../blocks/text-block.component';
  *
  * - Header: mono "memory" + neutral pill with section count + close ×.
  * - Body: when the source markdown contains the canonical section markers
- *   (## User Preferences / ## Feedback / ## Project / ## Reference) we render
- *   each as a mono kicker + dimmed text block — matching the mockup. Otherwise
- *   we fall back to the existing markdown pipeline via `<app-text-block>` so
- *   no project memory is ever silently dropped.
+ *   (## User / ## Project / ## Feedback / ## Reference) we render each as a
+ *   mono kicker + dimmed text block — matching the mockup. Otherwise we render
+ *   the raw source as preformatted plain text inside a <pre>. We deliberately
+ *   do not run the markdown pipeline here: MEMORY.md often contains relative
+ *   markdown links to per-memory files, and rendering them as <a> would let a
+ *   click navigate the embedded webview off the SPA route (white screen).
  */
 @Component({
   selector: 'app-memory-panel',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [TextBlockComponent, A11yModule, IconComponent],
+  imports: [A11yModule, IconComponent],
   template: `
     <ng-template #content>
       <div
@@ -89,7 +90,11 @@ import { TextBlockComponent } from '../blocks/text-block.component';
               }
             </div>
           } @else if (markdown()) {
-            <app-text-block [content]="markdown()" />
+            <pre
+              class="mono whitespace-pre-wrap break-words text-[11.5px] text-[var(--ink-dim)]"
+              data-testid="memory-panel-fallback"
+              >{{ fallbackText() }}</pre
+            >
           } @else {
             <p class="mono text-[11.5px] text-[var(--ink-mute)]" data-testid="memory-panel-empty">
               no memory yet
@@ -112,6 +117,8 @@ export class MemoryPanelComponent {
 
   /** Parsed sections (kicker + body) when markdown follows the canonical layout. */
   protected readonly sections = computed(() => parseSections(this.markdown()));
+  /** Same link-stripping rule as parseSections, applied to the unstructured fallback. */
+  protected readonly fallbackText = computed(() => stripPointerLinks(this.markdown()).trim());
   protected readonly sectionCount = computed(() => this.sections().length);
   protected readonly sectionLabel = computed(() => {
     const n = this.sectionCount();
@@ -200,11 +207,37 @@ export function parseSections(
     const start = matches[i].start;
     const end = i + 1 < matches.length ? matches[i + 1].start : markdown.length;
     const block = markdown.slice(start, end);
-    // Drop the heading line; trim trailing whitespace.
-    const body = block.replace(/^##\s+\S.*\r?\n?/, '').trim();
+    // Drop the heading line; trim trailing whitespace; strip pointer-style
+    // markdown links so entries like `- [name](file.md) — desc` collapse to
+    // `- desc` (the file is a link to the per-memory file, not user content).
+    const body = stripPointerLinks(block.replace(/^##\s+\S.*\r?\n?/, '')).trim();
     if (body) {
       sections.push({ id: matches[i].id, label: matches[i].label, body });
     }
   }
   return sections;
+}
+
+/**
+ * Removes pointer-style markdown links from MEMORY.md lines.
+ *
+ * MEMORY.md entries follow the shape `- [title](file.md) — description`, where
+ * the bracketed link is just a pointer to the per-memory file on disk (not
+ * something the user types). The drawer is a read-only summary, so we collapse
+ * each entry to its description: `- description`. Any leftover bare links are
+ * replaced with their visible text. Lines without links pass through untouched.
+ * @param text - Raw markdown source.
+ */
+export function stripPointerLinks(text: string): string {
+  return text
+    .split('\n')
+    .map((line) => {
+      const pointer = line.match(/^(\s*[-*]\s+)\[[^\]]+\]\([^)]+\)\s*[—–-]?\s*(.*)$/);
+      if (pointer) {
+        const [, bullet, rest] = pointer;
+        return rest ? `${bullet}${rest}` : bullet.trimEnd();
+      }
+      return line.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1');
+    })
+    .join('\n');
 }

--- a/desktop/src/src/app/chat/memory-panel/memory-panel.component.ts
+++ b/desktop/src/src/app/chat/memory-panel/memory-panel.component.ts
@@ -207,9 +207,6 @@ export function parseSections(
     const start = matches[i].start;
     const end = i + 1 < matches.length ? matches[i + 1].start : markdown.length;
     const block = markdown.slice(start, end);
-    // Drop the heading line; trim trailing whitespace; strip pointer-style
-    // markdown links so entries like `- [name](file.md) — desc` collapse to
-    // `- desc` (the file is a link to the per-memory file, not user content).
     const body = stripPointerLinks(block.replace(/^##\s+\S.*\r?\n?/, '')).trim();
     if (body) {
       sections.push({ id: matches[i].id, label: matches[i].label, body });
@@ -219,13 +216,8 @@ export function parseSections(
 }
 
 /**
- * Removes pointer-style markdown links from MEMORY.md lines.
- *
- * MEMORY.md entries follow the shape `- [title](file.md) — description`, where
- * the bracketed link is just a pointer to the per-memory file on disk (not
- * something the user types). The drawer is a read-only summary, so we collapse
- * each entry to its description: `- description`. Any leftover bare links are
- * replaced with their visible text. Lines without links pass through untouched.
+ * Collapses `- [title](file.md) — desc` to `- desc` so the drawer never renders
+ * a clickable pointer link (would navigate the webview off-route and white-screen).
  * @param text - Raw markdown source.
  */
 export function stripPointerLinks(text: string): string {


### PR DESCRIPTION
## Summary

- Memory drawer rendered MEMORY.md entries like `- [name](file.md) — description` through the markdown pipeline, producing real `<a>` tags. Clicking a relative link navigated the embedded webview off the SPA route and showed a white screen.
- Replace the markdown pipeline with a `<pre>` fallback and strip pointer-style links: `- [name](file.md) — desc` collapses to `- desc` in both the parsed-section branch and the unstructured-bullet-list fallback. Inline links elsewhere fall back to their visible text. No `<a>` is ever rendered.
- Boy-scout fixes in `crates/speedwave-runtime/src/compose.rs`:
  - exempt `WORKER_OS_URL` from the ADR-038 `PORT_WORKER` assertion (mcp-os runs on the host with a dynamically allocated port, not in-cluster);
  - switch the temp file in `ensure_worker_auth_token` to a per-call uuid name so concurrent writers no longer race on a shared `.tmp` path.

## Test plan

- [x] `make test` passes (1548 Angular tests, 1026 Rust tests)
- [x] `make check` passes (clippy + fmt + ESLint + tsc)
- [x] new specs cover: relative pointer links, http links, mixed canonical+pointer entries, `javascript:` scheme, em/en-dash/hyphen separators, orphan pointer without description, no-canonical-headers fallback path
- [x] manual: clicking entries in the memory drawer no longer triggers a white screen