### PR TITLE
fix(mcp): address codeql alerts post-#671 + bats EDR race

### DIFF
--- a/_tests/desktop/bundle-build-context.bats
+++ b/_tests/desktop/bundle-build-context.bats
@@ -11,14 +11,29 @@
 SCRIPT="$BATS_TEST_DIRNAME/../../scripts/bundle-build-context.sh"
 DEST="$BATS_TEST_DIRNAME/../../desktop/src-tauri"
 
+# macOS EDR products (Bitdefender, Microsoft Defender) open freshly-written
+# files for real-time scanning. `bundle-build-context.sh` writes ~100MB into
+# $DEST/build-context within a second; a follow-up `rm -rf` racing the
+# scanner's open fd surfaces as `Directory not empty`. Retry with a short
+# backoff so the scanner has time to release the fd.
+rm_with_retry() {
+    local target="$1"
+    local attempt
+    for attempt in 1 2 3 4 5; do
+        rm -rf "$target" 2>/dev/null && return 0
+        sleep 0.2
+    done
+    rm -rf "$target"
+}
+
 setup() {
-    rm -rf "$DEST/build-context"
-    rm -rf "$DEST/mcp-os"
+    rm_with_retry "$DEST/build-context"
+    rm_with_retry "$DEST/mcp-os"
 }
 
 teardown() {
-    rm -rf "$DEST/build-context"
-    rm -rf "$DEST/mcp-os"
+    rm_with_retry "$DEST/build-context"
+    rm_with_retry "$DEST/mcp-os"
 }
 
 @test "bundle script exists and is executable" {

--- a/mcp-servers/oauth/src/index.ts
+++ b/mcp-servers/oauth/src/index.ts
@@ -64,8 +64,13 @@ async function main(): Promise<void> {
     rateLimitOverride !== undefined &&
     (Number.isNaN(rateLimitSeconds!) || rateLimitSeconds! < 0)
   ) {
+    // Do NOT echo the offending value back: even though this is a numeric
+    // configuration name, an operator could put any string into the env var
+    // (incl. a paste of an unrelated secret), and CodeQL's taint-tracker
+    // correctly flags an unconditional log of `process.env.*` as a leak
+    // surface. The variable name in the message is enough to diagnose.
     console.error(
-      `${ts()} oauth FATAL: invalid OAUTH_REFRESH_RATE_LIMIT_SECONDS: ${rateLimitOverride}`
+      `${ts()} oauth FATAL: OAUTH_REFRESH_RATE_LIMIT_SECONDS must be a non-negative integer (got an invalid value)`
     );
     process.exit(1);
   }

--- a/mcp-servers/oauth/src/index.ts
+++ b/mcp-servers/oauth/src/index.ts
@@ -26,7 +26,10 @@ const SERVER_VERSION = '1.0.0';
 function resolvePort(): number {
   const port = Number.parseInt(process.env.PORT || '0', 10);
   if (Number.isNaN(port) || port < 0 || port > 65535) {
-    console.error(`${ts()} oauth FATAL: invalid PORT value: ${process.env.PORT}`);
+    // Do not echo env-var value — operator could put any string there (CodeQL js/clear-text-logging).
+    console.error(
+      `${ts()} oauth FATAL: PORT must be a valid port number 0–65535 (got an invalid value)`
+    );
     process.exit(1);
   }
   return port;
@@ -64,11 +67,7 @@ async function main(): Promise<void> {
     rateLimitOverride !== undefined &&
     (Number.isNaN(rateLimitSeconds!) || rateLimitSeconds! < 0)
   ) {
-    // Do NOT echo the offending value back: even though this is a numeric
-    // configuration name, an operator could put any string into the env var
-    // (incl. a paste of an unrelated secret), and CodeQL's taint-tracker
-    // correctly flags an unconditional log of `process.env.*` as a leak
-    // surface. The variable name in the message is enough to diagnose.
+    // Do not echo env-var value — operator could put any string there (CodeQL js/clear-text-logging).
     console.error(
       `${ts()} oauth FATAL: OAUTH_REFRESH_RATE_LIMIT_SECONDS must be a non-negative integer (got an invalid value)`
     );

--- a/mcp-servers/shared/src/server.ts
+++ b/mcp-servers/shared/src/server.ts
@@ -407,8 +407,8 @@ export function createMCPServer(options: MCPServerOptions): MCPServer {
 // Internal Helpers
 //═══════════════════════════════════════════════════════════════════════════════
 
-// Constant-time bearer-token compare: HMAC equalises lengths for timingSafeEqual.
-// Not a password hash — tokens are already high-entropy (CodeQL js/insufficient-password-hash dismissed).
+// Constant-time bearer-token compare via double-HMAC — equalises lengths for timingSafeEqual.
+// Not a password hash: bearer tokens are already high-entropy, so Argon2/bcrypt buys nothing.
 function safeTokenCompare(provided: string, expected: string): boolean {
   const hmac = (data: string) => createHmac('sha256', expected).update(data).digest();
   return timingSafeEqual(hmac(provided), hmac(expected));

--- a/mcp-servers/shared/src/server.ts
+++ b/mcp-servers/shared/src/server.ts
@@ -407,32 +407,8 @@ export function createMCPServer(options: MCPServerOptions): MCPServer {
 // Internal Helpers
 //═══════════════════════════════════════════════════════════════════════════════
 
-/**
- * Constant-time bearer-token comparison via double-HMAC.
- *
- * **NOT a password hashing function.** CodeQL's `js/insufficient-password-hash`
- * heuristic flags any `createHmac` that operates on a function argument named
- * suggestively (or a value flowing from a token-shaped source). The flag is a
- * false positive here:
- *
- * - Bearer tokens are **already** high-entropy random secrets (UUIDs, 256-bit
- *   random base64), not user-chosen passwords. There is nothing to "stretch" —
- *   the threat model that motivates Argon2/bcrypt/scrypt (offline dictionary
- *   attack on a low-entropy secret) does not apply.
- * - The function exists to compare two byte strings in constant time even
- *   when their lengths differ. Node's `timingSafeEqual` only accepts equal-
- *   length buffers (a length mismatch raises and leaks length via the
- *   exception path). HMAC-SHA256 keyed by `expected` equalises lengths and
- *   keeps the comparison constant-time — the OWASP-recommended pattern.
- * - Using Argon2/bcrypt here would add ~100ms per request to a hot auth path
- *   (DoS surface) **without** changing the security posture, since the
- *   secret is already high-entropy.
- *
- * If you change this function, keep these invariants: keyed HMAC over both
- * sides, then `timingSafeEqual` on the digests.
- * @param provided - the token presented by the caller (untrusted)
- * @param expected - the configured token to compare against (also used as HMAC key)
- */
+// Constant-time bearer-token compare: HMAC equalises lengths for timingSafeEqual.
+// Not a password hash — tokens are already high-entropy (CodeQL js/insufficient-password-hash dismissed).
 function safeTokenCompare(provided: string, expected: string): boolean {
   const hmac = (data: string) => createHmac('sha256', expected).update(data).digest();
   return timingSafeEqual(hmac(provided), hmac(expected));

--- a/mcp-servers/shared/src/server.ts
+++ b/mcp-servers/shared/src/server.ts
@@ -407,8 +407,32 @@ export function createMCPServer(options: MCPServerOptions): MCPServer {
 // Internal Helpers
 //═══════════════════════════════════════════════════════════════════════════════
 
-// Double-HMAC: avoids length-leak since timingSafeEqual requires equal-length buffers.
-// Keyed by `expected` so the comparison is constant-time regardless of input lengths.
+/**
+ * Constant-time bearer-token comparison via double-HMAC.
+ *
+ * **NOT a password hashing function.** CodeQL's `js/insufficient-password-hash`
+ * heuristic flags any `createHmac` that operates on a function argument named
+ * suggestively (or a value flowing from a token-shaped source). The flag is a
+ * false positive here:
+ *
+ * - Bearer tokens are **already** high-entropy random secrets (UUIDs, 256-bit
+ *   random base64), not user-chosen passwords. There is nothing to "stretch" —
+ *   the threat model that motivates Argon2/bcrypt/scrypt (offline dictionary
+ *   attack on a low-entropy secret) does not apply.
+ * - The function exists to compare two byte strings in constant time even
+ *   when their lengths differ. Node's `timingSafeEqual` only accepts equal-
+ *   length buffers (a length mismatch raises and leaks length via the
+ *   exception path). HMAC-SHA256 keyed by `expected` equalises lengths and
+ *   keeps the comparison constant-time — the OWASP-recommended pattern.
+ * - Using Argon2/bcrypt here would add ~100ms per request to a hot auth path
+ *   (DoS surface) **without** changing the security posture, since the
+ *   secret is already high-entropy.
+ *
+ * If you change this function, keep these invariants: keyed HMAC over both
+ * sides, then `timingSafeEqual` on the digests.
+ * @param provided - the token presented by the caller (untrusted)
+ * @param expected - the configured token to compare against (also used as HMAC key)
+ */
 function safeTokenCompare(provided: string, expected: string): boolean {
   const hmac = (data: string) => createHmac('sha256', expected).update(data).digest();
   return timingSafeEqual(hmac(provided), hmac(expected));


### PR DESCRIPTION
## Summary

Two follow-ups to PR #671 plus a test-infra fix that unblocked the push:

**CodeQL alerts (post-#671)**
- `mcp-servers/oauth/src/index.ts` — drop the offending value from the FATAL log for invalid `OAUTH_REFRESH_RATE_LIMIT_SECONDS`. The env var name is enough to diagnose, and CodeQL correctly flags an unconditional `console.error` of `process.env.*` as a leak surface (operator could paste a secret there).
- `mcp-servers/shared/src/server.ts` — document `safeTokenCompare()` as a constant-time bearer-token comparator, not a password hasher. CodeQL's `js/insufficient-password-hash` heuristic false-positives here; bearer tokens are already high-entropy, and the function exists to equalise lengths so `timingSafeEqual` stays constant-time. No behaviour change in the HMAC path.

**Test infra fix**
- `_tests/desktop/bundle-build-context.bats` — wrap `rm -rf` in setup/teardown with a 5-attempt × 0.2s retry. macOS EDR products (Bitdefender, Microsoft Defender) open freshly-written files for real-time scanning; `bundle-build-context.sh` writes ~100MB within a second, and the follow-up `rm -rf` racing the scanner's open fd surfaces as `Directory not empty`. On a clean machine the first attempt always succeeds; on machines with real-time AV the scanner releases the fd within the backoff window.

These three changes originated as later rounds of review on the now-merged PR #671 (`feat/sharepoint-pages-lists-oauth-refresh` branch). The squash merge of #671 captured the round-5 work conceptually, but the actual files were never reconciled into `dev` — that's what this PR does.

## Test plan
- [ ] CI green
- [ ] `bats _tests/desktop/bundle-build-context.bats` passes 19/19 (verified locally with EDR active)
- [ ] CodeQL alerts triggered by the original constructs do not re-surface