### PR TITLE
fix(desktop): refresh tray after setup completes, not after create_project

### DIFF
--- a/desktop/src-tauri/src/containers_cmd.rs
+++ b/desktop/src-tauri/src/containers_cmd.rs
@@ -452,7 +452,6 @@ pub async fn start_containers(
     crate::ensure_mcp_os_running(&mcp_os, &app, compose_lock.inner().clone());
     crate::ensure_ide_bridge_running(&ide_bridge, &app);
 
-    let app_for_refresh = app.clone();
     tokio::task::spawn_blocking(move || {
         ensure_images_ready()?;
         check_project(&project)?;
@@ -478,7 +477,7 @@ pub async fn start_containers(
     // project_created → containers_started; cli_linked is independent). Rebuild
     // the tray here so setup-gated items (the ADR-058 beta toggle) appear
     // immediately after the wizard finishes.
-    crate::tray::refresh_tray_menu(&app_for_refresh);
+    crate::tray::refresh_tray_menu(&app);
     Ok(())
 }
 

--- a/desktop/src-tauri/src/containers_cmd.rs
+++ b/desktop/src-tauri/src/containers_cmd.rs
@@ -281,7 +281,6 @@ pub async fn init_vm() -> Result<(), String> {
 
 #[tauri::command]
 pub async fn create_project(
-    app: tauri::AppHandle,
     name: String,
     dir: String,
 ) -> Result<(), String> {
@@ -293,12 +292,7 @@ pub async fn create_project(
         })
     })
     .await
-    .map_err(|e| e.to_string())??;
-
-    // Last setup step → `is_setup_complete()` flips true; rebuild so setup-gated
-    // tray items (the ADR-058 beta toggle) appear.
-    crate::tray::refresh_tray_menu(&app);
-    Ok(())
+    .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
@@ -458,6 +452,7 @@ pub async fn start_containers(
     crate::ensure_mcp_os_running(&mcp_os, &app, compose_lock.inner().clone());
     crate::ensure_ide_bridge_running(&ide_bridge, &app);
 
+    let app_for_refresh = app.clone();
     tokio::task::spawn_blocking(move || {
         ensure_images_ready()?;
         check_project(&project)?;
@@ -476,7 +471,15 @@ pub async fn start_containers(
         })
     })
     .await
-    .map_err(|e| e.to_string())?
+    .map_err(|e| e.to_string())??;
+
+    // `start_containers` is the last setup step that flips `is_setup_complete()`
+    // (the wizard order is runtime_ready → vm_ready → images_built →
+    // project_created → containers_started; cli_linked is independent). Rebuild
+    // the tray here so setup-gated items (the ADR-058 beta toggle) appear
+    // immediately after the wizard finishes.
+    crate::tray::refresh_tray_menu(&app_for_refresh);
+    Ok(())
 }
 
 #[tauri::command]
@@ -1854,6 +1857,54 @@ mod tests {
         assert!(
             fn_body.contains("check_os_warnings"),
             "run_system_check must call check_os_warnings()"
+        );
+    }
+
+    /// Structural test: `start_containers()` is the last setup step that flips
+    /// `is_setup_complete()`. It must call `refresh_tray_menu` so the
+    /// setup-gated tray items (the ADR-058 beta toggle) appear immediately
+    /// after the wizard finishes — without a manual refresh.
+    #[test]
+    fn start_containers_refreshes_tray_after_setup_completes() {
+        let source = include_str!("containers_cmd.rs");
+        let fn_start = source
+            .find("pub async fn start_containers(")
+            .expect("start_containers function must exist");
+        let fn_body = &source[fn_start..];
+        let next_fn = fn_body[1..]
+            .find("\npub ")
+            .map(|i| i + 1)
+            .unwrap_or(fn_body.len());
+        let fn_body = &fn_body[..next_fn];
+        assert!(
+            fn_body.contains("tray::refresh_tray_menu"),
+            "start_containers must call crate::tray::refresh_tray_menu so the \
+             ADR-058 beta toggle appears after the wizard's final step"
+        );
+    }
+
+    /// Structural test: `create_project()` must NOT call `refresh_tray_menu`.
+    /// It runs at step 4 of 5, before `containers_started = true` is
+    /// persisted, so `is_setup_complete()` would still return `false` and the
+    /// tray rebuild would drop the beta toggle anyway (the bug fixed in this
+    /// commit). The refresh belongs in `start_containers()` instead.
+    #[test]
+    fn create_project_does_not_refresh_tray_prematurely() {
+        let source = include_str!("containers_cmd.rs");
+        let fn_start = source
+            .find("pub async fn create_project(")
+            .expect("create_project function must exist");
+        let fn_body = &source[fn_start..];
+        let next_fn = fn_body[1..]
+            .find("\npub ")
+            .map(|i| i + 1)
+            .unwrap_or(fn_body.len());
+        let fn_body = &fn_body[..next_fn];
+        assert!(
+            !fn_body.contains("tray::refresh_tray_menu"),
+            "create_project must not call refresh_tray_menu — at that point \
+             is_setup_complete() is still false (containers_started is set \
+             later by start_containers)"
         );
     }
 }


