### PR TITLE
feat(desktop): handle CloudStorage TCC permission errors with retry UI (#579)

### DIFF
--- a/crates/speedwave-runtime/src/cloudstorage.rs
+++ b/crates/speedwave-runtime/src/cloudstorage.rs
@@ -1,0 +1,416 @@
+// CloudStorage TCC detection, probe, classification, and upstream helper.
+//
+// macOS CloudStorage services (OneDrive, Dropbox, Google Drive) require
+// Transparency Consent and Control (TCC) permission before the app can
+// read directories managed by those services. When TCC is missing,
+// `read_dir` returns EPERM (errno 13). This module centralizes all
+// detection and reporting logic so every Tauri command entry point uses
+// the same probe.
+
+use std::io::ErrorKind;
+use std::path::Path;
+use std::time::Duration;
+
+/// Error prefix embedded in `Err(...)` strings when a CloudStorage TCC
+/// permission failure is detected. Format: `"CloudStorage TCC required: {stable_id}|{dir}"`.
+/// Recognized by `restore_projects` (reconcile.rs) for substitution and by
+/// `compute_project_switch_failure_payload` (main.rs) for UI routing.
+///
+/// SSOT — TypeScript callers mirror this via `cloudstorage-prefix.ts`.
+pub use crate::consts::CLOUDSTORAGE_TCC_PREFIX;
+
+/// User-facing substituted message used by both interactive and
+/// non-interactive surfaces when a CloudStorage TCC failure is detected.
+/// SSOT — Rust callers use it directly; TypeScript callers can use a
+/// matching constant in cloudstorage-prefix.ts (test-asserted to match).
+pub const TCC_USER_REMEDIATION_MESSAGE: &str =
+    "Cloud storage permission required. Open the project from the project view to resolve.";
+
+/// Probe timeout for a single `read_dir` attempt on a CloudStorage path.
+/// CloudStorage directories under TCC denial respond immediately with EPERM,
+/// so 5 s is generous — the timeout primarily guards against unexpected
+/// network-backed mounts stalling.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Known CloudStorage provider identifiers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CloudStorageProvider {
+    OneDrive,
+    Dropbox,
+    GoogleDrive,
+}
+
+impl CloudStorageProvider {
+    /// Human-readable display name for UI messages.
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            Self::OneDrive => "OneDrive",
+            Self::Dropbox => "Dropbox",
+            Self::GoogleDrive => "Google Drive",
+        }
+    }
+
+    /// Stable lowercase identifier embedded in TCC prefix strings.
+    /// Kept stable across versions so prefix parsing is backward-compatible.
+    pub fn stable_id(&self) -> &'static str {
+        match self {
+            Self::OneDrive => "one_drive",
+            Self::Dropbox => "dropbox",
+            Self::GoogleDrive => "google_drive",
+        }
+    }
+
+    /// Parse a stable identifier back to its provider.
+    pub fn from_stable_id(id: &str) -> Option<Self> {
+        match id {
+            "one_drive" => Some(Self::OneDrive),
+            "dropbox" => Some(Self::Dropbox),
+            "google_drive" => Some(Self::GoogleDrive),
+            _ => None,
+        }
+    }
+}
+
+/// Detects whether `path` is inside a known CloudStorage managed directory.
+///
+/// Returns `Some(provider)` if the path is under a recognized CloudStorage
+/// root, `None` otherwise. macOS-only detection; other platforms always
+/// return `None`.
+#[cfg(target_os = "macos")]
+pub fn detect_cloudstorage_provider(path: &Path) -> Option<CloudStorageProvider> {
+    let path_str = path.to_string_lossy();
+
+    // OneDrive: ~/Library/CloudStorage/OneDrive-* or ~/OneDrive*
+    if path_str.contains("/Library/CloudStorage/OneDrive") || path_str.contains("/OneDrive") {
+        return Some(CloudStorageProvider::OneDrive);
+    }
+
+    // Dropbox: ~/Dropbox or ~/Library/CloudStorage/Dropbox
+    if path_str.contains("/Library/CloudStorage/Dropbox") || path_str.contains("/Dropbox") {
+        return Some(CloudStorageProvider::Dropbox);
+    }
+
+    // Google Drive: ~/Library/CloudStorage/GoogleDrive-*
+    if path_str.contains("/Library/CloudStorage/GoogleDrive") || path_str.contains("/Google Drive")
+    {
+        return Some(CloudStorageProvider::GoogleDrive);
+    }
+
+    None
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn detect_cloudstorage_provider(_path: &Path) -> Option<CloudStorageProvider> {
+    None
+}
+
+/// Returns `true` if the IO error represents a TCC/permission denial.
+pub fn is_permission_error(err: &std::io::Error) -> bool {
+    matches!(err.kind(), ErrorKind::PermissionDenied)
+}
+
+/// Probes whether `path` is readable with a timeout.
+///
+/// Spawns a blocking thread and joins with a timeout. If `read_dir` returns
+/// a permission error, classifies it as a TCC failure. Other errors and
+/// timeouts return `Ok(())` (non-CloudStorage failure — let the caller
+/// handle it normally).
+pub fn check_path_readable_with_timeout(path: &Path) -> Result<(), std::io::Error> {
+    let path_owned = path.to_path_buf();
+    let (tx, rx) = std::sync::mpsc::channel();
+
+    std::thread::spawn(move || {
+        let result = std::fs::read_dir(&path_owned);
+        let _ = tx.send(result);
+    });
+
+    match rx.recv_timeout(PROBE_TIMEOUT) {
+        Ok(result) => result.map(|_| ()),
+        Err(_timeout) => Ok(()), // timeout — treat as non-blocking, let normal path handle it
+    }
+}
+
+/// Classifies a runtime error string as a CloudStorage TCC failure.
+///
+/// Returns `Some(provider)` if the error message suggests a CloudStorage
+/// EPERM condition for a known provider path, `None` otherwise.
+pub fn classify_runtime_error(error: &str) -> Option<CloudStorageProvider> {
+    if !error.to_lowercase().contains("permission denied")
+        && !error.contains("os error 13")
+        && !error.to_lowercase().contains("eperm")
+    {
+        return None;
+    }
+
+    // Check for CloudStorage path fragments in the error
+    for (fragment, provider) in [
+        ("OneDrive", CloudStorageProvider::OneDrive),
+        ("Dropbox", CloudStorageProvider::Dropbox),
+        ("GoogleDrive", CloudStorageProvider::GoogleDrive),
+        ("Google Drive", CloudStorageProvider::GoogleDrive),
+        ("CloudStorage", CloudStorageProvider::OneDrive), // generic fallback
+    ] {
+        if error.contains(fragment) {
+            return Some(provider);
+        }
+    }
+
+    None
+}
+
+/// Checks whether a path under a detected CloudStorage provider is readable.
+///
+/// Returns:
+/// - `Ok(())` if not a CloudStorage path, or if readable
+/// - `Err(provider)` if CloudStorage detected and TCC EPERM observed
+pub fn check_cloudstorage_readability(path: &Path) -> Result<(), CloudStorageProvider> {
+    let Some(provider) = detect_cloudstorage_provider(path) else {
+        return Ok(());
+    };
+
+    match check_path_readable_with_timeout(path) {
+        Err(e) if is_permission_error(&e) => Err(provider),
+        _ => Ok(()),
+    }
+}
+
+/// Pre-flight check for Tauri command entry points.
+///
+/// If `project_path` is under a CloudStorage provider and reading it fails
+/// with EPERM, returns a prefix-encoded error string. The prefix is recognized
+/// by `restore_projects` (for substitution) and `compute_project_switch_failure_payload`
+/// (for UI routing). On non-macOS platforms or non-CloudStorage paths, returns `Ok(())`.
+pub fn check_project_readable_or_err(project_path: &Path) -> Result<(), String> {
+    match check_cloudstorage_readability(project_path) {
+        Ok(()) => Ok(()),
+        Err(provider) => Err(format!(
+            "{}{}|{}",
+            CLOUDSTORAGE_TCC_PREFIX,
+            provider.stable_id(),
+            project_path.display()
+        )),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    // -- TCC_USER_REMEDIATION_MESSAGE tests (§5.1) --
+
+    #[test]
+    fn tcc_user_remediation_message_is_non_empty_and_actionable() {
+        assert!(
+            !TCC_USER_REMEDIATION_MESSAGE.is_empty(),
+            "TCC_USER_REMEDIATION_MESSAGE must not be empty"
+        );
+        assert!(
+            TCC_USER_REMEDIATION_MESSAGE
+                .to_lowercase()
+                .contains("permission"),
+            "TCC_USER_REMEDIATION_MESSAGE must contain the word 'permission'"
+        );
+        assert!(
+            TCC_USER_REMEDIATION_MESSAGE.contains("project view"),
+            "TCC_USER_REMEDIATION_MESSAGE must mention 'project view'"
+        );
+    }
+
+    #[test]
+    fn tcc_user_remediation_message_does_not_leak_prefix() {
+        assert!(
+            !TCC_USER_REMEDIATION_MESSAGE.contains(crate::consts::CLOUDSTORAGE_TCC_PREFIX),
+            "TCC_USER_REMEDIATION_MESSAGE must not contain the TCC prefix (prevents re-substitution)"
+        );
+    }
+
+    // -- CloudStorageProvider tests --
+
+    #[test]
+    fn provider_display_names_are_non_empty() {
+        for provider in [
+            CloudStorageProvider::OneDrive,
+            CloudStorageProvider::Dropbox,
+            CloudStorageProvider::GoogleDrive,
+        ] {
+            assert!(
+                !provider.display_name().is_empty(),
+                "display_name for {:?} must not be empty",
+                provider
+            );
+        }
+    }
+
+    #[test]
+    fn provider_stable_ids_are_lowercase_with_underscores() {
+        for provider in [
+            CloudStorageProvider::OneDrive,
+            CloudStorageProvider::Dropbox,
+            CloudStorageProvider::GoogleDrive,
+        ] {
+            let id = provider.stable_id();
+            assert!(
+                id.chars().all(|c| c.is_ascii_lowercase() || c == '_'),
+                "stable_id for {:?} must be lowercase with underscores, got: {}",
+                provider,
+                id
+            );
+        }
+    }
+
+    #[test]
+    fn provider_from_stable_id_roundtrip() {
+        for provider in [
+            CloudStorageProvider::OneDrive,
+            CloudStorageProvider::Dropbox,
+            CloudStorageProvider::GoogleDrive,
+        ] {
+            let id = provider.stable_id();
+            let recovered = CloudStorageProvider::from_stable_id(id);
+            assert_eq!(
+                recovered,
+                Some(provider.clone()),
+                "from_stable_id({id}) must round-trip back to {:?}",
+                provider
+            );
+        }
+    }
+
+    #[test]
+    fn provider_from_stable_id_unknown_returns_none() {
+        assert!(CloudStorageProvider::from_stable_id("unknown").is_none());
+        assert!(CloudStorageProvider::from_stable_id("").is_none());
+        assert!(CloudStorageProvider::from_stable_id("onedrive").is_none());
+    }
+
+    // -- detect_cloudstorage_provider tests --
+
+    #[test]
+    fn detect_onedrive_library_cloudstorgage() {
+        let path = Path::new("/Users/alice/Library/CloudStorage/OneDrive-Personal/Projects/foo");
+        let result = detect_cloudstorage_provider(path);
+        #[cfg(target_os = "macos")]
+        assert_eq!(result, Some(CloudStorageProvider::OneDrive));
+        #[cfg(not(target_os = "macos"))]
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn detect_dropbox_home() {
+        let path = Path::new("/Users/alice/Dropbox/Projects/myproject");
+        let result = detect_cloudstorage_provider(path);
+        #[cfg(target_os = "macos")]
+        assert_eq!(result, Some(CloudStorageProvider::Dropbox));
+        #[cfg(not(target_os = "macos"))]
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn detect_google_drive_library() {
+        let path = Path::new(
+            "/Users/alice/Library/CloudStorage/GoogleDrive-alice@example.com/My Drive/Projects",
+        );
+        let result = detect_cloudstorage_provider(path);
+        #[cfg(target_os = "macos")]
+        assert_eq!(result, Some(CloudStorageProvider::GoogleDrive));
+        #[cfg(not(target_os = "macos"))]
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn detect_regular_home_dir_is_none() {
+        let path = Path::new("/Users/alice/Projects/myproject");
+        assert!(detect_cloudstorage_provider(path).is_none());
+    }
+
+    #[test]
+    fn detect_tmp_path_is_none() {
+        let path = Path::new("/tmp/myproject");
+        assert!(detect_cloudstorage_provider(path).is_none());
+    }
+
+    // -- is_permission_error tests --
+
+    #[test]
+    fn is_permission_error_detects_eperm() {
+        let err = std::io::Error::from(std::io::ErrorKind::PermissionDenied);
+        assert!(is_permission_error(&err));
+    }
+
+    #[test]
+    fn is_permission_error_does_not_match_not_found() {
+        let err = std::io::Error::from(std::io::ErrorKind::NotFound);
+        assert!(!is_permission_error(&err));
+    }
+
+    #[test]
+    fn is_permission_error_does_not_match_connection_refused() {
+        let err = std::io::Error::from(std::io::ErrorKind::ConnectionRefused);
+        assert!(!is_permission_error(&err));
+    }
+
+    // -- classify_runtime_error tests --
+
+    #[test]
+    fn classify_runtime_error_detects_onedrive_permission_denied() {
+        let err = "os error 13: Permission denied accessing /Users/alice/Library/CloudStorage/OneDrive-Personal/foo";
+        let result = classify_runtime_error(err);
+        assert!(result.is_some(), "should detect CloudStorage provider");
+    }
+
+    #[test]
+    fn classify_runtime_error_ignores_unrelated_permission_error() {
+        let err = "Permission denied accessing /etc/shadow";
+        let result = classify_runtime_error(err);
+        assert!(
+            result.is_none(),
+            "non-CloudStorage permission error must not be classified"
+        );
+    }
+
+    #[test]
+    fn classify_runtime_error_ignores_non_permission_error() {
+        let err = "network unreachable for /Users/alice/Library/CloudStorage/OneDrive-Personal/foo";
+        let result = classify_runtime_error(err);
+        assert!(
+            result.is_none(),
+            "non-permission error must not be classified"
+        );
+    }
+
+    // -- check_project_readable_or_err tests --
+
+    #[test]
+    fn check_project_readable_or_err_non_cloudstorage_returns_ok() {
+        let path = Path::new("/tmp");
+        let result = check_project_readable_or_err(path);
+        assert!(result.is_ok(), "non-CloudStorage path must return Ok");
+    }
+
+    #[test]
+    fn check_project_readable_or_err_error_contains_prefix() {
+        // This test simulates what would happen on macOS with a TCC-denied path.
+        // Since we can't reproduce the actual TCC denial in a unit test, we verify
+        // the error format by calling the formatting logic directly.
+        let provider = CloudStorageProvider::OneDrive;
+        let path = Path::new("/Users/alice/Library/CloudStorage/OneDrive-Personal/Projects/foo");
+        let formatted = format!(
+            "{}{}|{}",
+            crate::consts::CLOUDSTORAGE_TCC_PREFIX,
+            provider.stable_id(),
+            path.display()
+        );
+        assert!(formatted.starts_with(crate::consts::CLOUDSTORAGE_TCC_PREFIX));
+        assert!(formatted.contains("one_drive"));
+        assert!(formatted.contains(path.to_str().unwrap()));
+    }
+
+    #[test]
+    fn check_project_readable_or_err_existing_readable_dir_returns_ok() {
+        // /tmp is always readable and is not a CloudStorage path
+        let path = Path::new("/tmp");
+        let result = check_project_readable_or_err(path);
+        assert!(result.is_ok());
+    }
+}

--- a/crates/speedwave-runtime/src/cloudstorage.rs
+++ b/crates/speedwave-runtime/src/cloudstorage.rs
@@ -76,22 +76,68 @@ impl CloudStorageProvider {
 /// Returns `Some(provider)` if the path is under a recognized CloudStorage
 /// root, `None` otherwise. macOS-only detection; other platforms always
 /// return `None`.
+///
+/// Provider tokens are matched only at component boundaries — i.e. either
+/// directly under `~/Library/CloudStorage/<Token>...` or as a top-level
+/// subdirectory of the user's home (`/Users/<u>/<Token>...`). A path like
+/// `/Users/alice/Projects/NotOneDriveBackup` is **not** matched.
 #[cfg(target_os = "macos")]
 pub fn detect_cloudstorage_provider(path: &Path) -> Option<CloudStorageProvider> {
+    /// Returns true if `haystack` contains `needle` followed by a path
+    /// component boundary — the next byte is `/`, `-`, or end-of-string.
+    fn contains_at_boundary(haystack: &str, needle: &str) -> bool {
+        let mut search_from = 0;
+        while let Some(rel) = haystack[search_from..].find(needle) {
+            let abs = search_from + rel;
+            let after = abs + needle.len();
+            match haystack.as_bytes().get(after) {
+                None | Some(b'/') | Some(b'-') => return true,
+                _ => search_from = abs + 1,
+            }
+        }
+        false
+    }
+
+    /// Returns true if `path` is `/Users/<user>/<token>...` — i.e. `token`
+    /// appears as a top-level component directly under the user's home.
+    fn is_top_level_under_users(path: &str, token: &str) -> bool {
+        let after_users = match path.strip_prefix("/Users/") {
+            Some(rest) => rest,
+            None => return false,
+        };
+        // Skip the username component
+        let username_end = match after_users.find('/') {
+            Some(i) => i,
+            None => return false,
+        };
+        let after_user = &after_users[username_end + 1..];
+        // The remaining path must start with `<token>` and the next byte
+        // must be a component boundary.
+        if let Some(tail) = after_user.strip_prefix(token) {
+            return tail.is_empty() || tail.starts_with('/') || tail.starts_with('-');
+        }
+        false
+    }
+
     let path_str = path.to_string_lossy();
 
-    // OneDrive: ~/Library/CloudStorage/OneDrive-* or ~/OneDrive*
-    if path_str.contains("/Library/CloudStorage/OneDrive") || path_str.contains("/OneDrive") {
+    // OneDrive: ~/Library/CloudStorage/OneDrive(-…)? or ~/OneDrive(-…)?
+    if contains_at_boundary(&path_str, "/Library/CloudStorage/OneDrive")
+        || is_top_level_under_users(&path_str, "OneDrive")
+    {
         return Some(CloudStorageProvider::OneDrive);
     }
 
-    // Dropbox: ~/Dropbox or ~/Library/CloudStorage/Dropbox
-    if path_str.contains("/Library/CloudStorage/Dropbox") || path_str.contains("/Dropbox") {
+    // Dropbox: ~/Library/CloudStorage/Dropbox… or ~/Dropbox…
+    if contains_at_boundary(&path_str, "/Library/CloudStorage/Dropbox")
+        || is_top_level_under_users(&path_str, "Dropbox")
+    {
         return Some(CloudStorageProvider::Dropbox);
     }
 
-    // Google Drive: ~/Library/CloudStorage/GoogleDrive-*
-    if path_str.contains("/Library/CloudStorage/GoogleDrive") || path_str.contains("/Google Drive")
+    // Google Drive: ~/Library/CloudStorage/GoogleDrive(-…)? or ~/Google Drive…
+    if contains_at_boundary(&path_str, "/Library/CloudStorage/GoogleDrive")
+        || is_top_level_under_users(&path_str, "Google Drive")
     {
         return Some(CloudStorageProvider::GoogleDrive);
     }
@@ -128,34 +174,6 @@ pub fn check_path_readable_with_timeout(path: &Path) -> Result<(), std::io::Erro
         Ok(result) => result.map(|_| ()),
         Err(_timeout) => Ok(()), // timeout — treat as non-blocking, let normal path handle it
     }
-}
-
-/// Classifies a runtime error string as a CloudStorage TCC failure.
-///
-/// Returns `Some(provider)` if the error message suggests a CloudStorage
-/// EPERM condition for a known provider path, `None` otherwise.
-pub fn classify_runtime_error(error: &str) -> Option<CloudStorageProvider> {
-    if !error.to_lowercase().contains("permission denied")
-        && !error.contains("os error 13")
-        && !error.to_lowercase().contains("eperm")
-    {
-        return None;
-    }
-
-    // Check for CloudStorage path fragments in the error
-    for (fragment, provider) in [
-        ("OneDrive", CloudStorageProvider::OneDrive),
-        ("Dropbox", CloudStorageProvider::Dropbox),
-        ("GoogleDrive", CloudStorageProvider::GoogleDrive),
-        ("Google Drive", CloudStorageProvider::GoogleDrive),
-        ("CloudStorage", CloudStorageProvider::OneDrive), // generic fallback
-    ] {
-        if error.contains(fragment) {
-            return Some(provider);
-        }
-    }
-
-    None
 }
 
 /// Checks whether a path under a detected CloudStorage provider is readable.
@@ -287,7 +305,7 @@ mod tests {
     // -- detect_cloudstorage_provider tests --
 
     #[test]
-    fn detect_onedrive_library_cloudstorgage() {
+    fn detect_onedrive_library_cloudstorage() {
         let path = Path::new("/Users/alice/Library/CloudStorage/OneDrive-Personal/Projects/foo");
         let result = detect_cloudstorage_provider(path);
         #[cfg(target_os = "macos")]
@@ -330,6 +348,28 @@ mod tests {
         assert!(detect_cloudstorage_provider(path).is_none());
     }
 
+    #[test]
+    fn detect_substring_false_positive_is_none() {
+        // Regression: a directory whose name contains "OneDrive" mid-token
+        // (e.g. "NotOneDriveBackup") must NOT be misclassified as OneDrive.
+        let path = Path::new("/Users/alice/Projects/NotOneDriveBackup");
+        assert!(detect_cloudstorage_provider(path).is_none());
+    }
+
+    #[test]
+    fn detect_dropbox_substring_false_positive_is_none() {
+        let path = Path::new("/Users/alice/Projects/MyDropboxClone");
+        assert!(detect_cloudstorage_provider(path).is_none());
+    }
+
+    #[test]
+    fn detect_onedrive_outside_users_is_none() {
+        // Token at component boundary but not under /Users/ — not a real
+        // CloudStorage mount. Avoids matching test fixtures and tmp paths.
+        let path = Path::new("/tmp/OneDrive/foo");
+        assert!(detect_cloudstorage_provider(path).is_none());
+    }
+
     // -- is_permission_error tests --
 
     #[test]
@@ -348,35 +388,6 @@ mod tests {
     fn is_permission_error_does_not_match_connection_refused() {
         let err = std::io::Error::from(std::io::ErrorKind::ConnectionRefused);
         assert!(!is_permission_error(&err));
-    }
-
-    // -- classify_runtime_error tests --
-
-    #[test]
-    fn classify_runtime_error_detects_onedrive_permission_denied() {
-        let err = "os error 13: Permission denied accessing /Users/alice/Library/CloudStorage/OneDrive-Personal/foo";
-        let result = classify_runtime_error(err);
-        assert!(result.is_some(), "should detect CloudStorage provider");
-    }
-
-    #[test]
-    fn classify_runtime_error_ignores_unrelated_permission_error() {
-        let err = "Permission denied accessing /etc/shadow";
-        let result = classify_runtime_error(err);
-        assert!(
-            result.is_none(),
-            "non-CloudStorage permission error must not be classified"
-        );
-    }
-
-    #[test]
-    fn classify_runtime_error_ignores_non_permission_error() {
-        let err = "network unreachable for /Users/alice/Library/CloudStorage/OneDrive-Personal/foo";
-        let result = classify_runtime_error(err);
-        assert!(
-            result.is_none(),
-            "non-permission error must not be classified"
-        );
     }
 
     // -- check_project_readable_or_err tests --

--- a/crates/speedwave-runtime/src/consts.rs
+++ b/crates/speedwave-runtime/src/consts.rs
@@ -152,6 +152,15 @@ pub const LOCAL_LLM_SYSTEM_PROMPT_PATH: &str = "/speedwave/resources/system-prom
 /// from dismissable (error) failures.
 pub const SYSTEM_CHECK_FAILED_PREFIX: &str = "System check failed:";
 
+/// Error prefix embedded in `Err(...)` strings when a CloudStorage TCC
+/// permission failure is detected. Format:
+/// `"CloudStorage TCC required: {stable_id}|{dir}"`.
+///
+/// Recognized by `restore_projects` (reconcile.rs) for substitution and by
+/// `compute_project_switch_failure_payload` (main.rs) for UI routing.
+/// TypeScript callers mirror this via `cloudstorage-prefix.ts`.
+pub const CLOUDSTORAGE_TCC_PREFIX: &str = "CloudStorage TCC required: ";
+
 /// Default interval (in hours) between automatic update checks.
 /// Used by both the CLI (converted to seconds) and the Desktop updater
 /// (as the default for `UpdateSettings::check_interval_hours`).
@@ -1292,6 +1301,31 @@ mod tests {
             SYSTEM_CHECK_FAILED_PREFIX, "System check failed:",
             "Changing this prefix silently breaks the Desktop UI — \
              update project-state.service.ts startsWith check to match"
+        );
+    }
+
+    /// Guard: CLOUDSTORAGE_TCC_PREFIX must be non-empty and end with ": ".
+    #[test]
+    fn test_cloudstorage_tcc_prefix_is_non_empty_and_ends_with_colon_space() {
+        assert!(!CLOUDSTORAGE_TCC_PREFIX.is_empty());
+        assert!(
+            CLOUDSTORAGE_TCC_PREFIX.ends_with(": "),
+            "CLOUDSTORAGE_TCC_PREFIX must end with ': ' for consistent parsing, got: {:?}",
+            CLOUDSTORAGE_TCC_PREFIX
+        );
+    }
+
+    /// Guard: the two error prefixes must be disjoint — neither is a prefix of the other.
+    /// This prevents a single `starts_with` check from accidentally matching both.
+    #[test]
+    fn test_cloudstorage_and_system_check_prefixes_are_disjoint() {
+        assert!(
+            !CLOUDSTORAGE_TCC_PREFIX.starts_with(SYSTEM_CHECK_FAILED_PREFIX),
+            "CLOUDSTORAGE_TCC_PREFIX must not start with SYSTEM_CHECK_FAILED_PREFIX"
+        );
+        assert!(
+            !SYSTEM_CHECK_FAILED_PREFIX.starts_with(CLOUDSTORAGE_TCC_PREFIX),
+            "SYSTEM_CHECK_FAILED_PREFIX must not start with CLOUDSTORAGE_TCC_PREFIX"
         );
     }
 

--- a/crates/speedwave-runtime/src/lib.rs
+++ b/crates/speedwave-runtime/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod binary;
 pub mod build;
 pub mod bundle;
+pub mod cloudstorage;
 pub mod compose;
 pub mod config;
 pub mod consts;

--- a/desktop/src-tauri/src/cloudstorage_cmd.rs
+++ b/desktop/src-tauri/src/cloudstorage_cmd.rs
@@ -1,0 +1,73 @@
+// Tauri commands for CloudStorage detection (used by CreateProjectModal).
+
+use serde::Serialize;
+
+/// Response from `detect_cloudstorage_path`.
+#[derive(Debug, Serialize)]
+pub struct CloudStorageDetectionResult {
+    /// Whether the given path is inside a known CloudStorage managed directory.
+    pub is_cloudstorage: bool,
+    /// Human-readable provider name if detected (e.g. "OneDrive"), or null.
+    pub provider: Option<String>,
+}
+
+/// Detects whether `dir` is inside a known CloudStorage managed directory.
+///
+/// Used by `CreateProjectModal` to warn the user before they add a project
+/// from a CloudStorage location that may require TCC permission.
+#[tauri::command]
+pub fn detect_cloudstorage_path(dir: String) -> Result<CloudStorageDetectionResult, String> {
+    let path = std::path::Path::new(&dir);
+    match speedwave_runtime::cloudstorage::detect_cloudstorage_provider(path) {
+        Some(provider) => Ok(CloudStorageDetectionResult {
+            is_cloudstorage: true,
+            provider: Some(provider.display_name().to_string()),
+        }),
+        None => Ok(CloudStorageDetectionResult {
+            is_cloudstorage: false,
+            provider: None,
+        }),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_cloudstorage_path_non_cloudstorage_returns_false() {
+        let result = detect_cloudstorage_path("/tmp/myproject".to_string()).unwrap();
+        assert!(!result.is_cloudstorage);
+        assert!(result.provider.is_none());
+    }
+
+    #[test]
+    fn detect_cloudstorage_path_home_projects_returns_false() {
+        let result =
+            detect_cloudstorage_path("/Users/alice/Projects/myproject".to_string()).unwrap();
+        assert!(!result.is_cloudstorage);
+        assert!(result.provider.is_none());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn detect_cloudstorage_path_onedrive_returns_true() {
+        let result = detect_cloudstorage_path(
+            "/Users/alice/Library/CloudStorage/OneDrive-Personal/Projects/foo".to_string(),
+        )
+        .unwrap();
+        assert!(result.is_cloudstorage);
+        assert_eq!(result.provider.as_deref(), Some("OneDrive"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn detect_cloudstorage_path_dropbox_returns_true() {
+        let result =
+            detect_cloudstorage_path("/Users/alice/Dropbox/Projects/myproject".to_string())
+                .unwrap();
+        assert!(result.is_cloudstorage);
+        assert_eq!(result.provider.as_deref(), Some("Dropbox"));
+    }
+}

--- a/desktop/src-tauri/src/containers_cmd.rs
+++ b/desktop/src-tauri/src/containers_cmd.rs
@@ -137,6 +137,8 @@ pub(crate) fn render_and_save_compose(
         .ok_or_else(|| format!("project '{}' not found", project))?;
 
     let project_path = std::path::Path::new(&project_dir);
+    // Defense-in-depth: pre-flight CloudStorage TCC check before any compose render.
+    speedwave_runtime::cloudstorage::check_project_readable_or_err(project_path)?;
     let (resolved, integrations) =
         config::resolve_project_config(project_path, &user_config, project);
 
@@ -324,6 +326,20 @@ pub async fn add_project(
     // Start subsystems on-demand (e.g. after factory reset / fresh install)
     crate::ensure_mcp_os_running(&mcp_os, &app, compose_lock.inner().clone());
     crate::ensure_ide_bridge_running(&ide_bridge, &app);
+
+    // Pre-flight: detect CloudStorage TCC denial before adding project.
+    {
+        let dir_clone = dir.clone();
+        let preflight_result = tokio::task::spawn_blocking(move || {
+            speedwave_runtime::cloudstorage::check_project_readable_or_err(std::path::Path::new(
+                &dir_clone,
+            ))
+        })
+        .await
+        .map_err(|e| e.to_string())?;
+        preflight_result?;
+    }
+
     // Capture previous active project BEFORE runtime sets new one
     let previous = config::with_config_lock(|| {
         let cfg = config::load_user_config()?;
@@ -436,6 +452,14 @@ pub async fn start_containers(
     tokio::task::spawn_blocking(move || {
         ensure_images_ready()?;
         check_project(&project)?;
+        // Pre-flight: detect CloudStorage TCC denial before attempting container start.
+        if let Ok(cfg) = speedwave_runtime::config::load_user_config() {
+            if let Some(p) = cfg.find_project(&project) {
+                speedwave_runtime::cloudstorage::check_project_readable_or_err(
+                    std::path::Path::new(&p.dir),
+                )?;
+            }
+        }
         log::info!("start_containers: project={project}");
         setup_wizard::start_containers(&project).map_err(|e| {
             log::error!("start_containers: error: {e}");
@@ -495,6 +519,14 @@ pub async fn recreate_project_containers(project: String) -> Result<(), String> 
     tokio::task::spawn_blocking(move || {
         ensure_images_ready()?;
         check_project(&project)?;
+        // Pre-flight: detect CloudStorage TCC denial before container recreate.
+        if let Ok(cfg) = speedwave_runtime::config::load_user_config() {
+            if let Some(p) = cfg.find_project(&project) {
+                speedwave_runtime::cloudstorage::check_project_readable_or_err(
+                    std::path::Path::new(&p.dir),
+                )?;
+            }
+        }
         log::info!("recreate_project_containers: project={project}");
         let rt = speedwave_runtime::runtime::detect_runtime();
 

--- a/desktop/src-tauri/src/integrations_cmd.rs
+++ b/desktop/src-tauri/src/integrations_cmd.rs
@@ -664,6 +664,14 @@ pub fn delete_integration_credentials(project: String, service: String) -> Resul
 pub async fn restart_integration_containers(project: String) -> Result<(), String> {
     tokio::task::spawn_blocking(move || {
         check_project(&project)?;
+        // Pre-flight: detect CloudStorage TCC denial before restarting containers.
+        if let Ok(cfg) = speedwave_runtime::config::load_user_config() {
+            if let Some(p) = cfg.find_project(&project) {
+                speedwave_runtime::cloudstorage::check_project_readable_or_err(
+                    std::path::Path::new(&p.dir),
+                )?;
+            }
+        }
         log::info!("restart_integration_containers: project={project}");
         let rt = speedwave_runtime::runtime::detect_runtime();
 

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -10,6 +10,7 @@
 mod auth;
 mod auth_commands;
 mod chat;
+mod cloudstorage_cmd;
 mod container_logs_cmd;
 mod containers_cmd;
 mod diagnostics;
@@ -34,6 +35,7 @@ mod retry_cmd;
 mod setup_wizard;
 mod slash_cmd;
 mod subscribe_cmd;
+mod system_settings_cmd;
 mod tray;
 mod types;
 mod update_commands;
@@ -1453,6 +1455,9 @@ fn main() {
             slash_cmd::invalidate_slash_cache,
             // Git introspection (chat status strip)
             git_cmd::get_git_branch,
+            // CloudStorage TCC
+            system_settings_cmd::open_files_folders_pane,
+            cloudstorage_cmd::detect_cloudstorage_path,
         ])
         .on_window_event(move |window, event| {
             match event {

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -520,6 +520,54 @@ fn rebind_chat(
     session.start(app.clone(), None).map_err(|e| e.to_string())
 }
 
+/// Parses a prefix-encoded CloudStorage TCC error into the `(stable_id, dir)`
+/// pair if present, otherwise returns `None`.
+///
+/// Format produced by `cloudstorage::check_project_readable_or_err`:
+/// `"CloudStorage TCC required: {stable_id}|{dir}"`. Tolerates extra suffix
+/// text that downstream wrappers may have appended after the dir.
+fn parse_cloudstorage_tcc_error(error: &str) -> Option<(&str, &str)> {
+    let body = error.strip_prefix(speedwave_runtime::cloudstorage::CLOUDSTORAGE_TCC_PREFIX)?;
+    let pipe_idx = body.find('|')?;
+    let (stable_id, rest) = body.split_at(pipe_idx);
+    // rest starts with '|'
+    let dir = rest[1..]
+        .split_once(". ")
+        .map(|(d, _)| d)
+        .unwrap_or(&rest[1..]);
+    Some((stable_id, dir))
+}
+
+/// Builds the JSON payload for the `project_switch_failed` Tauri event.
+///
+/// Pure function (no IO) so it can be unit-tested independently of Tauri.
+/// When the error string is prefix-encoded with `CLOUDSTORAGE_TCC_PREFIX`,
+/// emits structured `error_kind`/`provider`/`project_dir` fields so the
+/// frontend can route to the CloudStorage remediation modal. Otherwise
+/// emits only `project` + `error`.
+pub(crate) fn compute_project_switch_failure_payload(
+    previous: Option<&str>,
+    full_error: &str,
+) -> serde_json::Value {
+    use speedwave_runtime::cloudstorage::CloudStorageProvider;
+
+    if let Some((stable_id, dir)) = parse_cloudstorage_tcc_error(full_error) {
+        let provider = CloudStorageProvider::from_stable_id(stable_id);
+        return serde_json::json!({
+            "project": previous,
+            "error": full_error,
+            "error_kind": "cloudstorage_tcc_required",
+            "provider": provider.as_ref().map(|p| p.display_name()),
+            "project_dir": dir,
+        });
+    }
+
+    serde_json::json!({
+        "project": previous,
+        "error": full_error,
+    })
+}
+
 pub(crate) fn rollback_and_emit_failed(
     app: &tauri::AppHandle,
     previous: Option<String>,
@@ -543,14 +591,10 @@ pub(crate) fn rollback_and_emit_failed(
     }
     let full_error = parts.join(". ");
 
+    let payload = compute_project_switch_failure_payload(previous.as_deref(), &full_error);
+
     use tauri::Emitter;
-    let _ = app.emit(
-        "project_switch_failed",
-        serde_json::json!({
-            "project": previous,
-            "error": full_error,
-        }),
-    );
+    let _ = app.emit("project_switch_failed", payload);
 
     full_error
 }
@@ -2136,5 +2180,65 @@ mod tests {
             body.contains("spawn_blocking"),
             "stop_chat must use spawn_blocking to avoid blocking the main thread"
         );
+    }
+
+    // -- compute_project_switch_failure_payload tests --
+
+    #[test]
+    fn payload_for_generic_error_omits_cloudstorage_fields() {
+        let payload =
+            compute_project_switch_failure_payload(Some("acme"), "Container restore failed");
+        assert_eq!(payload["project"], "acme");
+        assert_eq!(payload["error"], "Container restore failed");
+        assert!(payload.get("error_kind").is_none());
+        assert!(payload.get("provider").is_none());
+        assert!(payload.get("project_dir").is_none());
+    }
+
+    #[test]
+    fn payload_for_cloudstorage_error_includes_structured_fields() {
+        let err = "CloudStorage TCC required: one_drive|/Users/alice/Library/CloudStorage/OneDrive-Personal/p";
+        let payload = compute_project_switch_failure_payload(Some("acme"), err);
+        assert_eq!(payload["error_kind"], "cloudstorage_tcc_required");
+        assert_eq!(payload["provider"], "OneDrive");
+        assert_eq!(
+            payload["project_dir"],
+            "/Users/alice/Library/CloudStorage/OneDrive-Personal/p"
+        );
+        assert_eq!(payload["error"], err);
+        assert_eq!(payload["project"], "acme");
+    }
+
+    #[test]
+    fn payload_for_cloudstorage_error_with_appended_suffix_extracts_dir_only() {
+        let err = "CloudStorage TCC required: dropbox|/Users/alice/Dropbox/p. Config rollback failed: nope";
+        let payload = compute_project_switch_failure_payload(None, err);
+        assert_eq!(payload["error_kind"], "cloudstorage_tcc_required");
+        assert_eq!(payload["provider"], "Dropbox");
+        assert_eq!(payload["project_dir"], "/Users/alice/Dropbox/p");
+    }
+
+    #[test]
+    fn payload_for_cloudstorage_error_unknown_stable_id_emits_null_provider() {
+        let err = "CloudStorage TCC required: future_provider|/some/path";
+        let payload = compute_project_switch_failure_payload(None, err);
+        assert_eq!(payload["error_kind"], "cloudstorage_tcc_required");
+        assert!(payload["provider"].is_null());
+        assert_eq!(payload["project_dir"], "/some/path");
+    }
+
+    #[test]
+    fn payload_with_null_previous_serializes_as_null() {
+        let payload = compute_project_switch_failure_payload(None, "boom");
+        assert!(payload["project"].is_null());
+    }
+
+    #[test]
+    fn payload_for_malformed_prefix_without_pipe_falls_back_to_generic() {
+        let err = "CloudStorage TCC required: just_a_stable_id_without_pipe";
+        let payload = compute_project_switch_failure_payload(None, err);
+        assert!(payload.get("error_kind").is_none());
+        assert!(payload.get("provider").is_none());
+        assert!(payload.get("project_dir").is_none());
     }
 }

--- a/desktop/src-tauri/src/reconcile.rs
+++ b/desktop/src-tauri/src/reconcile.rs
@@ -180,15 +180,49 @@ pub(crate) fn list_running_projects(
     Ok(running)
 }
 
+/// Restores one project: compose_down, render, compose_up_recreate.
+/// Extracted for testability — `restore_projects` calls this in production.
+fn restore_one_project(
+    project: &str,
+    rt: &dyn speedwave_runtime::runtime::ContainerRuntime,
+) -> Result<(), String> {
+    let _ = rt.compose_down(project);
+    crate::containers_cmd::render_and_save_compose(project, rt)?;
+    rt.compose_up_recreate(project)
+        .map_err(|e| format!("compose_up_recreate failed for '{}': {}", project, e))
+}
+
+/// Test seam — takes the renderer as a function pointer so tests can inject stubs.
+#[cfg(test)]
+fn restore_one_project_with_renderer(
+    project: &str,
+    rt: &dyn speedwave_runtime::runtime::ContainerRuntime,
+    render: fn(&str, &dyn speedwave_runtime::runtime::ContainerRuntime) -> Result<(), String>,
+) -> Result<(), String> {
+    let _ = rt.compose_down(project);
+    render(project, rt)?;
+    rt.compose_up_recreate(project)
+        .map_err(|e| format!("compose_up_recreate failed for '{}': {}", project, e))
+}
+
 pub(crate) fn restore_projects(
     projects: &[String],
     rt: &dyn speedwave_runtime::runtime::ContainerRuntime,
 ) -> Result<(), String> {
     for project in projects {
-        let _ = rt.compose_down(project);
-        crate::containers_cmd::render_and_save_compose(project, rt)?;
-        rt.compose_up_recreate(project)
-            .map_err(|e| format!("compose_up_recreate failed for '{}': {}", project, e))?;
+        // NB1-v4 (Option C): substitute CloudStorage TCC prefix BEFORE the
+        // error escapes this function, so set_bundle_error and the wrapping
+        // "Project restore failed: {e}" caller receive user-readable text.
+        // The raw prefix is logged at warn level for diagnostics.
+        if let Err(e) = restore_one_project(project, rt) {
+            if e.starts_with(speedwave_runtime::consts::CLOUDSTORAGE_TCC_PREFIX) {
+                log::warn!("restore_projects: CloudStorage TCC required (raw prefix): {e}");
+                return Err(
+                    speedwave_runtime::cloudstorage::TCC_USER_REMEDIATION_MESSAGE.to_string(),
+                );
+            }
+            return Err(e);
+        }
     }
     Ok(())
 }

--- a/desktop/src-tauri/src/system_settings_cmd.rs
+++ b/desktop/src-tauri/src/system_settings_cmd.rs
@@ -1,0 +1,53 @@
+// Tauri commands for opening macOS System Settings panes.
+
+/// Opens the macOS System Settings "Files and Folders" (Privacy & Security) pane
+/// so the user can grant CloudStorage TCC permissions to Speedwave.
+///
+/// On non-macOS platforms this is a no-op (returns Ok).
+#[tauri::command]
+pub fn open_files_folders_pane() -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        // x-apple.systempreferences:com.apple.preference.security is the
+        // stable URL for the Privacy & Security pane on macOS 13+.
+        // The "Files and Folders" sub-pane is not directly addressable,
+        // but opening the parent pane guides the user to the right place.
+        let url = "x-apple.systempreferences:com.apple.preference.security?Privacy_FilesAndFolders";
+        std::process::Command::new("open")
+            .arg(url)
+            .spawn()
+            .map_err(|e| format!("Failed to open System Settings: {e}"))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_files_folders_pane_returns_ok_on_non_macos() {
+        // On non-macOS this is a no-op — verify it returns Ok without panicking.
+        #[cfg(not(target_os = "macos"))]
+        {
+            let result = open_files_folders_pane();
+            assert!(result.is_ok());
+        }
+        // On macOS we can only verify the function exists and compiles.
+        // Spawning `open` in CI may produce unwanted side effects.
+        #[cfg(target_os = "macos")]
+        {
+            // Structural: verify the URL constant is present in source.
+            let source = include_str!("system_settings_cmd.rs");
+            assert!(
+                source.contains("x-apple.systempreferences"),
+                "must contain the System Settings URL scheme"
+            );
+            assert!(
+                source.contains("Privacy_FilesAndFolders"),
+                "must target the Files and Folders privacy sub-pane"
+            );
+        }
+    }
+}

--- a/desktop/src/src/app/models/update.ts
+++ b/desktop/src/src/app/models/update.ts
@@ -64,3 +64,25 @@ export interface BundleReconcileStatus {
   pending_running_projects: string[];
   applied_bundle_id: string | null;
 }
+
+/**
+ * Payload emitted with the `project_switch_failed` Tauri event.
+ * Extends the basic error with optional CloudStorage failure context
+ * so the frontend can route to the CloudStorage remediation modal.
+ */
+export interface ProjectSwitchFailedPayload {
+  /** The project name that was active before the failed switch (may be null). */
+  project: string | null;
+  /** Full error message (may be user-readable or prefix-encoded). */
+  error: string;
+  /**
+   * Structured error kind for frontend routing.
+   * - `'cloudstorage_tcc_required'`: project directory is in CloudStorage with no TCC
+   * - `undefined`: generic error, show normal error banner
+   */
+  error_kind?: 'cloudstorage_tcc_required';
+  /** CloudStorage provider display name (e.g. "OneDrive") when error_kind is set. */
+  provider?: string;
+  /** Absolute path to the project directory that triggered the TCC failure. */
+  project_dir?: string;
+}

--- a/desktop/src/src/app/services/cloudstorage-prefix.ts
+++ b/desktop/src/src/app/services/cloudstorage-prefix.ts
@@ -1,0 +1,7 @@
+/**
+ * SSOT coupling helper for the CloudStorage TCC prefix string.
+ *
+ * Must stay in sync with `crates/speedwave-runtime/src/consts.rs::CLOUDSTORAGE_TCC_PREFIX`.
+ * Asserted by `cloudstorage_tcc_prefix_matches_rust_constant` in the Angular test suite.
+ */
+export const CLOUDSTORAGE_TCC_PREFIX = 'CloudStorage TCC required: ';

--- a/desktop/src/src/app/services/cloudstorage-prefix.ts
+++ b/desktop/src/src/app/services/cloudstorage-prefix.ts
@@ -5,3 +5,23 @@
  * Asserted by `cloudstorage_tcc_prefix_matches_rust_constant` in the Angular test suite.
  */
 export const CLOUDSTORAGE_TCC_PREFIX = 'CloudStorage TCC required: ';
+
+/**
+ * Maps a CloudStorage stable identifier to its display name.
+ * SSOT coupling — must stay in sync with `CloudStorageProvider::display_name`
+ * and `CloudStorageProvider::stable_id` in `crates/speedwave-runtime/src/cloudstorage.rs`.
+ * @param stableId - lowercase identifier embedded in the TCC prefix (e.g. `"one_drive"`)
+ * @returns the human-readable provider name, or `undefined` for unknown ids
+ */
+export function cloudstorageProviderDisplayName(stableId: string): string | undefined {
+  switch (stableId) {
+    case 'one_drive':
+      return 'OneDrive';
+    case 'dropbox':
+      return 'Dropbox';
+    case 'google_drive':
+      return 'Google Drive';
+    default:
+      return undefined;
+  }
+}

--- a/desktop/src/src/app/services/project-state.service.ts
+++ b/desktop/src/src/app/services/project-state.service.ts
@@ -1,6 +1,12 @@
 import { Injectable, inject } from '@angular/core';
 import { TauriService } from './tauri.service';
-import type { BundleReconcileStatus, ProjectEntry, ProjectList } from '../models/update';
+import type {
+  BundleReconcileStatus,
+  ProjectEntry,
+  ProjectList,
+  ProjectSwitchFailedPayload,
+} from '../models/update';
+import { CLOUDSTORAGE_TCC_PREFIX } from './cloudstorage-prefix';
 
 /** Lifecycle status of the project + container lifecycle. */
 export type ProjectStatus =
@@ -42,6 +48,17 @@ export class ProjectStateService {
   needsRestart = false;
   restarting = false;
   restartError = '';
+
+  /**
+   * Structured error kind set when a CloudStorage TCC failure is detected.
+   * `'cloudstorage_tcc_required'` routes the shell to `<app-cloudstorage-modal>`.
+   * Reset to `undefined` at the start of every new project switch attempt.
+   */
+  errorKind?: 'cloudstorage_tcc_required';
+  /** CloudStorage provider display name (e.g. "OneDrive") when errorKind is set. */
+  failureProvider?: string;
+  /** Absolute path to the project directory that triggered the TCC failure. */
+  failureProjectDir?: string;
 
   private initialized = false;
   private tauri = inject(TauriService);
@@ -193,8 +210,20 @@ export class ProjectStateService {
       // SSOT coupling: must match crates/speedwave-runtime/src/consts.rs SYSTEM_CHECK_FAILED_PREFIX
       if (msg.startsWith('System check failed:')) {
         this.status = 'check_failed';
+        this.errorKind = undefined;
+      } else if (msg.startsWith(CLOUDSTORAGE_TCC_PREFIX)) {
+        // CloudStorage TCC denial — parse stable_id and dir from prefix-encoded string.
+        // Format: "CloudStorage TCC required: {stable_id}|{dir}"
+        this.status = 'error';
+        this.errorKind = 'cloudstorage_tcc_required';
+        const body = msg.slice(CLOUDSTORAGE_TCC_PREFIX.length);
+        const pipeIdx = body.indexOf('|');
+        if (pipeIdx >= 0) {
+          this.failureProjectDir = body.slice(pipeIdx + 1);
+        }
       } else {
         this.status = 'error';
+        this.errorKind = undefined;
       }
       this.error = msg;
     }
@@ -248,6 +277,20 @@ export class ProjectStateService {
       this.status = 'auth_required';
       this.notifyChange();
     }
+  }
+
+  /**
+   * Retries container startup after a CloudStorage TCC (or other transient) error.
+   * Resets error state and re-runs `ensureContainersRunning`.
+   */
+  async retry(): Promise<void> {
+    this.errorKind = undefined;
+    this.failureProvider = undefined;
+    this.failureProjectDir = undefined;
+    this.error = '';
+    this.status = 'loading';
+    this.notifyChange();
+    await this.ensureContainersRunning();
   }
 
   /** Dismisses the error banner, checking containers first. */
@@ -336,6 +379,9 @@ export class ProjectStateService {
         this.targetProject = event.payload.project;
         this.status = 'switching';
         this.error = '';
+        this.errorKind = undefined;
+        this.failureProvider = undefined;
+        this.failureProjectDir = undefined;
         this.needsRestart = false;
         this.restarting = false;
         this.restartError = '';
@@ -357,18 +403,18 @@ export class ProjectStateService {
         void this.refreshProjectList();
       });
 
-      await this.tauri.listen<{ project: string | null; error: string }>(
-        'project_switch_failed',
-        (event) => {
-          this.activeProject = event.payload.project;
-          this.targetProject = null;
-          this.status = 'error';
-          this.error = event.payload.error;
-          this.notifyChange();
-          this.notifyFailed(event.payload.error);
-          this.notifySettled();
-        }
-      );
+      await this.tauri.listen<ProjectSwitchFailedPayload>('project_switch_failed', (event) => {
+        this.activeProject = event.payload.project;
+        this.targetProject = null;
+        this.status = 'error';
+        this.error = event.payload.error;
+        this.errorKind = event.payload.error_kind;
+        this.failureProvider = event.payload.provider;
+        this.failureProjectDir = event.payload.project_dir;
+        this.notifyChange();
+        this.notifyFailed(event.payload.error);
+        this.notifySettled();
+      });
 
       await this.tauri.listen<BundleReconcileStatus>('bundle_reconcile_status', (event) => {
         // Ignore reconcile events during active operations — backend

--- a/desktop/src/src/app/services/project-state.service.ts
+++ b/desktop/src/src/app/services/project-state.service.ts
@@ -6,7 +6,7 @@ import type {
   ProjectList,
   ProjectSwitchFailedPayload,
 } from '../models/update';
-import { CLOUDSTORAGE_TCC_PREFIX } from './cloudstorage-prefix';
+import { CLOUDSTORAGE_TCC_PREFIX, cloudstorageProviderDisplayName } from './cloudstorage-prefix';
 
 /** Lifecycle status of the project + container lifecycle. */
 export type ProjectStatus =
@@ -219,6 +219,7 @@ export class ProjectStateService {
         const body = msg.slice(CLOUDSTORAGE_TCC_PREFIX.length);
         const pipeIdx = body.indexOf('|');
         if (pipeIdx >= 0) {
+          this.failureProvider = cloudstorageProviderDisplayName(body.slice(0, pipeIdx));
           this.failureProjectDir = body.slice(pipeIdx + 1);
         }
       } else {

--- a/desktop/src/src/app/shared/cloudstorage-modal/cloudstorage-modal.component.spec.ts
+++ b/desktop/src/src/app/shared/cloudstorage-modal/cloudstorage-modal.component.spec.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CloudStorageModalComponent } from './cloudstorage-modal.component';
+import { TauriService } from '../../services/tauri.service';
+import { ProjectStateService } from '../../services/project-state.service';
+import { MockTauriService } from '../../testing/mock-tauri.service';
+
+describe('CloudStorageModalComponent', () => {
+  let fixture: ComponentFixture<CloudStorageModalComponent>;
+  let mockTauri: MockTauriService;
+  const invokeSpy = vi.fn<(cmd: string, args?: Record<string, unknown>) => Promise<unknown>>();
+  const retrySpy = vi.fn<() => Promise<void>>();
+
+  beforeEach(async () => {
+    invokeSpy.mockReset();
+    invokeSpy.mockResolvedValue(undefined);
+    retrySpy.mockReset();
+    retrySpy.mockResolvedValue(undefined);
+
+    mockTauri = new MockTauriService();
+    mockTauri.invokeHandler = invokeSpy;
+
+    const projectStateStub = { retry: retrySpy };
+
+    await TestBed.configureTestingModule({
+      imports: [CloudStorageModalComponent],
+      providers: [
+        { provide: TauriService, useValue: mockTauri },
+        { provide: ProjectStateService, useValue: projectStateStub },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CloudStorageModalComponent);
+  });
+
+  it('should not render when visible is false', () => {
+    fixture.componentRef.setInput('visible', false);
+    fixture.detectChanges();
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('[data-testid="cloudstorage-modal"]')).toBeNull();
+  });
+
+  it('should render modal when visible is true', () => {
+    fixture.componentRef.setInput('visible', true);
+    fixture.detectChanges();
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('[data-testid="cloudstorage-modal"]')).toBeTruthy();
+  });
+
+  it('should show provider name in heading when provider is set', () => {
+    fixture.componentRef.setInput('visible', true);
+    fixture.componentRef.setInput('provider', 'OneDrive');
+    fixture.detectChanges();
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.textContent).toContain('OneDrive');
+  });
+
+  it('should not show provider name when provider is undefined', () => {
+    fixture.componentRef.setInput('visible', true);
+    fixture.componentRef.setInput('provider', undefined);
+    fixture.detectChanges();
+    const el = fixture.nativeElement as HTMLElement;
+    const heading = el.querySelector('h2');
+    expect(heading?.textContent?.trim()).toBe('Speedwave needs access to');
+  });
+
+  it('should render manual instructions list', () => {
+    fixture.componentRef.setInput('visible', true);
+    fixture.detectChanges();
+    const el = fixture.nativeElement as HTMLElement;
+    const items = el.querySelectorAll('ol li');
+    expect(items.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('should render Open System Settings button', () => {
+    fixture.componentRef.setInput('visible', true);
+    fixture.detectChanges();
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('[data-testid="cloudstorage-open-settings-btn"]')).toBeTruthy();
+  });
+
+  it('should render Retry button', () => {
+    fixture.componentRef.setInput('visible', true);
+    fixture.detectChanges();
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('[data-testid="cloudstorage-retry-btn"]')).toBeTruthy();
+  });
+
+  it('should call open_files_folders_pane when Open System Settings clicked', async () => {
+    fixture.componentRef.setInput('visible', true);
+    fixture.detectChanges();
+    const el = fixture.nativeElement as HTMLElement;
+    const btn = el.querySelector<HTMLButtonElement>(
+      '[data-testid="cloudstorage-open-settings-btn"]'
+    )!;
+    btn.click();
+    await fixture.whenStable();
+    expect(invokeSpy).toHaveBeenCalledWith('open_files_folders_pane', undefined);
+  });
+
+  it('should call projectState.retry when Retry clicked', async () => {
+    fixture.componentRef.setInput('visible', true);
+    fixture.detectChanges();
+    const el = fixture.nativeElement as HTMLElement;
+    const btn = el.querySelector<HTMLButtonElement>('[data-testid="cloudstorage-retry-btn"]')!;
+    btn.click();
+    await fixture.whenStable();
+    expect(retrySpy).toHaveBeenCalled();
+  });
+});

--- a/desktop/src/src/app/shared/cloudstorage-modal/cloudstorage-modal.component.ts
+++ b/desktop/src/src/app/shared/cloudstorage-modal/cloudstorage-modal.component.ts
@@ -1,0 +1,119 @@
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  inject,
+  input,
+} from '@angular/core';
+import { TauriService } from '../../services/tauri.service';
+import { ProjectStateService } from '../../services/project-state.service';
+
+/**
+ * Modal shown when a CloudStorage TCC permission failure is detected.
+ *
+ * Provides:
+ * - Manual step-by-step instructions (always visible — no System Settings button fallback needed)
+ * - "Open System Settings" button that invokes `open_files_folders_pane` (macOS only)
+ * - "Retry" button that re-runs `ensureContainersRunning` via `projectState.retry()`
+ *
+ * The modal is rendered by `ShellComponent` when
+ * `projectState.errorKind === 'cloudstorage_tcc_required'`.
+ */
+@Component({
+  selector: 'app-cloudstorage-modal',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    @if (visible()) {
+      <div
+        class="fixed inset-0 z-[1200] flex items-center justify-center bg-black/75 backdrop-blur-sm"
+        role="alertdialog"
+        aria-modal="true"
+        aria-label="Cloud storage permission required"
+        data-testid="cloudstorage-modal"
+      >
+        <div
+          class="w-[min(30rem,calc(100vw-2rem))] rounded border border-[var(--line-strong)] bg-[var(--bg-1)] p-6"
+          role="document"
+        >
+          <div class="mono text-[11px] uppercase tracking-widest text-[var(--accent)]">
+            cloud storage permission required
+          </div>
+          <h2 class="mono mt-2 text-base font-semibold text-[var(--ink)]">
+            Speedwave needs access to{{ providerLabel() }}
+          </h2>
+          <p class="mono mt-3 text-[13px] text-[var(--ink-mute)]">
+            macOS is blocking access to your project folder. Grant permission in System Settings:
+          </p>
+
+          <!-- Always-visible manual instructions -->
+          <ol class="mono mt-3 list-decimal space-y-1 pl-5 text-[13px] text-[var(--ink-mute)]">
+            <li>
+              Open
+              <strong class="text-[var(--ink)]"
+                >System Settings → Privacy &amp; Security → Files and Folders</strong
+              >
+            </li>
+            <li>Find <strong class="text-[var(--ink)]">Speedwave</strong> in the list</li>
+            <li>
+              Enable access to
+              <strong class="text-[var(--ink)]">{{
+                providerLabel() || 'your cloud storage folder'
+              }}</strong>
+            </li>
+            <li>Return to Speedwave and click <strong class="text-[var(--ink)]">Retry</strong></li>
+          </ol>
+
+          <div class="mt-5 flex gap-3">
+            <button
+              type="button"
+              class="mono cursor-pointer rounded border-none bg-[var(--accent)] px-4 py-2 text-[13px] font-semibold text-[var(--on-accent)] transition-opacity hover:opacity-90"
+              data-testid="cloudstorage-open-settings-btn"
+              (click)="openSystemSettings()"
+            >
+              Open System Settings
+            </button>
+            <button
+              type="button"
+              class="mono cursor-pointer rounded border border-[var(--line)] bg-transparent px-4 py-2 text-[13px] text-[var(--ink)] hover:bg-[var(--bg-2)]"
+              data-testid="cloudstorage-retry-btn"
+              (click)="retry()"
+            >
+              Retry
+            </button>
+          </div>
+        </div>
+      </div>
+    }
+  `,
+})
+export class CloudStorageModalComponent {
+  /** Controls modal visibility — bind to `projectState.errorKind === 'cloudstorage_tcc_required'`. */
+  readonly visible = input<boolean>(false);
+  /** Optional provider display name to show in the message (e.g. "OneDrive"). */
+  readonly provider = input<string | undefined>(undefined);
+
+  private readonly tauri = inject(TauriService);
+  private readonly projectState = inject(ProjectStateService);
+  private readonly cdr = inject(ChangeDetectorRef);
+
+  /** Returns " OneDrive" (with leading space) or empty string for template interpolation. */
+  providerLabel(): string {
+    const p = this.provider();
+    return p ? ` ${p}` : '';
+  }
+
+  /** Launches macOS System Settings → Privacy & Security → Files and Folders pane. */
+  async openSystemSettings(): Promise<void> {
+    try {
+      await this.tauri.invoke('open_files_folders_pane');
+    } catch (err) {
+      console.warn('[CloudStorageModal] open_files_folders_pane failed:', err);
+    }
+  }
+
+  /** Re-triggers container startup after the user grants TCC permission. */
+  async retry(): Promise<void> {
+    await this.projectState.retry();
+    this.cdr.markForCheck();
+  }
+}

--- a/desktop/src/src/app/shared/create-project-modal/create-project-modal.component.spec.ts
+++ b/desktop/src/src/app/shared/create-project-modal/create-project-modal.component.spec.ts
@@ -179,6 +179,81 @@ describe('CreateProjectModalComponent', () => {
     });
   });
 
+  describe('CloudStorage warning (Step 10)', () => {
+    it('shows a warning when detect_cloudstorage_path returns is_cloudstorage=true', async () => {
+      vi.spyOn(mockTauri, 'invoke').mockImplementation((cmd: string) => {
+        if (cmd === 'detect_cloudstorage_path') {
+          return Promise.resolve({ is_cloudstorage: true, provider: 'OneDrive' });
+        }
+        return Promise.resolve(undefined);
+      });
+      openMock.mockResolvedValue('/Users/me/OneDrive/project');
+      await component.browse();
+      // Wait for the async detectCloudstorage microtask
+      await Promise.resolve();
+      fixture.detectChanges();
+      const warning = fixture.nativeElement.querySelector(
+        '[data-testid="create-project-cloudstorage-warning"]'
+      );
+      expect(warning).not.toBeNull();
+      expect(warning?.textContent).toContain('OneDrive');
+    });
+
+    it('does not show a warning when detect_cloudstorage_path returns is_cloudstorage=false', async () => {
+      vi.spyOn(mockTauri, 'invoke').mockImplementation((cmd: string) => {
+        if (cmd === 'detect_cloudstorage_path') {
+          return Promise.resolve({ is_cloudstorage: false });
+        }
+        return Promise.resolve(undefined);
+      });
+      openMock.mockResolvedValue('/Users/me/projects/normal');
+      await component.browse();
+      await Promise.resolve();
+      fixture.detectChanges();
+      const warning = fixture.nativeElement.querySelector(
+        '[data-testid="create-project-cloudstorage-warning"]'
+      );
+      expect(warning).toBeNull();
+    });
+
+    it('silently ignores detect_cloudstorage_path errors (outside Tauri)', async () => {
+      vi.spyOn(mockTauri, 'invoke').mockImplementation((cmd: string) => {
+        if (cmd === 'detect_cloudstorage_path') {
+          return Promise.reject(new Error('command not found'));
+        }
+        return Promise.resolve(undefined);
+      });
+      openMock.mockResolvedValue('/Users/me/projects/demo');
+      await component.browse();
+      await Promise.resolve();
+      fixture.detectChanges();
+      const warning = fixture.nativeElement.querySelector(
+        '[data-testid="create-project-cloudstorage-warning"]'
+      );
+      expect(warning).toBeNull();
+    });
+
+    it('clears the warning when the user cancels after a warning is shown', async () => {
+      vi.spyOn(mockTauri, 'invoke').mockImplementation((cmd: string) => {
+        if (cmd === 'detect_cloudstorage_path') {
+          return Promise.resolve({ is_cloudstorage: true, provider: 'Dropbox' });
+        }
+        return Promise.resolve(undefined);
+      });
+      openMock.mockResolvedValue('/Users/me/Dropbox/project');
+      await component.browse();
+      await Promise.resolve();
+      fixture.detectChanges();
+
+      component.cancel();
+      fixture.detectChanges();
+      const warning = fixture.nativeElement.querySelector(
+        '[data-testid="create-project-cloudstorage-warning"]'
+      );
+      expect(warning).toBeNull();
+    });
+  });
+
   describe('cancel() — dismissibility contract', () => {
     it('emits `closed` when dismissible (default)', () => {
       const closed = vi.fn();

--- a/desktop/src/src/app/shared/create-project-modal/create-project-modal.component.ts
+++ b/desktop/src/src/app/shared/create-project-modal/create-project-modal.component.ts
@@ -111,6 +111,16 @@ export interface CreatedProject {
             class="mono w-full rounded border border-[var(--line)] bg-[var(--bg-2)] px-2 py-1 text-[12px] text-[var(--ink)]"
           />
 
+          @if (cloudstorageWarning()) {
+            <div
+              class="mono mt-3 rounded border border-amber-500/30 bg-amber-500/5 p-2 text-[11.5px] text-amber-300"
+              data-testid="create-project-cloudstorage-warning"
+              role="alert"
+            >
+              {{ cloudstorageWarning() }}
+            </div>
+          }
+
           @if (error()) {
             <div
               class="mono mt-3 rounded border border-red-500/30 bg-red-500/5 p-2 text-[11.5px] text-red-300"
@@ -201,6 +211,8 @@ export class CreateProjectModalComponent {
   protected readonly busy = signal<boolean>(false);
   /** Inline error from the OS picker or `create_project`. */
   protected readonly error = signal<string | null>(null);
+  /** Non-null when the selected directory is inside a CloudStorage provider folder. */
+  protected readonly cloudstorageWarning = signal<string | null>(null);
 
   /** Submit button is enabled iff a directory and a non-empty name are present. */
   protected readonly canSubmit = computed(
@@ -237,7 +249,29 @@ export class CreateProjectModalComponent {
       dir: selected as string,
       name: nameDirty ? m.name : slugify(basename(selected as string)),
     }));
+    this.cloudstorageWarning.set(null);
+    // Non-blocking: fire-and-forget CloudStorage detection; ignore errors so a
+    // missing Tauri context (tests, browser preview) doesn't break the picker.
+    void this.detectCloudstorage(selected as string);
     this.cdr.markForCheck();
+  }
+
+  private async detectCloudstorage(dir: string): Promise<void> {
+    try {
+      const result = await this.tauri.invoke<{ is_cloudstorage: boolean; provider?: string }>(
+        'detect_cloudstorage_path',
+        { dir }
+      );
+      if (result?.is_cloudstorage) {
+        const provider = result.provider ? `${result.provider} ` : '';
+        this.cloudstorageWarning.set(
+          `This folder is inside a ${provider}sync directory. macOS may block Speedwave's access — you may be prompted to grant permission.`
+        );
+        this.cdr.markForCheck();
+      }
+    } catch {
+      // Outside Tauri or command unavailable — no warning shown.
+    }
   }
 
   /**
@@ -301,6 +335,7 @@ export class CreateProjectModalComponent {
     // as a fresh selection rather than a continuation of the previous edit.
     this.projectForm().reset();
     this.error.set(null);
+    this.cloudstorageWarning.set(null);
   }
 }
 

--- a/desktop/src/src/app/shell/shell.component.ts
+++ b/desktop/src/src/app/shell/shell.component.ts
@@ -20,6 +20,7 @@ import { CommandPaletteComponent } from './command-palette/command-palette.compo
 import { ModalOverlayComponent } from './modal-overlay/modal-overlay.component';
 import { NavRailComponent, type NavRailEntry } from './nav-rail/nav-rail.component';
 import { SpinIconComponent } from '../shared/spin-icon.component';
+import { CloudStorageModalComponent } from '../shared/cloudstorage-modal/cloudstorage-modal.component';
 
 /**
  * Application shell — hosts the left icon rail, the routed main content, and
@@ -39,6 +40,7 @@ import { SpinIconComponent } from '../shared/spin-icon.component';
     ModalOverlayComponent,
     CommandPaletteComponent,
     SpinIconComponent,
+    CloudStorageModalComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: { '(document:keydown)': 'onKeydown($event)' },
@@ -141,6 +143,12 @@ import { SpinIconComponent } from '../shared/spin-icon.component';
         }
       }
       <app-update-notification />
+
+      <!-- CloudStorage TCC modal — shown when project dir is in OneDrive/Dropbox/etc. and TCC is denied -->
+      <app-cloudstorage-modal
+        [visible]="projectState.errorKind === 'cloudstorage_tcc_required'"
+        [provider]="projectState.failureProvider"
+      />
 
       <div class="flex flex-1 overflow-hidden">
         <app-nav-rail

--- a/docs/architecture/platform-matrix.md
+++ b/docs/architecture/platform-matrix.md
@@ -15,6 +15,7 @@ Speedwave supports macOS, Linux, and Windows with platform-specific VM, containe
 - Lima manages the VM using Apple Virtualization Framework (same hypervisor as Docker Desktop 4.15+)
 - Lima is bundled inside `.app/Contents/Resources/lima/` with `LIMA_HOME=~/.speedwave/lima` for isolation (see [ADR-021](../adr/ADR-021-bundled-dependencies-and-zero-install-strategy.md))
 - IDE lock file: `~/.claude/ide/<port>.lock`
+- **CloudStorage TCC:** Project directories under `~/Library/CloudStorage/` (OneDrive, Dropbox, Google Drive) and top-level home folders like `~/OneDrive…` are gated by the macOS Files-and-Folders Transparency Consent and Control (TCC) permission. When permission is missing, `read_dir` returns EPERM and Speedwave surfaces a dedicated `CloudStorageModal` (with a deep-link to System Settings → Privacy & Security → Files and Folders, plus a one-click Retry). Detection runs at all four project-mutation entry points (`add_project`, `start_containers`, `recreate_project_containers`, `restart_integration_containers`) plus defense-in-depth in `render_and_save_compose`. SSOT: `crates/speedwave-runtime/src/cloudstorage.rs`.
 
 ## Linux
 


### PR DESCRIPTION
## Summary

- Detects macOS Files-and-Folders TCC denials when projects live under `~/Library/CloudStorage` (OneDrive, Dropbox, etc.) and surfaces a dedicated modal that links to System Settings and offers a one-click retry, instead of bubbling up an opaque "Operation not permitted" failure.
- New `cloudstorage` runtime SSOT with prefix-encoded errors substituted at `restore_projects` so the user-friendly message replaces the raw EPERM at every project-mutation entry point (`add_project`, `start_containers`, `recreate_project_containers`, `restart_integration_containers`) plus defense-in-depth in `render_and_save_compose`.
- New Tauri commands `open_files_folders_pane` (deep-link to System Settings) and `detect_cloudstorage_path`; new `CloudStorageModalComponent` rendered by `ShellComponent` when `errorKind === 'cloudstorage_tcc_required'`; `ProjectStateService` gains failure-context fields and a `retry()` method.

## Test plan

- [x] `make check` (clippy + lint + type-check + format) passes
- [x] `make test` passes — Rust + Angular (1586) + Desktop (1062) + MCP + entrypoint + CI workflow (29)
- [ ] Manual: project under `~/Library/CloudStorage/OneDrive-…/`, deny TCC, verify modal appears with provider name, "Open System Settings" deep-links to Files-and-Folders pane, "Retry" re-runs `ensureContainersRunning`

Closes #579