### PR TITLE
fix(desktop): unbreak Windows build by ungating Command import

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -330,3 +330,40 @@ jobs:
 
       - name: cargo test runtime::wsl
         run: cargo test -p speedwave-runtime --lib "runtime::wsl::"
+
+  desktop-windows-check:
+    # `desktop` job above only runs on ubuntu — it never catches Windows-only
+    # compile errors in speedwave-desktop (e.g. cfg-gated imports of types
+    # used in cross-platform fn signatures). This job runs `cargo check` on
+    # windows-latest with stubbed bundle resources to exercise the Windows
+    # codepaths without paying for a full Tauri bundle.
+    runs-on: windows-latest
+    timeout-minutes: 25
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7  # stable
+
+      - name: Cache Cargo
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            desktop/src-tauri/target/
+          key: ${{ runner.os }}-cargo-desktop-check-${{ hashFiles('desktop/src-tauri/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-desktop-check-
+
+      - name: Create resource stubs for Tauri build script
+        run: scripts/create-desktop-stubs.sh
+
+      - name: cargo check speedwave-desktop
+        working-directory: desktop/src-tauri
+        env:
+          SPEEDWAVE_ALLOW_BUNDLE_STUBS: "1"
+        run: cargo check --all-targets

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -178,25 +178,7 @@ jobs:
         run: npm ci
 
       - name: Create resource stubs for Tauri build script
-        run: |
-          mkdir -p desktop/src-tauri/nerdctl-full/{bin,lib,libexec,share}
-          mkdir -p desktop/src-tauri/THIRD-PARTY-LICENSES
-          mkdir -p desktop/src-tauri/build-context/containers/claude-resources
-          mkdir -p desktop/src-tauri/build-context/mcp-servers
-          mkdir -p desktop/src-tauri/mcp-os/os/dist
-          mkdir -p desktop/src-tauri/mcp-os/shared/dist
-          mkdir -p desktop/src-tauri/mcp-os/shared/node_modules
-          mkdir -p desktop/src-tauri/mcp-os/os/node_modules/@speedwave/mcp-shared
-          mkdir -p desktop/src-tauri/nodejs/bin
-          touch desktop/src-tauri/build-context/containers/Containerfile.claude
-          touch desktop/src-tauri/build-context/mcp-servers/tsconfig.base.json
-          touch desktop/src-tauri/mcp-os/os/dist/index.js
-          touch desktop/src-tauri/mcp-os/shared/package.json
-          touch desktop/src-tauri/mcp-os/shared/package-lock.json
-          touch desktop/src-tauri/nodejs/bin/node
-          touch desktop/src-tauri/nodejs/node.exe
-          mkdir -p desktop/src-tauri/cli
-          touch desktop/src-tauri/cli/speedwave
+        run: scripts/create-desktop-stubs.sh
 
       - name: Desktop clippy
         working-directory: desktop/src-tauri

--- a/desktop/src-tauri/src/mcp_os_process.rs
+++ b/desktop/src-tauri/src/mcp_os_process.rs
@@ -1,8 +1,6 @@
 use std::io::BufRead;
 use std::path::{Path, PathBuf};
-use std::process::Child;
-#[cfg(any(unix, test))]
-use std::process::Command;
+use std::process::{Child, Command};
 use std::thread::JoinHandle;
 
 use speedwave_runtime::consts;

--- a/desktop/src-tauri/src/mcp_os_process.rs
+++ b/desktop/src-tauri/src/mcp_os_process.rs
@@ -678,6 +678,7 @@ srv.listen(0, '127.0.0.1', () => {
         }
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_read_port_timeout_on_silent_child() {
         let mut child = Command::new("sleep")
@@ -732,6 +733,7 @@ srv.listen(0, '127.0.0.1', () => {
         }
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_kill_terminates_child() {
         let child = Command::new("sleep")
@@ -764,6 +766,7 @@ srv.listen(0, '127.0.0.1', () => {
         }
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_health_check_running() {
         let child = Command::new("sleep")
@@ -794,6 +797,7 @@ srv.listen(0, '127.0.0.1', () => {
         }
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_health_check_dead() {
         let child = Command::new("true")
@@ -824,6 +828,7 @@ srv.listen(0, '127.0.0.1', () => {
         }
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_drop_cleans_up_files() {
         let tmp = tempfile::tempdir().unwrap();
@@ -895,6 +900,7 @@ srv.listen(0, '127.0.0.1', () => {
         // node not available — skip
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_kill_stale_by_pid_file_skips_non_node_process() {
         // Spawn a non-node process — kill_stale should NOT kill it
@@ -1003,6 +1009,7 @@ srv.listen(0, '127.0.0.1', () => {
         assert!(token.chars().all(|c| c.is_ascii_hexdigit() || c == '-'));
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_stop_is_idempotent() {
         let child = Command::new("sleep")
@@ -1041,6 +1048,7 @@ srv.listen(0, '127.0.0.1', () => {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_is_node_process_returns_false_for_non_node() {
         let child = Command::new("sleep")
@@ -1229,7 +1237,8 @@ process.stdout.write(JSON.stringify({ leaked }));
     // ── drain_and_read_port edge cases ───────────────────────────────────
 
     /// Helper: spawn a child process that writes the given lines to stdout,
-    /// one per line, then exits.
+    /// one per line, then exits. Unix-only: uses `bash` + `printf`.
+    #[cfg(unix)]
     fn spawn_stdout_lines(lines: &[&str]) -> Child {
         // Use printf to write each line with a trailing newline
         Command::new("bash")
@@ -1241,6 +1250,7 @@ process.stdout.write(JSON.stringify({ leaked }));
     }
 
     /// Shell-quote a list of arguments for safe interpolation.
+    #[cfg(unix)]
     fn shell_quote_args(args: &[&str]) -> String {
         args.iter()
             .map(|a| format!("'{}'", a.replace('\'', "'\\''")))
@@ -1249,12 +1259,14 @@ process.stdout.write(JSON.stringify({ leaked }));
     }
 
     /// Helper: create a temp log path for drain tests.
+    #[cfg(unix)]
     fn temp_log_path() -> (tempfile::TempDir, PathBuf) {
         let tmp = tempfile::tempdir().unwrap();
         let log_path = tmp.path().join(consts::MCP_OS_LOG_FILE);
         (tmp, log_path)
     }
 
+    #[cfg(unix)]
     #[test]
     fn drain_and_read_port_skips_non_json_lines_before_port() {
         let (_tmp, log_path) = temp_log_path();
@@ -1275,6 +1287,7 @@ process.stdout.write(JSON.stringify({ leaked }));
         child.wait().ok();
     }
 
+    #[cfg(unix)]
     #[test]
     fn drain_and_read_port_rejects_port_zero() {
         let (_tmp, log_path) = temp_log_path();
@@ -1290,6 +1303,7 @@ process.stdout.write(JSON.stringify({ leaked }));
         child.wait().ok();
     }
 
+    #[cfg(unix)]
     #[test]
     fn drain_and_read_port_rejects_port_over_65535() {
         let (_tmp, log_path) = temp_log_path();
@@ -1309,6 +1323,7 @@ process.stdout.write(JSON.stringify({ leaked }));
         child.wait().ok();
     }
 
+    #[cfg(unix)]
     #[test]
     fn drain_and_read_port_rejects_port_max_u64() {
         let (_tmp, log_path) = temp_log_path();
@@ -1325,6 +1340,7 @@ process.stdout.write(JSON.stringify({ leaked }));
         child.wait().ok();
     }
 
+    #[cfg(unix)]
     #[test]
     fn drain_and_read_port_errors_on_exit_without_port() {
         let (_tmp, log_path) = temp_log_path();
@@ -1345,6 +1361,7 @@ process.stdout.write(JSON.stringify({ leaked }));
         child.wait().ok();
     }
 
+    #[cfg(unix)]
     #[test]
     fn drain_and_read_port_ignores_json_without_port_key() {
         let (_tmp, log_path) = temp_log_path();
@@ -1362,6 +1379,7 @@ process.stdout.write(JSON.stringify({ leaked }));
         child.wait().ok();
     }
 
+    #[cfg(unix)]
     #[test]
     fn drain_and_read_port_writes_to_log_file() {
         let (_tmp, log_path) = temp_log_path();

--- a/docs/architecture/platform-matrix.md
+++ b/docs/architecture/platform-matrix.md
@@ -35,6 +35,10 @@ Speedwave supports macOS, Linux, and Windows with platform-specific VM, containe
 - IDE lock file: `%USERPROFILE%\.claude\ide\<port>.lock`
 - **Nested virtualization:** WSL2 uses Hyper-V, which requires hardware virtualization. Running WSL2 inside a VM (VMware, VirtualBox, QEMU/KVM) is nested virtualization and may degrade I/O performance during container image builds. Speedwave applies a four-layer resilience strategy (see [ADR-032](../adr/ADR-032-nested-virtualization-resilience.md)): (1) `Containerfile.claude` uses `--force-unsafe-io` and `Acquire::Retries=3` to harden apt installs; (2) transient I/O errors trigger an automatic retry without a prune; (3) Speedwave detects the VM environment via `Get-CimInstance Win32_ComputerSystem` and shows a non-blocking warning in `speedwave check` and Desktop logs; (4) a bounded parallel worker pool limits I/O amplification during concurrent image builds.
 
+## Cross-platform Rust gating
+
+`speedwave-desktop` compiles for all three platforms above. The local `make check-desktop-clippy` only exercises the host target, so Windows-only compile errors (typically `cfg(unix)`-gated imports referenced by cross-platform function signatures) must be caught by the `desktop-windows-check` job in `.github/workflows/test.yml`. See [contributing/development-setup.md → Cross-platform Rust gating](../contributing/development-setup.md#cross-platform-rust-gating) for the rules every PR touching gated code must follow.
+
 ## See Also
 
 - [ADR-002: Lima as VM Manager on macOS](../adr/ADR-002-lima-as-vm-manager-on-macos.md)

--- a/docs/contributing/development-setup.md
+++ b/docs/contributing/development-setup.md
@@ -51,6 +51,16 @@ The `desktop/src-tauri/cli/` directory is in `.gitignore` — it is populated at
 
 `make dev` automatically builds the CLI first and copies it to `desktop/src-tauri/cli/` before starting Tauri dev mode. This ensures the "Open Terminal" feature works during development.
 
+## Cross-platform Rust gating
+
+`speedwave-desktop` compiles for macOS, Linux, and Windows. `make check-desktop-clippy` only exercises the host target — Windows-specific compile errors are caught later by the `desktop-windows-check` job in `.github/workflows/test.yml` and the `desktop-build` workflow on push. To stay green:
+
+- **Imports of types used in cross-platform function signatures must be unconditional.** A `#[cfg(any(unix, test))] use std::process::Command;` paired with a public `fn apply_child_env(cmd: &mut Command, …)` will compile on macOS/Linux/in tests and silently break the Windows build. If a type appears in any non-gated `fn`/`impl`/`struct`/`type` declaration, import it without a `cfg`.
+- **Symmetric platform branches.** When a function has a `#[cfg(unix)]` arm, ensure the `#[cfg(windows)]` arm exists too — or fail the build with `compile_error!` on unsupported targets, rather than letting the call site fall through to a missing symbol.
+- **Local Windows pre-flight.** If you are touching gated code (`grep -nR "cfg(unix\|cfg(windows\|cfg(target_os" desktop/src-tauri/src/`), run `cargo check -p speedwave-desktop --target x86_64-pc-windows-msvc` (requires `rustup target add x86_64-pc-windows-msvc` and a Windows-capable linker) before opening the PR. Otherwise rely on the `desktop-windows-check` CI job.
+
+See [`docs/architecture/platform-matrix.md`](../architecture/platform-matrix.md) for the platform-specific runtime/feature breakdown.
+
 ## See Also
 
 - [Contributing](../../CONTRIBUTING.md)

--- a/docs/contributing/development-setup.md
+++ b/docs/contributing/development-setup.md
@@ -57,7 +57,7 @@ The `desktop/src-tauri/cli/` directory is in `.gitignore` — it is populated at
 
 - **Imports of types used in cross-platform function signatures must be unconditional.** A `#[cfg(any(unix, test))] use std::process::Command;` paired with a public `fn apply_child_env(cmd: &mut Command, …)` will compile on macOS/Linux/in tests and silently break the Windows build. If a type appears in any non-gated `fn`/`impl`/`struct`/`type` declaration, import it without a `cfg`.
 - **Symmetric platform branches.** When a function has a `#[cfg(unix)]` arm, ensure the `#[cfg(windows)]` arm exists too — or fail the build with `compile_error!` on unsupported targets, rather than letting the call site fall through to a missing symbol.
-- **Local Windows pre-flight.** If you are touching gated code (`grep -nR "cfg(unix\|cfg(windows\|cfg(target_os" desktop/src-tauri/src/`), run `cargo check -p speedwave-desktop --target x86_64-pc-windows-msvc` (requires `rustup target add x86_64-pc-windows-msvc` and a Windows-capable linker) before opening the PR. Otherwise rely on the `desktop-windows-check` CI job.
+- **Local Windows pre-flight.** If you are touching gated code (`grep -nRE 'cfg\((unix|windows|target_os)' desktop/src-tauri/src/`), run `cargo check -p speedwave-desktop --target x86_64-pc-windows-msvc` (requires `rustup target add x86_64-pc-windows-msvc` and a Windows-capable linker) before opening the PR. Otherwise rely on the `desktop-windows-check` CI job.
 
 See [`docs/architecture/platform-matrix.md`](../architecture/platform-matrix.md) for the platform-specific runtime/feature breakdown.
 


### PR DESCRIPTION
## Summary

- Remove `#[cfg(any(unix, test))]` from the `std::process::Command` import in `desktop/src-tauri/src/mcp_os_process.rs` — it was left over from PR #430 and silently broke the Windows build once a later refactor extracted `apply_child_env(cmd: &mut Command, …)` as a cross-platform fn signature.
- Add a `desktop-windows-check` job to `test.yml` that runs `cargo check --all-targets` against `speedwave-desktop` on `windows-latest` for every PR, using the existing `scripts/create-desktop-stubs.sh` + `SPEEDWAVE_ALLOW_BUNDLE_STUBS=1`. The current `desktop-build.yml` matrix only runs Windows on `push`, so PRs were never gated on Windows compilation.
- Document the cross-platform Rust gating rule in `docs/contributing/development-setup.md` and link from `docs/architecture/platform-matrix.md`.

## Why

`make test-e2e-all` against the real Windows VM caught a Tauri build error:

```
error[E0425]: cannot find type `Command` in this scope
   --> src\mcp_os_process.rs:295:30
fn apply_child_env(cmd: &mut Command, env: &dyn EnvSource) {
                              ^^^^^^^ not found in this scope
error: could not compile `speedwave-desktop`
```

Linux + macOS e2e passed 7/7 specs (clean install + reinstall). Windows never reached the test phase because the desktop crate didn't compile.

## Test plan

- [x] `cargo check --all-targets` on host (`speedwave-desktop` clean, only pre-existing dead_code warnings in `reconcile.rs`)
- [x] `cargo test --bin speedwave-desktop mcp_os_process` — 38/38 passed
- [x] `make check` (clippy `0 warnings` on `speedwave-runtime` + `speedwave-cli`)
- [ ] CI: new `desktop-windows-check` job goes green on `windows-latest`
- [ ] CI: existing `desktop` job (Ubuntu) still green
- [ ] Manual: re-run `make _e2e-windows` after merge to confirm the NSIS bundle builds end-to-end