### PR TITLE
fix(desktop): remove unused Target::Webview to fix Linux startup deadlock

### DIFF
--- a/.claude/rules/logging.md
+++ b/.claude/rules/logging.md
@@ -12,7 +12,7 @@ All Rust code uses the `log` crate facade for diagnostic output. **Never use `ep
 
 | Binary                        | Backend                                         | Config                                     |
 | ----------------------------- | ----------------------------------------------- | ------------------------------------------ |
-| Desktop (`speedwave-desktop`) | `tauri-plugin-log` v2 (file + stdout + webview) | Initialized in `main.rs` `.plugin()` chain |
+| Desktop (`speedwave-desktop`) | `tauri-plugin-log` v2 (file + stdout)           | Initialized in `main.rs` `.plugin()` chain |
 | CLI (`speedwave`)             | `env_logger` (stderr, respects `RUST_LOG`)      | Initialized at CLI `main()` start          |
 | Library (`speedwave-runtime`) | `log` crate facade only (no backend opinion)    | Callers provide the backend                |
 

--- a/Makefile
+++ b/Makefile
@@ -307,10 +307,14 @@ test-rust:
 
 test-transcription:
 	@echo "🧪 Testing speedwave-runtime with the audio-transcription feature..."
-	@# whisper-rs / sherpa-onnx / cpal are added to this feature in later phases
-	@# (1b/1c/4) and need `cmake` + network access at build time then; for now
-	@# the feature only pulls in `hound` (WAV I/O), so a plain cargo build works.
-	SPEEDWAVE_DATA_DIR= cargo test -p speedwave-runtime --features audio-transcription -- --test-threads=1
+	@# Only the `transcription` module is gated behind this feature (see
+	@# `src/lib.rs` — `#[cfg(feature = "audio-transcription")] pub mod transcription;`).
+	@# The rest of the crate (compose, plugin, build, …) is identical with or
+	@# without the feature and is already exercised by `test-rust`. Without the
+	@# `transcription::` filter, cargo re-runs the whole suite a second time
+	@# (~100 compose tests at ~5s each under `--test-threads=1`), which alone
+	@# blows past the 15-minute CI job budget.
+	SPEEDWAVE_DATA_DIR= cargo test -p speedwave-runtime --features audio-transcription transcription:: -- --test-threads=1
 	@echo "✅ audio-transcription tests passed"
 
 test-cli:

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -1329,7 +1329,6 @@ fn main() {
                     Target::new(TargetKind::LogDir {
                         file_name: Some("speedwave-desktop".into()),
                     }),
-                    Target::new(TargetKind::Webview),
                 ])
                 .level(log::LevelFilter::Trace)
                 .level_for("hyper", log::LevelFilter::Warn)


### PR DESCRIPTION
## Summary

- Removes `Target::Webview` from `tauri-plugin-log` targets — it was a **dead stream** (no frontend code subscribes to `log://log` events) and the cause of a hard startup deadlock on Linux.

## Root cause

While `PluginStore::initialize_all` synchronously initializes other Tauri plugins, an internal log call from `zbus` (used by `tauri-plugin-single-instance` / `clipboard-manager` / `dialog` for DBus IPC on Linux) reenters our fern format closure → `Target::Webview` → `tauri::async_runtime::spawn`, which lazy-inits a `OnceLock` for the async runtime. The async runtime is **not yet up** because we are still inside `Builder::build`, so the `OnceLock` blocks on a futex that nobody will signal.

Result on Linux: main thread deadlock, the GUI never starts, WebDriver plugin never opens `:4445`, every e2e spec returns `ECONNREFUSED`.

Captured live with `gdb -batch -p <pid> -ex 'thread apply all bt'` against the hung process:

` ` `
syscall → futex_wait
OnceLock::initialize
tauri::async_runtime::spawn
<fern Output::call::CallShim as log::Log>::log
fern::log_impl::FormatCallback::finish
speedwave_desktop::main::{{closure}}        ← our custom log format
fern::log_impl::Dispatch as log::Log::log
tracing::span::Span::record_all
zbus::handshake::Client::perform::{{closure}}
zbus::connection::builder::Builder::build_
…
PluginStore::initialize_all
tauri::app::Builder::build
` ` `

## Why removing is safe on all OS

Audited every consumer of `tauri-plugin-log` in the repo. **Nobody subscribes to `log://log`** events.

| Consumer | Reads from |
|---|---|
| `logs-view` UI section | `~/.local/share/pl.speedwave.desktop/logs/speedwave-desktop.log` (Target::LogDir) |
| Diagnostics ZIP (`diagnostics.rs`) | LogDir files |
| Terminal / dev mode | Target::Stdout |
| Frontend → backend logs (`logger.service.ts`, `error-handler.ts`) | IPC command `plugin:log\|log` (separate API, unrelated to Webview target) |
| **Target::Webview** | **nobody** |

No `attachLogger` / `attachConsole` / `listen('log://log')` anywhere in `desktop/src/src/**` or `desktop/src-tauri/src/**`. The target was registered "just in case" but never wired to anything.

## Test plan

- [x] Reproduced the deadlock on the Linux e2e VM (`make _e2e-linux`): app hangs after `arboard::x11 Started serve requests thread`, wdio gets `ECONNREFUSED` on `:4445`
- [x] Captured gdb backtrace of the hung process — confirms the OnceLock futex wait inside `zbus`-driven log reentry
- [x] With `Target::Webview` removed: app starts, window opens, first-launch wizard runs
- [x] Linux e2e: specs 01..06 PASSED (`app-lifecycle`, `setup-wizard`, `container-health`, `navigation`, `settings`, `project-management`). One unrelated failure on spec 08 (`host-exec`) — separate from this fix
- [ ] Full e2e suite (Linux + macOS + Windows) green