### PR TITLE
fix(desktop): bats 17 leaks chmod 0755 to test 18 in bundle-build-context

### DIFF
--- a/_tests/desktop/bundle-build-context.bats
+++ b/_tests/desktop/bundle-build-context.bats
@@ -193,6 +193,8 @@ teardown() {
     local backup
     backup="$(mktemp)"
     cp "$src" "$backup"
+    local src_perms
+    src_perms=$(stat -f '%A' "$src" 2>/dev/null || stat -c '%a' "$src")
 
     printf '#!/bin/bash\r\necho hi\r\n' > "$src"
     chmod 0755 "$src"
@@ -201,6 +203,7 @@ teardown() {
     local bundler_status=$status
 
     cp "$backup" "$src"
+    chmod "$src_perms" "$src"
     rm -f "$backup"
 
     [ "$bundler_status" -eq 0 ]


### PR DESCRIPTION
## Summary

The `desktop / Desktop bats tests` step has been failing on `dev` ever since #604 because **test 17 leaks state into test 18**:

```bash
# test 17 — "strips CR from a CRLF source script"
cp "$src" "$backup"   # mktemp → backup at mode 600
chmod 0755 "$src"     # src=755
...
cp "$backup" "$src"   # cp into existing target keeps target's mode (755)
```

After test 17, `containers/install-claude.sh` is left at mode 755. Test 18 (`bundle script preserves source script permissions`) then asserts `src_perms == dst_perms` after the bundle script runs `sed -i.bak` on Linux — GNU sed rewrites the file with the runner's umask (022), reducing dst to 644. With src stuck at 755 from the previous test, the assertion fails.

This was hidden until #606 unblocked YAML parsing of `test.yml` — before that, the `Tests` workflow couldn't start at all on `dev`.

## Fix

Capture the original src mode before mutating it and restore it explicitly via `chmod` after the test. With clean state, src=644, dst=644, assertion passes.

## Test plan

- [x] `bats _tests/desktop/bundle-build-context.bats` passes locally (19/19)
- [ ] `desktop / Desktop bats tests` step turns green in CI
- [ ] PR #607 (release) auto-rebases and `desktop` job goes fully green