### PR TITLE
fix(plugins): refresh slash menu after container restart

### DIFF
--- a/desktop/src/src/app/services/project-state.service.spec.ts
+++ b/desktop/src/src/app/services/project-state.service.spec.ts
@@ -826,11 +826,13 @@ describe('ProjectStateService', () => {
       expect(spy.mock.calls.length).toBe(callsBefore);
     });
 
-    it('restartContainers invalidates the slash cache and fires onProjectReady on success', async () => {
+    it('restartContainers invalidates the slash cache and fires onProjectReady + onProjectSettled on success', async () => {
       service.requestRestart();
       const spy = vi.spyOn(mockTauri, 'invoke');
       const readyCallback = vi.fn();
+      const settledCallback = vi.fn();
       service.onProjectReady(readyCallback);
+      service.onProjectSettled(settledCallback);
 
       await service.restartContainers();
 
@@ -838,12 +840,15 @@ describe('ProjectStateService', () => {
       // re-runs discovery — otherwise the chat composer keeps the
       // pre-restart skill list (10-min cache).
       expect(spy).toHaveBeenCalledWith('invalidate_slash_cache', { projectId: 'test' });
-      // onProjectReady must fire so the composer (and other view consumers)
-      // re-fetch their per-project state with the new container set.
+      // onProjectReady must fire so the composer + chat re-fetch their
+      // per-project state with the new container set.
       expect(readyCallback).toHaveBeenCalled();
+      // onProjectSettled must fire too — integrations.component and
+      // project-switcher refresh through this listener path, not ready.
+      expect(settledCallback).toHaveBeenCalled();
     });
 
-    it('restartContainers does not invalidate slash cache or fire ready when restart fails', async () => {
+    it('restartContainers does not invalidate slash cache or fire ready/settled when restart fails', async () => {
       service.requestRestart();
       mockTauri.invokeHandler = (cmd: string) => {
         if (cmd === 'restart_integration_containers') {
@@ -853,16 +858,45 @@ describe('ProjectStateService', () => {
       };
       const spy = vi.spyOn(mockTauri, 'invoke');
       const readyCallback = vi.fn();
+      const settledCallback = vi.fn();
       service.onProjectReady(readyCallback);
+      service.onProjectSettled(settledCallback);
 
       await service.restartContainers();
 
       expect(service.restartError).toBe('boom');
-      // The post-success steps (cache invalidate + ready fanout) MUST NOT run
-      // when the restart itself failed: state has not advanced, and firing
-      // ready could mask the error or trigger consumers to refetch stale data.
+      // The post-success steps (cache invalidate + ready/settled fanout)
+      // MUST NOT run when the restart itself failed: state has not
+      // advanced, and firing ready could mask the error or trigger
+      // consumers to refetch stale data.
       expect(spy).not.toHaveBeenCalledWith('invalidate_slash_cache', expect.anything());
       expect(readyCallback).not.toHaveBeenCalled();
+      expect(settledCallback).not.toHaveBeenCalled();
+    });
+
+    it('restartContainers still fires onProjectReady when invalidate_slash_cache itself fails', async () => {
+      // Regression guard: a future refactor that moves `restartedOk = true`
+      // inside the inner try would silently break the "ready fires even
+      // when invalidation fails" guarantee. The cache eventually expires,
+      // so the invalidate call is best-effort.
+      service.requestRestart();
+      mockTauri.invokeHandler = (cmd: string) => {
+        if (cmd === 'invalidate_slash_cache') {
+          return Promise.reject(new Error('cache error'));
+        }
+        return Promise.resolve(undefined);
+      };
+      const readyCallback = vi.fn();
+      const settledCallback = vi.fn();
+      service.onProjectReady(readyCallback);
+      service.onProjectSettled(settledCallback);
+
+      await service.restartContainers();
+
+      expect(service.restartError).toBe('');
+      expect(service.needsRestart).toBe(false);
+      expect(readyCallback).toHaveBeenCalled();
+      expect(settledCallback).toHaveBeenCalled();
     });
 
     it('dismissRestart does not affect restarting flag', () => {

--- a/desktop/src/src/app/services/project-state.service.spec.ts
+++ b/desktop/src/src/app/services/project-state.service.spec.ts
@@ -826,6 +826,45 @@ describe('ProjectStateService', () => {
       expect(spy.mock.calls.length).toBe(callsBefore);
     });
 
+    it('restartContainers invalidates the slash cache and fires onProjectReady on success', async () => {
+      service.requestRestart();
+      const spy = vi.spyOn(mockTauri, 'invoke');
+      const readyCallback = vi.fn();
+      service.onProjectReady(readyCallback);
+
+      await service.restartContainers();
+
+      // Slash cache must be invalidated so the next slash-menu open
+      // re-runs discovery — otherwise the chat composer keeps the
+      // pre-restart skill list (10-min cache).
+      expect(spy).toHaveBeenCalledWith('invalidate_slash_cache', { projectId: 'test' });
+      // onProjectReady must fire so the composer (and other view consumers)
+      // re-fetch their per-project state with the new container set.
+      expect(readyCallback).toHaveBeenCalled();
+    });
+
+    it('restartContainers does not invalidate slash cache or fire ready when restart fails', async () => {
+      service.requestRestart();
+      mockTauri.invokeHandler = (cmd: string) => {
+        if (cmd === 'restart_integration_containers') {
+          return Promise.reject(new Error('boom'));
+        }
+        return Promise.resolve(undefined);
+      };
+      const spy = vi.spyOn(mockTauri, 'invoke');
+      const readyCallback = vi.fn();
+      service.onProjectReady(readyCallback);
+
+      await service.restartContainers();
+
+      expect(service.restartError).toBe('boom');
+      // The post-success steps (cache invalidate + ready fanout) MUST NOT run
+      // when the restart itself failed: state has not advanced, and firing
+      // ready could mask the error or trigger consumers to refetch stale data.
+      expect(spy).not.toHaveBeenCalledWith('invalidate_slash_cache', expect.anything());
+      expect(readyCallback).not.toHaveBeenCalled();
+    });
+
     it('dismissRestart does not affect restarting flag', () => {
       service.needsRestart = true;
       service.restarting = true;

--- a/desktop/src/src/app/services/project-state.service.ts
+++ b/desktop/src/src/app/services/project-state.service.ts
@@ -287,12 +287,9 @@ export class ProjectStateService {
       await this.tauri.invoke('restart_integration_containers', { project });
       this.needsRestart = false;
       restartedOk = true;
-      // Skills/commands/agents are discovered from inside the claude
-      // container; toggling a plugin (or installing/removing one) and
-      // restarting changes the in-container resource set. The discovery
-      // result is cached per-project for 10 min, so without this nudge
-      // the next slash-menu open returns the pre-restart list. Failure
-      // to invalidate is non-fatal — the cache will eventually expire.
+      // Slash discovery is cached host-side for 10 min; compose recreate
+      // does not invalidate it. Without this nudge, the next slash-menu
+      // open returns the pre-restart list. Cache miss is non-fatal.
       try {
         await this.tauri.invoke('invalidate_slash_cache', { projectId: project });
       } catch (err: unknown) {
@@ -303,11 +300,10 @@ export class ProjectStateService {
     }
     this.restarting = false;
     this.notifyChange();
-    // Fire onProjectReady so consumers (composer, chat, plugins view)
-    // refetch their per-project state — same listener path as the
-    // initial project boot, since the container set has just been
-    // recreated. Skip on failure: state has not actually advanced.
-    if (restartedOk) this.notifyReady();
+    if (restartedOk) {
+      this.notifyReady();
+      this.notifySettled();
+    }
   }
 
   /** Dismisses the restart overlay without restarting. */

--- a/desktop/src/src/app/services/project-state.service.ts
+++ b/desktop/src/src/app/services/project-state.service.ts
@@ -278,19 +278,36 @@ export class ProjectStateService {
   /** Restarts integration containers to apply pending changes. */
   async restartContainers(): Promise<void> {
     if (!this.activeProject || this.restarting) return;
+    const project = this.activeProject;
     this.restarting = true;
     this.restartError = '';
     this.notifyChange();
+    let restartedOk = false;
     try {
-      await this.tauri.invoke('restart_integration_containers', {
-        project: this.activeProject,
-      });
+      await this.tauri.invoke('restart_integration_containers', { project });
       this.needsRestart = false;
+      restartedOk = true;
+      // Skills/commands/agents are discovered from inside the claude
+      // container; toggling a plugin (or installing/removing one) and
+      // restarting changes the in-container resource set. The discovery
+      // result is cached per-project for 10 min, so without this nudge
+      // the next slash-menu open returns the pre-restart list. Failure
+      // to invalidate is non-fatal — the cache will eventually expire.
+      try {
+        await this.tauri.invoke('invalidate_slash_cache', { projectId: project });
+      } catch (err: unknown) {
+        console.warn('[ProjectStateService] invalidate_slash_cache failed:', err);
+      }
     } catch (e: unknown) {
       this.restartError = e instanceof Error ? e.message : String(e);
     }
     this.restarting = false;
     this.notifyChange();
+    // Fire onProjectReady so consumers (composer, chat, plugins view)
+    // refetch their per-project state — same listener path as the
+    // initial project boot, since the container set has just been
+    // recreated. Skip on failure: state has not actually advanced.
+    if (restartedOk) this.notifyReady();
   }
 
   /** Dismisses the restart overlay without restarting. */


### PR DESCRIPTION
## Summary

Bug followup do PR #582 (issue #400): po włączeniu pluginu w projekcie B i kliknięciu "restart now" w bannerze, slash menu w czacie nie pokazywało nowych skills z pluginu — choć w pierwszym projekcie po install/restart skills pojawiały się natychmiast.

## Root cause

Dwa współdziałające problemy:

1. **Backend cache** — `slash::discover_slash_commands` cachuje wynik per-project na 10 min. `compose recreate` nie czyści tego cache'u (cache żyje w host Tauri process, nie w kontenerze), więc po restart kolejne wywołanie `list_slash_commands` zwracało pre-restart listę.

2. **Frontend nigdy nie odświeżał** — composer woła `slashService.refresh(id)` tylko w `onProjectReady`, który firuje na switch_project / boot, nigdy po restart w tym samym projekcie. Nawet gdyby cache był invalidated, composer nadal trzymał starą listę w sygnale.

## Fix

`ProjectStateService.restartContainers()`, po pomyślnym restart:
- woła `invalidate_slash_cache` dla projektu który właśnie się zrestartował
- woła `notifyReady()` żeby każdy `onProjectReady` consumer (composer, chat, plugins view) re-fetched swój per-project state

Oba kroki guard'owane przez `restartedOk` — nie odpalają się gdy restart się nie powiódł.

## Repro

1. Install presale w projekcie A → toggle on → restart → nowe skills widoczne ✅
2. Switch do projektu B → toggle presale on → restart → nowe skills **niewidoczne** ❌ (przed fix)

Po tym fix scenario 2 też działa.

## Tests

- `project-state.service.spec.ts` — 2 nowe testy:
  - happy: restart + invalidate_slash_cache + notifyReady
  - error: restart fail → ani invalidate ani ready nie odpalają (guard)
- 1572/1572 frontend tests pass
- Lint + prettier clean