### PR TITLE
fix(desktop): expose Opus 4.6 + log llm writes + honest default label

### DIFF
--- a/crates/speedwave-runtime/src/defaults.rs
+++ b/crates/speedwave-runtime/src/defaults.rs
@@ -72,16 +72,21 @@ pub const ANTHROPIC_MODELS: &[AnthropicModelInfo] = &[
 /// resolves to at runtime — i.e. what `ANTHROPIC_DEFAULT_OPUS_MODEL` points
 /// at when `model` is left blank. Used by the Settings UI to render an
 /// honest hint like *"Default — Opus 4.7 (switchable via /model)"* instead
-/// of the previous mglista *"let Claude Code choose"* placeholder.
+/// of the previous vague *"let Claude Code choose"* placeholder.
 ///
 /// Reads from `ANTHROPIC_MODELS` (the SSOT) so a future Opus bump (e.g. 4.8)
 /// updates the UI hint without touching this helper. Returns `None` if the
 /// catalog has no `latest = true` Opus entry — frontend falls back to the
 /// generic placeholder in that case.
+///
+/// Identifies the Opus entry by `id.starts_with("claude-opus-")` rather than
+/// `family.starts_with("Opus")` — the API id is a stable contract with
+/// Anthropic, while the display label is mutable (e.g. someone could relabel
+/// "Opus 4.7" to "Claude Opus 4.7" without rebreaking this lookup).
 pub fn default_anthropic_family_label() -> Option<&'static str> {
     ANTHROPIC_MODELS
         .iter()
-        .find(|m| m.family.starts_with("Opus") && m.latest)
+        .find(|m| m.id.starts_with("claude-opus-") && m.latest)
         .map(|m| m.family)
 }
 

--- a/crates/speedwave-runtime/src/defaults.rs
+++ b/crates/speedwave-runtime/src/defaults.rs
@@ -60,7 +60,30 @@ pub const ANTHROPIC_MODELS: &[AnthropicModelInfo] = &[
         context_tokens: 200_000,
         latest: true,
     },
+    AnthropicModelInfo {
+        id: "claude-opus-4-6",
+        family: "Opus 4.6",
+        context_tokens: 1_000_000,
+        latest: false,
+    },
 ];
+
+/// The display label of the Opus model that the `(default)` dropdown option
+/// resolves to at runtime — i.e. what `ANTHROPIC_DEFAULT_OPUS_MODEL` points
+/// at when `model` is left blank. Used by the Settings UI to render an
+/// honest hint like *"Default — Opus 4.7 (switchable via /model)"* instead
+/// of the previous mglista *"let Claude Code choose"* placeholder.
+///
+/// Reads from `ANTHROPIC_MODELS` (the SSOT) so a future Opus bump (e.g. 4.8)
+/// updates the UI hint without touching this helper. Returns `None` if the
+/// catalog has no `latest = true` Opus entry — frontend falls back to the
+/// generic placeholder in that case.
+pub fn default_anthropic_family_label() -> Option<&'static str> {
+    ANTHROPIC_MODELS
+        .iter()
+        .find(|m| m.family.starts_with("Opus") && m.latest)
+        .map(|m| m.family)
+}
 
 pub const DEFAULT_FLAGS: &[&str] = &[
     // SECURITY RATIONALE: --dangerously-skip-permissions is safe in this context because:
@@ -422,5 +445,14 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn default_anthropic_family_label_returns_latest_opus_family() {
+        // Forces the constant in this assertion to be updated alongside the
+        // SSOT when a new Opus snapshot lands (e.g. Opus 4.8). If the test
+        // breaks on a model bump, the helper still works — the assertion
+        // just needs to follow the family label.
+        assert_eq!(default_anthropic_family_label(), Some("Opus 4.7"));
     }
 }

