### PR TITLE
fix(ci): unbreak test.yml YAML — trailing :: in step name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -313,7 +313,7 @@ jobs:
       - name: cargo test runtime::wsl
         run: cargo test -p speedwave-runtime --lib "runtime::wsl::"
 
-      - name: Run runtime build:: tests on Windows
+      - name: cargo test runtime build
         shell: bash
         run: cargo test -p speedwave-runtime --lib "build::"
 


### PR DESCRIPTION
## Summary

- Step name `Run runtime build:: tests on Windows` (introduced in #604) has a trailing `::` before whitespace, which GitHub's YAML parser reads as `build:` key + `: tests on Windows` mapping value.
- Result: `test.yml` failed to start with "workflow file issue" on every push to `dev` since #604 (commits `a6b91d2`, `9809b45`). CI has been silent for two pushes.
- Fix: rename the step to `cargo test runtime build` — matches the surrounding `cargo test runtime::*` pattern, parses cleanly because there's no trailing `::`.
- Validated locally with `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"`.

## Test plan

- [ ] CI runs `test.yml` on this PR (was silent on the last two `dev` pushes)
- [ ] Windows runtime job executes the renamed `cargo test runtime build` step