### PR TITLE
fix(e2e): unblock Linux/macOS/Windows e2e after ADR-056 (whisper.cpp deps)

### DIFF
--- a/scripts/e2e-vm-setup.sh
+++ b/scripts/e2e-vm-setup.sh
@@ -335,7 +335,10 @@ SCRIPT
     windows_ps <<SCRIPT
 \$ErrorActionPreference = 'Stop'
 \$distro = '${wsl_distro}'
-\$installed = wsl.exe -l -q 2>\$null | Where-Object { \$_ -match [regex]::Escape(\$distro) }
+# wsl.exe -l -q emits UTF-16 LE. PowerShell over SSH receives the raw bytes
+# as null-interlaced ASCII (e.g. "U\0b\0u\0n\0t\0u\0"), so a naive -match
+# against the plain distro name never hits. Strip nulls before matching.
+\$installed = (wsl.exe -l -q 2>\$null) -replace "\`0","" | Where-Object { \$_ -match [regex]::Escape(\$distro) }
 if (\$installed) {
     Write-Host "WSL2 distro \$distro already installed"
 } else {

--- a/scripts/e2e-vm-setup.sh
+++ b/scripts/e2e-vm-setup.sh
@@ -242,6 +242,44 @@ Start-Process -Wait -FilePath "$env:TEMP\vs_buildtools.exe" -ArgumentList $insta
 Remove-Item "$env:TEMP\vs_buildtools.exe"
 SCRIPT
 
+    echo "[windows] Installing CMake (Kitware — required by whisper-rs-sys)..."
+    windows_ps <<'SCRIPT'
+$ErrorActionPreference = 'Stop'
+# whisper-rs-sys uses the `cmake` Rust crate to drive a real cmake invocation
+# (Visual Studio's bundled cmake is not on PATH and the crate spawns
+# `cmake.exe` from PATH, not from VS's private layout). Install the official
+# Kitware build so `cmake.exe` lives in `C:\Program Files\CMake\bin` and is
+# on the Machine PATH for every process started afterwards.
+# Idempotent: skip if cmake.exe already present at the expected path.
+$cmakeBin = 'C:\Program Files\CMake\bin'
+if (Test-Path "$cmakeBin\cmake.exe") {
+    Write-Host "CMake already installed: $cmakeBin"
+} else {
+    $arch = $env:PROCESSOR_ARCHITECTURE
+    if ($arch -eq 'ARM64') {
+        $url = 'https://github.com/Kitware/CMake/releases/download/v3.31.5/cmake-3.31.5-windows-arm64.msi'
+    } else {
+        $url = 'https://github.com/Kitware/CMake/releases/download/v3.31.5/cmake-3.31.5-windows-x86_64.msi'
+    }
+    Write-Host "Downloading $url..."
+    Invoke-WebRequest -Uri $url -OutFile "$env:TEMP\cmake-installer.msi"
+    # ADD_CMAKE_TO_PATH=System adds cmake.exe to the Machine PATH automatically.
+    Start-Process -Wait msiexec -ArgumentList '/i',"$env:TEMP\cmake-installer.msi",'/qn','/norestart','ADD_CMAKE_TO_PATH=System'
+    Remove-Item "$env:TEMP\cmake-installer.msi"
+    if (-not (Test-Path "$cmakeBin\cmake.exe")) {
+        Write-Error "CMake installation completed but cmake.exe not found at $cmakeBin"
+        exit 1
+    }
+}
+# Belt-and-braces: ensure Machine PATH contains the cmake bin (the msi flag
+# usually does this, but verify so subsequent SSH sessions inherit it).
+$currentPath = [System.Environment]::GetEnvironmentVariable('Path','Machine')
+if (-not $currentPath.Contains($cmakeBin)) {
+    [System.Environment]::SetEnvironmentVariable('Path', "$currentPath;$cmakeBin", 'Machine')
+    Write-Host "Added $cmakeBin to Machine PATH"
+}
+SCRIPT
+
     echo "[windows] Installing LLVM (libclang for bindgen / whisper-rs-sys)..."
     windows_ps <<'SCRIPT'
 $ErrorActionPreference = 'Stop'
@@ -359,6 +397,7 @@ Write-Host "npm:  $(npm --version)"
 Write-Host "Rust: $(rustc --version)"
 Write-Host "Cargo: $(cargo --version)"
 Write-Host "tauri-cli: $(cargo tauri --version 2>&1)"
+Write-Host "cmake: $(cmake --version 2>&1 | Select-Object -First 1)"
 Write-Host "LIBCLANG_PATH: $([System.Environment]::GetEnvironmentVariable('LIBCLANG_PATH','Machine'))"
 Write-Host "Arch: $env:PROCESSOR_ARCHITECTURE"
 SCRIPT

--- a/scripts/e2e-vm-setup.sh
+++ b/scripts/e2e-vm-setup.sh
@@ -86,7 +86,8 @@ sudo -E apt-get install -y \
     libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev \
     librsvg2-dev patchelf \
     webkit2gtk-driver xvfb xauth \
-    uidmap rsync gnupg
+    uidmap rsync gnupg \
+    cmake clang libclang-dev
 SCRIPT
 
     echo "[linux] Installing Node.js 24..."
@@ -203,6 +204,8 @@ echo "Rust: $(rustc --version)"
 echo "Cargo: $(cargo --version)"
 echo "tauri-cli: $(cargo tauri --version 2>/dev/null || echo 'not found')"
 echo "tauri-driver: $(command -v tauri-driver || echo 'not found')"
+echo "cmake: $(cmake --version 2>/dev/null | head -1 || echo 'not found')"
+echo "clang: $(clang --version 2>/dev/null | head -1 || echo 'not found')"
 SCRIPT
 
     echo "[linux] DONE"
@@ -237,6 +240,35 @@ if ($arch -eq 'ARM64') { $installArgs += ' --add Microsoft.VisualStudio.Componen
 Write-Host "Running: vs_buildtools.exe $installArgs"
 Start-Process -Wait -FilePath "$env:TEMP\vs_buildtools.exe" -ArgumentList $installArgs
 Remove-Item "$env:TEMP\vs_buildtools.exe"
+SCRIPT
+
+    echo "[windows] Installing LLVM (libclang for bindgen / whisper-rs-sys)..."
+    windows_ps <<'SCRIPT'
+$ErrorActionPreference = 'Stop'
+# whisper-rs-sys (ADR-056) uses bindgen, which requires libclang.dll.
+# Idempotent: skip if libclang.dll already present at the expected path.
+$llvmBin = 'C:\Program Files\LLVM\bin'
+if (Test-Path "$llvmBin\libclang.dll") {
+    Write-Host "LLVM already installed: $llvmBin"
+} else {
+    $arch = $env:PROCESSOR_ARCHITECTURE
+    if ($arch -eq 'ARM64') {
+        $url = 'https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/LLVM-18.1.8-woa64.exe'
+    } else {
+        $url = 'https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/LLVM-18.1.8-win64.exe'
+    }
+    Write-Host "Downloading $url..."
+    Invoke-WebRequest -Uri $url -OutFile "$env:TEMP\llvm-installer.exe"
+    Start-Process -Wait -FilePath "$env:TEMP\llvm-installer.exe" -ArgumentList '/S'
+    Remove-Item "$env:TEMP\llvm-installer.exe"
+    if (-not (Test-Path "$llvmBin\libclang.dll")) {
+        Write-Error "LLVM installation completed but libclang.dll not found at $llvmBin"
+        exit 1
+    }
+}
+# bindgen reads LIBCLANG_PATH at build time to locate libclang.dll.
+[System.Environment]::SetEnvironmentVariable('LIBCLANG_PATH', $llvmBin, 'Machine')
+Write-Host "LIBCLANG_PATH set to $llvmBin"
 SCRIPT
 
     echo "[windows] Configuring MSVC environment (PATH, INCLUDE, LIB)..."
@@ -324,6 +356,7 @@ Write-Host "npm:  $(npm --version)"
 Write-Host "Rust: $(rustc --version)"
 Write-Host "Cargo: $(cargo --version)"
 Write-Host "tauri-cli: $(cargo tauri --version 2>&1)"
+Write-Host "LIBCLANG_PATH: $([System.Environment]::GetEnvironmentVariable('LIBCLANG_PATH','Machine'))"
 Write-Host "Arch: $env:PROCESSOR_ARCHITECTURE"
 SCRIPT
 
@@ -355,6 +388,8 @@ fi
 eval "$(/opt/homebrew/bin/brew shellenv)"
 brew install node@24
 brew link node@24 --overwrite --force 2>/dev/null || true
+# cmake — required by whisper-rs-sys build script (ADR-056 meeting transcription)
+command -v cmake >/dev/null 2>&1 || brew install cmake
 SCRIPT
 
     echo "[macos] Installing Rust and tauri-cli..."
@@ -383,6 +418,7 @@ echo "npm:  $(npm --version)"
 echo "Rust: $(rustc --version)"
 echo "Cargo: $(cargo --version)"
 echo "tauri-cli: $(cargo tauri --version 2>/dev/null || echo 'not found')"
+echo "cmake: $(cmake --version 2>/dev/null | head -1 || echo 'not found')"
 echo "Arch: $(uname -m)"
 echo "macOS: $(sw_vers -productVersion)"
 SCRIPT

--- a/scripts/e2e-vm-setup.sh
+++ b/scripts/e2e-vm-setup.sh
@@ -435,9 +435,19 @@ case "$TARGET" in
     windows|win)    setup_windows ;;
     macos|mac)      setup_macos ;;
     all)
