### PR TITLE
feat(desktop): gate office + host-exec behind beta toggle (ADR-058)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 

--- a/desktop/src/src/app/integrations/integrations.component.spec.ts
+++ b/desktop/src/src/app/integrations/integrations.component.spec.ts
@@ -167,8 +167,7 @@ describe('IntegrationsComponent', () => {
   let mockTauri: MockTauriService;
   let projectState: ProjectStateService;
   let mockLogger: ReturnType<typeof makeMockLogger>;
-  // Stub BetaService so each test controls beta-gating directly. Default
-  // matches production: beta off until the user toggles it via tray menu.
+  // BetaService stub; defaults false to match production (tray toggles it).
   const betaEnabled = signal(false);
 
   beforeEach(async () => {

--- a/desktop/src/src/app/integrations/integrations.component.spec.ts
+++ b/desktop/src/src/app/integrations/integrations.component.spec.ts
@@ -256,9 +256,11 @@ describe('IntegrationsComponent', () => {
   });
 
   describe('beta gating (ADR-058)', () => {
+    const betaServices = ['office', 'github', 'atlassian'] as const;
+
     // Backend always returns the beta services; whether the user sees them is governed by the BetaService signal.
     function setupWithBetaServices(): void {
-      const extra = ['office', 'github', 'atlassian'].map((svc) => ({
+      const extra = betaServices.map((svc) => ({
         service: svc,
         enabled: false,
         configured: false,
@@ -292,17 +294,14 @@ describe('IntegrationsComponent', () => {
       };
     }
 
-    it.each(['office', 'github', 'atlassian'])(
-      'hides %s row when beta is off (default for new users)',
-      async (svc) => {
-        setupWithBetaServices();
-        betaEnabled.set(false);
-        await component.ngOnInit();
-        expect(component.services.map((s) => s.service)).not.toContain(svc);
-      }
-    );
+    it.each(betaServices)('hides %s row when beta is off (default for new users)', async (svc) => {
+      setupWithBetaServices();
+      betaEnabled.set(false);
+      await component.ngOnInit();
+      expect(component.services.map((s) => s.service)).not.toContain(svc);
+    });
 
-    it.each(['office', 'github', 'atlassian'])('shows %s row when beta is on', async (svc) => {
+    it.each(betaServices)('shows %s row when beta is on', async (svc) => {
       setupWithBetaServices();
       betaEnabled.set(true);
       await component.ngOnInit();
@@ -335,7 +334,7 @@ describe('IntegrationsComponent', () => {
       await component.ngOnInit();
       fixture.detectChanges();
       const namesOff = component.services.map((s) => s.service);
-      for (const svc of ['office', 'github', 'atlassian']) {
+      for (const svc of betaServices) {
         expect(namesOff).not.toContain(svc);
       }
       expect(
@@ -348,7 +347,7 @@ describe('IntegrationsComponent', () => {
       fixture.detectChanges();
 
       const namesOn = component.services.map((s) => s.service);
-      for (const svc of ['office', 'github', 'atlassian']) {
+      for (const svc of betaServices) {
         expect(namesOn).toContain(svc);
       }
       expect(

--- a/desktop/src/src/app/integrations/integrations.component.spec.ts
+++ b/desktop/src/src/app/integrations/integrations.component.spec.ts
@@ -256,8 +256,18 @@ describe('IntegrationsComponent', () => {
   });
 
   describe('beta gating (ADR-058)', () => {
-    // Backend always includes office; whether the user sees it is governed by the BetaService signal.
-    function setupWithOffice(): void {
+    // Backend always returns the beta services; whether the user sees them is governed by the BetaService signal.
+    function setupWithBetaServices(): void {
+      const extra = ['office', 'github', 'atlassian'].map((svc) => ({
+        service: svc,
+        enabled: false,
+        configured: false,
+        display_name: svc,
+        description: '',
+        auth_fields: [],
+        current_values: {},
+        mappings: undefined,
+      }));
       mockTauri.invokeHandler = async (cmd: string) => {
         switch (cmd) {
           case 'list_projects':
@@ -267,19 +277,7 @@ describe('IntegrationsComponent', () => {
             };
           case 'get_integrations':
             return {
-              services: [
-                ...cloneMockIntegrations().services,
-                {
-                  service: 'office',
-                  enabled: false,
-                  configured: false,
-                  display_name: 'Office documents',
-                  description: 'Word/Excel/PowerPoint/PDF',
-                  auth_fields: [],
-                  current_values: {},
-                  mappings: undefined,
-                },
-              ],
+              services: [...cloneMockIntegrations().services, ...extra],
               os: [],
             };
           case 'list_available_ides':
@@ -294,18 +292,21 @@ describe('IntegrationsComponent', () => {
       };
     }
 
-    it('hides office row when beta is off (default for new users)', async () => {
-      setupWithOffice();
-      betaEnabled.set(false);
-      await component.ngOnInit();
-      expect(component.services.map((s) => s.service)).not.toContain('office');
-    });
+    it.each(['office', 'github', 'atlassian'])(
+      'hides %s row when beta is off (default for new users)',
+      async (svc) => {
+        setupWithBetaServices();
+        betaEnabled.set(false);
+        await component.ngOnInit();
+        expect(component.services.map((s) => s.service)).not.toContain(svc);
+      }
+    );
 
-    it('shows office row when beta is on', async () => {
-      setupWithOffice();
+    it.each(['office', 'github', 'atlassian'])('shows %s row when beta is on', async (svc) => {
+      setupWithBetaServices();
       betaEnabled.set(true);
       await component.ngOnInit();
-      expect(component.services.map((s) => s.service)).toContain('office');
+      expect(component.services.map((s) => s.service)).toContain(svc);
     });
 
     it('hides host-exec slot when beta is off', async () => {
@@ -328,12 +329,15 @@ describe('IntegrationsComponent', () => {
       expect(slot).not.toBeNull();
     });
 
-    it('reveals office + host-exec when beta toggles off → on mid-session', async () => {
-      setupWithOffice();
+    it('reveals all beta surfaces when beta toggles off → on mid-session', async () => {
+      setupWithBetaServices();
       betaEnabled.set(false);
       await component.ngOnInit();
       fixture.detectChanges();
-      expect(component.services.map((s) => s.service)).not.toContain('office');
+      const namesOff = component.services.map((s) => s.service);
+      for (const svc of ['office', 'github', 'atlassian']) {
+        expect(namesOff).not.toContain(svc);
+      }
       expect(
         fixture.nativeElement.querySelector('[data-testid="integrations-host-exec-slot"]')
       ).toBeNull();
@@ -343,7 +347,10 @@ describe('IntegrationsComponent', () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
       fixture.detectChanges();
 
-      expect(component.services.map((s) => s.service)).toContain('office');
+      const namesOn = component.services.map((s) => s.service);
+      for (const svc of ['office', 'github', 'atlassian']) {
+        expect(namesOn).toContain(svc);
+      }
       expect(
         fixture.nativeElement.querySelector('[data-testid="integrations-host-exec-slot"]')
       ).not.toBeNull();

--- a/desktop/src/src/app/integrations/integrations.component.spec.ts
+++ b/desktop/src/src/app/integrations/integrations.component.spec.ts
@@ -257,11 +257,7 @@ describe('IntegrationsComponent', () => {
   });
 
   describe('beta gating (ADR-058)', () => {
-    /**
-     * Backend handler that returns the mock services + an extra `office` row.
-     * Whether the user sees `office` is governed entirely by the BetaService
-     * stub signal, not by the backend payload — exactly like production.
-     */
+    // Backend always includes office; whether the user sees it is governed by the BetaService signal.
     function setupWithOffice(): void {
       mockTauri.invokeHandler = async (cmd: string) => {
         switch (cmd) {

--- a/desktop/src/src/app/integrations/integrations.component.spec.ts
+++ b/desktop/src/src/app/integrations/integrations.component.spec.ts
@@ -344,7 +344,8 @@ describe('IntegrationsComponent', () => {
       ).toBeNull();
 
       betaEnabled.set(true);
-      // Wait for the effect's auto-loadIntegrations to settle.
+      // One macrotask lets the signal-effect's microtask queue flush
+      // (fakeAsync doesn't integrate with Angular Signals under Vitest).
       await new Promise((resolve) => setTimeout(resolve, 0));
       fixture.detectChanges();
 

--- a/desktop/src/src/app/integrations/integrations.component.spec.ts
+++ b/desktop/src/src/app/integrations/integrations.component.spec.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { IntegrationsComponent } from './integrations.component';
 import { TauriService } from '../services/tauri.service';
 import { ProjectStateService } from '../services/project-state.service';
 import { LoggerService } from '../services/logger.service';
+import { BetaService } from '../services/beta.service';
 import { MockTauriService } from '../testing/mock-tauri.service';
 
 /**
@@ -165,8 +167,12 @@ describe('IntegrationsComponent', () => {
   let mockTauri: MockTauriService;
   let projectState: ProjectStateService;
   let mockLogger: ReturnType<typeof makeMockLogger>;
+  // Stub BetaService so each test controls beta-gating directly. Default
+  // matches production: beta off until the user toggles it via tray menu.
+  const betaEnabled = signal(false);
 
   beforeEach(async () => {
+    betaEnabled.set(false);
     mockTauri = new MockTauriService();
     setupMockTauri(mockTauri);
     mockLogger = makeMockLogger();
@@ -183,6 +189,7 @@ describe('IntegrationsComponent', () => {
       providers: [
         { provide: TauriService, useValue: mockTauri },
         { provide: LoggerService, useValue: mockLogger },
+        { provide: BetaService, useValue: { enabled: betaEnabled.asReadonly() } },
       ],
     }).compileComponents();
 
@@ -247,6 +254,105 @@ describe('IntegrationsComponent', () => {
     expect(serviceNames).toContain('sharepoint');
     expect(serviceNames).toContain('gitlab');
     expect(serviceNames).toContain('redmine');
+  });
+
+  describe('beta gating (ADR-058)', () => {
+    /**
+     * Backend handler that returns the mock services + an extra `office` row.
+     * Whether the user sees `office` is governed entirely by the BetaService
+     * stub signal, not by the backend payload — exactly like production.
+     */
+    function setupWithOffice(): void {
+      mockTauri.invokeHandler = async (cmd: string) => {
+        switch (cmd) {
+          case 'list_projects':
+            return {
+              projects: [{ name: 'test-project', dir: '/tmp/test' }],
+              active_project: 'test-project',
+            };
+          case 'get_integrations':
+            return {
+              services: [
+                ...cloneMockIntegrations().services,
+                {
+                  service: 'office',
+                  enabled: false,
+                  configured: false,
+                  display_name: 'Office documents',
+                  description: 'Word/Excel/PowerPoint/PDF',
+                  auth_fields: [],
+                  current_values: {},
+                  mappings: undefined,
+                },
+              ],
+              os: [],
+            };
+          case 'list_available_ides':
+            return [];
+          case 'get_selected_ide':
+            return null;
+          case 'validate_os_integrations_on_startup':
+            return [];
+          default:
+            return undefined;
+        }
+      };
+    }
+
+    it('hides office row when beta is off (default for new users)', async () => {
+      setupWithOffice();
+      betaEnabled.set(false);
+      await component.ngOnInit();
+      expect(component.services.map((s) => s.service)).not.toContain('office');
+    });
+
+    it('shows office row when beta is on', async () => {
+      setupWithOffice();
+      betaEnabled.set(true);
+      await component.ngOnInit();
+      expect(component.services.map((s) => s.service)).toContain('office');
+    });
+
+    it('hides host-exec slot when beta is off', async () => {
+      betaEnabled.set(false);
+      await component.ngOnInit();
+      fixture.detectChanges();
+      const slot = fixture.nativeElement.querySelector(
+        '[data-testid="integrations-host-exec-slot"]'
+      );
+      expect(slot).toBeNull();
+    });
+
+    it('shows host-exec slot when beta is on', async () => {
+      betaEnabled.set(true);
+      await component.ngOnInit();
+      fixture.detectChanges();
+      const slot = fixture.nativeElement.querySelector(
+        '[data-testid="integrations-host-exec-slot"]'
+      );
+      expect(slot).not.toBeNull();
+    });
+
+    it('reveals office + host-exec when beta toggles off → on mid-session', async () => {
+      setupWithOffice();
+      betaEnabled.set(false);
+      await component.ngOnInit();
+      fixture.detectChanges();
+      expect(component.services.map((s) => s.service)).not.toContain('office');
+      expect(
+        fixture.nativeElement.querySelector('[data-testid="integrations-host-exec-slot"]')
+      ).toBeNull();
+
+      betaEnabled.set(true);
+      // Wait for the effect's auto-loadIntegrations to settle.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      fixture.detectChanges();
+
+      expect(component.services.map((s) => s.service)).toContain('office');
+      expect(
+        fixture.nativeElement.querySelector('[data-testid="integrations-host-exec-slot"]')
+      ).not.toBeNull();
+    });
   });
 
   it('should set error when loadIntegrations fails', async () => {

--- a/desktop/src/src/app/integrations/integrations.component.spec.ts
+++ b/desktop/src/src/app/integrations/integrations.component.spec.ts
@@ -339,8 +339,7 @@ describe('IntegrationsComponent', () => {
       ).toBeNull();
 
       betaEnabled.set(true);
-      // One macrotask lets the signal-effect's microtask queue flush
-      // (fakeAsync doesn't integrate with Angular Signals under Vitest).
+      // fakeAsync doesn't integrate with Angular Signals under Vitest — one macrotask lets the effect flush.
       await new Promise((resolve) => setTimeout(resolve, 0));
       fixture.detectChanges();
 

--- a/desktop/src/src/app/integrations/integrations.component.ts
+++ b/desktop/src/src/app/integrations/integrations.component.ts
@@ -376,7 +376,7 @@ export class IntegrationsComponent implements OnInit, OnDestroy {
 
   readonly betaEnabled = this.beta.enabled;
 
-  /** Re-fetch on beta toggle — response.services is not cached, so filter-only won't reveal office. */
+  /** Re-fetch on beta toggle — response.services is not cached, so filter-only won't reveal beta-only services. */
   constructor() {
     effect(() => {
       this.betaEnabled();
@@ -551,7 +551,7 @@ export class IntegrationsComponent implements OnInit, OnDestroy {
       const response = await this.tauri.invoke<IntegrationsResponse>('get_integrations', {
         project: this.activeProject,
       });
-      // Slack is not yet publicly available (#91); office is beta-only (ADR-058).
+      // Slack hidden always (#91); BETA_ONLY_SERVICES hidden unless beta is on (ADR-058).
       const betaOn = this.betaEnabled();
       this.services = response.services.filter(
         (s) =>

--- a/desktop/src/src/app/integrations/integrations.component.ts
+++ b/desktop/src/src/app/integrations/integrations.component.ts
@@ -376,11 +376,7 @@ export class IntegrationsComponent implements OnInit, OnDestroy {
 
   readonly betaEnabled = this.beta.enabled;
 
-  /**
-   * Reloads the services list when the beta toggle flips mid-session so
-   * `office` + the host-exec slot appear (or disappear) without a manual
-   * refresh — the raw `response.services` payload is not cached.
-   */
+  /** Re-fetch on beta toggle — response.services is not cached, so filter-only won't reveal office. */
   constructor() {
     effect(() => {
       this.betaEnabled();

--- a/desktop/src/src/app/integrations/integrations.component.ts
+++ b/desktop/src/src/app/integrations/integrations.component.ts
@@ -2,7 +2,6 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
-  EffectRef,
   OnDestroy,
   OnInit,
   effect,
@@ -375,14 +374,19 @@ export class IntegrationsComponent implements OnInit, OnDestroy {
   private unsubProjectSettled: (() => void) | null = null;
   private unsubStatusRefresher: (() => void) | null = null;
 
-  /** Live signal: beta-features toggle (ADR-058). Gates office + host-exec. */
   readonly betaEnabled = this.beta.enabled;
 
-  /** Re-filter the services table when beta toggles mid-session. */
-  private betaEffect: EffectRef = effect(() => {
-    this.betaEnabled();
-    if (this.activeProject) void this.loadIntegrations();
-  });
+  /**
+   * Reloads the services list when the beta toggle flips mid-session so
+   * `office` + the host-exec slot appear (or disappear) without a manual
+   * refresh — the raw `response.services` payload is not cached.
+   */
+  constructor() {
+    effect(() => {
+      this.betaEnabled();
+      if (this.activeProject) void this.loadIntegrations();
+    });
+  }
 
   /** Loads the active project and integrations on init. */
   async ngOnInit(): Promise<void> {

--- a/desktop/src/src/app/integrations/integrations.component.ts
+++ b/desktop/src/src/app/integrations/integrations.component.ts
@@ -2,13 +2,16 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  EffectRef,
   OnDestroy,
   OnInit,
+  effect,
   inject,
 } from '@angular/core';
 import { TauriService } from '../services/tauri.service';
 import { ProjectStateService } from '../services/project-state.service';
 import { LoggerService } from '../services/logger.service';
+import { BetaService } from '../services/beta.service';
 import {
   DeviceCodeInfo,
   IntegrationsResponse,
@@ -274,9 +277,11 @@ function dotColourFor(svc: IntegrationStatusEntry, index: number): string {
           }
         }
 
-        <div class="mt-6" data-testid="integrations-host-exec-slot">
-          <app-host-exec-config />
-        </div>
+        @if (betaEnabled()) {
+          <div class="mt-6" data-testid="integrations-host-exec-slot">
+            <app-host-exec-config />
+          </div>
+        }
 
         <div class="mt-6" data-testid="integrations-ide-bridge-slot">
           <app-ide-bridge />
@@ -322,6 +327,7 @@ function dotColourFor(svc: IntegrationStatusEntry, index: number): string {
 })
 export class IntegrationsComponent implements OnInit, OnDestroy {
   private static readonly HIDDEN_SERVICES = new Set(['slack']);
+  private static readonly BETA_ONLY_SERVICES = new Set(['office']);
 
   /** List of container-based MCP service integrations. */
   services: IntegrationStatusEntry[] = [];
@@ -365,8 +371,18 @@ export class IntegrationsComponent implements OnInit, OnDestroy {
   private tauri = inject(TauriService);
   private projectState = inject(ProjectStateService);
   private logger = inject(LoggerService);
+  private beta = inject(BetaService);
   private unsubProjectSettled: (() => void) | null = null;
   private unsubStatusRefresher: (() => void) | null = null;
+
+  /** Live signal: beta-features toggle (ADR-058). Gates office + host-exec. */
+  readonly betaEnabled = this.beta.enabled;
+
+  /** Re-filter the services table when beta toggles mid-session. */
+  private betaEffect: EffectRef = effect(() => {
+    this.betaEnabled();
+    if (this.activeProject) void this.loadIntegrations();
+  });
 
   /** Loads the active project and integrations on init. */
   async ngOnInit(): Promise<void> {
@@ -535,9 +551,12 @@ export class IntegrationsComponent implements OnInit, OnDestroy {
       const response = await this.tauri.invoke<IntegrationsResponse>('get_integrations', {
         project: this.activeProject,
       });
-      // Slack is not yet publicly available (#91)
+      // Slack is not yet publicly available (#91); office is beta-only (ADR-058).
+      const betaOn = this.betaEnabled();
       this.services = response.services.filter(
-        (s) => !IntegrationsComponent.HIDDEN_SERVICES.has(s.service)
+        (s) =>
+          !IntegrationsComponent.HIDDEN_SERVICES.has(s.service) &&
+          (betaOn || !IntegrationsComponent.BETA_ONLY_SERVICES.has(s.service))
       );
       this.osIntegrations = response.os;
     } catch (e: unknown) {

--- a/desktop/src/src/app/integrations/integrations.component.ts
+++ b/desktop/src/src/app/integrations/integrations.component.ts
@@ -326,7 +326,7 @@ function dotColourFor(svc: IntegrationStatusEntry, index: number): string {
 })
 export class IntegrationsComponent implements OnInit, OnDestroy {
   private static readonly HIDDEN_SERVICES = new Set(['slack']);
-  private static readonly BETA_ONLY_SERVICES = new Set(['office']);
+  private static readonly BETA_ONLY_SERVICES = new Set(['office', 'github', 'atlassian']);
 
   /** List of container-based MCP service integrations. */
   services: IntegrationStatusEntry[] = [];


### PR DESCRIPTION
## Summary
- Hide `office` row in `/integrations` table when beta is off (mirrors the slack `HIDDEN_SERVICES` pattern via new `BETA_ONLY_SERVICES`).
- Wrap the `host-exec` slot in `@if (betaEnabled())` so it's removed from the DOM for non-beta users.
- `effect()` re-runs `loadIntegrations` when the BetaService signal toggles mid-session, so the row + slot appear live without a manual refresh.

## Why
Both features landed in 0.10.0 (`mcp-office` #644, `host-exec` #657) but were not gated. ADR-058 establishes beta toggle as the single gate for work-in-progress UI surfaces; meeting-transcription already uses it. This commit brings office + host-exec under the same policy. Default = off for new users and all upgraders (BetaService getter `unwrap_or(false)`).

## Test plan
- [x] `make check` (clippy, fmt, type-check, ESLint) — passed
- [x] `make test` — all 1845 Angular tests + Rust + MCP + entrypoint + desktop bats passed
- [x] New unit tests (`integrations.component.spec.ts`):
  - beta off → office hidden in services list
  - beta on → office visible
  - beta off → `[data-testid=integrations-host-exec-slot]` null
  - beta on → slot rendered
  - off → on mid-session reveals both via effect