--- a/desktop/src-tauri/src/containers_cmd.rs
+++ b/desktop/src-tauri/src/containers_cmd.rs
@@ -657,7 +657,7 @@ pub fn list_anthropic_models() -> &'static [speedwave_runtime::defaults::Anthrop
 /// Returns the display label of the Opus model that the dropdown's
 /// `(default)` option resolves to at runtime — used by the Settings UI to
 /// render an honest hint like *"Default — Opus 4.7 (switchable via /model)"*
-/// instead of the previous mglista *"let Claude Code choose"* placeholder.
+/// instead of the previous vague *"let Claude Code choose"* placeholder.
 ///
 /// `None` when the SSOT has no `latest = true` Opus family — frontend then
 /// falls back to the generic placeholder.
@@ -714,11 +714,15 @@ fn apply_llm_config(
 
 #[tauri::command]
 pub fn update_llm_config(update: config::LlmConfig) -> Result<(), String> {
+    // Log non-sensitive fields up-front for diagnostics (provider/model never
+    // carry credentials). `base_url` is logged only AFTER the SSRF guard
+    // passes, and even then with userinfo / query / fragment stripped — so a
+    // user submitting `http://user:pass@host?token=...` never has the secret
+    // captured in the log buffer (see `.claude/rules/logging.md`).
     log::info!(
-        "update_llm_config: provider={:?} model={:?} base_url={:?} context_tokens={:?}",
+        "update_llm_config: provider={:?} model={:?} context_tokens={:?}",
         update.provider,
         update.model,
-        update.base_url,
         update.context_tokens
     );
     // Local providers (ollama, lmstudio, llamacpp) cannot start a session
@@ -761,10 +765,22 @@ pub fn update_llm_config(update: config::LlmConfig) -> Result<(), String> {
         // SSRF guard — same policy as LLM discovery probe. Blocks link-local,
         // metadata, IPv6-mapped bypasses, embedded credentials, query/fragment.
         // See ADR-041.
-        crate::llm_cmd::validate_llm_base_url(&normalized).map_err(|e| e.to_string())?;
+        let parsed =
+            crate::llm_cmd::validate_llm_base_url(&normalized).map_err(|e| e.to_string())?;
         // validate_base_url also rejects path components (http://host/path),
         // which validate_llm_base_url does not check.
         speedwave_runtime::compose::validate_base_url(&normalized).map_err(|e| e.to_string())?;
+        // Log the post-validation URL with userinfo / path / query / fragment
+        // stripped — only scheme+host[:port] survives. validate_llm_base_url
+        // already rejects userinfo, but keeping the log scrubbed independently
+        // satisfies the "log_sanitizer is a safety net, not a license" rule
+        // from .claude/rules/logging.md.
+        let port_str = parsed.port().map(|p| format!(":{p}")).unwrap_or_default();
+        log::info!(
+            "update_llm_config: base_url={}://{}{port_str}",
+            parsed.scheme(),
+            parsed.host_str().unwrap_or("<no-host>"),
+        );
     }
     config::with_config_lock(|| {
         let mut user_config = config::load_user_config()?;

--- a/desktop/src-tauri/src/containers_cmd.rs
+++ b/desktop/src-tauri/src/containers_cmd.rs
@@ -654,6 +654,18 @@ pub fn list_anthropic_models() -> &'static [speedwave_runtime::defaults::Anthrop
     speedwave_runtime::defaults::ANTHROPIC_MODELS
 }
 
+/// Returns the display label of the Opus model that the dropdown's
+/// `(default)` option resolves to at runtime — used by the Settings UI to
+/// render an honest hint like *"Default — Opus 4.7 (switchable via /model)"*
+/// instead of the previous mglista *"let Claude Code choose"* placeholder.
+///
+/// `None` when the SSOT has no `latest = true` Opus family — frontend then
+/// falls back to the generic placeholder.
+#[tauri::command]
+pub fn get_default_anthropic_model_label() -> Option<&'static str> {
+    speedwave_runtime::defaults::default_anthropic_family_label()
+}
+
 /// Applies LLM config to the active project in-memory. Extracted for
 /// testability and reused by `update_llm_config`.
 ///
@@ -702,6 +714,13 @@ fn apply_llm_config(
 
 #[tauri::command]
 pub fn update_llm_config(update: config::LlmConfig) -> Result<(), String> {
+    log::info!(
+        "update_llm_config: provider={:?} model={:?} base_url={:?} context_tokens={:?}",
+        update.provider,
+        update.model,
+        update.base_url,
+        update.context_tokens
+    );
     // Local providers (ollama, lmstudio, llamacpp) cannot start a session
     // without a model — `compose::apply_llm_config` rejects the compose
     // render, which only surfaces when the user tries to run Claude.
@@ -749,8 +768,14 @@ pub fn update_llm_config(update: config::LlmConfig) -> Result<(), String> {
     }
     config::with_config_lock(|| {
         let mut user_config = config::load_user_config()?;
+        let active = user_config.active_project.clone();
         apply_llm_config(&mut user_config, update)?;
-        config::save_user_config(&user_config)
+        config::save_user_config(&user_config)?;
+        log::info!(
+            "update_llm_config: persisted to active_project={:?}",
+            active
+        );
+        Ok(())
     })
     .map_err(|e| e.to_string())
 }

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -1409,6 +1409,7 @@ fn main() {
             containers_cmd::get_llm_config,
             containers_cmd::get_default_base_url,
             containers_cmd::list_anthropic_models,
+            containers_cmd::get_default_anthropic_model_label,
             containers_cmd::update_llm_config,
             llm_cmd::discover_llm_models,
             // Authentication

--- a/desktop/src/src/app/settings/llm-provider/llm-provider.component.spec.ts
+++ b/desktop/src/src/app/settings/llm-provider/llm-provider.component.spec.ts
@@ -523,7 +523,7 @@ describe('LlmProviderComponent', () => {
 
   it('falls back to the generic placeholder when backend returns null', async () => {
     // Older backends (or backends in dev mode without the new command)
-    // may return null. The component must keep the previous mglista
+    // may return null. The component must keep the generic placeholder
     // wording rather than render a broken half-string.
     mockTauri.invokeHandler = async (cmd: string, args?: Record<string, unknown>) => {
       switch (cmd) {

--- a/desktop/src/src/app/settings/llm-provider/llm-provider.component.spec.ts
+++ b/desktop/src/src/app/settings/llm-provider/llm-provider.component.spec.ts
@@ -53,6 +53,8 @@ function setupMockTauri(mockTauri: MockTauriService, provider = 'anthropic'): vo
         return DEFAULT_BASE_URLS[(args?.['provider'] as string) ?? ''] ?? null;
       case 'list_anthropic_models':
         return TEST_ANTHROPIC_MODELS;
+      case 'get_default_anthropic_model_label':
+        return 'Opus 4.7';
       case 'update_llm_config':
         return undefined;
       case 'discover_llm_models':
@@ -424,7 +426,10 @@ describe('LlmProviderComponent', () => {
     const defaultLabel = (
       modelEl.querySelector('option[value=""]') as HTMLOptionElement
     )?.textContent?.trim();
-    expect(defaultLabel).toContain('default');
+    // Default option carries the SSOT-resolved Opus family label so the
+    // user knows which model the alias-mode actually steers toward. The
+    // exact string is verified by the dedicated tests below.
+    expect(defaultLabel?.toLowerCase()).toContain('default');
 
     // Latest entries land in an optgroup labelled "Latest" so users see
     // the recommended families at the top.
@@ -492,6 +497,64 @@ describe('LlmProviderComponent', () => {
       .find((o) => o.value === 'claude-opus-4-1');
     expect(stray).toBeTruthy();
     expect(stray?.textContent).toContain('not in catalog');
+  });
+
+  it('renders dynamic Default — <family> label when backend returns a label', async () => {
+    // Backend SSOT returns the Opus family label so the dropdown surfaces
+    // what `(default)` actually steers toward (alias mode → Opus 4.7 today).
+    // Anything but the dynamic form would hide the resolved model from the
+    // user — exactly the regression this PR fixes.
+    component.ngOnInit();
+    await fixture.whenStable();
+    await flushMicrotasks();
+    fixture.changeDetectorRef.markForCheck();
+    fixture.detectChanges();
+
+    const modelEl = fixture.nativeElement.querySelector(
+      '[data-testid="settings-llm-model"]'
+    ) as HTMLSelectElement;
+    const defaultLabel = (
+      modelEl.querySelector('option[value=""]') as HTMLOptionElement
+    )?.textContent?.trim();
+    expect(defaultLabel).toBe('Default — Opus 4.7 (switchable via /model)');
+  });
+
+  it('falls back to the generic placeholder when backend returns null', async () => {
+    // Older backends (or backends in dev mode without the new command)
+    // may return null. The component must keep the previous mglista
+    // wording rather than render a broken half-string.
+    mockTauri.invokeHandler = async (cmd: string, args?: Record<string, unknown>) => {
+      switch (cmd) {
+        case 'get_llm_config':
+          return {
+            provider: 'anthropic',
+            model: null,
+            base_url: null,
+            default_base_url: null,
+          };
+        case 'get_default_base_url':
+          return DEFAULT_BASE_URLS[(args?.['provider'] as string) ?? ''] ?? null;
+        case 'list_anthropic_models':
+          return TEST_ANTHROPIC_MODELS;
+        case 'get_default_anthropic_model_label':
+          return null;
+        default:
+          return undefined;
+      }
+    };
+    component.ngOnInit();
+    await fixture.whenStable();
+    await flushMicrotasks();
+    fixture.changeDetectorRef.markForCheck();
+    fixture.detectChanges();
+
+    const modelEl = fixture.nativeElement.querySelector(
+      '[data-testid="settings-llm-model"]'
+    ) as HTMLSelectElement;
+    const defaultLabel = (
+      modelEl.querySelector('option[value=""]') as HTMLOptionElement
+    )?.textContent?.trim();
+    expect(defaultLabel).toBe('(default — let Claude Code choose)');
   });
 
   it('shows model and base URL fields for ollama provider', async () => {

--- a/desktop/src/src/app/settings/llm-provider/llm-provider.component.spec.ts
+++ b/desktop/src/src/app/settings/llm-provider/llm-provider.component.spec.ts
@@ -479,6 +479,8 @@ describe('LlmProviderComponent', () => {
           return DEFAULT_BASE_URLS[(args?.['provider'] as string) ?? ''] ?? null;
         case 'list_anthropic_models':
           return TEST_ANTHROPIC_MODELS;
+        case 'get_default_anthropic_model_label':
+          return 'Opus 4.7';
         default:
           return undefined;
       }

--- a/desktop/src/src/app/settings/llm-provider/llm-provider.component.ts
+++ b/desktop/src/src/app/settings/llm-provider/llm-provider.component.ts
@@ -144,8 +144,15 @@ const PROVIDER_CARDS: readonly ProviderCard[] = [
               data-testid="settings-llm-model"
             >
               <!-- Empty value = no ANTHROPIC_MODEL injected; Claude Code
-                   picks its built-in default. -->
-              <option value="">(default — let Claude Code choose)</option>
+                   picks its built-in default via ANTHROPIC_DEFAULT_OPUS_MODEL
+                   (set by compose::apply_llm_config). The label resolves the
+                   Opus family from the SSOT so the user knows what they
+                   actually get instead of the previous mglista wording. -->
+              @if (defaultAnthropicLabel(); as label) {
+                <option value="">Default — {{ label }} (switchable via /model)</option>
+              } @else {
+                <option value="">(default — let Claude Code choose)</option>
+              }
               @if (latestAnthropicModels().length > 0) {
                 <optgroup label="Latest">
                   @for (m of latestAnthropicModels(); track m.id) {
@@ -316,10 +323,19 @@ export class LlmProviderComponent implements OnInit {
     this.anthropicCatalog().filter((m) => !m.latest)
   );
 
+  /**
+   * Family label of the Opus model that the dropdown's `(default)` option
+   * resolves to at runtime. Sourced from `get_default_anthropic_model_label`
+   * (backend SSOT). `null` until first fetch resolves; falsy values fall
+   * back to the generic placeholder text in the template.
+   */
+  protected readonly defaultAnthropicLabel = signal<string | null>(null);
+
   /** Loads the LLM configuration + the SSOT model catalog from the backend on init. */
   ngOnInit(): void {
     this.loadConfig();
     void this.loadAnthropicCatalog();
+    void this.loadDefaultAnthropicLabel();
   }
 
   /**
@@ -397,6 +413,22 @@ export class LlmProviderComponent implements OnInit {
     const list = await this.anthropicModels.list();
     this.anthropicCatalog.set(list);
     this.cdr.markForCheck();
+  }
+
+  /**
+   * Fetches the SSOT family label of the Opus model that anchors the
+   * `(default)` dropdown option. Failure is silent — the template falls
+   * back to the generic placeholder when the signal stays null (e.g. dev
+   * mode without Tauri, or a backend that pre-dates this command).
+   */
+  private async loadDefaultAnthropicLabel(): Promise<void> {
+    try {
+      const label = await this.tauri.invoke<string | null>('get_default_anthropic_model_label');
+      this.defaultAnthropicLabel.set(label);
+      this.cdr.markForCheck();
+    } catch {
+      // Stay on the generic placeholder.
+    }
   }
 
   /**

--- a/desktop/src/src/app/settings/llm-provider/llm-provider.component.ts
+++ b/desktop/src/src/app/settings/llm-provider/llm-provider.component.ts
@@ -147,8 +147,16 @@ const PROVIDER_CARDS: readonly ProviderCard[] = [
                    picks its built-in default via ANTHROPIC_DEFAULT_OPUS_MODEL
                    (set by compose::apply_llm_config). The label resolves the
                    Opus family from the SSOT so the user knows what they
-                   actually get instead of the previous mglista wording. -->
-              @if (defaultAnthropicLabel(); as label) {
+                   actually get. Three-state render: undefined keeps the
+                   option blank-but-valid while the SSOT label is in flight
+                   (so a model=null config still has something selectable
+                   and we do not flash the misleading generic wording);
+                   string renders the dynamic hint; null (resolved without
+                   a label, e.g. older backend) falls back to the generic
+                   wording. -->
+              @if (defaultAnthropicLabel() === undefined) {
+                <option value=""></option>
+              } @else if (defaultAnthropicLabel(); as label) {
                 <option value="">Default — {{ label }} (switchable via /model)</option>
               } @else {
                 <option value="">(default — let Claude Code choose)</option>
@@ -326,10 +334,14 @@ export class LlmProviderComponent implements OnInit {
   /**
    * Family label of the Opus model that the dropdown's `(default)` option
    * resolves to at runtime. Sourced from `get_default_anthropic_model_label`
-   * (backend SSOT). `null` until first fetch resolves; falsy values fall
-   * back to the generic placeholder text in the template.
+   * (backend SSOT). Three-state to avoid the on-init placeholder flash:
+   *   - `undefined` → fetch still in flight; template hides the option
+   *     until we know what to render.
+   *   - `null` → fetch resolved with no label (older backend, dev mode
+   *     without Tauri) — template renders the generic placeholder.
+   *   - `string` → render the dynamic "Default — <family>" hint.
    */
-  protected readonly defaultAnthropicLabel = signal<string | null>(null);
+  protected readonly defaultAnthropicLabel = signal<string | null | undefined>(undefined);
 
   /** Loads the LLM configuration + the SSOT model catalog from the backend on init. */
   ngOnInit(): void {
@@ -424,10 +436,17 @@ export class LlmProviderComponent implements OnInit {
   private async loadDefaultAnthropicLabel(): Promise<void> {
     try {
       const label = await this.tauri.invoke<string | null>('get_default_anthropic_model_label');
-      this.defaultAnthropicLabel.set(label);
+      // Backend may return null when the catalog has no `latest=true` Opus.
+      // Treat both cases (resolved-as-null, resolved-as-string) as "fetched";
+      // collapse `undefined` from older invokeHandlers to `null` so the
+      // template's loading branch only triggers while genuinely in flight.
+      this.defaultAnthropicLabel.set(label ?? null);
       this.cdr.markForCheck();
     } catch {
-      // Stay on the generic placeholder.
+      // Mark as resolved-with-no-label so the template falls back to the
+      // generic placeholder instead of staying invisible.
+      this.defaultAnthropicLabel.set(null);
+      this.cdr.markForCheck();
     }
   }
 


### PR DESCRIPTION
## Summary

- **defaults.rs**: Add `claude-opus-4-6` to `ANTHROPIC_MODELS` as a `latest=false` legacy entry (1M context, sourced from official Anthropic docs). Adds `default_anthropic_family_label()` helper that reads the SSOT and returns the family of the active `latest=true` Opus — so a future Opus bump (4.8) propagates to the UI hint without touching the helper.
- **containers_cmd.rs**:
  - New `get_default_anthropic_model_label` Tauri command exposing the helper to the frontend.
  - `update_llm_config` now logs inputs (`provider, model, base_url, context_tokens`) and the persisted `active_project`. Closes a real diagnostic gap — without these lines, a user reporting "Save didn't persist what I clicked" cannot be verified from logs.
- **llm-provider.component.ts**: Replace the misleading `(default — let Claude Code choose)` placeholder with a dynamic `Default — Opus 4.7 (switchable via /model)` hint sourced from the SSOT. Falls back to the previous wording when the new backend command returns `null` (older backends, dev mode without Tauri).
- **main.rs**: Register the new Tauri command in `generate_handler!`.

## Behavior

| Stan configu | Przed | Po |
|---|---|---|
| `provider=anthropic, model=null` | UI: `(default — let Claude Code choose)`; alias-mode w kontenerze | UI: `Default — Opus 4.7 (switchable via /model)`; alias-mode bez zmian |
| `provider=anthropic, model=claude-opus-4-6` (dziś tylko ręczna edycja) | UI: `(not in catalog)` | UI: `Opus 4.6 · 1M ctx (claude-opus-4-6)` w "Legacy" optgroup |
| `provider=anthropic, model=claude-opus-4-7\|sonnet-4-6\|haiku-4-5` | bez zmian | bez zmian |
| Local providers (ollama/lmstudio/llamacpp) | bez zmian | bez zmian |

`apply_llm_config`, `anthropic_default_models_env`, alias-mode i ścieżka zapisu — **bez zmian**. Zero migracji, zero zapisu na dysk z runtime.

## Test plan

- [x] `make check` passes (clippy 0 warnings, fmt OK, prettier OK, ESLint OK on MCP + Angular)
- [x] `make test` passes (Rust + Angular + MCP + entrypoint + desktop + CI bats)
- [x] New unit test `default_anthropic_family_label_returns_latest_opus_family` asserts `Some("Opus 4.7")` (forces the test to be updated alongside an Opus bump)
- [x] New frontend tests: dynamic `Default — Opus 4.7` label rendering + null fallback to generic placeholder
- [x] Smoke test in dev mode (`SPEEDWAVE_DATA_DIR=~/.speedwave-dev make dev`):
  - [x] Dropdown shows: dynamic Default + Latest optgroup (3) + Legacy optgroup (Opus 4.6)
  - [x] Selecting Opus 4.6 → Save → `~/.speedwave-dev/config.json` shows `model: "claude-opus-4-6"`
  - [x] Log: `update_llm_config: provider=Some("anthropic") model=Some("claude-opus-4-6") ... persisted to active_project=Some("presales")`
  - [x] Selecting llamacpp + custom URL + Save round-trips correctly
  - [x] Chat with Opus 4.6 confirms model: statusline `opus-4.6 · 19 tok · \$0.126`, model self-identifies as `claude-opus-4-6`