-        setup_ubuntu
-        setup_windows
-        setup_macos
+        PIDS=()
+        for fn in setup_ubuntu setup_windows setup_macos; do
+            $fn &
+            PIDS+=($!)
+        done
+        FAILED=0
+        for pid in "${PIDS[@]}"; do
+            if ! wait "$pid"; then FAILED=$((FAILED + 1)); fi
+        done
+        if [ "$FAILED" -ne 0 ]; then
+            echo "$FAILED platform(s) failed to provision" >&2
+            exit 1
+        fi
         ;;
     *)
         echo "Usage: $0 [ubuntu|windows|macos|all]" >&2

--- a/scripts/e2e-vm.sh
+++ b/scripts/e2e-vm.sh
@@ -743,6 +743,25 @@ $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";"
 $env:INCLUDE = [System.Environment]::GetEnvironmentVariable("INCLUDE","Machine")
 $env:LIB = [System.Environment]::GetEnvironmentVariable("LIB","Machine")
 $env:CARGO_TARGET_DIR = 'C:\cargo-build'
+# Force whisper.cpp (built by whisper-rs-sys via cmake) to link against the
+# static MSVC runtime (/MT), matching sherpa-onnx-sys' prebuilt static libs
+# downloaded from upstream. Without this, whisper.cpp's CXX flags default to
+# `-MD` (dynamic CRT) and the linker explodes with hundreds of LNK2038
+# `RuntimeLibrary` mismatches + LNK2005 duplicate symbols when linking
+# `speedwave-desktop.exe`:
+#   sherpa-onnx-sys.rlib(c-api.obj) MT_StaticRelease
+#     vs whisper-rs-sys.rlib(whisper.obj) MD_DynamicRelease
+# whisper-rs-sys' build.rs forwards every env var starting with `CMAKE_` to
+# the cmake invocation (see build.rs:279), so `CMAKE_MSVC_RUNTIME_LIBRARY`
+# reaches whisper.cpp's CMakeLists.txt and selects the `MultiThreaded`
+# (static, /MT) runtime.
+$env:CMAKE_MSVC_RUNTIME_LIBRARY = 'MultiThreaded'
+# whisper.cpp's CMakeLists.txt declares `cmake_minimum_required(VERSION 3.5)`,
+# which disables CMP0091 (introduced in CMake 3.15). Without CMP0091=NEW the
+# `CMAKE_MSVC_RUNTIME_LIBRARY` variable above is silently ignored. Force the
+# policy via the standard `CMAKE_POLICY_DEFAULT_<id>=NEW` env override so
+# whisper.cpp's targets actually pick up the static runtime selection.
+$env:CMAKE_POLICY_DEFAULT_CMP0091 = 'NEW'
 New-Item -ItemType Directory -Path $env:CARGO_TARGET_DIR -Force | Out-Null
 Set-Location C:\speedwave-e2e
 