### PR DESCRIPTION
## Summary

After ADR-058 (#663), users who run the setup wizard end to end on a fresh install **don't see the "Beta features" toggle in the tray menu** — the wizard finishes, the rest of the app boots, but the menu only has _Open Speedwave / Check for Updates / Quit_.

Root cause: the original PR wired `refresh_tray_menu` into the **wrong** Tauri command. Fix wires it into the right one and adds two structural tests so it cannot regress.

## Root cause

`tray_menu_spec` (the SSOT for tray contents) only emits the beta toggle when `is_setup_complete()` returns true. `is_complete()` requires **five** booleans:

` ` `
runtime_ready → vm_ready → images_built → project_created → containers_started
` ` `

The original commit added `crate::tray::refresh_tray_menu(&app)` to `create_project` with a comment claiming it was the *"last setup step"*. It isn't — `create_project` only flips `project_created` (step 4 of 5). When `refresh_tray_menu` runs at that point, `is_setup_complete()` still returns false, so the rebuild produces a menu without the beta item — exactly what the user observed.

Verified on a real Linux box by introspecting the DBus menu after a complete wizard run:

` ` `
$ dbus-send … com.canonical.dbusmenu.GetLayout 0 -1 array:string:
  → Open Speedwave / Separator / Check for Updates / Separator / Quit
` ` `

No beta item, even though setup had finished and the rest of the app was working.

## Fix

- Move the refresh from `create_project` to `start_containers`, which flips `containers_started = true` — the actual final gating flag. `setup_wizard::start_containers` persists this *before* returning, so `is_setup_complete()` already reads true by the time we rebuild.
- Drop the now-unused `app: tauri::AppHandle` parameter from `create_project` — the frontend already calls it with only `{ name, dir }` (see `create-project-modal.component.spec.ts`), so this is a no-op for callers but cleans up a now-dead argument.

## Tests

Two structural tests pin the contract:

- `start_containers_refreshes_tray_after_setup_completes` — asserts `start_containers` calls `tray::refresh_tray_menu`
- `create_project_does_not_refresh_tray_prematurely` — asserts `create_project` does **not** call it (would re-introduce the bug)

Both pass:

` ` `
cargo test start_containers_refreshes
test result: ok. 1 passed; 0 failed
cargo test create_project_does_not
test result: ok. 1 passed; 0 failed
` ` `

## Test plan

- [x] Reproduced on Linux: wizard finishes end to end, tray DBus menu has no Beta features item
- [x] Two structural tests pass locally
- [ ] After merge: re-run wizard on the Linux test machine, confirm Beta features appears in the tray immediately after the final wizard step