### PR TITLE
feat(desktop): beta-features toggle in tray menu (ADR-055)

### DIFF
--- a/crates/speedwave-cli/src/main.rs
+++ b/crates/speedwave-cli/src/main.rs
@@ -1207,6 +1207,7 @@ mod tests {
             active_project: None,
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
 
         let result = resolve_project_for_cwd(&canonical, &user_config).unwrap();
@@ -1231,6 +1232,7 @@ mod tests {
             active_project: None,
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
 
         let result = resolve_project_for_cwd(&sub, &user_config).unwrap();
@@ -1266,6 +1268,7 @@ mod tests {
             active_project: None,
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
 
         // CWD inside nested project should match web-proj (longer prefix)
@@ -1286,6 +1289,7 @@ mod tests {
             active_project: Some("fallback-project".to_string()),
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
 
         // Use a tempdir as CWD that doesn't match any project
@@ -1301,6 +1305,7 @@ mod tests {
             active_project: None,
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
 
         let tmp = tempfile::tempdir().unwrap();
@@ -1326,6 +1331,7 @@ mod tests {
             active_project: None,
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
 
         // canonicalize strips trailing slash, so exact match should work

--- a/crates/speedwave-runtime/src/config.rs
+++ b/crates/speedwave-runtime/src/config.rs
@@ -192,7 +192,7 @@ pub struct SelectedIde {
     pub port: u16,
 }
 
-/// UI preferences (ADR-057). Top-level user-only — a checked-in repo
+/// UI preferences (ADR-055). Top-level user-only — a checked-in repo
 /// `.speedwave.json` is not allowed to flip beta UI on or off.
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct UiPrefsConfig {
@@ -206,7 +206,7 @@ pub struct SpeedwaveUserConfig {
     pub active_project: Option<String>,
     pub selected_ide: Option<SelectedIde>,
     pub log_level: Option<String>,
-    /// UI preferences (ADR-057). Top-level, user-only.
+    /// UI preferences (ADR-055). Top-level, user-only.
     pub ui: Option<UiPrefsConfig>,
 }
 
@@ -487,7 +487,7 @@ mod tests {
     use super::*;
     use std::io::Write;
 
-    // ---- UiPrefsConfig (ADR-057) -------------------------------------------
+    // ---- UiPrefsConfig (ADR-055) -------------------------------------------
 
     #[test]
     fn beta_disabled_by_default() {

--- a/crates/speedwave-runtime/src/config.rs
+++ b/crates/speedwave-runtime/src/config.rs
@@ -192,12 +192,22 @@ pub struct SelectedIde {
     pub port: u16,
 }
 
+/// UI preferences (ADR-057). Top-level user-only — a checked-in repo
+/// `.speedwave.json` is not allowed to flip beta UI on or off.
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
+pub struct UiPrefsConfig {
+    /// Reveal hidden / work-in-progress UI surfaces. Default = off.
+    pub beta_enabled: Option<bool>,
+}
+
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub struct SpeedwaveUserConfig {
     pub projects: Vec<ProjectUserEntry>,
     pub active_project: Option<String>,
     pub selected_ide: Option<SelectedIde>,
     pub log_level: Option<String>,
+    /// UI preferences (ADR-057). Top-level, user-only.
+    pub ui: Option<UiPrefsConfig>,
 }
 
 impl SpeedwaveUserConfig {
@@ -223,6 +233,14 @@ impl SpeedwaveUserConfig {
         self.active_project
             .as_deref()
             .and_then(|n| self.find_project(n))
+    }
+
+    /// `true` if beta-features UI surface is enabled (top-level only).
+    pub fn beta_enabled(&self) -> bool {
+        self.ui
+            .as_ref()
+            .and_then(|u| u.beta_enabled)
+            .unwrap_or(false)
     }
 }
 
@@ -469,6 +487,66 @@ mod tests {
     use super::*;
     use std::io::Write;
 
+    // ---- UiPrefsConfig (ADR-057) -------------------------------------------
+
+    #[test]
+    fn beta_disabled_by_default() {
+        let cfg = SpeedwaveUserConfig::default();
+        assert!(!cfg.beta_enabled());
+        assert!(cfg.ui.is_none());
+    }
+
+    #[test]
+    fn beta_enabled_only_when_user_set_it() {
+        let cfg_on = SpeedwaveUserConfig {
+            ui: Some(UiPrefsConfig {
+                beta_enabled: Some(true),
+            }),
+            ..Default::default()
+        };
+        assert!(cfg_on.beta_enabled());
+
+        let cfg_off = SpeedwaveUserConfig {
+            ui: Some(UiPrefsConfig {
+                beta_enabled: Some(false),
+            }),
+            ..Default::default()
+        };
+        assert!(!cfg_off.beta_enabled());
+
+        let cfg_unset = SpeedwaveUserConfig {
+            ui: Some(UiPrefsConfig::default()),
+            ..Default::default()
+        };
+        assert!(!cfg_unset.beta_enabled());
+    }
+
+    #[test]
+    fn ui_prefs_round_trip_through_serde() {
+        let cfg = SpeedwaveUserConfig {
+            ui: Some(UiPrefsConfig {
+                beta_enabled: Some(true),
+            }),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&cfg).expect("serialize");
+        let back: SpeedwaveUserConfig = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.ui, cfg.ui);
+    }
+
+    #[test]
+    fn user_config_without_ui_field_still_parses() {
+        let pre_adr_json = r#"{
+            "projects": [],
+            "active_project": null,
+            "selected_ide": null,
+            "log_level": null
+        }"#;
+        let parsed: SpeedwaveUserConfig = serde_json::from_str(pre_adr_json).expect("parse");
+        assert!(parsed.ui.is_none());
+        assert!(!parsed.beta_enabled());
+    }
+
     #[test]
     fn test_default_config_has_expected_env() {
         let defaults = defaults::base_env();
@@ -580,6 +658,7 @@ mod tests {
             active_project: None,
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
 
         let resolved = resolve_claude_config(tmp.path(), &user_config, "test-project");
@@ -628,6 +707,7 @@ mod tests {
             active_project: None,
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
 
         let resolved = resolve_claude_config(tmp.path(), &user_config, "test-project");
@@ -722,6 +802,7 @@ mod tests {
             active_project: Some("acme".to_string()),
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
         let json = serde_json::to_string(&config).unwrap();
         let parsed: SpeedwaveUserConfig = serde_json::from_str(&json).unwrap();
@@ -746,6 +827,7 @@ mod tests {
             active_project: Some("test".to_string()),
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
 
         save_user_config_to(&config, &config_path).unwrap();
@@ -767,6 +849,7 @@ mod tests {
             active_project: None,
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
 
         save_user_config_to(&config, &config_path).unwrap();
@@ -789,6 +872,7 @@ mod tests {
             active_project: Some("test".to_string()),
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
 
         save_user_config_to(&config, &config_path).unwrap();
@@ -822,6 +906,7 @@ mod tests {
             active_project: Some("v1".to_string()),
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
         save_user_config_to(&config_v1, &config_path).unwrap();
 
@@ -837,6 +922,7 @@ mod tests {
             active_project: Some("v2".to_string()),
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
         save_user_config_to(&config_v2, &config_path).unwrap();
 
@@ -857,6 +943,7 @@ mod tests {
             active_project: None,
             selected_ide: None,
             log_level: Some("debug".to_string()),
+            ui: None,
         };
         let json = serde_json::to_string(&config).unwrap();
         let parsed: SpeedwaveUserConfig = serde_json::from_str(&json).unwrap();
@@ -896,6 +983,7 @@ mod tests {
             active_project: None,
             selected_ide: None,
             log_level: None,
+            ui: None,
         }
     }
 
@@ -944,6 +1032,7 @@ mod tests {
             active_project: None,
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
         let resolved = resolve_claude_config(tmp.path(), &user_config, "test-project");
         let flags = &resolved.flags;
@@ -1175,6 +1264,7 @@ mod tests {
             active_project: None,
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
 
         let resolved = resolve_integrations(tmp.path(), &user_config, "test-project");
@@ -1215,6 +1305,7 @@ mod tests {
             active_project: None,
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
 
         let tmp = tempfile::tempdir().unwrap();
@@ -1250,6 +1341,7 @@ mod tests {
             active_project: None,
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
 
         let tmp = tempfile::tempdir().unwrap();
@@ -1535,6 +1627,7 @@ mod tests {
             active_project: None,
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
 
         let resolved = resolve_integrations(tmp.path(), &user_config, "test-project");
@@ -1566,6 +1659,7 @@ mod tests {
             active_project: None,
             selected_ide: None,
             log_level: None,
+            ui: None,
         }
     }
 
@@ -1640,6 +1734,7 @@ mod tests {
             active_project: Some("beta".to_string()),
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
         let entry = config.active_project_entry();
         assert!(entry.is_some());
@@ -1665,6 +1760,7 @@ mod tests {
             active_project: Some("deleted-project".to_string()),
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
         assert!(
             config.active_project_entry().is_none(),

--- a/crates/speedwave-runtime/src/project.rs
+++ b/crates/speedwave-runtime/src/project.rs
@@ -339,6 +339,7 @@ mod tests {
             active_project: Some("existing".to_string()),
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
         save_user_config_to(&config, &data_dir.join("config.json")).unwrap();
 
@@ -380,6 +381,7 @@ mod tests {
             active_project: None,
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
         save_user_config_to(&config, &data_dir.join("config.json")).unwrap();
 

--- a/desktop/src-tauri/src/chat.rs
+++ b/desktop/src-tauri/src/chat.rs
@@ -3926,6 +3926,7 @@ mod tests {
             active_project: None,
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
         let result = ChatSession::prepare_args("nonexistent", &user_config, None, None);
         assert!(result.is_err());
@@ -3949,6 +3950,7 @@ mod tests {
             active_project: None,
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
         let result =
             ChatSession::prepare_args("test", &user_config, Some("../../../etc/passwd"), None);
@@ -3968,6 +3970,7 @@ mod tests {
             active_project: None,
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
         let result = ChatSession::prepare_args(
             "test",
@@ -3991,6 +3994,7 @@ mod tests {
             active_project: None,
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
         let result = ChatSession::prepare_args("myproject", &user_config, None, None);
         assert!(result.is_ok());
@@ -4012,6 +4016,7 @@ mod tests {
             active_project: None,
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
         let session_id = "550e8400-e29b-41d4-a716-446655440000";
         let result = ChatSession::prepare_args("proj", &user_config, Some(session_id), None);
@@ -4035,6 +4040,7 @@ mod tests {
             active_project: None,
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
         let session_id = "550e8400-e29b-41d4-a716-446655440000";
         let uuid = "msg_retry_me";

--- a/desktop/src-tauri/src/containers_cmd.rs
+++ b/desktop/src-tauri/src/containers_cmd.rs
@@ -280,7 +280,11 @@ pub async fn init_vm() -> Result<(), String> {
 }
 
 #[tauri::command]
-pub async fn create_project(name: String, dir: String) -> Result<(), String> {
+pub async fn create_project(
+    app: tauri::AppHandle,
+    name: String,
+    dir: String,
+) -> Result<(), String> {
     tokio::task::spawn_blocking(move || {
         log::info!("create_project: name={name}, dir={dir}");
         setup_wizard::create_project(&name, &dir).map_err(|e| {
@@ -289,7 +293,13 @@ pub async fn create_project(name: String, dir: String) -> Result<(), String> {
         })
     })
     .await
-    .map_err(|e| e.to_string())?
+    .map_err(|e| e.to_string())??;
+
+    // `create_project` is the last setup step; `is_setup_complete()` now flips
+    // to `true`, so rebuild the tray menu to surface items gated on it (ADR-057
+    // beta toggle).
+    crate::tray::refresh_tray_menu(&app);
+    Ok(())
 }
 
 #[tauri::command]
@@ -836,6 +846,7 @@ mod tests {
             active_project: Some("alpha".to_string()),
             selected_ide: None,
             log_level: None,
+            ui: None,
         }
     }
 
@@ -927,6 +938,7 @@ mod tests {
             active_project: None,
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
 
         // Use a non-local provider so the new local-provider+model guard
@@ -953,6 +965,7 @@ mod tests {
             active_project: Some("nonexistent".to_string()),
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
 
         // Anthropic skips the local-provider+model guard so the project-not-
@@ -986,6 +999,7 @@ mod tests {
             active_project: Some("proj".to_string()),
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
 
         apply_llm_config(&mut cfg, llm("ollama", Some("llama3.3"), None)).unwrap();

--- a/desktop/src-tauri/src/containers_cmd.rs
+++ b/desktop/src-tauri/src/containers_cmd.rs
@@ -295,9 +295,8 @@ pub async fn create_project(
     .await
     .map_err(|e| e.to_string())??;
 
-    // `create_project` is the last setup step; `is_setup_complete()` now flips
-    // to `true`, so rebuild the tray menu to surface items gated on it (ADR-057
-    // beta toggle).
+    // Last setup step → `is_setup_complete()` flips true; rebuild so setup-gated
+    // tray items (the ADR-055 beta toggle) appear.
     crate::tray::refresh_tray_menu(&app);
     Ok(())
 }

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -41,6 +41,7 @@ mod subscribe_cmd;
 mod system_settings_cmd;
 mod tray;
 mod types;
+mod ui_prefs_cmd;
 mod update_commands;
 mod updater;
 mod url_validation;
@@ -115,9 +116,6 @@ pub(crate) fn stash_cleanup_handle(
         }
     }
 }
-
-/// Tracks the latest available update version for the system tray menu.
-type SharedUpdateVersion = Arc<Mutex<Option<String>>>;
 
 /// Serialises compose operations across `start_chat`, `resume_conversation`,
 /// and `reconcile_compose_port` to prevent concurrent `compose_up` /
@@ -1047,11 +1045,12 @@ fn main() {
     let queue_service = speedwave_runtime::session::QueuedMessageService::new();
     let msg_store_registry = subscribe_cmd::MsgStoreRegistry::new();
 
-    // Shared state for IDE Bridge, mcp-os process, auto-check handle, and tray update version
+    // Shared state for IDE Bridge, mcp-os process, and auto-check handle.
+    // The tray menu's variable state (`update_version`, `beta_enabled`) is
+    // managed via `app.manage(TrayMenuState::default())` below — see ADR-057.
     let ide_bridge: SharedIdeBridge = Arc::new(Mutex::new(None));
     let mcp_os: SharedMcpOs = Arc::new(Mutex::new(None));
     let auto_check_handle: SharedAutoCheckHandle = Arc::new(Mutex::new(None));
-    let update_version: SharedUpdateVersion = Arc::new(Mutex::new(None));
 
     let tray_available = Arc::new(AtomicBool::new(false));
     #[cfg_attr(target_os = "linux", allow(unused_variables))]
@@ -1067,7 +1066,16 @@ fn main() {
     };
     let cleanup_ctx_window = cleanup_ctx.clone();
     let cleanup_ctx_runevent = cleanup_ctx.clone();
-    let update_version_setup = update_version.clone();
+
+    // Seed tray state from persisted user-config so the beta-features
+    // checkbox reflects the previous session's choice on startup.
+    let initial_beta_enabled = config::load_user_config()
+        .map(|c| c.beta_enabled())
+        .unwrap_or(false);
+    let tray_state = tray::TrayMenuState {
+        update_version: Mutex::new(None),
+        beta_enabled: Mutex::new(initial_beta_enabled),
+    };
 
     // Register SIGTERM/SIGINT handler so process signals trigger the same
     // cleanup as graceful window close. The CLEANUP_ONCE guard in
@@ -1172,6 +1180,7 @@ fn main() {
         .manage(mcp_os.clone())
         .manage(queue_service.clone())
         .manage(msg_store_registry.clone())
+        .manage(tray_state)
         .setup(move |app| {
             // Restore persisted log level (default: Info)
             let initial_level = config::load_user_config()
@@ -1284,9 +1293,24 @@ fn main() {
                 reconcile::reconcile_bundle_update(app.handle());
             }
 
-            // Build system tray.
-            let tray_menu = tray::build_tray_menu(app.handle(), &None)?;
-            let update_version_tray = update_version_setup.clone();
+            // Build system tray. Initial state is read from the managed
+            // `TrayMenuState`; mutations (update_version, beta_enabled) flow
+            // through `refresh_tray_menu(app)` from anywhere.
+            use tauri::Manager;
+            let tray_menu = {
+                let state = app.state::<tray::TrayMenuState>();
+                let beta = state
+                    .beta_enabled
+                    .lock()
+                    .map(|g| *g)
+                    .unwrap_or(false);
+                tray::build_tray_menu(
+                    app.handle(),
+                    None,
+                    beta,
+                    setup_wizard::is_setup_complete(),
+                )?
+            };
             let tray_icon = tray::load_tray_icon()?;
 
             #[cfg_attr(target_os = "linux", allow(unused_mut))]
@@ -1329,11 +1353,16 @@ fn main() {
                         });
                     }
                     "install_update" => {
+                        let app_for_state = app.clone();
                         #[cfg(not(target_os = "linux"))]
                         let app_clone = app.clone();
-                        let uv = update_version_tray.clone();
                         tauri::async_runtime::spawn(async move {
-                            let version = uv.lock().ok().and_then(|g| g.clone());
+                            let version = app_for_state
+                                .state::<tray::TrayMenuState>()
+                                .update_version
+                                .lock()
+                                .ok()
+                                .and_then(|g| g.clone());
                             if let Some(expected) = version {
                                 #[cfg(target_os = "linux")]
                                 let result = {
@@ -1361,6 +1390,24 @@ fn main() {
                                 }
                             } else {
                                 log::warn!("tray: install_update clicked but no version available");
+                            }
+                        });
+                    }
+                    "toggle_beta" => {
+                        let app_clone = app.clone();
+                        tauri::async_runtime::spawn(async move {
+                            let current = match app_clone
+                                .state::<tray::TrayMenuState>()
+                                .beta_enabled
+                                .lock()
+                            {
+                                Ok(g) => *g,
+                                Err(p) => *p.into_inner(),
+                            };
+                            if let Err(e) =
+                                ui_prefs_cmd::apply_beta_toggle_inner(&app_clone, !current).await
+                            {
+                                log::error!("tray: beta toggle failed: {e}");
                             }
                         });
                     }
@@ -1453,20 +1500,19 @@ fn main() {
                 }
             }
 
-            // Listen for update_available events (from auto-check) to update tray menu
-            let update_version_listener = update_version_setup.clone();
+            // Listen for update_available events (from auto-check) to update tray menu.
             let app_handle_listener = app.handle().clone();
             use tauri::Listener;
             app.listen(
                 "update_available",
                 move |event| match serde_json::from_str::<updater::UpdateInfo>(event.payload()) {
                     Ok(info) => {
-                        let version = info.version;
-                        match update_version_listener.lock() {
-                            Ok(mut guard) => *guard = Some(version.clone()),
+                        let state = app_handle_listener.state::<tray::TrayMenuState>();
+                        match state.update_version.lock() {
+                            Ok(mut guard) => *guard = Some(info.version.clone()),
                             Err(e) => log::warn!("update version mutex poisoned: {e}"),
                         }
-                        tray::refresh_tray_menu(&app_handle_listener, &Some(version));
+                        tray::refresh_tray_menu(&app_handle_listener);
                     }
                     Err(e) => {
                         log::warn!("tray: failed to deserialize update_available payload: {e}");
@@ -1558,6 +1604,9 @@ fn main() {
             // Logging
             set_log_level,
             get_log_level,
+            // UI preferences (ADR-057)
+            ui_prefs_cmd::get_beta_enabled,
+            ui_prefs_cmd::set_beta_enabled,
             // Diagnostics
             export_diagnostics,
             // Integrations
@@ -2026,6 +2075,7 @@ mod tests {
             active_project: Some("alpha".to_string()),
             selected_ide: None,
             log_level: None,
+            ui: None,
         }
     }
 
@@ -2096,6 +2146,7 @@ mod tests {
             active_project: None,
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
 
         let result = apply_switch_project(&mut cfg, "only");

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -1046,8 +1046,7 @@ fn main() {
     let msg_store_registry = subscribe_cmd::MsgStoreRegistry::new();
 
     // Shared state for IDE Bridge, mcp-os process, and auto-check handle.
-    // The tray menu's variable state (`update_version`, `beta_enabled`) is
-    // managed via `app.manage(TrayMenuState::default())` below — see ADR-057.
+    // (Tray menu state lives in a managed `TrayMenuState`, set up below.)
     let ide_bridge: SharedIdeBridge = Arc::new(Mutex::new(None));
     let mcp_os: SharedMcpOs = Arc::new(Mutex::new(None));
     let auto_check_handle: SharedAutoCheckHandle = Arc::new(Mutex::new(None));
@@ -1072,10 +1071,7 @@ fn main() {
     let initial_beta_enabled = config::load_user_config()
         .map(|c| c.beta_enabled())
         .unwrap_or(false);
-    let tray_state = tray::TrayMenuState {
-        update_version: Mutex::new(None),
-        beta_enabled: Mutex::new(initial_beta_enabled),
-    };
+    let tray_state = tray::TrayMenuState::new(initial_beta_enabled);
 
     // Register SIGTERM/SIGINT handler so process signals trigger the same
     // cleanup as graceful window close. The CLEANUP_ONCE guard in
@@ -1293,24 +1289,14 @@ fn main() {
                 reconcile::reconcile_bundle_update(app.handle());
             }
 
-            // Build system tray. Initial state is read from the managed
-            // `TrayMenuState`; mutations (update_version, beta_enabled) flow
-            // through `refresh_tray_menu(app)` from anywhere.
+            // Build system tray from the managed `TrayMenuState`.
             use tauri::Manager;
-            let tray_menu = {
-                let state = app.state::<tray::TrayMenuState>();
-                let beta = state
-                    .beta_enabled
-                    .lock()
-                    .map(|g| *g)
-                    .unwrap_or(false);
-                tray::build_tray_menu(
-                    app.handle(),
-                    None,
-                    beta,
-                    setup_wizard::is_setup_complete(),
-                )?
-            };
+            let tray_menu = tray::build_tray_menu(
+                app.handle(),
+                None,
+                app.state::<tray::TrayMenuState>().beta_enabled(),
+                setup_wizard::is_setup_complete(),
+            )?;
             let tray_icon = tray::load_tray_icon()?;
 
             #[cfg_attr(target_os = "linux", allow(unused_mut))]
@@ -1357,12 +1343,8 @@ fn main() {
                         #[cfg(not(target_os = "linux"))]
                         let app_clone = app.clone();
                         tauri::async_runtime::spawn(async move {
-                            let version = app_for_state
-                                .state::<tray::TrayMenuState>()
-                                .update_version
-                                .lock()
-                                .ok()
-                                .and_then(|g| g.clone());
+                            let version =
+                                app_for_state.state::<tray::TrayMenuState>().update_version();
                             if let Some(expected) = version {
                                 #[cfg(target_os = "linux")]
                                 let result = {
@@ -1396,14 +1378,8 @@ fn main() {
                     "toggle_beta" => {
                         let app_clone = app.clone();
                         tauri::async_runtime::spawn(async move {
-                            let current = match app_clone
-                                .state::<tray::TrayMenuState>()
-                                .beta_enabled
-                                .lock()
-                            {
-                                Ok(g) => *g,
-                                Err(p) => *p.into_inner(),
-                            };
+                            let current =
+                                app_clone.state::<tray::TrayMenuState>().beta_enabled();
                             if let Err(e) =
                                 ui_prefs_cmd::apply_beta_toggle_inner(&app_clone, !current).await
                             {
@@ -1507,11 +1483,9 @@ fn main() {
                 "update_available",
                 move |event| match serde_json::from_str::<updater::UpdateInfo>(event.payload()) {
                     Ok(info) => {
-                        let state = app_handle_listener.state::<tray::TrayMenuState>();
-                        match state.update_version.lock() {
-                            Ok(mut guard) => *guard = Some(info.version.clone()),
-                            Err(e) => log::warn!("update version mutex poisoned: {e}"),
-                        }
+                        app_handle_listener
+                            .state::<tray::TrayMenuState>()
+                            .set_update_version(Some(info.version));
                         tray::refresh_tray_menu(&app_handle_listener);
                     }
                     Err(e) => {
@@ -1604,7 +1578,7 @@ fn main() {
             // Logging
             set_log_level,
             get_log_level,
-            // UI preferences (ADR-057)
+            // UI preferences (ADR-055)
             ui_prefs_cmd::get_beta_enabled,
             ui_prefs_cmd::set_beta_enabled,
             // Diagnostics

--- a/desktop/src-tauri/src/plugin_cmd.rs
+++ b/desktop/src-tauri/src/plugin_cmd.rs
@@ -925,6 +925,7 @@ mod tests {
             active_project: Some("test-project".into()),
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
         let json = serde_json::to_string_pretty(&initial_config).unwrap();
         std::fs::write(&config_path, &json).unwrap();
@@ -971,6 +972,7 @@ mod tests {
             active_project: Some("test-project".into()),
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
 
         // Load for unknown plugin — should return empty object
@@ -997,6 +999,7 @@ mod tests {
             active_project: Some("test-project".into()),
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
 
         let loaded2 = cfg2
@@ -1051,6 +1054,7 @@ mod tests {
             active_project: None,
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
 
         // Simulate the cleanup logic from remove_plugin
@@ -1117,6 +1121,7 @@ mod tests {
             active_project: None,
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
 
         let service_id = "presale";
@@ -1418,6 +1423,7 @@ mod tests {
             active_project: Some("my-project".into()),
             selected_ide: None,
             log_level: None,
+            ui: None,
         };
         // Simulate the auto-enable block from install_plugin
         let plugin_key = "my-skills";

--- a/desktop/src-tauri/src/tray.rs
+++ b/desktop/src-tauri/src/tray.rs
@@ -1,12 +1,67 @@
-// System tray menu construction and refresh.
+//! System tray icon and context menu.
+//!
+//! `TrayMenuState` (managed via `app.manage`) is the single source of truth
+//! for the menu's variable bits — `update_version` (set by the updater) and
+//! `beta_enabled` (toggled by the user). Any callsite can mutate it then call
+//! `refresh_tray_menu(app)` for a consistent rebuild. See ADR-057.
+
+use std::sync::Mutex;
 
 use tauri::image::Image;
-use tauri::menu::{MenuBuilder, MenuItemBuilder};
+use tauri::menu::{CheckMenuItemBuilder, MenuBuilder, MenuItemBuilder};
+use tauri::Manager;
 
 #[cfg(target_os = "macos")]
 const TRAY_ICON_PNG: &[u8] = include_bytes!("../icons/tray-icon.png");
 #[cfg(not(target_os = "macos"))]
 const TRAY_ICON_PNG: &[u8] = include_bytes!("../icons/tray-icon-white.png");
+
+/// Shared tray-menu inputs. Use via `app.manage(TrayMenuState::default())`.
+#[derive(Default)]
+pub(crate) struct TrayMenuState {
+    pub update_version: Mutex<Option<String>>,
+    pub beta_enabled: Mutex<bool>,
+}
+
+/// Describes the tray menu shape independently of the Tauri `Menu` builder so
+/// menu composition can be unit-tested without an `AppHandle`.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum TrayItemSpec {
+    Open,
+    Separator,
+    CheckUpdate,
+    InstallUpdate(String),
+    Beta { enabled: bool },
+    Quit,
+}
+
+/// Returns the ordered menu items for the given inputs. Beta toggle is hidden
+/// before setup completion — the toggle writes to user-config and the wizard
+/// owns data-dir creation, so we don't show a developer switch that could
+/// race the wizard.
+pub(crate) fn tray_menu_spec(
+    update_version: Option<&str>,
+    beta_enabled: bool,
+    setup_complete: bool,
+) -> Vec<TrayItemSpec> {
+    let mut items = vec![
+        TrayItemSpec::Open,
+        TrayItemSpec::Separator,
+        TrayItemSpec::CheckUpdate,
+    ];
+    if let Some(v) = update_version {
+        items.push(TrayItemSpec::InstallUpdate(v.to_string()));
+    }
+    if setup_complete {
+        items.push(TrayItemSpec::Separator);
+        items.push(TrayItemSpec::Beta {
+            enabled: beta_enabled,
+        });
+    }
+    items.push(TrayItemSpec::Separator);
+    items.push(TrayItemSpec::Quit);
+    items
+}
 
 /// Loads the platform-appropriate tray icon embedded in the binary.
 ///
@@ -18,38 +73,69 @@ pub(crate) fn load_tray_icon() -> Result<Image<'static>, tauri::Error> {
     Image::from_bytes(TRAY_ICON_PNG)
 }
 
-/// Builds the system tray context menu. If an update is available, includes
-/// an "Install Update" item.
+/// Builds the system tray context menu from the current state.
 pub(crate) fn build_tray_menu(
     app: &tauri::AppHandle,
-    update_version: &Option<String>,
+    update_version: Option<&str>,
+    beta_enabled: bool,
+    setup_complete: bool,
 ) -> Result<tauri::menu::Menu<tauri::Wry>, tauri::Error> {
-    let open = MenuItemBuilder::with_id("open", "Open Speedwave").build(app)?;
-    let check_update = MenuItemBuilder::with_id("check_update", "Check for Updates").build(app)?;
-    let quit = MenuItemBuilder::with_id("quit", "Quit").build(app)?;
-
-    let mut builder = MenuBuilder::new(app)
-        .item(&open)
-        .separator()
-        .item(&check_update);
-
-    if let Some(version) = update_version {
-        #[cfg(target_os = "linux")]
-        let update_label = format!("Download Update v{version}");
-
-        #[cfg(not(target_os = "linux"))]
-        let update_label = format!("Install Update v{version}");
-
-        let install_update = MenuItemBuilder::with_id("install_update", update_label).build(app)?;
-        builder = builder.item(&install_update);
+    let spec = tray_menu_spec(update_version, beta_enabled, setup_complete);
+    let mut builder = MenuBuilder::new(app);
+    for item in spec {
+        match item {
+            TrayItemSpec::Open => {
+                let it = MenuItemBuilder::with_id("open", "Open Speedwave").build(app)?;
+                builder = builder.item(&it);
+            }
+            TrayItemSpec::Separator => {
+                builder = builder.separator();
+            }
+            TrayItemSpec::CheckUpdate => {
+                let it =
+                    MenuItemBuilder::with_id("check_update", "Check for Updates").build(app)?;
+                builder = builder.item(&it);
+            }
+            TrayItemSpec::InstallUpdate(version) => {
+                #[cfg(target_os = "linux")]
+                let label = format!("Download Update v{version}");
+                #[cfg(not(target_os = "linux"))]
+                let label = format!("Install Update v{version}");
+                let it = MenuItemBuilder::with_id("install_update", label).build(app)?;
+                builder = builder.item(&it);
+            }
+            TrayItemSpec::Beta { enabled } => {
+                let it = CheckMenuItemBuilder::with_id("toggle_beta", "Beta features")
+                    .checked(enabled)
+                    .build(app)?;
+                builder = builder.item(&it);
+            }
+            TrayItemSpec::Quit => {
+                let it = MenuItemBuilder::with_id("quit", "Quit").build(app)?;
+                builder = builder.item(&it);
+            }
+        }
     }
-
-    builder.separator().item(&quit).build()
+    builder.build()
 }
 
-/// Rebuilds the tray menu to reflect a newly discovered update version.
-pub(crate) fn refresh_tray_menu(app: &tauri::AppHandle, update_version: &Option<String>) {
-    match build_tray_menu(app, update_version) {
+/// Rebuilds the tray menu from the current `TrayMenuState` and setup-complete
+/// status.
+pub(crate) fn refresh_tray_menu(app: &tauri::AppHandle) {
+    let state = app.state::<TrayMenuState>();
+    let update_version = state
+        .update_version
+        .lock()
+        .map(|g| g.clone())
+        .unwrap_or_else(|p| p.into_inner().clone());
+    let beta_enabled = state
+        .beta_enabled
+        .lock()
+        .map(|g| *g)
+        .unwrap_or_else(|p| *p.into_inner());
+    let setup_complete = crate::setup_wizard::is_setup_complete();
+
+    match build_tray_menu(app, update_version.as_deref(), beta_enabled, setup_complete) {
         Ok(menu) => {
             if let Some(tray) = app.tray_by_id("main-tray") {
                 if let Err(e) = tray.set_menu(Some(menu)) {
@@ -87,6 +173,70 @@ mod tests {
             icon.width(),
             icon.height(),
             "tray icon must be square for consistent rendering at all scales"
+        );
+    }
+
+    #[test]
+    fn spec_setup_complete_no_update_shows_unchecked_beta() {
+        let spec = tray_menu_spec(None, false, true);
+        assert_eq!(
+            spec,
+            vec![
+                TrayItemSpec::Open,
+                TrayItemSpec::Separator,
+                TrayItemSpec::CheckUpdate,
+                TrayItemSpec::Separator,
+                TrayItemSpec::Beta { enabled: false },
+                TrayItemSpec::Separator,
+                TrayItemSpec::Quit,
+            ]
+        );
+    }
+
+    #[test]
+    fn spec_setup_complete_with_update_keeps_install_and_beta() {
+        // ADR-057 regression: toggling beta must not drop "Install Update".
+        let spec = tray_menu_spec(Some("1.2.3"), true, true);
+        assert_eq!(
+            spec,
+            vec![
+                TrayItemSpec::Open,
+                TrayItemSpec::Separator,
+                TrayItemSpec::CheckUpdate,
+                TrayItemSpec::InstallUpdate("1.2.3".to_string()),
+                TrayItemSpec::Separator,
+                TrayItemSpec::Beta { enabled: true },
+                TrayItemSpec::Separator,
+                TrayItemSpec::Quit,
+            ]
+        );
+    }
+
+    #[test]
+    fn spec_setup_incomplete_hides_beta_even_with_update() {
+        // ADR-057 regression: beta toggle must not appear before setup.
+        let spec = tray_menu_spec(Some("9.9.9"), true, false);
+        assert!(
+            !spec.iter().any(|i| matches!(i, TrayItemSpec::Beta { .. })),
+            "no beta item before setup completion"
+        );
+        assert!(spec
+            .iter()
+            .any(|i| matches!(i, TrayItemSpec::InstallUpdate(v) if v == "9.9.9")));
+    }
+
+    #[test]
+    fn spec_fresh_install_shows_only_open_check_quit() {
+        let spec = tray_menu_spec(None, false, false);
+        assert_eq!(
+            spec,
+            vec![
+                TrayItemSpec::Open,
+                TrayItemSpec::Separator,
+                TrayItemSpec::CheckUpdate,
+                TrayItemSpec::Separator,
+                TrayItemSpec::Quit,
+            ]
         );
     }
 }

--- a/desktop/src-tauri/src/tray.rs
+++ b/desktop/src-tauri/src/tray.rs
@@ -1,9 +1,5 @@
-//! System tray icon and context menu.
-//!
-//! `TrayMenuState` (managed via `app.manage`) is the single source of truth
-//! for the menu's variable bits — `update_version` (set by the updater) and
-//! `beta_enabled` (toggled by the user). Any callsite can mutate it then call
-//! `refresh_tray_menu(app)` for a consistent rebuild. See ADR-057.
+//! System tray icon and context menu. `TrayMenuState` owns the menu's variable
+//! bits; callers mutate via its accessors then call `refresh_tray_menu`. ADR-055.
 
 use std::sync::Mutex;
 
@@ -16,11 +12,51 @@ const TRAY_ICON_PNG: &[u8] = include_bytes!("../icons/tray-icon.png");
 #[cfg(not(target_os = "macos"))]
 const TRAY_ICON_PNG: &[u8] = include_bytes!("../icons/tray-icon-white.png");
 
-/// Shared tray-menu inputs. Use via `app.manage(TrayMenuState::default())`.
+/// Variable inputs to the tray menu — `update_version` (set by the updater) and
+/// `beta_enabled` (toggled by the user). Managed via `app.manage`; the inner
+/// mutexes are private so all access goes through the accessors below, which
+/// recover from poisoning rather than panicking.
 #[derive(Default)]
 pub(crate) struct TrayMenuState {
-    pub update_version: Mutex<Option<String>>,
-    pub beta_enabled: Mutex<bool>,
+    update_version: Mutex<Option<String>>,
+    beta_enabled: Mutex<bool>,
+}
+
+impl TrayMenuState {
+    pub(crate) fn new(beta_enabled: bool) -> Self {
+        Self {
+            update_version: Mutex::new(None),
+            beta_enabled: Mutex::new(beta_enabled),
+        }
+    }
+
+    pub(crate) fn update_version(&self) -> Option<String> {
+        match self.update_version.lock() {
+            Ok(g) => g.clone(),
+            Err(p) => p.into_inner().clone(),
+        }
+    }
+
+    pub(crate) fn set_update_version(&self, version: Option<String>) {
+        match self.update_version.lock() {
+            Ok(mut g) => *g = version,
+            Err(p) => *p.into_inner() = version,
+        }
+    }
+
+    pub(crate) fn beta_enabled(&self) -> bool {
+        match self.beta_enabled.lock() {
+            Ok(g) => *g,
+            Err(p) => *p.into_inner(),
+        }
+    }
+
+    pub(crate) fn set_beta_enabled(&self, enabled: bool) {
+        match self.beta_enabled.lock() {
+            Ok(mut g) => *g = enabled,
+            Err(p) => *p.into_inner() = enabled,
+        }
+    }
 }
 
 /// Describes the tray menu shape independently of the Tauri `Menu` builder so
@@ -123,16 +159,8 @@ pub(crate) fn build_tray_menu(
 /// status.
 pub(crate) fn refresh_tray_menu(app: &tauri::AppHandle) {
     let state = app.state::<TrayMenuState>();
-    let update_version = state
-        .update_version
-        .lock()
-        .map(|g| g.clone())
-        .unwrap_or_else(|p| p.into_inner().clone());
-    let beta_enabled = state
-        .beta_enabled
-        .lock()
-        .map(|g| *g)
-        .unwrap_or_else(|p| *p.into_inner());
+    let update_version = state.update_version();
+    let beta_enabled = state.beta_enabled();
     let setup_complete = crate::setup_wizard::is_setup_complete();
 
     match build_tray_menu(app, update_version.as_deref(), beta_enabled, setup_complete) {
@@ -195,7 +223,7 @@ mod tests {
 
     #[test]
     fn spec_setup_complete_with_update_keeps_install_and_beta() {
-        // ADR-057 regression: toggling beta must not drop "Install Update".
+        // ADR-055 regression: toggling beta must not drop "Install Update".
         let spec = tray_menu_spec(Some("1.2.3"), true, true);
         assert_eq!(
             spec,
@@ -214,7 +242,7 @@ mod tests {
 
     #[test]
     fn spec_setup_incomplete_hides_beta_even_with_update() {
-        // ADR-057 regression: beta toggle must not appear before setup.
+        // ADR-055 regression: beta toggle must not appear before setup.
         let spec = tray_menu_spec(Some("9.9.9"), true, false);
         assert!(
             !spec.iter().any(|i| matches!(i, TrayItemSpec::Beta { .. })),

--- a/desktop/src-tauri/src/ui_prefs_cmd.rs
+++ b/desktop/src-tauri/src/ui_prefs_cmd.rs
@@ -1,0 +1,98 @@
+//! UI preferences commands — currently the beta-features toggle (ADR-057).
+//!
+//! `apply_beta_toggle_inner` is the shared write path used by both the
+//! `set_beta_enabled` Tauri command and the tray menu's `toggle_beta` arm; it
+//! locks the user-config, persists the new value, updates `TrayMenuState`,
+//! rebuilds the tray menu, and emits `beta-changed` so the frontend can react.
+
+use speedwave_runtime::config;
+use tauri::{AppHandle, Emitter, Manager};
+
+use crate::tray;
+
+/// Reads the persisted beta-features flag from user-config. Returns `false`
+/// when the file is absent or the field is unset.
+#[tauri::command]
+pub async fn get_beta_enabled() -> Result<bool, String> {
+    tokio::task::spawn_blocking(|| -> anyhow::Result<bool> {
+        let cfg = config::load_user_config()?;
+        Ok(cfg.beta_enabled())
+    })
+    .await
+    .map_err(|e| e.to_string())?
+    .map_err(|e| e.to_string())
+}
+
+/// Persists the beta-features flag and reflects the new state in the tray
+/// menu + frontend.
+#[tauri::command]
+pub async fn set_beta_enabled(app: AppHandle, enabled: bool) -> Result<(), String> {
+    apply_beta_toggle_inner(&app, enabled).await
+}
+
+/// Internal write path shared by the Tauri command and the tray menu arm.
+/// Tray callers spawn this on the async runtime to avoid blocking the UI
+/// thread.
+pub(crate) async fn apply_beta_toggle_inner(
+    app: &AppHandle,
+    enabled: bool,
+) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
+        config::with_config_lock(|| {
+            let mut cfg = config::load_user_config()?;
+            let mut ui = cfg.ui.unwrap_or_default();
+            ui.beta_enabled = Some(enabled);
+            cfg.ui = Some(ui);
+            config::save_user_config(&cfg)
+        })
+    })
+    .await
+    .map_err(|e| e.to_string())?
+    .map_err(|e| e.to_string())?;
+
+    {
+        let state = app.state::<tray::TrayMenuState>();
+        match state.beta_enabled.lock() {
+            Ok(mut g) => *g = enabled,
+            Err(p) => *p.into_inner() = enabled,
+        };
+    }
+    tray::refresh_tray_menu(app);
+    app.emit("beta-changed", enabled).map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use speedwave_runtime::config::{SpeedwaveUserConfig, UiPrefsConfig};
+
+    /// `beta_enabled()` reads the user-config getter we rely on.
+    #[test]
+    fn getter_default_is_false() {
+        let cfg = SpeedwaveUserConfig::default();
+        assert!(!cfg.beta_enabled());
+    }
+
+    #[test]
+    fn getter_reads_persisted_true() {
+        let cfg = SpeedwaveUserConfig {
+            ui: Some(UiPrefsConfig {
+                beta_enabled: Some(true),
+            }),
+            ..Default::default()
+        };
+        assert!(cfg.beta_enabled());
+    }
+
+    #[test]
+    fn getter_reads_persisted_false() {
+        let cfg = SpeedwaveUserConfig {
+            ui: Some(UiPrefsConfig {
+                beta_enabled: Some(false),
+            }),
+            ..Default::default()
+        };
+        assert!(!cfg.beta_enabled());
+    }
+}

--- a/desktop/src-tauri/src/ui_prefs_cmd.rs
+++ b/desktop/src-tauri/src/ui_prefs_cmd.rs
@@ -1,4 +1,4 @@
-//! UI preferences commands — currently the beta-features toggle (ADR-057).
+//! UI preferences commands — currently the beta-features toggle (ADR-055).
 //!
 //! `apply_beta_toggle_inner` is the shared write path used by both the
 //! `set_beta_enabled` Tauri command and the tray menu's `toggle_beta` arm; it
@@ -32,31 +32,31 @@ pub async fn set_beta_enabled(app: AppHandle, enabled: bool) -> Result<(), Strin
 
 /// Internal write path shared by the Tauri command and the tray menu arm.
 /// Tray callers spawn this on the async runtime to avoid blocking the UI
-/// thread.
+/// thread. No-op (no write, no event, no menu rebuild) when the value is
+/// already what's requested.
 pub(crate) async fn apply_beta_toggle_inner(
     app: &AppHandle,
     enabled: bool,
 ) -> Result<(), String> {
-    tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
+    let changed = tokio::task::spawn_blocking(move || -> anyhow::Result<bool> {
         config::with_config_lock(|| {
             let mut cfg = config::load_user_config()?;
-            let mut ui = cfg.ui.unwrap_or_default();
-            ui.beta_enabled = Some(enabled);
-            cfg.ui = Some(ui);
-            config::save_user_config(&cfg)
+            if cfg.beta_enabled() == enabled {
+                return Ok(false);
+            }
+            cfg.ui.get_or_insert_with(Default::default).beta_enabled = Some(enabled);
+            config::save_user_config(&cfg)?;
+            Ok(true)
         })
     })
     .await
     .map_err(|e| e.to_string())?
     .map_err(|e| e.to_string())?;
 
-    {
-        let state = app.state::<tray::TrayMenuState>();
-        match state.beta_enabled.lock() {
-            Ok(mut g) => *g = enabled,
-            Err(p) => *p.into_inner() = enabled,
-        };
+    if !changed {
+        return Ok(());
     }
+    app.state::<tray::TrayMenuState>().set_beta_enabled(enabled);
     tray::refresh_tray_menu(app);
     app.emit("beta-changed", enabled).map_err(|e| e.to_string())?;
     Ok(())

--- a/desktop/src/src/app/services/beta.service.spec.ts
+++ b/desktop/src/src/app/services/beta.service.spec.ts
@@ -1,0 +1,60 @@
+import { TestBed } from '@angular/core/testing';
+import { BetaService } from './beta.service';
+import { TauriService } from './tauri.service';
+import { MockTauriService } from '../testing/mock-tauri.service';
+
+describe('BetaService', () => {
+  let mockTauri: MockTauriService;
+
+  function createService(): BetaService {
+    TestBed.configureTestingModule({
+      providers: [{ provide: TauriService, useValue: mockTauri }],
+    });
+    return TestBed.inject(BetaService);
+  }
+
+  beforeEach(() => {
+    mockTauri = new MockTauriService();
+  });
+
+  /** Waits until `BetaService.init()` has registered its `beta-changed` listener. */
+  async function awaitInit(): Promise<void> {
+    for (let i = 0; i < 20 && !mockTauri.listenHandlers['beta-changed']; i++) {
+      await Promise.resolve();
+    }
+  }
+
+  it('seeds the signal from get_beta_enabled', async () => {
+    mockTauri.invokeHandler = async (cmd) => (cmd === 'get_beta_enabled' ? true : undefined);
+
+    const service = createService();
+    await awaitInit();
+
+    expect(service.enabled()).toBe(true);
+  });
+
+  it('updates on beta-changed events', async () => {
+    mockTauri.invokeHandler = async (cmd) => (cmd === 'get_beta_enabled' ? false : undefined);
+
+    const service = createService();
+    await awaitInit();
+    expect(service.enabled()).toBe(false);
+
+    mockTauri.dispatchEvent('beta-changed', true);
+    expect(service.enabled()).toBe(true);
+
+    mockTauri.dispatchEvent('beta-changed', false);
+    expect(service.enabled()).toBe(false);
+  });
+
+  it('stays off when invoke throws (no Tauri host)', async () => {
+    mockTauri.invokeHandler = async () => {
+      throw new Error('not running inside Tauri');
+    };
+
+    const service = createService();
+    await awaitInit();
+
+    expect(service.enabled()).toBe(false);
+  });
+});

--- a/desktop/src/src/app/services/beta.service.ts
+++ b/desktop/src/src/app/services/beta.service.ts
@@ -2,7 +2,7 @@ import { Injectable, inject, signal, type Signal } from '@angular/core';
 import { TauriService } from './tauri.service';
 
 /**
- * Beta-features toggle (ADR-054). Reads the persisted state from user-config
+ * Beta-features toggle (ADR-055). Reads the persisted state from user-config
  * on startup and tracks live toggles emitted by the tray menu via the
  * `beta-changed` Tauri event. UI surfaces gate hidden / work-in-progress
  * sections on `enabled()`. Default = `false` when running outside Tauri

--- a/desktop/src/src/app/services/beta.service.ts
+++ b/desktop/src/src/app/services/beta.service.ts
@@ -1,0 +1,39 @@
+import { Injectable, inject, signal, type Signal } from '@angular/core';
+import { TauriService } from './tauri.service';
+
+/**
+ * Beta-features toggle (ADR-054). Reads the persisted state from user-config
+ * on startup and tracks live toggles emitted by the tray menu via the
+ * `beta-changed` Tauri event. UI surfaces gate hidden / work-in-progress
+ * sections on `enabled()`. Default = `false` when running outside Tauri
+ * (e.g. Karma/Vitest unit tests).
+ */
+@Injectable({ providedIn: 'root' })
+export class BetaService {
+  private readonly tauri = inject(TauriService);
+  private readonly state = signal<boolean>(false);
+
+  /** Read-only signal of the active beta-features state. */
+  readonly enabled: Signal<boolean> = this.state.asReadonly();
+
+  /** Seeds the state from `get_beta_enabled` and subscribes to `beta-changed`. */
+  constructor() {
+    void this.init();
+  }
+
+  private async init(): Promise<void> {
+    try {
+      const value = await this.tauri.invoke<boolean>('get_beta_enabled');
+      this.state.set(value);
+    } catch {
+      // No Tauri host (web tests) or command not registered yet — stay off.
+    }
+    try {
+      await this.tauri.listen<boolean>('beta-changed', (event) => {
+        this.state.set(event.payload);
+      });
+    } catch {
+      // Ignore — listen() throws only when the Tauri event bus is absent.
+    }
+  }
+}

--- a/desktop/src/src/app/shell/shell.component.ts
+++ b/desktop/src/src/app/shell/shell.component.ts
@@ -13,6 +13,7 @@ import type { Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
 import { ProjectSwitcherComponent } from '../project-switcher/project-switcher.component';
 import { UpdateNotificationComponent } from '../update-notification/update-notification.component';
+import { BetaService } from '../services/beta.service';
 import { ProjectStateService } from '../services/project-state.service';
 import { ThemeService } from '../services/theme.service';
 import { UiStateService } from '../services/ui-state.service';
@@ -168,6 +169,15 @@ import { CloudStorageModalComponent } from '../shared/cloudstorage-modal/cloudst
 
       <!-- Command palette modal — ⌘K opens, ESC (handled in shell) closes. -->
       <app-command-palette />
+
+      @if (beta.enabled()) {
+        <span
+          class="mono pointer-events-none fixed bottom-1.5 right-2 z-[1000] select-none rounded border border-[var(--line)] px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-[var(--ink-mute)]"
+          data-testid="beta-badge"
+          aria-label="Beta features enabled"
+          >Beta</span
+        >
+      }
     </div>
   `,
 })
@@ -175,6 +185,7 @@ export class ShellComponent implements OnInit, OnDestroy {
   readonly projectState = inject(ProjectStateService);
   readonly ui = inject(UiStateService);
   readonly theme = inject(ThemeService);
+  readonly beta = inject(BetaService);
   private cdr = inject(ChangeDetectorRef);
   private router = inject(Router);
   private unsubscribe: (() => void) | null = null;

--- a/docs/adr/ADR-054-beta-features-toggle.md
+++ b/docs/adr/ADR-054-beta-features-toggle.md
@@ -1,0 +1,57 @@
+# ADR-054: Beta Features Toggle in the Tray Menu
+
+**Status:** Accepted
+
+**Date:** 2026-05-12
+
+## Context
+
+Work-in-progress UI surfaces (new views, experimental panels) need a way to ship behind a switch that a developer or early user can flip at runtime, without rebuilding the app and without exposing the surface to every user. The Desktop app already has a system tray icon with a context menu (`Open / Check for Updates / Quit`) built in `desktop/src-tauri/src/tray.rs`. Putting the switch there keeps it out of the way for ordinary users while remaining a single click away.
+
+The tray menu's variable parts already include an `Install Update vX` item driven by a `Arc<Mutex<Option<String>>>` threaded through two closures (`check_update` handler, `update_available` listener). Adding a second variable input (the beta flag) the same way would mean two parallel ad-hoc states and a real risk that rebuilding the menu for one input drops the other.
+
+## Decision
+
+### State
+
+A single `TrayMenuState` struct, managed via `app.manage(...)`, holds both variable inputs:
+
+```rust
+pub(crate) struct TrayMenuState {
+    pub update_version: Mutex<Option<String>>,
+    pub beta_enabled: Mutex<bool>,
+}
+```
+
+`refresh_tray_menu(app)` reads both fields plus `setup_wizard::is_setup_complete()` and rebuilds the whole menu. Any callsite that has an `AppHandle` mutates the relevant field then calls `refresh_tray_menu(app)` — there is one rebuild path, so no input can be silently dropped. The `update_version` `Arc` previously threaded through `main.rs` is removed.
+
+### Menu composition
+
+The visible menu shape is produced by a pure function `tray_menu_spec(update_version, beta_enabled, setup_complete) -> Vec<TrayItemSpec>`, so composition is unit-testable without an `AppHandle`. `build_tray_menu` maps the spec onto Tauri builders.[^1] The beta entry is a `CheckMenuItem`[^2] with id `toggle_beta`, checked when the flag is on.
+
+### Persistence
+
+The flag lives in top-level user-config: `SpeedwaveUserConfig.ui.beta_enabled: Option<bool>` (new `UiPrefsConfig` struct), defaulting to `false`. It is **user-only** — a checked-in repo `.speedwave.json` cannot set it, consistent with how privacy- and behaviour-sensitive flags are handled elsewhere. Reads/writes go through the existing `config::with_config_lock` + `tokio::task::spawn_blocking` pattern (same as `set_log_level`), so the UI thread never does synchronous config I/O.
+
+### Write path
+
+`ui_prefs_cmd::apply_beta_toggle_inner(app, enabled)` is the single internal write path: it persists the flag under the config lock, updates `TrayMenuState.beta_enabled`, calls `refresh_tray_menu(app)`, and emits a `beta-changed` Tauri event. Both the `set_beta_enabled` Tauri command and the tray menu's `toggle_beta` arm call this function — the tray arm does **not** call the command handler. The tray arm spawns the call on the async runtime because the `on_menu_event` closure is synchronous.
+
+### Frontend
+
+`BetaService` (`providedIn: 'root'`) holds an Angular `signal<boolean>`, seeded from `get_beta_enabled` on construction and updated by the `beta-changed` event. UI surfaces gate hidden sections with `@if (beta.enabled()) { ... }`. The `ShellComponent` renders a discreet `BETA` badge in the corner whenever the flag is on. When running outside Tauri (Karma unit tests), `invoke` throws and the signal stays `false`.
+
+### Hidden before setup completion
+
+The `toggle_beta` item is **not added** to the tray menu while `is_setup_complete()` is `false`. The toggle writes to user-config, and `save_user_config` creates `~/.speedwave/` if it is missing — showing the switch on a fresh install (or after factory reset) before the setup wizard owns that directory would let a tray click race the wizard. `create_project` (the last wizard step) calls `refresh_tray_menu(app)` after it succeeds, so the item appears once setup is genuinely complete. We chose "hide" over "disable" because a developer-only switch has no reason to be visible on an unconfigured app.
+
+## Consequences
+
+- **Positive:** simple mechanism — no telemetry, no per-project state, no plugin-facing API. `TrayMenuState` centralises the tray menu's variable inputs, replacing the previously scattered `Arc<Mutex>` for the update version. The beta state survives restarts (read from user-config on startup).
+- **Negative — global, not per-project:** the flag is user-wide. Beta surfaces are developer/early-adopter features, not project-scoped configuration, so this is deliberate.
+- **Negative — not a security boundary:** this toggle is purely a UI surface gate. Nothing that requires a real permission check (host capability, credential access, network policy) may be hidden behind it; those must keep their own enforcement regardless of the flag.
+- **Negative — invisible on fresh install:** the tray item does not appear until the setup wizard finishes. A user mid-setup cannot enable beta features; that is the trade-off for not letting a tray click recreate the data dir out from under the wizard.
+
+[^1]: Tauri v2 menu builder API (`MenuBuilder`, `MenuItemBuilder`): https://docs.rs/tauri/latest/tauri/menu/struct.MenuBuilder.html
+
+[^2]: Tauri v2 `CheckMenuItem` — a menu item with a checkmark that toggles: https://docs.rs/tauri/latest/tauri/menu/struct.CheckMenuItem.html

--- a/docs/adr/ADR-055-beta-features-toggle.md
+++ b/docs/adr/ADR-055-beta-features-toggle.md
@@ -1,4 +1,4 @@
-# ADR-054: Beta Features Toggle in the Tray Menu
+# ADR-055: Beta Features Toggle in the Tray Menu
 
 **Status:** Accepted
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -60,7 +60,7 @@ This directory contains all Architecture Decision Records (ADRs) for Speedwave. 
 | [ADR-051](ADR-051-plugin-signature-runtime-verification.md)            | Plugin Signature as a Runtime Invariant                     | Accepted              |
 | [ADR-052](ADR-052-anthropic-oauth-login-flow.md)                       | Claude Code Login Surface + Clipboard Bridge                | Accepted              |
 | [ADR-053](ADR-053-worker-implementation-own-vs-wrap-official-mcp.md)   | Worker Implementation — Own Thin Worker vs Wrapping an Official MCP Server | Accepted          |
-| [ADR-054](ADR-054-beta-features-toggle.md)                             | Beta Features Toggle in the Tray Menu                       | Accepted              |
+| [ADR-055](ADR-055-beta-features-toggle.md)                             | Beta Features Toggle in the Tray Menu                       | Accepted              |
 
 ## Creating a New ADR
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -60,6 +60,7 @@ This directory contains all Architecture Decision Records (ADRs) for Speedwave. 
 | [ADR-051](ADR-051-plugin-signature-runtime-verification.md)            | Plugin Signature as a Runtime Invariant                     | Accepted              |
 | [ADR-052](ADR-052-anthropic-oauth-login-flow.md)                       | Claude Code Login Surface + Clipboard Bridge                | Accepted              |
 | [ADR-053](ADR-053-worker-implementation-own-vs-wrap-official-mcp.md)   | Worker Implementation — Own Thin Worker vs Wrapping an Official MCP Server | Accepted          |
+| [ADR-054](ADR-054-beta-features-toggle.md)                             | Beta Features Toggle in the Tray Menu                       | Accepted              |
 
 ## Creating a New ADR
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -41,9 +41,14 @@ The user-level config file stores project definitions, the active project, IDE s
   ],
   "active_project": "acme-corp",
   "selected_ide": null,
-  "log_level": null
+  "log_level": null,
+  "ui": { "beta_enabled": false }
 }
 ```
+
+### `ui.beta_enabled`
+
+Optional, top-level, user-only (a checked-in `.speedwave.json` cannot set it). When `true`, the Desktop app reveals hidden / work-in-progress UI surfaces and shows a small `BETA` badge in the corner. Default is off. Toggle it from the tray-icon menu → **Beta features** (the item appears once initial setup is complete), or edit this field directly. This is a UI surface gate only — it is **not** a security control and does not unlock any privileged capability. See [ADR-054](../adr/ADR-054-beta-features-toggle.md).
 
 ## Per-Project: `.speedwave.json`
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -48,7 +48,7 @@ The user-level config file stores project definitions, the active project, IDE s
 
 ### `ui.beta_enabled`
 
-Optional, top-level, user-only (a checked-in `.speedwave.json` cannot set it). When `true`, the Desktop app reveals hidden / work-in-progress UI surfaces and shows a small `BETA` badge in the corner. Default is off. Toggle it from the tray-icon menu → **Beta features** (the item appears once initial setup is complete), or edit this field directly. This is a UI surface gate only — it is **not** a security control and does not unlock any privileged capability. See [ADR-054](../adr/ADR-054-beta-features-toggle.md).
+Optional, top-level, user-only (a checked-in `.speedwave.json` cannot set it). When `true`, the Desktop app reveals hidden / work-in-progress UI surfaces and shows a small `BETA` badge in the corner. Default is off. Toggle it from the tray-icon menu → **Beta features** (the item appears once initial setup is complete), or edit this field directly. This is a UI surface gate only — it is **not** a security control and does not unlock any privileged capability. See [ADR-055](../adr/ADR-055-beta-features-toggle.md).
 
 ## Per-Project: `.speedwave.json`
 


### PR DESCRIPTION
## Summary

- Adds a **Beta features** `CheckMenuItem` to the system tray. Toggling it reveals hidden / work-in-progress UI surfaces (gate them with `@if (beta.enabled())`) and shows a discreet `BETA` badge in the shell corner.
- State persists in user-config (`ui.beta_enabled`, top-level, user-only — a checked-in `.speedwave.json` can't set it). Toggles take effect immediately via a `beta-changed` Tauri event → Angular `BetaService` signal; no window reload.
- The tray item is **hidden until setup completion** — the toggle writes to user-config and `save_user_config` would recreate `~/.speedwave/`, so showing the switch before the wizard owns that directory could race it. `create_project` (last wizard step) refreshes the tray afterward.
- Refactors the tray menu's variable state into a managed `TrayMenuState { update_version, beta_enabled }`, replacing the scattered `Arc<Mutex<Option<String>>>` for the update version. Menu composition is a pure `tray_menu_spec(...)` function so it's unit-testable without an `AppHandle`. `refresh_tray_menu(app)` is the single rebuild path — no input can be silently dropped (regression test covers "Install Update" surviving a beta toggle).
- Shared write path `ui_prefs_cmd::apply_beta_toggle_inner` used by both the `set_beta_enabled` command and the `toggle_beta` tray arm (tray arm calls the internal fn, not the command handler); config I/O goes through `with_config_lock` + `spawn_blocking`.
- New ADR-054 + `configuration.md` `ui.beta_enabled` section.

## Test plan

- [x] `cargo test -p speedwave-runtime -p speedwave-cli` — 1190 + 65 pass (incl. new `UiPrefsConfig` serde/backward-compat tests)
- [x] desktop `cargo test` — `tray_menu_spec` ×5 (incl. P1.1 update-survives-toggle, P1.3 hidden-before-setup regressions), `ui_prefs_cmd` getter tests
- [x] Angular `ng test` — 1630 pass (incl. `BetaService` init / event / no-Tauri-fallback)
- [x] `cargo clippy -D warnings` (runtime, cli, desktop) + `eslint` clean + `cargo fmt --check`
- [x] `make dev` — app launches; tray menu, toggle, badge, persistence verified manually