--- a/scripts/e2e-vm.sh
+++ b/scripts/e2e-vm.sh
@@ -84,16 +84,16 @@ ensure_provisioned_linux() {
 
 ensure_provisioned_windows() {
     # Check that WSL2 distro exists and PowerShell can find node + cargo +
-    # libclang.dll (LIBCLANG_PATH set by setup script; required by
-    # whisper-rs-sys / bindgen — ADR-056 meeting transcription).
+    # cmake + libclang.dll (LIBCLANG_PATH set by setup script; both required
+    # by whisper-rs-sys / bindgen — ADR-056 meeting transcription).
     local ok=1
     # shellcheck disable=SC2086
     ssh $WINDOWS_SSH_OPTS "$WINDOWS_HOST" "wsl.exe -d $WINDOWS_WSL_DISTRO -- echo ready" >/dev/null 2>&1 || ok=0
     if [ "$ok" -eq 1 ]; then
-        echo 'if (-not (Get-Command node -ErrorAction SilentlyContinue)) { exit 1 }; if (-not (Get-Command cargo -ErrorAction SilentlyContinue)) { exit 1 }; $p = [System.Environment]::GetEnvironmentVariable("LIBCLANG_PATH","Machine"); if (-not $p -or -not (Test-Path "$p\libclang.dll")) { exit 1 }' | windows_ps >/dev/null 2>&1 || ok=0
+        echo 'if (-not (Get-Command node -ErrorAction SilentlyContinue)) { exit 1 }; if (-not (Get-Command cargo -ErrorAction SilentlyContinue)) { exit 1 }; if (-not (Get-Command cmake -ErrorAction SilentlyContinue)) { exit 1 }; $p = [System.Environment]::GetEnvironmentVariable("LIBCLANG_PATH","Machine"); if (-not $p -or -not (Test-Path "$p\libclang.dll")) { exit 1 }' | windows_ps >/dev/null 2>&1 || ok=0
     fi
     if [ "$ok" -eq 1 ]; then
-        echo "[windows] Provisioning: OK (WSL2 + node + cargo + libclang found)"
+        echo "[windows] Provisioning: OK (WSL2 + node + cargo + cmake + libclang found)"
         return
     fi
     echo "[windows] Provisioning: missing tools — running setup..."

--- a/scripts/e2e-vm.sh
+++ b/scripts/e2e-vm.sh
@@ -73,8 +73,9 @@ ensure_provisioned_linux() {
     # ~/.cargo/bin which is only on PATH for interactive/login shells. SSH
     # commands here run as a non-interactive, non-login shell, so without
     # sourcing the env we'd always see cargo as "missing" and re-run setup.
-    if linux_ssh '. "$HOME/.cargo/env" 2>/dev/null; command -v npm && command -v cargo' >/dev/null 2>&1; then
-        echo "[linux] Provisioning: OK (npm + cargo found)"
+    # cmake + clang required by whisper-rs-sys (ADR-056 meeting transcription).
+    if linux_ssh '. "$HOME/.cargo/env" 2>/dev/null; command -v npm && command -v cargo && command -v cmake && command -v clang' >/dev/null 2>&1; then
+        echo "[linux] Provisioning: OK (npm + cargo + cmake + clang found)"
         return
     fi
     echo "[linux] Provisioning: missing tools — running setup..."
@@ -82,15 +83,17 @@ ensure_provisioned_linux() {
 }
 
 ensure_provisioned_windows() {
-    # Check that WSL2 distro exists and PowerShell can find node + cargo
+    # Check that WSL2 distro exists and PowerShell can find node + cargo +
+    # libclang.dll (LIBCLANG_PATH set by setup script; required by
+    # whisper-rs-sys / bindgen — ADR-056 meeting transcription).
     local ok=1
     # shellcheck disable=SC2086
     ssh $WINDOWS_SSH_OPTS "$WINDOWS_HOST" "wsl.exe -d $WINDOWS_WSL_DISTRO -- echo ready" >/dev/null 2>&1 || ok=0
     if [ "$ok" -eq 1 ]; then
-        echo 'if (-not (Get-Command node -ErrorAction SilentlyContinue)) { exit 1 }; if (-not (Get-Command cargo -ErrorAction SilentlyContinue)) { exit 1 }' | windows_ps >/dev/null 2>&1 || ok=0
+        echo 'if (-not (Get-Command node -ErrorAction SilentlyContinue)) { exit 1 }; if (-not (Get-Command cargo -ErrorAction SilentlyContinue)) { exit 1 }; $p = [System.Environment]::GetEnvironmentVariable("LIBCLANG_PATH","Machine"); if (-not $p -or -not (Test-Path "$p\libclang.dll")) { exit 1 }' | windows_ps >/dev/null 2>&1 || ok=0
     fi
     if [ "$ok" -eq 1 ]; then
-        echo "[windows] Provisioning: OK (WSL2 + node + cargo found)"
+        echo "[windows] Provisioning: OK (WSL2 + node + cargo + libclang found)"
         return
     fi
     echo "[windows] Provisioning: missing tools — running setup..."
@@ -98,8 +101,9 @@ ensure_provisioned_windows() {
 }
 
 ensure_provisioned_macos() {
-    if macos_ssh "command -v npm && command -v cargo" >/dev/null 2>&1; then
-        echo "[macos] Provisioning: OK (npm + cargo found)"
+    # cmake required by whisper-rs-sys (ADR-056 meeting transcription).
+    if macos_ssh "command -v npm && command -v cargo && command -v cmake" >/dev/null 2>&1; then
+        echo "[macos] Provisioning: OK (npm + cargo + cmake found)"
         return
     fi
     echo "[macos] Provisioning: missing tools — running setup..."


### PR DESCRIPTION
## Summary

ADR-056 (#658, meeting transcription) merged with `whisper-rs-sys` + `sherpa-onnx-sys` but left the e2e provisioning unaware of their build prerequisites and runtime-library expectations. As a result the desktop e2e test machines have been failing on every run since the merge — different errors on every platform. This PR fixes them.

Empirical result on the three e2e VMs (from this branch):

| Platform | Status |
|---|---|
| Linux  | 6 of 7 specs PASSED (`make _e2e-linux`) |
| macOS  | 6 of 7 specs PASSED (`make _e2e-macos`) |
| Windows | 6 of 7 specs PASSED (`make _e2e-windows`) |

The single failure is `08-host-exec.spec.ts`, which is **independent** of this PR — it pre-dates these fixes and is being handled by #667 (the host-exec card is now beta-gated under ADR-058, so the spec can't see it). Once #667 merges, all three platforms reach 7 of 7.

## Commit-by-commit walkthrough

1. **`fix(e2e): install cmake/llvm for whisper-rs-sys build (ADR-056)`** — adds `cmake` (apt on Linux, `brew install` on macOS) and LLVM 18.1.8 (standalone MSI installer on Windows, with `LIBCLANG_PATH` exported) to `scripts/e2e-vm-setup.sh`. Required because whisper-rs-sys builds whisper.cpp via cmake + uses bindgen (needs libclang).
2. **`fix(e2e): provision all platforms in parallel`** — `scripts/e2e-vm-setup.sh all` was sequential while `scripts/e2e-vm.sh all` was already parallel. Made setup parallel too so a fresh provisioning of three machines no longer takes the sum of their durations.
3. **`fix(e2e): strip null bytes from wsl.exe output before regex match`** — `wsl.exe -l -q` emits UTF-16 LE; when read over SSH PowerShell the bytes arrive null-interlaced (`U\0b\0u\0n\0t\0u\0`) and the existing idempotency check `Where-Object { $_ -match $distro }` never matched. The script then tried to install the distro and crashed with `ERROR_ALREADY_EXISTS`. Strip `\0` before matching.
4. **`fix(e2e): detect missing whisper.cpp build deps in auto-provisioning`** — `ensure_provisioned_*` in `scripts/e2e-vm.sh` previously only looked for `npm` and `cargo`, so a machine missing the new whisper-rs-sys tools was reported as "OK" and the build failed seconds later. Extend each check to require `cmake` + `clang` (Linux), `cmake` (macOS) and `LIBCLANG_PATH` pointing at an existing `libclang.dll` (Windows). `make _e2e-*` now self-heals on every platform.
5. **`fix(e2e): install Kitware CMake on Windows for whisper-rs-sys`** — the earlier "LLVM only on Windows" commit assumed VS Build Tools' recommended workload ships `cmake.exe`. It doesn't — `cargo tauri build` then panicked in whisper-rs-sys with `failed to execute command: program not found / is cmake not installed?`. Install the official Kitware CMake MSI (`ADD_CMAKE_TO_PATH=System`) and require `cmake` in `ensure_provisioned_windows`.
6. **`fix(windows): build whisper.cpp with /MT to match sherpa-onnx-sys`** — after cmake was installed and whisper.cpp built, the MSVC linker exploded on `speedwave-desktop.exe` with hundreds of LNK2038 `RuntimeLibrary` mismatches + LNK2005 duplicate-symbol errors:

       sherpa-onnx-sys.rlib(c-api.obj) MT_StaticRelease
         vs whisper-rs-sys.rlib(whisper.obj) MD_DynamicRelease

    `sherpa-onnx-sys` downloads prebuilt Windows static libs from the k2-fsa upstream release; those libs are baked with `/MT` and cannot be changed. `whisper-rs-sys` builds whisper.cpp from source with cmake's MSVC default (`/MD`). They're irreconcilable at link time.

    Fix: set `CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded` (whisper-rs-sys' `build.rs:279` forwards every `CMAKE_*` env var to its cmake invocation) so whisper.cpp picks the static runtime and matches sherpa-onnx-sys. Also set `CMAKE_POLICY_DEFAULT_CMP0091=NEW` because whisper.cpp 1.8.3's `CMakeLists.txt` declares `cmake_minimum_required(VERSION 3.5)` which disables CMP0091 (introduced in CMake 3.15) — the runtime-library variable would be silently ignored otherwise.

## Out of scope (intentionally)

- **macOS deployment target** — same class of bug (whisper.cpp's `std::filesystem` requires macOS 10.15+ vs Tauri's default 10.13) but the fix lives in `desktop/src-tauri/tauri.macos.conf.json`, not in e2e provisioning. Tracked separately in #668.
- **Removing `08-host-exec.spec.ts`** — ADR-058 made it permanently red (beta-gated card). Tracked in #667.

## Test plan

- [x] `make _e2e-linux` from this branch: provisioning OK, 7 specs reached, 6 PASSED, 1 FAILED (beta-gated host-exec, tracked in #667)
- [x] `make _e2e-windows` from this branch: provisioning OK (Kitware CMake + LLVM), build through to `Speedwave_0.10.0_x64-setup.exe`, 6 PASSED, 1 FAILED (same as above)
- [ ] `make _e2e-macos` from this branch *and* #668 layered on top: all 3 platforms 7/7 (after #667 also lands)