### PR TITLE
fix(desktop): bats stat probe order — GNU first, BSD fallback

### DIFF
--- a/_tests/desktop/bundle-build-context.bats
+++ b/_tests/desktop/bundle-build-context.bats
@@ -194,7 +194,7 @@ teardown() {
     backup="$(mktemp)"
     cp "$src" "$backup"
     local src_perms
-    src_perms=$(stat -f '%A' "$src" 2>/dev/null || stat -c '%a' "$src")
+    src_perms=$(stat -c '%a' "$src" 2>/dev/null || stat -f '%A' "$src")
 
     printf '#!/bin/bash\r\necho hi\r\n' > "$src"
     chmod 0755 "$src"
@@ -220,11 +220,13 @@ teardown() {
     local src="$BATS_TEST_DIRNAME/../../containers/install-claude.sh"
     local dst="$DEST/build-context/containers/install-claude.sh"
 
-    # BSD stat (macOS) vs GNU stat (Linux/Git Bash).
+    # GNU stat (Linux/Git Bash) first; BSD stat (macOS) is the fallback. Order
+    # matters: GNU `stat -f` means `--file-system` (exit 0 with garbage output),
+    # so probing BSD first on Linux yields wrong results without errors.
     local src_perms
     local dst_perms
-    src_perms=$(stat -f '%A' "$src" 2>/dev/null || stat -c '%a' "$src")
-    dst_perms=$(stat -f '%A' "$dst" 2>/dev/null || stat -c '%a' "$dst")
+    src_perms=$(stat -c '%a' "$src" 2>/dev/null || stat -f '%A' "$src")
+    dst_perms=$(stat -c '%a' "$dst" 2>/dev/null || stat -f '%A' "$dst")
     [ "$src_perms" = "$dst_perms" ]
 }
 


### PR DESCRIPTION
## Summary

#609 used the wrong order to probe `stat` portably:

```bash
src_perms=$(stat -f '%A' "$src" 2>/dev/null || stat -c '%a' "$src")
```

GNU `stat -f` is `--file-system` — it exits 0 on Linux with garbage output (`File: ... ID: ... 644`). The fallback never fires; downstream consumers (`chmod`, string compare) get garbage. On macOS the original order worked because `stat -f '%A'` is BSD format-string syntax.

CI failure on PR #607 right after #609 merged:

```
not ok 17 ... `chmod "$src_perms" "$src"' failed
chmod: invalid mode: '  File: "..."\n    ID: 9ce72a... ...644'
```

## Fix

- Swap probe order: GNU `stat -c '%a'` first (no flag collision on BSD — BSD has no `-c`), BSD `stat -f '%A'` as fallback.
- Updated comment to explain the GNU `-f` collision so the order isn't "fixed" back later.

## Test plan

- [x] `bats _tests/desktop/bundle-build-context.bats` passes locally on macOS (BSD fallback path)
- [ ] CI `desktop` job goes green on Linux runner (GNU primary path)
- [ ] PR #607 (release) auto-rebases and `desktop` job goes fully green