### PR TITLE
fix(desktop): add missing JSDoc params on AskUser components

### DIFF
--- a/desktop/src/src/app/chat/blocks/ask-user-block.component.ts
+++ b/desktop/src/src/app/chat/blocks/ask-user-block.component.ts
@@ -163,6 +163,10 @@ export class AskUserBlockComponent {
     return q.questions[idx];
   });
 
+  /**
+   * Wires the per-input reset effect that clears `selected` and `freeformText`
+   * whenever the parent reducer hands us a new `question()` block.
+   */
   constructor() {
     // Reset transient input state whenever the parent reducer hands us a
     // new question() input. Lives in an effect (not a computed) because
@@ -179,7 +183,10 @@ export class AskUserBlockComponent {
     });
   }
 
-  /** Shared "question N of M · " prefix for legends; empty for 1-question blocks. */
+  /**
+   * Shared "question N of M · " prefix for legends; empty for 1-question blocks.
+   * @param idx Zero-based index of the question whose legend is being rendered.
+   */
   private progressPrefix(idx: number): string {
     const total = this.question().questions.length;
     return total > 1 ? `question ${idx + 1} of ${total} · ` : '';
@@ -243,7 +250,11 @@ export class AskUserBlockComponent {
     return !q.header && q.options.length === 0 && !q.multi_select;
   });
 
-  /** Legend rendered for previously-answered (locked) slots. */
+  /**
+   * Legend rendered for previously-answered (locked) slots.
+   * @param q The already-answered question item.
+   * @param i Zero-based index of the locked slot in the questions array.
+   */
   legendForLocked(q: AskUserQuestionItem, i: number): string {
     return `${this.progressPrefix(i)}✓ answered${q.header ? ` · ${q.header}` : ''}`;
   }
@@ -251,6 +262,7 @@ export class AskUserBlockComponent {
   /**
    * Checks whether a given option value is currently selected for the
    * active question.
+   * @param value Option value to test against the active selection set.
    */
   isSelected(value: string): boolean {
     return this.selected().has(value);
@@ -259,6 +271,7 @@ export class AskUserBlockComponent {
   /**
    * Toggles selection of an option value (single or multi-select) for the
    * active question.
+   * @param value Option value to add or remove from the active selection set.
    */
   toggleOption(value: string): void {
     const q = this.activeQuestion();
@@ -303,13 +316,19 @@ export class AskUserBlockComponent {
     }
   }
 
-  /** Stores the input value on each input event for the active question. */
+  /**
+   * Stores the input value on each input event for the active question.
+   * @param event DOM input event whose target carries the latest text value.
+   */
   onFreeformInput(event: Event): void {
     const target = event.target as HTMLInputElement | null;
     this.freeformText.set(target?.value ?? '');
   }
 
-  /** Submits on Enter (without Shift) for a keyboard-friendly workflow. */
+  /**
+   * Submits on Enter (without Shift) for a keyboard-friendly workflow.
+   * @param event Keyboard event triggered by the Enter keypress on the freeform input.
+   */
   onFreeformEnter(event: Event): void {
     const ke = event as KeyboardEvent;
     if (ke.shiftKey) return;

--- a/desktop/src/src/app/chat/chat.component.ts
+++ b/desktop/src/src/app/chat/chat.component.ts
@@ -277,6 +277,9 @@ export class ChatComponent implements OnInit, OnDestroy {
    * Forwards an answered AskUserQuestion slot to the chat-state service.
    * @param event - tool id, slot index, and the chosen value (single string;
    *   multi-select labels are joined with `", "` upstream).
+   * @param event.toolId Identifier of the AskUserQuestion tool call being answered.
+   * @param event.questionIdx Zero-based index of the answered slot within the questions array.
+   * @param event.value Final answer string forwarded to the agent SDK.
    */
   async onQuestionAnswered(event: {
     toolId: string;

--- a/desktop/src/src/app/services/chat-state.service.ts
+++ b/desktop/src/src/app/services/chat-state.service.ts
@@ -454,7 +454,6 @@ export class ChatStateService {
    * Optimistically advances the block's `current_index` to the
    * next unanswered slot, then forwards to the host. On error, reverts the
    * slot and appends an error block.
-   *
    * @param toolUseId   tool_use_id of the AskUserQuestion control_request.
    * @param questionIdx slot index being answered (0-based).
    * @param value       chosen value (single string; multi-select labels are
@@ -1480,6 +1479,11 @@ function cloneQuestionItem(q: AskUserQuestionItem): AskUserQuestionItem {
   };
 }
 
+/**
+ * Converts SDK message blocks into the serializable shape persisted to the
+ * chat state store (drops live-only fields and normalizes tool payloads).
+ * @param blocks Live message blocks emitted by the agent SDK for one turn.
+ */
 export function messageBlocksToState(blocks: readonly MessageBlock[]): MessageBlockState[] {
   const out: MessageBlockState[] = [];
   for (const b of blocks) {


### PR DESCRIPTION
## Summary

Angular ESLint failed on `dev` with **16 errors** (`jsdoc/require-jsdoc` + `jsdoc/require-param`) against the multi-question AskUserQuestion code shipped in #605. This blocked the v0.10.0 release PR (#607).

The local pre-push hook didn't catch it because `make test` runs vitest on Angular, not the `npx eslint 'src/**/*.ts'` step that runs in CI's `desktop` workflow.

## Changes

- `ask-user-block.component.ts` — JSDoc on constructor + `@param` descriptions for `progressPrefix`, `legendForLocked`, `isSelected`, `toggleOption`, `onFreeformInput`, `onFreeformEnter`
- `chat.component.ts` — `@param event.toolId` / `event.questionIdx` / `event.value` descriptions on `onQuestionAnswered`
- `chat-state.service.ts` — JSDoc block + `@param blocks` on exported `messageBlocksToState`

No behavior changes — pure documentation.

## Test plan

- [ ] `desktop / Angular ESLint` passes (was failing on `dev` HEAD)
- [ ] No new prettier/eslint warnings introduced
- [ ] #607 (release PR) auto-updates and goes green