### PR TITLE
fix(macos): raise minimumSystemVersion to 10.15 — required by whisper.cpp

### DIFF
--- a/desktop/src-tauri/tauri.macos.conf.json
+++ b/desktop/src-tauri/tauri.macos.conf.json
@@ -1,5 +1,8 @@
 {
   "bundle": {
+    "macOS": {
+      "minimumSystemVersion": "10.15"
+    },
     "resources": {
       "lima/bin/limactl": "lima/bin/limactl",
       "lima/share/": "lima/share/",


### PR DESCRIPTION
## Summary

Sets `bundle.macOS.minimumSystemVersion = "10.15"` in `tauri.macos.conf.json`. ADR-056 (whisper-rs-sys / whisper.cpp) hard-requires this — without it, the macOS build of `speedwave-desktop` has been failing on every e2e run since ADR-056 merged.

## Root cause

Tauri's default `bundle.macOS.minimumSystemVersion` is `"10.13"` (declared in `tauri-utils-2.8.3/src/config.rs:691` — `fn macos_minimum_system_version() -> Option<String> { Some("10.13".into()) }`).

`tauri-build` propagates this to the entire cargo build:

` ` `
// tauri-build-2.6.1/src/lib.rs:592
println!("cargo:rustc-env=MACOSX_DEPLOYMENT_TARGET={version}");
` ` `

`cc-rs` reads the env var and passes it as `-mmacosx-version-min=10.13` to every C/C++ compile under `whisper-rs-sys` → `whisper.cpp` → `ggml/src/ggml-backend-reg.cpp`. That source uses `std::filesystem::path`, which clang flags as **"introduced in macOS 10.15"** for any target < 10.15:

` ` `
ggml-backend-reg.cpp:436:35: error: 'path<const char *, void>' is
  unavailable: introduced in macOS 10.15
ggml-backend-reg.cpp:514:12: error: 'path' is unavailable: introduced in macOS 10.15
…
20 errors generated.
fatal error: too many errors emitted, stopping now
build script failed, must exit now
make: *** [test-e2e-desktop-build] Error 1
` ` `

This is **deterministic** — every macOS `make _e2e-macos` / `make test-e2e-all` run since ADR-056 hits it.

## Why 10.15

- whisper.cpp's `std::filesystem` use is the binding constraint
- macOS 10.15 (Catalina) shipped October 2019. Every Mac sold in the last 5+ years runs macOS 11 or newer
- Going higher (e.g. 11.0) is no extra hardware support but rules out a few late-2014 / early-2015 Macs still on Catalina

10.15 is the **lowest bump** that unblocks the build.

## Test plan

- [x] Repro: `make _e2e-macos` from `dev` → fails with the cmake/whisper-rs-sys error above
- [x] With this PR: `make _e2e-macos` → builds whisper-rs-sys cleanly, app launches, **6 of 7 specs PASSED** (3 + 10 + 1 + 6 + 5 + 9 = 34 tests). The 7th failure is `08-host-exec.spec.ts` — already known to be permanently red because ADR-058 gated the host-exec card behind the beta toggle; tracked in #667 (removes that spec entirely). After #667 merges and this branch is rebased, expected 7/7.