### PR TITLE
feat(mcp-context7): native Context7 integration with optional API key

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -30,6 +30,7 @@ export default {
         'mcp-atlassian',
         'mcp-office',
         'mcp-playwright',
+        'mcp-context7',
         'mcp-os',
         'mcp-host-exec',
         'containers',

--- a/containers/claude-resources/skills/context7/SKILL.md
+++ b/containers/claude-resources/skills/context7/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: context7
+description: This skill should be used when the user asks about libraries, frameworks, APIs, CLI tools, cloud services, or needs code examples. Activates for setup questions, code generation involving external dependencies, version migration, or mentions of specific projects by name. Sources indexed include Git repositories, official documentation websites, OpenAPI specs, npm packages, llms.txt files, and Confluence spaces.
+---
+
+When the user asks about a library, framework, API, CLI tool, or cloud service, use Context7 to fetch current documentation instead of relying on training data.
+
+## When to Use This Skill
+
+Activate when the user:
+
+- Asks setup or configuration questions ("How do I configure Next.js middleware?")
+- Requests code involving libraries ("Write a Prisma query for...")
+- Needs API references ("What are the Supabase auth methods?")
+- Mentions specific projects by name (frameworks, SDKs, CLIs, cloud APIs)
+- Asks about version migration or upgrade paths
+
+## How to Fetch Documentation
+
+### Step 1: Resolve the ID
+
+Call `context7.resolve_library_id` with:
+
+- `libraryName`: the project name extracted from the user's question (free-text)
+- `query`: the user's full question (improves relevance ranking)
+
+The parameter name `libraryName` is historical — it accepts any indexable source, not only code libraries.
+
+### Step 2: Select the Best Match
+
+From the resolution results, choose based on:
+
+- Exact or closest name match
+- Higher `trustScore` / `benchmarkScore`
+- If the user mentioned a version (e.g. "React 19", "Next.js 15"), prefer the version-specific ID (`/vercel/next.js/v15.1.8` or `/vercel/next.js@v15.1.8`)
+
+### Step 3: Fetch the Documentation
+
+Call `context7.query_docs` with:
+
+- `libraryId`: the selected Context7 ID (e.g. `/vercel/next.js`)
+- `query`: the user's specific question
+- `tokens` (optional): default 5000, raise up to 15000 for deep dives
+
+### Step 4: Use the Documentation
+
+- Answer using the fetched snippets, not your training data
+- Include code examples adapted from the docs
+- Cite the project version when relevant — `tier` and source info are in the response
+
+## Guidelines
+
+- **Be specific**: pass the user's full question as `query` for better ranking
+- **Version awareness**: if the user mentions a version, pin it in the ID
+- **Prefer official sources**: pick official/primary entries over community forks
+- **One resolve per project per conversation**: cache the ID — don't re-resolve every turn

--- a/containers/compose.template.yml
+++ b/containers/compose.template.yml
@@ -61,6 +61,7 @@ services:
       - WORKER_ATLASSIAN_URL=http://mcp-atlassian:${PORT_WORKER}
       - WORKER_OFFICE_URL=http://mcp-office:${PORT_WORKER}
       - WORKER_PLAYWRIGHT_URL=http://mcp-playwright:${PORT_WORKER}
+      - WORKER_CONTEXT7_URL=http://mcp-context7:${PORT_WORKER}
     networks:
       - ${NETWORK_NAME}
       # Also on the egress-less office network so the hub can reach mcp-office (ADR-055).
@@ -296,6 +297,32 @@ services:
         limits:
           cpus: '2.0'
           memory: 2048m
+
+  mcp-context7:
+    image: ${IMAGE_MCP_CONTEXT7}
+    pull_policy: never
+    container_name: ${COMPOSE_PREFIX}_${PROJECT_NAME}_mcp_context7
+    read_only: true
+    user: "${CONTAINER_USER}"
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /tmp:noexec,nosuid,size=64m
+    volumes:
+      # Optional /tokens/api_key — anonymous mode (per-IP rate limit) if absent.
+      # See docs/architecture/security.md for the third-party data-flow note.
+      - ${TOKENS_DIR}/context7:/tokens:ro
+    environment:
+      - PORT=${PORT_WORKER}
+    networks:
+      - ${NETWORK_NAME}
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 128m
 
 networks:
   ${NETWORK_NAME}:

--- a/crates/speedwave-runtime/src/build.rs
+++ b/crates/speedwave-runtime/src/build.rs
@@ -34,6 +34,7 @@ pub const IMAGE_MCP_GITHUB: &str = "speedwave-mcp-github";
 pub const IMAGE_MCP_ATLASSIAN: &str = "speedwave-mcp-atlassian";
 pub const IMAGE_MCP_OFFICE: &str = "speedwave-mcp-office";
 pub const IMAGE_MCP_PLAYWRIGHT: &str = "speedwave-mcp-playwright";
+pub const IMAGE_MCP_CONTEXT7: &str = "speedwave-mcp-context7";
 
 pub const IMAGES: &[ImageDef] = &[
     ImageDef {
@@ -94,6 +95,12 @@ pub const IMAGES: &[ImageDef] = &[
         name: IMAGE_MCP_PLAYWRIGHT,
         context_dir: "mcp-servers",
         containerfile: "mcp-servers/playwright/Containerfile",
+        build_args: &[],
+    },
+    ImageDef {
+        name: IMAGE_MCP_CONTEXT7,
+        context_dir: "mcp-servers",
+        containerfile: "mcp-servers/context7/Dockerfile",
         build_args: &[],
     },
 ];
@@ -1541,7 +1548,7 @@ mod tests {
     fn test_images_count() {
         // Catalogue size, not build behaviour — the build set is filtered per
         // project by `enabled_images`. Bump this when adding a built-in worker.
-        assert_eq!(IMAGES.len(), 10);
+        assert_eq!(IMAGES.len(), 11);
     }
 
     #[test]

--- a/crates/speedwave-runtime/src/compose.rs
+++ b/crates/speedwave-runtime/src/compose.rs
@@ -108,6 +108,10 @@ pub fn render_compose(
         "${IMAGE_MCP_PLAYWRIGHT}",
         &build::image_ref(build::IMAGE_MCP_PLAYWRIGHT, &bundle_manifest.bundle_id),
     );
+    yaml = yaml.replace(
+        "${IMAGE_MCP_CONTEXT7}",
+        &build::image_ref(build::IMAGE_MCP_CONTEXT7, &bundle_manifest.bundle_id),
+    );
 
     // Bridge writes lock files directly to ~/.speedwave/ide-bridge/
     // Mount it as /home/speedwave/.claude/ide/ — no copying needed.
@@ -2746,6 +2750,7 @@ services:
       - WORKER_ATLASSIAN_URL=http://mcp-atlassian:3000
       - WORKER_OFFICE_URL=http://mcp-office:3000
       - WORKER_PLAYWRIGHT_URL=http://mcp-playwright:3000
+      - WORKER_CONTEXT7_URL=http://mcp-context7:3000
     networks:
       - speedwave_test_network
       - speedwave_test_network_office
@@ -2798,6 +2803,24 @@ services:
     tmpfs:
       - /tmp:noexec,nosuid,size=1g
     shm_size: 2g
+    environment:
+      - PORT=3000
+    networks:
+      - speedwave_test_network
+
+  mcp-context7:
+    image: speedwave-mcp-context7:latest
+    container_name: speedwave_test_mcp_context7
+    read_only: true
+    user: "1000:1000"
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /tmp:noexec,nosuid,size=64m
+    volumes:
+      - /home/user/.speedwave/tokens/test/context7:/tokens:ro
     environment:
       - PORT=3000
     networks:
@@ -3141,6 +3164,10 @@ services:
         )));
         assert!(yaml.contains(&build::image_ref(
             build::IMAGE_MCP_ATLASSIAN,
+            &manifest.bundle_id
+        )));
+        assert!(yaml.contains(&build::image_ref(
+            build::IMAGE_MCP_CONTEXT7,
             &manifest.bundle_id
         )));
 
@@ -6713,6 +6740,7 @@ services:
             atlassian: true,
             office: true,
             playwright: true,
+            context7: true,
             ..ResolvedIntegrationsConfig::default()
         };
         let result =
@@ -7739,6 +7767,7 @@ services:
       - WORKER_ATLASSIAN_URL=http://mcp-atlassian:3000
       - WORKER_OFFICE_URL=http://mcp-office:3000
       - WORKER_PLAYWRIGHT_URL=http://mcp-playwright:3000
+      - WORKER_CONTEXT7_URL=http://mcp-context7:3000
     networks:
       - speedwave_test_network
       - speedwave_test_network_office
@@ -7887,6 +7916,24 @@ services:
     networks:
       - speedwave_test_network
 
+  mcp-context7:
+    image: speedwave-mcp-context7:latest
+    container_name: speedwave_test_mcp_context7
+    read_only: true
+    user: "1000:1000"
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /tmp:noexec,nosuid,size=64m
+    volumes:
+      - /home/user/.speedwave/tokens/test/context7:/tokens:ro
+    environment:
+      - PORT=3000
+    networks:
+      - speedwave_test_network
+
 networks:
   speedwave_test_network:
     driver: bridge
@@ -7905,6 +7952,7 @@ networks:
             atlassian: true,
             office: true,
             playwright: true,
+            context7: true,
             ..Default::default()
         }
     }

--- a/crates/speedwave-runtime/src/config.rs
+++ b/crates/speedwave-runtime/src/config.rs
@@ -122,6 +122,7 @@ pub struct IntegrationsConfig {
     pub atlassian: Option<IntegrationConfig>,
     pub office: Option<IntegrationConfig>,
     pub playwright: Option<IntegrationConfig>,
+    pub context7: Option<IntegrationConfig>,
     pub os: Option<OsIntegrationsConfig>,
     /// Per-project `host_exec` whitelist (ADR-054). User-config only.
     #[serde(default, rename = "hostExec", skip_serializing_if = "Option::is_none")]
@@ -143,6 +144,7 @@ impl IntegrationsConfig {
             "atlassian" => self.atlassian = Some(cfg),
             "office" => self.office = Some(cfg),
             "playwright" => self.playwright = Some(cfg),
+            "context7" => self.context7 = Some(cfg),
             _ => return false,
         }
         true
@@ -184,6 +186,7 @@ pub struct ResolvedIntegrationsConfig {
     pub atlassian: bool,
     pub office: bool,
     pub playwright: bool,
+    pub context7: bool,
     pub os_reminders: bool,
     pub os_calendar: bool,
     pub os_mail: bool,
@@ -210,6 +213,7 @@ impl ResolvedIntegrationsConfig {
             "atlassian" => Some(self.atlassian),
             "office" => Some(self.office),
             "playwright" => Some(self.playwright),
+            "context7" => Some(self.context7),
             _ => None,
         }
     }
@@ -471,6 +475,7 @@ fn apply_integrations_layer(
     apply_toggle(&mut result.atlassian, &layer.atlassian);
     apply_toggle(&mut result.office, &layer.office);
     apply_toggle(&mut result.playwright, &layer.playwright);
+    apply_toggle(&mut result.context7, &layer.context7);
     if let Some(ref os) = layer.os {
         apply_toggle(&mut result.os_reminders, &os.reminders);
         apply_toggle(&mut result.os_calendar, &os.calendar);
@@ -1423,6 +1428,7 @@ mod tests {
             atlassian: None,
             office: None,
             playwright: None,
+            context7: None,
             host_exec: None,
             os: Some(OsIntegrationsConfig {
                 reminders: Some(IntegrationConfig {
@@ -1481,6 +1487,7 @@ mod tests {
                     atlassian: None,
                     office: None,
                     playwright: None,
+                    context7: None,
                     host_exec: None,
                     os: None,
                     plugins: None,
@@ -1736,6 +1743,7 @@ mod tests {
                     atlassian: None,
                     office: None,
                     playwright: None,
+                    context7: None,
                     host_exec: None,
                     os: Some(OsIntegrationsConfig {
                         reminders: Some(IntegrationConfig {
@@ -1784,6 +1792,7 @@ mod tests {
                     atlassian: None,
                     office: None,
                     playwright: None,
+                    context7: None,
                     host_exec: None,
                     os: None,
                     plugins: None,
@@ -2076,6 +2085,7 @@ mod tests {
                     atlassian: None,
                     office: None,
                     playwright: None,
+                    context7: None,
                     host_exec: None,
                     os: None,
                     plugins: Some(HashMap::from([(

--- a/crates/speedwave-runtime/src/consts.rs
+++ b/crates/speedwave-runtime/src/consts.rs
@@ -750,6 +750,33 @@ pub const TOGGLEABLE_MCP_SERVICES: &[McpServiceDescriptor] = &[
         egress_less: false,
         uses_oauth_refresh: false,
     },
+    McpServiceDescriptor {
+        config_key: "context7",
+        compose_name: "mcp-context7",
+        worker_env: "WORKER_CONTEXT7_URL",
+        display_name: "Context7",
+        description: "Up-to-date library documentation (React, Spring, Django, …)",
+        // `api_key` is OPTIONAL: anonymous mode works (per-IP rate limit ~200/day,
+        // see docs/architecture/security.md). The Tauri layer overrides the badge
+        // dynamically — present when the file is empty/absent, absent when the key
+        // is set. Default here is the unconfigured display.
+        auth_fields: &[McpAuthFieldDescriptor {
+            key: "api_key",
+            label: "API Key (optional — higher rate limits)",
+            field_type: "password",
+            placeholder: "ctx7sk_…",
+            is_secret: true,
+            stored_in_config_json: false,
+            oauth_flow: false,
+            optional: true,
+            storage: FieldStorage::WorkerMountedToken,
+        }],
+        credential_files: &["api_key"],
+        oauth_state_fields: None,
+        badge: Some("Anonymous"),
+        egress_less: false,
+        uses_oauth_refresh: false,
+    },
 ];
 
 /// Descriptor for a toggleable OS integration service (macOS only).
@@ -824,6 +851,7 @@ pub const BUILT_IN_SERVICES: &[&str] = &[
     "mcp-atlassian",
     "mcp-office",
     "mcp-playwright",
+    "mcp-context7",
 ];
 
 /// Built-in service IDs (logical names, not compose names).
@@ -844,6 +872,7 @@ pub const BUILT_IN_SERVICE_IDS: &[&str] = &[
     "atlassian",
     "office",
     "playwright",
+    "context7",
     "os",
     "host_exec",
     // Host-side OAuth refresh worker (ADR-060). Reserved so plugins cannot
@@ -1125,7 +1154,7 @@ mod tests {
         let resolved = crate::config::ResolvedIntegrationsConfig::default();
         // Explicit field enumeration — update this when adding/removing MCP fields.
         // Using a const to force a compile-time reminder when struct changes.
-        const EXPECTED_MCP_FIELDS: usize = 8; // slack, sharepoint, redmine, gitlab, github, atlassian, office, playwright
+        const EXPECTED_MCP_FIELDS: usize = 9; // slack, sharepoint, redmine, gitlab, github, atlassian, office, playwright, context7
         let _ = (
             resolved.slack,
             resolved.sharepoint,
@@ -1135,6 +1164,7 @@ mod tests {
             resolved.atlassian,
             resolved.office,
             resolved.playwright,
+            resolved.context7,
         );
         assert_eq!(
             TOGGLEABLE_MCP_SERVICES.len(),
@@ -1206,6 +1236,7 @@ mod tests {
             ("atlassian", 5),
             ("office", 0),
             ("playwright", 0),
+            ("context7", 1),
         ];
         for &(key, count) in expected {
             let svc =
@@ -1412,6 +1443,8 @@ mod tests {
                 "atlassian",
                 vec!["jira_project_keys", "confluence_space_keys"],
             ),
+            // Context7 works in anonymous mode; api_key is the only field and it is optional.
+            ("context7", vec!["api_key"]),
         ]
         .into_iter()
         .collect();
@@ -1818,14 +1851,22 @@ mod tests {
 
     #[test]
     fn test_credential_services_have_no_badge() {
+        // Exception: services whose only credentials are all optional may carry
+        // an informational badge ("Anonymous") that the Tauri layer overrides
+        // dynamically once a key is set. See context7's descriptor.
         for svc in TOGGLEABLE_MCP_SERVICES {
-            if !svc.auth_fields.is_empty() {
-                assert_eq!(
-                    svc.badge, None,
-                    "service '{}' with credentials should not have a badge",
-                    svc.config_key
-                );
+            if svc.auth_fields.is_empty() {
+                continue;
             }
+            let all_optional = svc.auth_fields.iter().all(|f| f.optional);
+            if all_optional {
+                continue;
+            }
+            assert_eq!(
+                svc.badge, None,
+                "service '{}' with required credentials should not have a badge",
+                svc.config_key
+            );
         }
     }
 

--- a/desktop/src-tauri/oauth/shared/package-lock.json
+++ b/desktop/src-tauri/oauth/shared/package-lock.json
@@ -3103,9 +3103,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/desktop/src-tauri/src/integrations_cmd.rs
+++ b/desktop/src-tauri/src/integrations_cmd.rs
@@ -81,6 +81,16 @@ fn redmine_config_json_fields() -> Vec<&'static str> {
 
 /// Reads and parses a service's config.json. Returns an empty JSON object
 /// on missing or unreadable files.
+/// True when any of `files` exists as a non-empty file under `svc_token_dir`.
+/// Used to drop the "Anonymous"-style badge once a key has been written.
+fn has_any_credential_file(svc_token_dir: &std::path::Path, files: &[&str]) -> bool {
+    files.iter().any(|name| {
+        std::fs::metadata(svc_token_dir.join(name))
+            .map(|m| m.len() > 0)
+            .unwrap_or(false)
+    })
+}
+
 fn read_service_config(svc_token_dir: &std::path::Path) -> serde_json::Value {
     let config_path = svc_token_dir.join("config.json");
     std::fs::read_to_string(&config_path)
@@ -251,6 +261,16 @@ pub fn get_integrations(project: String) -> Result<IntegrationsResponse, String>
             None
         };
 
+        // Optional-only services (e.g. context7): badge from descriptor only when
+        // no key is set — once configured, drop the badge to mirror configured state.
+        let all_optional = !svc_desc.auth_fields.is_empty()
+            && svc_desc.auth_fields.iter().all(|f| f.optional);
+        let badge = if all_optional && configured && has_any_credential_file(&svc_token_dir, svc_desc.credential_files) {
+            None
+        } else {
+            svc_desc.badge.map(|b| b.to_string())
+        };
+
         service_entries.push(IntegrationStatusEntry {
             service: svc.to_string(),
             enabled,
@@ -260,7 +280,7 @@ pub fn get_integrations(project: String) -> Result<IntegrationsResponse, String>
             auth_fields: auth_fields.clone(),
             current_values,
             mappings,
-            badge: svc_desc.badge.map(|b| b.to_string()),
+            badge,
             oauth_action_required,
         });
     }
@@ -1089,20 +1109,27 @@ pub fn delete_integration_credentials(project: String, service: String) -> Resul
         }
     }
 
-    // Auto-disable the integration since credentials are now removed
-    config::with_config_lock(|| {
-        let mut user_config = config::load_user_config()?;
-        if let Some(entry) = user_config.find_project_mut(&project) {
-            let integrations = entry.integrations.get_or_insert_with(Default::default);
-            let cfg = config::IntegrationConfig {
-                enabled: Some(false),
-            };
-            integrations.set_service(&service, cfg);
-            config::save_user_config(&user_config)?;
-        }
-        Ok(())
-    })
-    .map_err(|e| e.to_string())?;
+    // Optional-only services (e.g. context7) keep working in anonymous mode after
+    // credential removal — skip auto-disable so the toggle stays as the user left it.
+    let all_optional = svc_desc
+        .map(|d| !d.auth_fields.is_empty() && d.auth_fields.iter().all(|f| f.optional))
+        .unwrap_or(false);
+
+    if !all_optional {
+        config::with_config_lock(|| {
+            let mut user_config = config::load_user_config()?;
+            if let Some(entry) = user_config.find_project_mut(&project) {
+                let integrations = entry.integrations.get_or_insert_with(Default::default);
+                let cfg = config::IntegrationConfig {
+                    enabled: Some(false),
+                };
+                integrations.set_service(&service, cfg);
+                config::save_user_config(&user_config)?;
+            }
+            Ok(())
+        })
+        .map_err(|e| e.to_string())?;
+    }
 
     Ok(())
 }

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -298,7 +298,7 @@ The `mcp-context7` worker calls `https://context7.com/api/v2/*` (Upstash) to res
 
 **Anonymous mode (no key):** ~200 requests per day per source IP (from the `ratelimit-limit` response header). For a multi-user host on one corporate NAT this is shared across all users; if it runs out, Upstash returns 429 with a `ratelimit-reset` Unix timestamp. There is no SLA and no DPA in anonymous mode — for compliance-sensitive deployments, each developer should generate a free key at [context7.com/dashboard](https://context7.com/dashboard).
 
-**Container constraints (identical to other workers):** `cap_drop: ALL`, `no-new-privileges`, `read_only`, `tmpfs /tmp:noexec,nosuid`, 128 MiB memory cap. The `api_key` file is mounted `:ro`. Redirects from Context7 are explicitly NOT followed (undici v7 default + `mapErrorStatus` rejects 3xx). HTTP body is capped at 5 MiB by `undici` timeouts (30 s headers + 30 s body).
+**Container constraints (identical to other workers):** `cap_drop: ALL`, `no-new-privileges`, `read_only`, `tmpfs /tmp:noexec,nosuid`, 128 MiB memory cap. The `api_key` file is mounted `:ro`. Redirects from Context7 are explicitly NOT followed (undici v7 default + `mapErrorStatus` rejects 3xx). HTTP body is capped at 5 MiB by `readBodyLimited` in `client.ts` (drains the stream with a byte counter and aborts cleanly before the 128 MiB container cap would OOM-kill the worker). Timeouts cap time independently: 30 s headers + 30 s body via undici options.
 
 ## Redmine API Proxy Commands
 

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -278,6 +278,28 @@ Both OS prereq failures and `SecurityCheck` compose violations block the applica
 
 Additionally, `check_os_warnings()` provides non-blocking diagnostic warnings (e.g. nested virtualization detected) logged via `log::warn!` during system checks. These warnings do not block container operations but appear in `speedwave check` output and Desktop log files.
 
+## Third-party services
+
+Some MCP workers reach external SaaS endpoints from inside their container. The `claude` container itself never makes outbound HTTP — every third-party hop is mediated by a worker with a narrow scope and an audited data flow.
+
+### Context7 (library documentation)
+
+The `mcp-context7` worker calls `https://context7.com/api/v2/*` (Upstash) to resolve library names to IDs and fetch documentation snippets.
+
+**Data sent to Upstash on every call:**
+
+- Query string (the natural-language question the user typed)
+- `libraryName` / `libraryId` (e.g. `"react"` / `/facebook/react`)
+- Optional API key (`ctx7sk_…`) when configured — sent in `Authorization: Bearer`
+- `User-Agent: Speedwave-Context7/<version>` and standard HTTP headers
+- Source IP (the worker's egress IP — Upstash documents that IPs are stored encrypted)
+
+**Per Context7's documented data use, queries may be retained and used for benchmarking and reranking, including by third-party LLMs.** Anything sensitive in the user's question crosses a trust boundary — the same way it would if Claude itself called the API.
+
+**Anonymous mode (no key):** ~200 requests per day per source IP (from the `ratelimit-limit` response header). For a multi-user host on one corporate NAT this is shared across all users; if it runs out, Upstash returns 429 with a `ratelimit-reset` Unix timestamp. There is no SLA and no DPA in anonymous mode — for compliance-sensitive deployments, each developer should generate a free key at [context7.com/dashboard](https://context7.com/dashboard).
+
+**Container constraints (identical to other workers):** `cap_drop: ALL`, `no-new-privileges`, `read_only`, `tmpfs /tmp:noexec,nosuid`, 128 MiB memory cap. The `api_key` file is mounted `:ro`. Redirects from Context7 are explicitly NOT followed (undici v7 default + `mapErrorStatus` rejects 3xx). HTTP body is capped at 5 MiB by `undici` timeouts (30 s headers + 30 s body).
+
 ## Redmine API Proxy Commands
 
 The Desktop app includes two Tauri commands that make HTTP requests to external Redmine instances during integration configuration: `validate_redmine_credentials` and `fetch_redmine_enumerations`. These run on the Desktop host process, not inside containers, because the MCP Redmine worker doesn't exist during configuration — the user hasn't saved credentials yet.

--- a/docs/guides/integrations.md
+++ b/docs/guides/integrations.md
@@ -14,6 +14,7 @@ Speedwave connects Claude Code with external services through MCP (Model Context
 | Redmine     | Issue tracking     | `speedwave_<project>_mcp_redmine`    | `~/.speedwave/tokens/<project>/redmine/`      |
 | Office      | Word/Excel/PPT/PDF | `speedwave_<project>_mcp_office`     | N/A (no credentials)                          |
 | Playwright  | Browser automation | `speedwave_<project>_mcp_playwright` | N/A (no credentials)                          |
+| Context7    | Library docs       | `speedwave_<project>_mcp_context7`   | `~/.speedwave/tokens/<project>/context7/` (optional) |
 | OS          | Host services      | mcp-os (host process)                | N/A (runs on host)                            |
 | Host Exec   | Project toolchain  | host-exec (per-project host process) | N/A (whitelist in `~/.speedwave/config.json`) |
 
@@ -284,6 +285,38 @@ Container hardening is otherwise identical to every other MCP worker: `cap_drop:
 - **Tracing** — `browser_start_tracing`, `browser_start_video`, `browser_stop_tracing` (gated behind `--caps devtools` when explicitly enabled).
 
 Refer to the [upstream README](https://github.com/microsoft/playwright-mcp) for the full list and parameter schemas.
+
+### Context7 — Library Documentation
+
+[Context7](https://context7.com) (project of Upstash) hosts an index of ~50k libraries with current code snippets and exposes a REST API. The Speedwave worker calls `https://context7.com/api/v2/*` directly — no MCP-in-MCP layer.
+
+#### Anonymous mode vs API key
+
+The integration works **without an API key** (anonymous tier, per-IP rate limit). For higher limits, paste a free key from [context7.com/dashboard](https://context7.com/dashboard) into the API Key field in Settings → Integrations → Context7. The badge "Anonymous" disappears once a key is set.
+
+Removing the key returns to anonymous mode — the toggle stays enabled (unlike other integrations, which auto-disable when credentials are deleted).
+
+#### Tool surface
+
+| Tool                 | Parameters                            | Description                                                        |
+| -------------------- | ------------------------------------- | ------------------------------------------------------------------ |
+| `resolve_library_id` | `libraryName`, `query`                | Resolve a name (e.g. "react") to a Context7 ID (e.g. `/facebook/react`). Returns top 10 matches with `trustScore` and version list. |
+| `query_docs`         | `libraryId`, `query`, `tokens?`       | Fetch documentation snippets for a known ID. `tokens` defaults to 5000, clamped to `[500, 15000]` to bound context-window usage. |
+
+The Hub exposes both tools through `execute_code` (preferred) — e.g. `await context7.resolve_library_id({libraryName: "react", query: "useState"})`.
+
+#### Example prompts
+
+- *"Implement Next.js middleware that checks JWT in cookies. use context7"*
+- *"How do I configure Spring Boot JWT filter authentication? use context7"*
+
+#### Skill
+
+Speedwave ships `context7/SKILL.md` (in `containers/claude-resources/skills/`) that teaches Claude to prefer Context7 over training data for library, framework, API, CLI, and cloud-service questions. The skill runs the standard `resolve_library_id` → `query_docs` workflow.
+
+#### Network and security
+
+The Context7 worker makes outbound HTTPS to `context7.com/api/v2/*` only. See [security.md](../architecture/security.md#third-party-services) for the data-flow disclosure (queries, library names, optional API key, client headers, IP).
 
 ## MCP Hub Architecture
 

--- a/mcp-servers/context7/Dockerfile
+++ b/mcp-servers/context7/Dockerfile
@@ -1,0 +1,72 @@
+# Speedwave MCP Context7 Worker
+# Up-to-date library documentation via Context7 REST API.
+#
+# Security:
+# - Optional API key mounted at /tokens/api_key (anonymous mode if absent)
+# - No access to other service tokens
+# - Per-IP rate limit when anonymous (~200/day) — see docs/architecture/security.md
+
+# Build stage
+FROM node:24-alpine AS builder
+
+WORKDIR /build
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Stage 1: Build shared library first (dependency)
+# ─────────────────────────────────────────────────────────────────────────────
+COPY tsconfig.base.json ./
+COPY shared/package*.json ./shared/
+RUN --mount=type=cache,target=/root/.npm cd shared && npm install
+
+COPY shared/src ./shared/src
+COPY shared/tsconfig.json ./shared/
+RUN cd shared && npm run build
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Stage 2: Build worker (imports from ../shared/dist)
+# ─────────────────────────────────────────────────────────────────────────────
+COPY context7/package*.json ./context7/
+RUN --mount=type=cache,target=/root/.npm cd context7 && npm install
+
+COPY context7/src ./context7/src
+COPY context7/tsconfig.json ./context7/
+RUN cd context7 && npm run build
+
+# Prune devDependencies
+RUN cd context7 && npm prune --omit=dev
+
+# Production stage
+FROM node:24-alpine
+
+# curl for healthcheck; tzdata for TZ env — keep aligned with tz.rs (see CLAUDE.md SSOT).
+RUN apk add --no-cache curl tzdata
+
+WORKDIR /app
+
+# Copy built shared library (required at runtime for relative imports)
+COPY --from=builder /build/shared/dist ../shared/dist
+COPY --from=builder /build/shared/package.json ../shared/
+COPY --from=builder /build/shared/node_modules ../shared/node_modules
+
+# Copy built worker application
+COPY --from=builder /build/context7/package*.json ./
+COPY --from=builder /build/context7/dist ./dist
+COPY --from=builder /build/context7/node_modules ./node_modules
+
+# Create tokens and project config directories
+RUN mkdir -p /tokens /project && chown -R node:node /tokens /project /app /app/../shared
+
+# Security: non-root user
+USER node
+
+# Health check (LOCAL readiness — does NOT hit Context7 API to preserve anonymous quota)
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD curl -sf http://localhost:3000/health || exit 1
+
+EXPOSE 3000
+
+ENV PORT=3000 \
+    TOKENS_DIR=/tokens \
+    NODE_ENV=production
+
+CMD ["node", "dist/index.js"]

--- a/mcp-servers/context7/package.json
+++ b/mcp-servers/context7/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@speedwave/mcp-context7",
+  "version": "0.1.0",
+  "description": "Speedwave MCP Context7 Worker - up-to-date library documentation",
+  "main": "dist/index.js",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc --watch",
+    "start": "node dist/index.js",
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
+  },
+  "keywords": [
+    "speedwave",
+    "mcp",
+    "context7",
+    "documentation",
+    "worker"
+  ],
+  "author": "Speednet",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@speedwave/mcp-shared": "file:../shared",
+    "undici": "^7.16.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.2",
+    "@vitest/coverage-v8": "^4.1.6",
+    "typescript": "^6.0.3",
+    "vitest": "^4.0.16"
+  }
+}

--- a/mcp-servers/context7/src/auth.test.ts
+++ b/mcp-servers/context7/src/auth.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Context7 worker auth wiring tests.
+ *
+ * Verifies that mcp-context7 reads MCP_CONTEXT7_AUTH_TOKEN before starting,
+ * loads the optional /tokens/api_key when present, and falls back to
+ * anonymous mode when the key is absent.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { chmod, mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir, platform } from 'node:os';
+import { join } from 'node:path';
+
+const exec = promisify(execFile);
+
+const WORKER_CWD = new URL('..', import.meta.url).pathname;
+
+/** Spawn the worker once and capture its stdout/stderr/exit. */
+async function runWorker(env: NodeJS.ProcessEnv): Promise<{
+  code: number;
+  stdout: string;
+  stderr: string;
+}> {
+  try {
+    const result = await exec('node', ['dist/index.js'], {
+      cwd: WORKER_CWD,
+      env: { ...process.env, ...env },
+      timeout: 4000,
+    });
+    return { code: 0, stdout: result.stdout, stderr: result.stderr };
+  } catch (error: unknown) {
+    const e = error as { code?: number; stdout?: string; stderr?: string };
+    return { code: e.code ?? 1, stdout: e.stdout ?? '', stderr: e.stderr ?? '' };
+  }
+}
+
+describe('context7 auth enforcement', () => {
+  it('exits with code 1 when MCP_CONTEXT7_AUTH_TOKEN is not set', async () => {
+    const result = await runWorker({ MCP_CONTEXT7_AUTH_TOKEN: '' });
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('MCP_CONTEXT7_AUTH_TOKEN is required');
+  }, 10_000);
+});
+
+describe('context7 optional API key', () => {
+  let dir: string;
+
+  it('starts in anonymous mode when /tokens/api_key is absent', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'mcp-context7-test-'));
+    try {
+      const result = await runWorker({
+        MCP_CONTEXT7_AUTH_TOKEN: 'test-token',
+        TOKENS_DIR: dir,
+        // Force the server to bind ephemerally and exit fast — we just want
+        // to observe the startup log, not actually serve traffic. The 4s
+        // timeout in runWorker will kill it.
+        PORT: '0',
+      });
+      // The worker keeps running until SIGTERM (timeout in runWorker). Look at
+      // its stdout/stderr for the anonymous-mode log.
+      expect(result.stdout + result.stderr).toMatch(/anonymous mode/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  }, 10_000);
+
+  it('loads key when /tokens/api_key has content', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'mcp-context7-test-'));
+    try {
+      await writeFile(join(dir, 'api_key'), 'ctx7sk_dummy\n');
+      const result = await runWorker({
+        MCP_CONTEXT7_AUTH_TOKEN: 'test-token',
+        TOKENS_DIR: dir,
+        PORT: '0',
+      });
+      expect(result.stdout + result.stderr).toMatch(/API key loaded/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  }, 10_000);
+
+  it('trims trailing whitespace from api_key — end-to-end via loadToken', async () => {
+    // Whitespace is stripped by mcp-shared's `loadToken`. End-to-end this means
+    // a user who pastes "ctx7sk_xxx\n" into Settings doesn't end up sending
+    // "Bearer ctx7sk_xxx\n" (which Context7 rejects with 401).
+    const { loadToken } = await import('@speedwave/mcp-shared');
+    dir = await mkdtemp(join(tmpdir(), 'mcp-context7-test-'));
+    try {
+      await writeFile(join(dir, 'api_key'), '  ctx7sk_padded  \n\n');
+      const value = await loadToken(join(dir, 'api_key'));
+      expect(value).toBe('ctx7sk_padded');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rethrows on EACCES — never silently falls back to anonymous on a real misconfig', async () => {
+    // POSIX-only: chmod 000 doesn't deny root, and the CI image runs as root.
+    // Skip on Windows (different ACL model) and when running as root.
+    if (platform() === 'win32') return;
+    if (typeof process.getuid === 'function' && process.getuid() === 0) return;
+
+    dir = await mkdtemp(join(tmpdir(), 'mcp-context7-test-'));
+    try {
+      const path = join(dir, 'api_key');
+      await writeFile(path, 'ctx7sk_secret');
+      await chmod(path, 0o000);
+
+      const { loadToken } = await import('@speedwave/mcp-shared');
+      await expect(loadToken(path)).rejects.toThrow(/Permission denied/);
+    } finally {
+      // Restore perms so rm can clean up.
+      await chmod(join(dir, 'api_key'), 0o600).catch(() => undefined);
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/mcp-servers/context7/src/client.test.ts
+++ b/mcp-servers/context7/src/client.test.ts
@@ -326,6 +326,18 @@ describe('Context7Client misc', () => {
     expect(e.tier).toBe('anonymous');
     expect(e.retryable).toBe(false);
   });
+
+  it('aborts when response body exceeds MAX_RESPONSE_BYTES — OOM regression guard', async () => {
+    const { client, mock } = makeClient();
+    // 6 MiB of payload — over the 5 MiB cap. The mock streams it as one chunk;
+    // readBodyLimited must reject before buffering the whole thing.
+    const oversized = 'x'.repeat(6 * 1024 * 1024);
+    mock
+      .intercept({ path: '/api/v2/libs/search?libraryName=react&query=q', method: 'GET' })
+      .reply(200, oversized, { headers: { 'content-type': 'application/json' } });
+
+    await expect(client.searchLibraries('react', 'q')).rejects.toThrow(/exceeded/);
+  });
 });
 
 describe('clampTokens', () => {

--- a/mcp-servers/context7/src/client.test.ts
+++ b/mcp-servers/context7/src/client.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Tests for Context7 REST client.
+ *
+ * Uses undici's built-in MockAgent — same approach as official undici docs,
+ * no extra dependency on msw/nock. Each test creates a fresh mock and pins
+ * it as the client's dispatcher so global state never leaks between tests.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { MockAgent } from 'undici';
+import { Context7Client, Context7Error, clampTokens } from './client.js';
+import { MAX_OUTPUT_TOKENS, MIN_OUTPUT_TOKENS } from './consts.js';
+
+const ORIGIN = 'https://context7.com';
+
+/** Build a MockAgent → Context7Client pair so tests can intercept HTTP. */
+function makeClient(apiKey?: string): {
+  client: Context7Client;
+  mock: ReturnType<MockAgent['get']>;
+  agent: MockAgent;
+} {
+  const agent = new MockAgent();
+  agent.disableNetConnect();
+  const mock = agent.get(ORIGIN);
+  const client = new Context7Client({ apiKey, dispatcher: agent });
+  return { client, mock, agent };
+}
+
+describe('Context7Client.searchLibraries', () => {
+  it('returns parsed results and tier on 200', async () => {
+    const { client, mock } = makeClient();
+    mock
+      .intercept({ path: '/api/v2/libs/search?libraryName=react&query=hooks', method: 'GET' })
+      .reply(
+        200,
+        JSON.stringify({
+          results: [{ id: '/facebook/react', title: 'React', description: 'UI library' }],
+        }),
+        { headers: { 'content-type': 'application/json', 'context7-quota-tier': 'anonymous' } }
+      );
+
+    const { data, tier } = await client.searchLibraries('react', 'hooks');
+    expect(tier).toBe('anonymous');
+    expect(data).toHaveLength(1);
+    expect(data[0].id).toBe('/facebook/react');
+  });
+
+  it('caps results to top-10 even when server returns more', async () => {
+    const { client, mock } = makeClient();
+    const big = Array.from({ length: 25 }, (_, i) => ({
+      id: `/owner/lib${i}`,
+      title: `Lib ${i}`,
+      description: '',
+    }));
+    mock
+      .intercept({ path: '/api/v2/libs/search?libraryName=react&query=hooks', method: 'GET' })
+      .reply(200, JSON.stringify({ results: big }), {
+        headers: { 'content-type': 'application/json' },
+      });
+
+    const { data } = await client.searchLibraries('react', 'hooks');
+    expect(data).toHaveLength(10);
+  });
+
+  it('sends Authorization header when api key set', async () => {
+    const { client, mock } = makeClient('ctx7sk_test');
+    mock
+      .intercept({
+        path: '/api/v2/libs/search?libraryName=react&query=h',
+        method: 'GET',
+        headers: { authorization: 'Bearer ctx7sk_test' },
+      })
+      .reply(200, JSON.stringify({ results: [] }));
+
+    // If the header was missing, the intercept would not match and undici
+    // would throw "no matching interceptor" — assertion via behaviour.
+    await client.searchLibraries('react', 'h');
+  });
+
+  it('omits Authorization header in anonymous mode', async () => {
+    const { client, mock } = makeClient();
+    mock
+      .intercept({
+        path: '/api/v2/libs/search?libraryName=react&query=h',
+        method: 'GET',
+        headers: (headers) => !('authorization' in headers),
+      })
+      .reply(200, JSON.stringify({ results: [] }));
+
+    await client.searchLibraries('react', 'h');
+  });
+
+  it('rejects empty libraryName before HTTP', async () => {
+    const { client } = makeClient();
+    await expect(client.searchLibraries('', 'q')).rejects.toThrow('libraryName');
+  });
+
+  it('rejects empty query before HTTP', async () => {
+    const { client } = makeClient();
+    await expect(client.searchLibraries('react', '')).rejects.toThrow('query');
+  });
+
+  it('URL-encodes special chars in libraryName', async () => {
+    const { client, mock } = makeClient();
+    mock
+      .intercept({
+        path: '/api/v2/libs/search?libraryName=spring%20boot&query=jwt',
+        method: 'GET',
+      })
+      .reply(200, JSON.stringify({ results: [] }));
+
+    await client.searchLibraries('spring boot', 'jwt');
+  });
+});
+
+describe('Context7Client.getContext', () => {
+  it('returns plain text body and tier on 200', async () => {
+    const { client, mock } = makeClient('ctx7sk_test');
+    mock
+      .intercept({
+        path: '/api/v2/context?libraryId=%2Ffacebook%2Freact&query=useState&tokens=5000',
+        method: 'GET',
+      })
+      .reply(200, '### useState example\n\nconst [c, set] = useState(0)', {
+        headers: { 'content-type': 'text/plain', 'context7-quota-tier': 'pro' },
+      });
+
+    const { data, tier } = await client.getContext('/facebook/react', 'useState', 5000);
+    expect(tier).toBe('pro');
+    expect(data).toContain('useState example');
+  });
+
+  it('clamps tokens to MAX_OUTPUT_TOKENS', async () => {
+    const { client, mock } = makeClient();
+    mock
+      .intercept({
+        path: `/api/v2/context?libraryId=%2Ffacebook%2Freact&query=q&tokens=${MAX_OUTPUT_TOKENS}`,
+        method: 'GET',
+      })
+      .reply(200, 'docs');
+
+    const { data } = await client.getContext('/facebook/react', 'q', 999_999);
+    expect(data).toBe('docs');
+  });
+
+  it('clamps tokens up to MIN_OUTPUT_TOKENS', async () => {
+    const { client, mock } = makeClient();
+    mock
+      .intercept({
+        path: `/api/v2/context?libraryId=%2Ffacebook%2Freact&query=q&tokens=${MIN_OUTPUT_TOKENS}`,
+        method: 'GET',
+      })
+      .reply(200, 'docs');
+
+    await client.getContext('/facebook/react', 'q', 1);
+  });
+});
+
+describe('Context7Client error mapping', () => {
+  it('202 → indexing-in-progress, not retryable', async () => {
+    const { client, mock } = makeClient();
+    mock
+      .intercept({ path: '/api/v2/libs/search?libraryName=react&query=q', method: 'GET' })
+      .reply(202, '');
+    await expect(client.searchLibraries('react', 'q')).rejects.toMatchObject({
+      status: 202,
+      retryable: false,
+    });
+  });
+
+  it('301 → unexpected redirect (not followed)', async () => {
+    const { client, mock } = makeClient();
+    mock
+      .intercept({ path: '/api/v2/libs/search?libraryName=react&query=q', method: 'GET' })
+      .reply(301, '', { headers: { location: 'https://evil.example.com/' } });
+    await expect(client.searchLibraries('react', 'q')).rejects.toMatchObject({
+      status: 301,
+      retryable: false,
+    });
+  });
+
+  it('400 → bad request with extracted message', async () => {
+    const { client, mock } = makeClient();
+    mock
+      .intercept({ path: '/api/v2/libs/search?libraryName=react&query=q', method: 'GET' })
+      .reply(400, JSON.stringify({ message: 'missing libraryName' }), {
+        headers: { 'content-type': 'application/json' },
+      });
+    await expect(client.searchLibraries('react', 'q')).rejects.toThrow(/missing libraryName/);
+  });
+
+  it('401 → invalid API key, retryable=false', async () => {
+    const { client, mock } = makeClient('ctx7sk_bad');
+    mock
+      .intercept({ path: '/api/v2/libs/search?libraryName=react&query=q', method: 'GET' })
+      .reply(401, '');
+    await expect(client.searchLibraries('react', 'q')).rejects.toMatchObject({
+      status: 401,
+      retryable: false,
+    });
+  });
+
+  it('403 → forbidden', async () => {
+    const { client, mock } = makeClient('ctx7sk_x');
+    mock
+      .intercept({ path: '/api/v2/libs/search?libraryName=react&query=q', method: 'GET' })
+      .reply(403, JSON.stringify({ message: 'private repo' }), {
+        headers: { 'content-type': 'application/json' },
+      });
+    await expect(client.searchLibraries('react', 'q')).rejects.toThrow(/Forbidden/);
+  });
+
+  it('404 → library not found', async () => {
+    const { client, mock } = makeClient();
+    mock
+      .intercept({ path: '/api/v2/libs/search?libraryName=react&query=q', method: 'GET' })
+      .reply(404, '');
+    await expect(client.searchLibraries('react', 'q')).rejects.toThrow(/not found/);
+  });
+
+  it('422 → unprocessable entity', async () => {
+    const { client, mock } = makeClient();
+    mock
+      .intercept({ path: '/api/v2/libs/search?libraryName=react&query=q', method: 'GET' })
+      .reply(422, JSON.stringify({ message: 'malformed libraryId' }), {
+        headers: { 'content-type': 'application/json' },
+      });
+    await expect(client.searchLibraries('react', 'q')).rejects.toThrow(/malformed libraryId/);
+  });
+
+  it('429 → rate limit, message mentions tier + reset', async () => {
+    const { client, mock } = makeClient();
+    mock
+      .intercept({ path: '/api/v2/libs/search?libraryName=react&query=q', method: 'GET' })
+      .reply(429, '', {
+        headers: {
+          'context7-quota-tier': 'anonymous',
+          'ratelimit-reset': '1780000000',
+        },
+      });
+    await expect(client.searchLibraries('react', 'q')).rejects.toThrow(/Tier: anonymous/);
+  });
+
+  it('500 → retries then succeeds', async () => {
+    const { client, mock } = makeClient();
+    mock
+      .intercept({ path: '/api/v2/libs/search?libraryName=react&query=q', method: 'GET' })
+      .reply(500, '');
+    mock
+      .intercept({ path: '/api/v2/libs/search?libraryName=react&query=q', method: 'GET' })
+      .reply(200, JSON.stringify({ results: [{ id: '/x/y', title: 'X' }] }), {
+        headers: { 'content-type': 'application/json' },
+      });
+
+    const { data } = await client.searchLibraries('react', 'q');
+    expect(data).toHaveLength(1);
+  }, 20_000);
+
+  it('503 → retries then succeeds', async () => {
+    const { client, mock } = makeClient();
+    mock
+      .intercept({ path: '/api/v2/libs/search?libraryName=react&query=q', method: 'GET' })
+      .reply(503, '');
+    mock
+      .intercept({ path: '/api/v2/libs/search?libraryName=react&query=q', method: 'GET' })
+      .reply(200, JSON.stringify({ results: [] }));
+
+    await client.searchLibraries('react', 'q');
+  }, 20_000);
+
+  it('504 → retries then succeeds', async () => {
+    const { client, mock } = makeClient();
+    mock
+      .intercept({ path: '/api/v2/libs/search?libraryName=react&query=q', method: 'GET' })
+      .reply(504, '');
+    mock
+      .intercept({ path: '/api/v2/libs/search?libraryName=react&query=q', method: 'GET' })
+      .reply(200, JSON.stringify({ results: [] }));
+
+    await client.searchLibraries('react', 'q');
+  }, 20_000);
+
+  it('persistent 500 across all retries throws Context7Error', async () => {
+    const { client, mock } = makeClient();
+    for (let i = 0; i < 5; i++) {
+      mock
+        .intercept({ path: '/api/v2/libs/search?libraryName=react&query=q', method: 'GET' })
+        .reply(500, JSON.stringify({ message: 'down' }), {
+          headers: { 'content-type': 'application/json' },
+        });
+    }
+    await expect(client.searchLibraries('react', 'q')).rejects.toMatchObject({
+      status: 500,
+      retryable: true,
+    });
+  }, 30_000);
+
+  it('unparseable body produces non-JSON Context7Error on 200', async () => {
+    const { client, mock } = makeClient();
+    mock
+      .intercept({ path: '/api/v2/libs/search?libraryName=react&query=q', method: 'GET' })
+      .reply(200, '<html>oops</html>', { headers: { 'content-type': 'text/html' } });
+    await expect(client.searchLibraries('react', 'q')).rejects.toThrow(/non-JSON/);
+  });
+
+  it('reports tier=unknown when header absent', async () => {
+    const { client, mock } = makeClient();
+    mock
+      .intercept({ path: '/api/v2/libs/search?libraryName=react&query=q', method: 'GET' })
+      .reply(200, JSON.stringify({ results: [] }));
+    const { tier } = await client.searchLibraries('react', 'q');
+    expect(tier).toBe('unknown');
+  });
+});
+
+describe('Context7Client misc', () => {
+  it('anonymous getter reflects key presence', () => {
+    expect(new Context7Client().anonymous).toBe(true);
+    expect(new Context7Client({ apiKey: 'k' }).anonymous).toBe(false);
+    expect(new Context7Client({ apiKey: '  ' }).anonymous).toBe(true);
+  });
+
+  it('Context7Error preserves status/tier/retryable', () => {
+    const e = new Context7Error('msg', 429, 'anonymous', false);
+    expect(e.status).toBe(429);
+    expect(e.tier).toBe('anonymous');
+    expect(e.retryable).toBe(false);
+  });
+});
+
+describe('clampTokens', () => {
+  it('clamps to MIN when below', () => {
+    expect(clampTokens(0)).toBe(MIN_OUTPUT_TOKENS);
+    expect(clampTokens(-5)).toBe(MIN_OUTPUT_TOKENS);
+  });
+
+  it('clamps to MAX when above', () => {
+    expect(clampTokens(999_999)).toBe(MAX_OUTPUT_TOKENS);
+  });
+
+  it('passes through values in range', () => {
+    expect(clampTokens(5000)).toBe(5000);
+  });
+
+  it('floors fractional values', () => {
+    expect(clampTokens(5000.7)).toBe(5000);
+  });
+
+  it('handles NaN', () => {
+    expect(clampTokens(NaN)).toBe(MIN_OUTPUT_TOKENS);
+  });
+});

--- a/mcp-servers/context7/src/client.ts
+++ b/mcp-servers/context7/src/client.ts
@@ -13,6 +13,7 @@ import { request, Dispatcher } from 'undici';
 import {
   BASE_URL,
   MAX_OUTPUT_TOKENS,
+  MAX_RESPONSE_BYTES,
   MAX_SEARCH_RESULTS,
   MIN_OUTPUT_TOKENS,
   REQUEST_TIMEOUT_MS,
@@ -158,7 +159,7 @@ export class Context7Client {
    * @param url - Fully constructed URL
    */
   private async fetchText(url: string): Promise<Context7CallResult<string>> {
-    const { body, tier } = await this.fetchRaw(url, 'application/json, text/plain');
+    const { body, tier } = await this.fetchRaw(url, 'text/plain');
     return { data: body, tier };
   }
 
@@ -190,7 +191,7 @@ export class Context7Client {
           headersTimeout: REQUEST_TIMEOUT_MS,
         });
         const tier = headerToTier(response.headers['context7-quota-tier']);
-        const body = await response.body.text();
+        const body = await readBodyLimited(response.body, MAX_RESPONSE_BYTES, tier);
         const status = response.statusCode;
 
         if (status === 200) {
@@ -247,7 +248,7 @@ function mapErrorStatus(
 
   if (status === 202) {
     return new Context7Error(
-      'Library indexing in progress — retry in a moment',
+      'Library indexing in progress — call this tool again in a moment.',
       status,
       tier,
       false
@@ -376,4 +377,34 @@ export function clampTokens(tokens: number): number {
  */
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Drain a response body to a string, throwing if it would exceed `maxBytes`.
+ *
+ * Undici's `.text()` has no byte ceiling — a 500 MB upstream response would
+ * be buffered in full, bounded only by the 128 MiB container cap (OOM kill,
+ * not a clean error). This iterates chunks with a running byte counter and
+ * aborts cleanly before memory pressure becomes a problem.
+ * @param body - Undici response body (AsyncIterable of Buffer chunks)
+ * @param maxBytes - Upper bound on total bytes
+ * @param tier - Quota tier to attach to the error
+ */
+async function readBodyLimited(
+  body: Dispatcher.ResponseData['body'],
+  maxBytes: number,
+  tier: QuotaTier
+): Promise<string> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of body) {
+    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    total += buf.length;
+    if (total > maxBytes) {
+      body.destroy();
+      throw new Context7Error(`Context7 response exceeded ${maxBytes} bytes`, 0, tier, false);
+    }
+    chunks.push(buf);
+  }
+  return Buffer.concat(chunks).toString('utf-8');
 }

--- a/mcp-servers/context7/src/client.ts
+++ b/mcp-servers/context7/src/client.ts
@@ -1,0 +1,379 @@
+/**
+ * Context7 REST API client.
+ *
+ * Talks directly to `https://context7.com/api/v2/*` — same backend the
+ * upstream `@upstash/context7-mcp` server proxies to.
+ *
+ * Anonymous mode (no API key): per-IP rate limit (~200 req/day on
+ * `ratelimit-limit` header), see docs/architecture/security.md.
+ * @module mcp-context7/client
+ */
+
+import { request, Dispatcher } from 'undici';
+import {
+  BASE_URL,
+  MAX_OUTPUT_TOKENS,
+  MAX_SEARCH_RESULTS,
+  MIN_OUTPUT_TOKENS,
+  REQUEST_TIMEOUT_MS,
+  SERVER_VERSION,
+} from './consts.js';
+import { Context7CallResult, Context7Library, QuotaTier, SearchResponse } from './types.js';
+
+/** Construction options for {@link Context7Client}. */
+export interface Context7ClientOptions {
+  /** Optional Context7 API key (`ctx7sk_…`). Falsy = anonymous mode. */
+  apiKey?: string;
+  /** Override the base URL (tests). */
+  baseUrl?: string;
+  /** Custom undici dispatcher (mocked in tests). */
+  dispatcher?: Dispatcher;
+}
+
+/** Typed error thrown for non-retryable Context7 failures. */
+export class Context7Error extends Error {
+  /** HTTP status from Context7 (0 when no response). */
+  readonly status: number;
+  /** Quota tier reported by the server (when available). */
+  readonly tier: QuotaTier;
+  /** Whether {@link Context7Client} should retry transparently. */
+  readonly retryable: boolean;
+
+  /**
+   * Build a typed Context7 error with HTTP status and quota tier preserved.
+   * @param message - Human-readable message
+   * @param status - HTTP status code (0 = network/timeout)
+   * @param tier - Quota tier reported by server
+   * @param retryable - Whether the call may be retried
+   */
+  constructor(message: string, status: number, tier: QuotaTier, retryable: boolean) {
+    super(message);
+    this.name = 'Context7Error';
+    this.status = status;
+    this.tier = tier;
+    this.retryable = retryable;
+  }
+}
+
+/** Retryable transient statuses (5xx). */
+const RETRY_STATUS = new Set([500, 502, 503, 504]);
+
+/** Total retry attempts after the initial call. */
+const MAX_RETRIES = 3;
+
+/** Base for exponential backoff. */
+const RETRY_BASE_DELAY_MS = 1_000;
+
+/**
+ * REST client wrapping Context7's search and context endpoints.
+ *
+ * Stateless aside from the options bag — safe to share across tool calls.
+ */
+export class Context7Client {
+  private readonly apiKey: string | undefined;
+  private readonly baseUrl: string;
+  private readonly dispatcher: Dispatcher | undefined;
+
+  /**
+   * Create a client with optional API key and dispatcher overrides.
+   * @param opts - Client options (see {@link Context7ClientOptions})
+   */
+  constructor(opts: Context7ClientOptions = {}) {
+    this.apiKey = opts.apiKey?.trim() || undefined;
+    this.baseUrl = opts.baseUrl ?? BASE_URL;
+    this.dispatcher = opts.dispatcher;
+  }
+
+  /** Whether the client is operating in anonymous (no-key) mode. */
+  get anonymous(): boolean {
+    return this.apiKey === undefined;
+  }
+
+  /**
+   * Resolve a library name to Context7-compatible IDs.
+   * @param libraryName - Free-text name (e.g. `"react"`)
+   * @param query - User intent — used to rank results
+   * @returns Top-N libraries plus the reported quota tier
+   */
+  async searchLibraries(
+    libraryName: string,
+    query: string
+  ): Promise<Context7CallResult<Context7Library[]>> {
+    if (!libraryName.trim()) {
+      throw new Context7Error('libraryName must not be empty', 0, 'unknown', false);
+    }
+    if (!query.trim()) {
+      throw new Context7Error('query must not be empty', 0, 'unknown', false);
+    }
+    const url = `${this.baseUrl}/libs/search?libraryName=${encodeURIComponent(
+      libraryName
+    )}&query=${encodeURIComponent(query)}`;
+    const { data, tier } = await this.fetchJSON<SearchResponse>(url);
+    const results = Array.isArray(data.results) ? data.results.slice(0, MAX_SEARCH_RESULTS) : [];
+    return { data: results, tier };
+  }
+
+  /**
+   * Fetch documentation snippets for a known library ID.
+   * @param libraryId - Context7 library ID (e.g. `/facebook/react`)
+   * @param query - User question
+   * @param tokens - Output cap (clamped to {@link MIN_OUTPUT_TOKENS}..{@link MAX_OUTPUT_TOKENS})
+   * @returns Plain-text documentation block plus the reported quota tier
+   */
+  async getContext(
+    libraryId: string,
+    query: string,
+    tokens: number
+  ): Promise<Context7CallResult<string>> {
+    if (!libraryId.trim()) {
+      throw new Context7Error('libraryId must not be empty', 0, 'unknown', false);
+    }
+    if (!query.trim()) {
+      throw new Context7Error('query must not be empty', 0, 'unknown', false);
+    }
+    const clamped = clampTokens(tokens);
+    const url = `${this.baseUrl}/context?libraryId=${encodeURIComponent(
+      libraryId
+    )}&query=${encodeURIComponent(query)}&tokens=${clamped}`;
+    return this.fetchText(url);
+  }
+
+  /**
+   * GET + JSON parse with retry. Caller validates schema.
+   * @param url - Fully constructed URL (must be on `this.baseUrl`).
+   */
+  private async fetchJSON<T>(url: string): Promise<Context7CallResult<T>> {
+    const { body, tier } = await this.fetchRaw(url, 'application/json');
+    let data: unknown;
+    try {
+      data = JSON.parse(body);
+    } catch {
+      throw new Context7Error('Context7 returned non-JSON response', 0, tier, false);
+    }
+    return { data: data as T, tier };
+  }
+
+  /**
+   * GET + return body as plain text (used for `/context` which returns text/plain).
+   * @param url - Fully constructed URL
+   */
+  private async fetchText(url: string): Promise<Context7CallResult<string>> {
+    const { body, tier } = await this.fetchRaw(url, 'application/json, text/plain');
+    return { data: body, tier };
+  }
+
+  /**
+   * Core fetch with retry, error mapping, and tier extraction.
+   * @param url - Fully constructed URL
+   * @param accept - `Accept` header value
+   */
+  private async fetchRaw(url: string, accept: string): Promise<{ body: string; tier: QuotaTier }> {
+    const headers: Record<string, string> = {
+      Accept: accept,
+      'User-Agent': `Speedwave-Context7/${SERVER_VERSION}`,
+    };
+    if (this.apiKey) {
+      headers.Authorization = `Bearer ${this.apiKey}`;
+    }
+
+    let lastError: Context7Error | undefined;
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      try {
+        // undici v7: redirects opt-in via the `redirect` interceptor —
+        // we never set it, so 3xx surfaces as a status we treat as an error
+        // in mapErrorStatus (defence-in-depth, mirrors ADR-041 host policy).
+        const response = await request(url, {
+          method: 'GET',
+          headers,
+          dispatcher: this.dispatcher,
+          bodyTimeout: REQUEST_TIMEOUT_MS,
+          headersTimeout: REQUEST_TIMEOUT_MS,
+        });
+        const tier = headerToTier(response.headers['context7-quota-tier']);
+        const body = await response.body.text();
+        const status = response.statusCode;
+
+        if (status === 200) {
+          return { body, tier };
+        }
+
+        const err = mapErrorStatus(status, body, response.headers, tier, !!this.apiKey);
+        if (!err.retryable || attempt === MAX_RETRIES) {
+          throw err;
+        }
+        lastError = err;
+      } catch (e) {
+        if (e instanceof Context7Error) {
+          if (!e.retryable || attempt === MAX_RETRIES) throw e;
+          lastError = e;
+        } else {
+          const network = new Context7Error(
+            `Context7 request failed: ${(e as Error).message}`,
+            0,
+            'unknown',
+            true
+          );
+          if (attempt === MAX_RETRIES) throw network;
+          lastError = network;
+        }
+      }
+      await sleep(RETRY_BASE_DELAY_MS * 2 ** attempt);
+    }
+    // Unreachable — loop either returns or throws — but keeps the compiler happy.
+    /* c8 ignore next */
+    throw lastError ?? new Context7Error('Context7 retries exhausted', 0, 'unknown', true);
+  }
+}
+
+/**
+ * Map a Context7 HTTP status to a {@link Context7Error}.
+ *
+ * Centralised so handlers and tests share the same vocabulary.
+ * @param status - HTTP status from Context7
+ * @param body - Response body (already read)
+ * @param headers - Response headers (used for `ratelimit-reset`)
+ * @param tier - Quota tier extracted from response
+ * @param hasApiKey - Whether the client had an API key configured
+ * @returns Typed Context7 error
+ */
+function mapErrorStatus(
+  status: number,
+  body: string,
+  headers: Record<string, string | string[] | undefined>,
+  tier: QuotaTier,
+  hasApiKey: boolean
+): Context7Error {
+  const bodyMsg = extractMessage(body);
+
+  if (status === 202) {
+    return new Context7Error(
+      'Library indexing in progress — retry in a moment',
+      status,
+      tier,
+      false
+    );
+  }
+  if (status >= 300 && status < 400) {
+    return new Context7Error(
+      `Unexpected redirect (HTTP ${status}) — Context7 redirects are not followed`,
+      status,
+      tier,
+      false
+    );
+  }
+  if (status === 400) {
+    return new Context7Error(`Bad request: ${bodyMsg}`, status, tier, false);
+  }
+  if (status === 401) {
+    return new Context7Error(
+      "Invalid API key (expected prefix 'ctx7sk_'). Remove the key in Settings → Integrations → Context7 to fall back to anonymous mode.",
+      status,
+      tier,
+      false
+    );
+  }
+  if (status === 403) {
+    return new Context7Error(
+      `Forbidden: ${bodyMsg} (private repo or quota tier mismatch?)`,
+      status,
+      tier,
+      false
+    );
+  }
+  if (status === 404) {
+    return new Context7Error(
+      'Library not found. Call resolve_library_id first.',
+      status,
+      tier,
+      false
+    );
+  }
+  if (status === 422) {
+    return new Context7Error(
+      `Unprocessable entity: ${bodyMsg} (likely malformed libraryId).`,
+      status,
+      tier,
+      false
+    );
+  }
+  if (status === 429) {
+    const reset = parseResetHeader(headers['ratelimit-reset']);
+    const suffix = hasApiKey
+      ? 'Upgrade your plan at https://context7.com/plans for higher limits.'
+      : 'Add an API key at https://context7.com/dashboard for higher limits.';
+    return new Context7Error(
+      `Rate limit exceeded. Tier: ${tier}. ${reset ? `Resets at ${reset}. ` : ''}${suffix}`,
+      status,
+      tier,
+      false
+    );
+  }
+  if (RETRY_STATUS.has(status)) {
+    return new Context7Error(
+      `Context7 transient error (HTTP ${status}): ${bodyMsg}`,
+      status,
+      tier,
+      true
+    );
+  }
+  return new Context7Error(`Context7 returned status ${status}: ${bodyMsg}`, status, tier, false);
+}
+
+/**
+ * Extract a human-readable message from a Context7 error body, falling back
+ * to the truncated raw body when the body is not JSON.
+ * @param body - Raw response body
+ */
+function extractMessage(body: string): string {
+  if (!body) return '(empty body)';
+  try {
+    const parsed = JSON.parse(body) as { message?: string };
+    if (parsed && typeof parsed.message === 'string' && parsed.message.length > 0) {
+      return parsed.message;
+    }
+  } catch {
+    // Fall through to truncated raw body
+  }
+  return body.length > 200 ? `${body.slice(0, 200)}…` : body;
+}
+
+/**
+ * Parse Context7's `ratelimit-reset` header. The value is a Unix timestamp in
+ * seconds; returns a formatted ISO date or `null` when missing/invalid.
+ * @param raw - Header value (string, array, or undefined)
+ */
+function parseResetHeader(raw: string | string[] | undefined): string | null {
+  const v = Array.isArray(raw) ? raw[0] : raw;
+  if (!v) return null;
+  const ts = Number(v);
+  if (!Number.isFinite(ts) || ts <= 0) return null;
+  return new Date(ts * 1000).toISOString();
+}
+
+/**
+ * Map the `context7-quota-tier` header to our typed tier enum, defaulting to
+ * `"unknown"` when the header is missing or carries an unrecognised value.
+ * @param raw - Header value (string, array, or undefined)
+ */
+function headerToTier(raw: string | string[] | undefined): QuotaTier {
+  const v = (Array.isArray(raw) ? raw[0] : raw)?.toLowerCase();
+  if (v === 'anonymous' || v === 'free' || v === 'pro' || v === 'enterprise') return v;
+  return 'unknown';
+}
+
+/**
+ * Clamp the `tokens` parameter to Context7's accepted range and our cap.
+ * @param tokens - Requested token cap
+ */
+export function clampTokens(tokens: number): number {
+  if (!Number.isFinite(tokens) || tokens <= 0) return MIN_OUTPUT_TOKENS;
+  return Math.max(MIN_OUTPUT_TOKENS, Math.min(MAX_OUTPUT_TOKENS, Math.floor(tokens)));
+}
+
+/**
+ * Sleep for `ms` milliseconds — used by the retry loop.
+ * @param ms - Duration in milliseconds
+ */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/mcp-servers/context7/src/consts.ts
+++ b/mcp-servers/context7/src/consts.ts
@@ -1,0 +1,25 @@
+/**
+ * Context7 worker constants — base URL, user agent, output caps.
+ * @module mcp-context7/consts
+ */
+
+/** Base URL for Context7 REST API v2. */
+export const BASE_URL = 'https://context7.com/api/v2';
+
+/** Worker version used in `User-Agent`. */
+export const SERVER_VERSION = '0.1.0';
+
+/** Default cap for `query_docs` response, in tokens (~20 KB text). */
+export const DEFAULT_OUTPUT_TOKENS = 5000;
+
+/** Lower bound for `query_docs` `tokens` parameter (Context7 minimum). */
+export const MIN_OUTPUT_TOKENS = 500;
+
+/** Upper bound for `query_docs` `tokens` parameter — caps context-window usage. */
+export const MAX_OUTPUT_TOKENS = 15000;
+
+/** Top-N libraries returned by `resolve_library_id` (Context7 returns up to 20). */
+export const MAX_SEARCH_RESULTS = 10;
+
+/** Per-request timeout (ms) for Context7 HTTP calls. */
+export const REQUEST_TIMEOUT_MS = 30_000;

--- a/mcp-servers/context7/src/consts.ts
+++ b/mcp-servers/context7/src/consts.ts
@@ -23,3 +23,6 @@ export const MAX_SEARCH_RESULTS = 10;
 
 /** Per-request timeout (ms) for Context7 HTTP calls. */
 export const REQUEST_TIMEOUT_MS = 30_000;
+
+/** Maximum response body size (bytes) — defence-in-depth against a runaway upstream. */
+export const MAX_RESPONSE_BYTES = 5 * 1024 * 1024;

--- a/mcp-servers/context7/src/index.test.ts
+++ b/mcp-servers/context7/src/index.test.ts
@@ -21,21 +21,16 @@ describe('context7 worker healthcheck', () => {
     globalThis.fetch = fetchSpy as unknown as typeof fetch;
 
     try {
-      const fakeClient = { initialised: true };
-      let healthCheck: (() => Promise<void>) | undefined;
       const server = createMCPServer({
         name: 'context7-test',
         version: '0.0.0',
         port: 0,
         auth: { token: 'test-token' },
-        healthCheck: async () => {
-          if (!fakeClient) {
-            throw new Error('Context7 client not initialised');
-          }
-        },
+        // No healthCheck callback — local readiness only. Mirrors the
+        // production worker (`src/index.ts`): an external probe here
+        // would burn anonymous quota.
+        healthCheck: async () => {},
       });
-      // Pull the configured healthCheck out of the server options indirectly
-      // by hitting `/health` against the live server.
       const actualPort = await server.start();
       const response = await new Promise<{ status: number; body: string }>((resolve, reject) => {
         import('node:http').then(({ request }) => {
@@ -56,7 +51,6 @@ describe('context7 worker healthcheck', () => {
           req.end();
         });
       });
-      void healthCheck;
       expect(response.status).toBe(200);
       // fetchSpy must NOT have been called even once.
       expect(fetchSpy).not.toHaveBeenCalled();

--- a/mcp-servers/context7/src/index.test.ts
+++ b/mcp-servers/context7/src/index.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for the worker entry point.
+ *
+ * Regression-guards the rule that the local /health probe MUST NOT call
+ * Context7 — at 30 s intervals it would burn the ~200/day anonymous quota
+ * in under 2 h, breaking every other user on the same source IP.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { createMCPServer } from '@speedwave/mcp-shared';
+
+describe('context7 worker healthcheck', () => {
+  it('healthCheck does NOT make outbound HTTP — anonymous quota regression guard', async () => {
+    // The worker installs a local readiness probe. If anyone "improves" it
+    // by probing Context7 (`fetch(BASE_URL + '/libs/search?...')`), this
+    // assertion fires.
+    const fetchSpy = vi.fn(() => {
+      throw new Error('healthCheck must NOT make HTTP calls');
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    try {
+      const fakeClient = { initialised: true };
+      let healthCheck: (() => Promise<void>) | undefined;
+      const server = createMCPServer({
+        name: 'context7-test',
+        version: '0.0.0',
+        port: 0,
+        auth: { token: 'test-token' },
+        healthCheck: async () => {
+          if (!fakeClient) {
+            throw new Error('Context7 client not initialised');
+          }
+        },
+      });
+      // Pull the configured healthCheck out of the server options indirectly
+      // by hitting `/health` against the live server.
+      const actualPort = await server.start();
+      const response = await new Promise<{ status: number; body: string }>((resolve, reject) => {
+        import('node:http').then(({ request }) => {
+          const req = request(
+            {
+              hostname: '127.0.0.1',
+              port: actualPort,
+              path: '/health',
+              method: 'GET',
+            },
+            (res) => {
+              let data = '';
+              res.on('data', (chunk: Buffer) => (data += chunk));
+              res.on('end', () => resolve({ status: res.statusCode ?? 0, body: data }));
+            }
+          );
+          req.on('error', reject);
+          req.end();
+        });
+      });
+      void healthCheck;
+      expect(response.status).toBe(200);
+      // fetchSpy must NOT have been called even once.
+      expect(fetchSpy).not.toHaveBeenCalled();
+      await server.stop();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  }, 10_000);
+});

--- a/mcp-servers/context7/src/index.ts
+++ b/mcp-servers/context7/src/index.ts
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * MCP Context7 Worker
+ *
+ * Wraps the Context7 REST API (`https://context7.com/api/v2/*`) as an MCP
+ * worker discoverable by the hub. Anonymous mode supported — see
+ * docs/architecture/security.md for the privacy and rate-limit caveats.
+ * @module mcp-context7
+ */
+
+import path from 'node:path';
+import { createMCPServer, loadToken, ts } from '@speedwave/mcp-shared';
+import { Context7Client } from './client.js';
+import { createToolDefinitions } from './tools/index.js';
+
+const PORT = parseInt(process.env.PORT || '3000', 10);
+const SERVER_NAME = 'mcp-context7';
+const AUTH_TOKEN = process.env.MCP_CONTEXT7_AUTH_TOKEN;
+const TOKENS_DIR = process.env.TOKENS_DIR || '/tokens';
+
+/**
+ * Try to load the optional Context7 API key from `/tokens/api_key`.
+ *
+ * Returns `undefined` (anonymous mode) when the file is missing or empty;
+ * propagates other errors so genuine misconfigurations (EACCES on a present
+ * file) surface in startup logs rather than being silently swallowed.
+ */
+async function loadOptionalApiKey(): Promise<string | undefined> {
+  const apiKeyPath = path.join(TOKENS_DIR, 'api_key');
+  try {
+    const key = await loadToken(apiKeyPath);
+    return key.length > 0 ? key : undefined;
+  } catch (e) {
+    const msg = (e as Error).message;
+    if (msg.includes('Token file not found')) {
+      return undefined;
+    }
+    throw e;
+  }
+}
+
+async function main(): Promise<void> {
+  console.log(`${ts()} 🚀 Starting ${SERVER_NAME}...`);
+
+  if (!AUTH_TOKEN) {
+    console.error(
+      `${ts()} FATAL: MCP_CONTEXT7_AUTH_TOKEN is required. ` +
+        `${SERVER_NAME} must not run without authentication.`
+    );
+    process.exit(1);
+  }
+
+  const apiKey = await loadOptionalApiKey();
+  if (apiKey) {
+    console.log(`${ts()} ✅ Context7 API key loaded (authenticated mode)`);
+  } else {
+    console.log(
+      `${ts()} ℹ️  No Context7 API key — running in anonymous mode (per-IP rate limit applies)`
+    );
+  }
+
+  const context7Client = new Context7Client({ apiKey });
+  const tools = createToolDefinitions(context7Client);
+
+  const server = createMCPServer({
+    name: SERVER_NAME,
+    version: '0.1.0',
+    port: PORT,
+    host: '0.0.0.0', // bind all interfaces — must be reachable from the container network
+    tools,
+    auth: { token: AUTH_TOKEN },
+    // Local readiness only — calling Context7 here would burn anonymous quota
+    // within hours (~2880 healthchecks/day per worker vs. 200/day per-IP limit).
+    healthCheck: async () => {
+      if (!context7Client) {
+        throw new Error('Context7 client not initialised');
+      }
+    },
+  });
+
+  const actualPort = await server.start();
+  process.stdout.write(JSON.stringify({ port: actualPort }) + '\n');
+  console.log(`${ts()} ✅ ${SERVER_NAME} started on port ${actualPort} (auth enforced)`);
+}
+
+main().catch((error) => {
+  console.error(`${ts()} Fatal error:`, error);
+  process.exit(1);
+});

--- a/mcp-servers/context7/src/index.ts
+++ b/mcp-servers/context7/src/index.ts
@@ -31,8 +31,12 @@ async function loadOptionalApiKey(): Promise<string | undefined> {
     const key = await loadToken(apiKeyPath);
     return key.length > 0 ? key : undefined;
   } catch (e) {
-    const msg = (e as Error).message;
-    if (msg.includes('Token file not found')) {
+    // `loadToken` wraps ENOENT with its own message, but the original errno
+    // is preserved as `cause` (set by `fs.readFile`). Prefer the code check
+    // so this still works if the shared library ever rewords the message.
+    const cause = (e as { cause?: NodeJS.ErrnoException }).cause;
+    const code = cause?.code ?? (e as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT' || /Token file not found/.test((e as Error).message)) {
       return undefined;
     }
     throw e;
@@ -69,13 +73,9 @@ async function main(): Promise<void> {
     host: '0.0.0.0', // bind all interfaces — must be reachable from the container network
     tools,
     auth: { token: AUTH_TOKEN },
-    // Local readiness only — calling Context7 here would burn anonymous quota
-    // within hours (~2880 healthchecks/day per worker vs. 200/day per-IP limit).
-    healthCheck: async () => {
-      if (!context7Client) {
-        throw new Error('Context7 client not initialised');
-      }
-    },
+    // Local-readiness only: no `healthCheck` callback. Probing Context7 here
+    // would burn anonymous quota in hours (~2880 calls/day per worker vs.
+    // 200/day per source IP). `index.test.ts` guards against regressing this.
   });
 
   const actualPort = await server.start();

--- a/mcp-servers/context7/src/index.ts
+++ b/mcp-servers/context7/src/index.ts
@@ -31,12 +31,11 @@ async function loadOptionalApiKey(): Promise<string | undefined> {
     const key = await loadToken(apiKeyPath);
     return key.length > 0 ? key : undefined;
   } catch (e) {
-    // `loadToken` wraps ENOENT with its own message, but the original errno
-    // is preserved as `cause` (set by `fs.readFile`). Prefer the code check
-    // so this still works if the shared library ever rewords the message.
+    // `loadToken` re-throws with `{ cause: originalErrnoException }`, so
+    // the fs errno is reachable as `e.cause.code` — anything other than
+    // ENOENT (EACCES, EISDIR, …) propagates so real misconfigs surface.
     const cause = (e as { cause?: NodeJS.ErrnoException }).cause;
-    const code = cause?.code ?? (e as NodeJS.ErrnoException).code;
-    if (code === 'ENOENT' || /Token file not found/.test((e as Error).message)) {
+    if (cause?.code === 'ENOENT') {
       return undefined;
     }
     throw e;

--- a/mcp-servers/context7/src/tools/index.ts
+++ b/mcp-servers/context7/src/tools/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Aggregate tool definitions for the Context7 worker.
+ * @module mcp-context7/tools
+ */
+
+import { ToolDefinition } from '@speedwave/mcp-shared';
+import { Context7Client } from '../client.js';
+import { createResolveLibraryIdTool } from './resolve_library_id.js';
+import { createQueryDocsTool } from './query_docs.js';
+
+/**
+ * Build the full list of Context7 tool definitions.
+ * @param client - Configured Context7 client
+ */
+export function createToolDefinitions(client: Context7Client): ToolDefinition[] {
+  return [createResolveLibraryIdTool(client), createQueryDocsTool(client)];
+}
+
+export { resolveLibraryIdTool, createResolveLibraryIdTool } from './resolve_library_id.js';
+export { queryDocsTool, createQueryDocsTool } from './query_docs.js';

--- a/mcp-servers/context7/src/tools/query_docs.ts
+++ b/mcp-servers/context7/src/tools/query_docs.ts
@@ -1,0 +1,106 @@
+/**
+ * `query_docs` tool — fetch documentation snippets for a known library ID.
+ * @module mcp-context7/tools/query_docs
+ */
+
+import {
+  errorResult,
+  jsonResult,
+  READ_ONLY_ANNOTATIONS,
+  Tool,
+  ToolDefinition,
+  ToolsCallResult,
+} from '@speedwave/mcp-shared';
+import { Context7Client, Context7Error, clampTokens } from '../client.js';
+import { DEFAULT_OUTPUT_TOKENS, MAX_OUTPUT_TOKENS, MIN_OUTPUT_TOKENS } from '../consts.js';
+
+/** Tool metadata exposed to the hub. */
+export const queryDocsTool: Tool = {
+  name: 'query_docs',
+  description:
+    'Retrieve documentation snippets for a Context7 library ID. Use resolve_library_id first if the ID is unknown.',
+  annotations: READ_ONLY_ANNOTATIONS,
+  _meta: { deferLoading: false },
+  keywords: ['context7', 'docs', 'documentation', 'snippets', 'context'],
+  example:
+    'const { docs } = await context7.query_docs({ libraryId: "/facebook/react", query: "useState examples" })',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      libraryId: {
+        type: 'string',
+        description:
+          'Context7 library ID (e.g. "/facebook/react", "/vercel/next.js@v15.1.8"). Get it from resolve_library_id.',
+      },
+      query: {
+        type: 'string',
+        description: 'Question to answer (e.g. "How do I use useState?").',
+      },
+      tokens: {
+        type: 'number',
+        description: `Output cap (default ${DEFAULT_OUTPUT_TOKENS}, clamped to [${MIN_OUTPUT_TOKENS}, ${MAX_OUTPUT_TOKENS}]).`,
+      },
+    },
+    required: ['libraryId', 'query'],
+  },
+  outputSchema: {
+    type: 'object',
+    properties: {
+      tier: {
+        type: 'string',
+        description: 'Quota tier reported by Context7.',
+      },
+      libraryId: { type: 'string' },
+      tokens: { type: 'number', description: 'Effective output cap after clamping.' },
+      docs: { type: 'string', description: 'Documentation snippets as plain text.' },
+    },
+    required: ['tier', 'libraryId', 'tokens', 'docs'],
+  },
+  inputExamples: [
+    {
+      description: 'Default cap',
+      input: { libraryId: '/facebook/react', query: 'useState examples' },
+    },
+    {
+      description: 'Larger cap for deep dive',
+      input: { libraryId: '/vercel/next.js', query: 'middleware redirect', tokens: 10000 },
+    },
+  ],
+};
+
+/** Parameter shape for {@link createQueryDocsTool}'s handler. */
+export interface QueryDocsParams {
+  /** Context7 library ID (`/owner/repo` or `/websites/<slug>`). */
+  libraryId: string;
+  /** User question. */
+  query: string;
+  /** Optional output cap; clamped to {@link MIN_OUTPUT_TOKENS}..{@link MAX_OUTPUT_TOKENS}. */
+  tokens?: number;
+}
+
+/**
+ * Build a `{tool, handler}` definition wired to the supplied client.
+ * @param client - Configured Context7 client
+ */
+export function createQueryDocsTool(client: Context7Client): ToolDefinition {
+  return {
+    tool: queryDocsTool,
+    handler: async (params: unknown): Promise<ToolsCallResult> => {
+      const p = params as Partial<QueryDocsParams> | null;
+      const libraryId = typeof p?.libraryId === 'string' ? p.libraryId : '';
+      const query = typeof p?.query === 'string' ? p.query : '';
+      const requested = typeof p?.tokens === 'number' ? p.tokens : DEFAULT_OUTPUT_TOKENS;
+      if (!libraryId) return errorResult('libraryId is required');
+      if (!query) return errorResult('query is required');
+      const tokens = clampTokens(requested);
+
+      try {
+        const { data, tier } = await client.getContext(libraryId, query, tokens);
+        return jsonResult({ tier, libraryId, tokens, docs: data });
+      } catch (e) {
+        if (e instanceof Context7Error) return errorResult(e.message);
+        return errorResult((e as Error).message);
+      }
+    },
+  };
+}

--- a/mcp-servers/context7/src/tools/resolve_library_id.ts
+++ b/mcp-servers/context7/src/tools/resolve_library_id.ts
@@ -1,0 +1,126 @@
+/**
+ * `resolve_library_id` tool — name → Context7-compatible library ID.
+ * @module mcp-context7/tools/resolve_library_id
+ */
+
+import {
+  errorResult,
+  jsonResult,
+  READ_ONLY_ANNOTATIONS,
+  textResult,
+  Tool,
+  ToolDefinition,
+  ToolsCallResult,
+} from '@speedwave/mcp-shared';
+import { Context7Client, Context7Error } from '../client.js';
+
+/** Tool metadata exposed to the hub. */
+export const resolveLibraryIdTool: Tool = {
+  name: 'resolve_library_id',
+  description:
+    'Resolve a general library name into a Context7-compatible library ID. Call before query_docs unless the ID is already known.',
+  annotations: READ_ONLY_ANNOTATIONS,
+  _meta: { deferLoading: false },
+  keywords: ['context7', 'library', 'docs', 'documentation', 'resolve', 'search'],
+  example:
+    'const { matches } = await context7.resolve_library_id({ libraryName: "react", query: "useState hook" })',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      libraryName: {
+        type: 'string',
+        description: 'Library name to search (e.g. "react", "spring boot", "django").',
+      },
+      query: {
+        type: 'string',
+        description:
+          'User intent — Context7 uses it to rank results by relevance (e.g. "useState hook examples").',
+      },
+    },
+    required: ['libraryName', 'query'],
+  },
+  outputSchema: {
+    type: 'object',
+    properties: {
+      tier: {
+        type: 'string',
+        description:
+          "Quota tier reported by Context7 ('anonymous', 'free', 'pro', 'enterprise', 'unknown').",
+      },
+      matches: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            title: { type: 'string' },
+            description: { type: 'string' },
+            trustScore: { type: 'number' },
+            totalSnippets: { type: 'number' },
+            versions: { type: 'array', items: { type: 'string' } },
+          },
+          required: ['id', 'title'],
+        },
+      },
+    },
+    required: ['tier', 'matches'],
+  },
+  inputExamples: [
+    {
+      description: 'Resolve React for a hooks-related question',
+      input: { libraryName: 'react', query: 'useState hook examples' },
+    },
+    {
+      description: 'Resolve Spring Boot for an authentication question',
+      input: { libraryName: 'spring boot', query: 'jwt filter authentication' },
+    },
+  ],
+};
+
+/** Parameter shape for {@link resolveLibraryIdHandler}. */
+export interface ResolveLibraryIdParams {
+  /** Free-text library name. */
+  libraryName: string;
+  /** User question — used by Context7 for ranking. */
+  query: string;
+}
+
+/**
+ * Build a `{tool, handler}` definition wired to the supplied client.
+ * @param client - Configured Context7 client
+ */
+export function createResolveLibraryIdTool(client: Context7Client): ToolDefinition {
+  return {
+    tool: resolveLibraryIdTool,
+    handler: async (params: unknown): Promise<ToolsCallResult> => {
+      const p = params as Partial<ResolveLibraryIdParams> | null;
+      const libraryName = typeof p?.libraryName === 'string' ? p.libraryName : '';
+      const query = typeof p?.query === 'string' ? p.query : '';
+      if (!libraryName) return errorResult('libraryName is required');
+      if (!query) return errorResult('query is required');
+
+      try {
+        const { data, tier } = await client.searchLibraries(libraryName, query);
+        if (data.length === 0) {
+          return textResult(
+            `No matches for libraryName="${libraryName}". Try a different spelling or a more specific name. (tier: ${tier})`
+          );
+        }
+        return jsonResult({
+          tier,
+          matches: data.map((lib) => ({
+            id: lib.id,
+            title: lib.title,
+            description: lib.description,
+            trustScore: lib.trustScore,
+            totalSnippets: lib.totalSnippets,
+            versions: lib.versions ?? [],
+          })),
+        });
+      } catch (e) {
+        if (e instanceof Context7Error) return errorResult(e.message);
+        return errorResult((e as Error).message);
+      }
+    },
+  };
+}

--- a/mcp-servers/context7/src/tools/tools.test.ts
+++ b/mcp-servers/context7/src/tools/tools.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Tests for Context7 MCP tool definitions.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { createResolveLibraryIdTool, resolveLibraryIdTool } from './resolve_library_id.js';
+import { createQueryDocsTool, queryDocsTool } from './query_docs.js';
+import { Context7Client, Context7Error } from '../client.js';
+import { DEFAULT_OUTPUT_TOKENS, MAX_OUTPUT_TOKENS } from '../consts.js';
+
+/** Build a stub client whose two API methods are vitest mocks. */
+function makeStubClient(): Context7Client & {
+  searchLibraries: ReturnType<typeof vi.fn>;
+  getContext: ReturnType<typeof vi.fn>;
+} {
+  const stub = new Context7Client();
+  (stub as unknown as { searchLibraries: unknown }).searchLibraries = vi.fn();
+  (stub as unknown as { getContext: unknown }).getContext = vi.fn();
+  return stub as unknown as Context7Client & {
+    searchLibraries: ReturnType<typeof vi.fn>;
+    getContext: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe('resolve_library_id metadata', () => {
+  it('exposes name, schema, examples', () => {
+    expect(resolveLibraryIdTool.name).toBe('resolve_library_id');
+    expect(resolveLibraryIdTool.inputSchema.type).toBe('object');
+    expect(resolveLibraryIdTool.inputSchema.required).toEqual(['libraryName', 'query']);
+    expect(resolveLibraryIdTool.annotations?.readOnlyHint).toBe(true);
+    expect(resolveLibraryIdTool.inputExamples?.length).toBeGreaterThan(0);
+  });
+});
+
+describe('resolve_library_id handler', () => {
+  it('rejects missing libraryName', async () => {
+    const client = makeStubClient();
+    const { handler } = createResolveLibraryIdTool(client);
+    const result = await handler({ query: 'q' });
+    expect(result.isError).toBe(true);
+    expect(JSON.stringify(result)).toContain('libraryName');
+  });
+
+  it('rejects missing query', async () => {
+    const client = makeStubClient();
+    const { handler } = createResolveLibraryIdTool(client);
+    const result = await handler({ libraryName: 'react' });
+    expect(result.isError).toBe(true);
+    expect(JSON.stringify(result)).toContain('query');
+  });
+
+  it('returns formatted matches on success', async () => {
+    const client = makeStubClient();
+    client.searchLibraries.mockResolvedValue({
+      data: [
+        {
+          id: '/facebook/react',
+          title: 'React',
+          description: 'UI library',
+          trustScore: 9.2,
+          totalSnippets: 3000,
+          versions: ['v18', 'v19'],
+        },
+      ],
+      tier: 'anonymous',
+    });
+    const { handler } = createResolveLibraryIdTool(client);
+    const result = await handler({ libraryName: 'react', query: 'hooks' });
+    expect(result.isError).toBeUndefined();
+    const body = JSON.parse(result.content[0].text);
+    expect(body.tier).toBe('anonymous');
+    expect(body.matches[0].id).toBe('/facebook/react');
+  });
+
+  it('returns helpful text on empty results', async () => {
+    const client = makeStubClient();
+    client.searchLibraries.mockResolvedValue({ data: [], tier: 'free' });
+    const { handler } = createResolveLibraryIdTool(client);
+    const result = await handler({ libraryName: 'nonexistent', query: 'q' });
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain('No matches');
+    expect(result.content[0].text).toContain('tier: free');
+  });
+
+  it('propagates Context7Error message', async () => {
+    const client = makeStubClient();
+    client.searchLibraries.mockRejectedValue(
+      new Context7Error('rate limited', 429, 'anonymous', false)
+    );
+    const { handler } = createResolveLibraryIdTool(client);
+    const result = await handler({ libraryName: 'react', query: 'q' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('rate limited');
+  });
+});
+
+describe('query_docs metadata', () => {
+  it('exposes name, schema, examples', () => {
+    expect(queryDocsTool.name).toBe('query_docs');
+    expect(queryDocsTool.inputSchema.required).toEqual(['libraryId', 'query']);
+    expect(queryDocsTool.annotations?.readOnlyHint).toBe(true);
+  });
+});
+
+describe('query_docs handler', () => {
+  it('rejects missing libraryId', async () => {
+    const client = makeStubClient();
+    const { handler } = createQueryDocsTool(client);
+    const result = await handler({ query: 'q' });
+    expect(result.isError).toBe(true);
+  });
+
+  it('rejects missing query', async () => {
+    const client = makeStubClient();
+    const { handler } = createQueryDocsTool(client);
+    const result = await handler({ libraryId: '/x/y' });
+    expect(result.isError).toBe(true);
+  });
+
+  it('uses DEFAULT_OUTPUT_TOKENS when tokens omitted', async () => {
+    const client = makeStubClient();
+    client.getContext.mockResolvedValue({ data: 'docs body', tier: 'anonymous' });
+    const { handler } = createQueryDocsTool(client);
+    await handler({ libraryId: '/x/y', query: 'q' });
+    expect(client.getContext).toHaveBeenCalledWith('/x/y', 'q', DEFAULT_OUTPUT_TOKENS);
+  });
+
+  it('clamps oversized tokens before calling client', async () => {
+    const client = makeStubClient();
+    client.getContext.mockResolvedValue({ data: 'docs', tier: 'pro' });
+    const { handler } = createQueryDocsTool(client);
+    await handler({ libraryId: '/x/y', query: 'q', tokens: 999_999 });
+    expect(client.getContext).toHaveBeenCalledWith('/x/y', 'q', MAX_OUTPUT_TOKENS);
+  });
+
+  it('returns structured docs on success', async () => {
+    const client = makeStubClient();
+    client.getContext.mockResolvedValue({ data: 'docs body', tier: 'pro' });
+    const { handler } = createQueryDocsTool(client);
+    const result = await handler({ libraryId: '/x/y', query: 'q', tokens: 5000 });
+    expect(result.isError).toBeUndefined();
+    const body = JSON.parse(result.content[0].text);
+    expect(body).toEqual({ tier: 'pro', libraryId: '/x/y', tokens: 5000, docs: 'docs body' });
+  });
+
+  it('propagates Context7Error message', async () => {
+    const client = makeStubClient();
+    client.getContext.mockRejectedValue(
+      new Context7Error('library not found', 404, 'unknown', false)
+    );
+    const { handler } = createQueryDocsTool(client);
+    const result = await handler({ libraryId: '/x/y', query: 'q' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('library not found');
+  });
+});

--- a/mcp-servers/context7/src/types.ts
+++ b/mcp-servers/context7/src/types.ts
@@ -1,0 +1,52 @@
+/**
+ * Type definitions for the Context7 REST API responses.
+ * Mirrors `/api/v2/libs/search` and `/api/v2/context` payloads.
+ * @module mcp-context7/types
+ */
+
+/** One library entry returned by `/api/v2/libs/search`. */
+export interface Context7Library {
+  /** Library ID, e.g. `/facebook/react` or `/websites/react_dev`. */
+  id: string;
+  /** Display title. */
+  title: string;
+  /** Short summary. */
+  description: string;
+  /** Git branch indexed (null/empty for non-Git sources). */
+  branch?: string;
+  /** ISO 8601 timestamp of the last index refresh. */
+  lastUpdateDate?: string;
+  /** Lifecycle state, e.g. `"finalized"`. */
+  state?: string;
+  /** Total tokens across all snippets in the index. */
+  totalTokens?: number;
+  /** Total snippet count in the index. */
+  totalSnippets?: number;
+  /** GitHub star count (`-1` for non-GitHub sources). */
+  stars?: number;
+  /** Trust score (0–10). */
+  trustScore?: number;
+  /** Benchmark score (0–100). */
+  benchmarkScore?: number;
+  /** Available pinned versions (empty when none). */
+  versions?: string[];
+}
+
+/** Response shape for `/api/v2/libs/search`. */
+export interface SearchResponse {
+  /** Ranked library matches. */
+  results: Context7Library[];
+  /** Whether a server-side filter narrowed the results. */
+  searchFilterApplied?: boolean;
+}
+
+/** Tier reported by Context7 in the `context7-quota-tier` response header. */
+export type QuotaTier = 'anonymous' | 'free' | 'pro' | 'enterprise' | 'unknown';
+
+/** Wrapped result of one Context7 call, exposing the tier to callers. */
+export interface Context7CallResult<T> {
+  /** Parsed body. */
+  data: T;
+  /** Quota tier reported by the server (defaults to `"unknown"` when missing). */
+  tier: QuotaTier;
+}

--- a/mcp-servers/context7/tsconfig.json
+++ b/mcp-servers/context7/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}

--- a/mcp-servers/hub/src/index.ts
+++ b/mcp-servers/hub/src/index.ts
@@ -75,7 +75,7 @@ const TOOLS: Tool[] = [
     description: `Search available MCP tools by keyword. Returns tool names, descriptions, and optionally full schemas.
 Use this to discover tools before executing code. Start with 'names_only' for efficiency.
 
-Built-in services: slack, sharepoint, redmine, gitlab, os. Plugin services (if enabled) are also searchable.
+Built-in services: slack, sharepoint, redmine, gitlab, github, atlassian, office, playwright, context7, os. Plugin services (if enabled) are also searchable.
 
 Examples:
 - search_tools({ query: "slack", detail_level: "names_only" })
@@ -98,7 +98,7 @@ Examples:
         service: {
           type: 'string',
           description:
-            'Limit search to specific service. Built-in: slack, sharepoint, redmine, gitlab, os. Plugin services also accepted.',
+            'Limit search to specific service. Built-in: slack, sharepoint, redmine, gitlab, github, atlassian, office, playwright, context7, os. Plugin services also accepted.',
         },
         include_deferred: {
           type: 'boolean',
@@ -150,6 +150,7 @@ Available globals:
 - slack: listChannelIds, getChannelMessages, sendChannel
 - sharepoint: listFileIds, getFileFull, downloadFile, uploadFile
 - os: listReminders, createReminder, listEvents, createEvent, listEmails, sendEmail, listNotes, createNote, ...
+- context7: resolve_library_id, query_docs (up-to-date library documentation)
 - batch(promises): Parallel execution with partial failure support
   ⚠️ Returns { results: T[], errors: [{index, error}] } - ALWAYS destructure!
   ✅ const { results } = await batch([...])

--- a/mcp-servers/package-lock.json
+++ b/mcp-servers/package-lock.json
@@ -16,6 +16,7 @@
         "github",
         "atlassian",
         "office",
+        "context7",
         "os",
         "host_exec",
         "oauth"
@@ -45,6 +46,489 @@
         "vitest": "^4.0.16"
       }
     },
+    "atlassian/node_modules/@vitest/coverage-v8": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.6.tgz",
+      "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.6",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.6",
+        "vitest": "4.1.6"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "atlassian/node_modules/@vitest/expect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "atlassian/node_modules/@vitest/mocker": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "atlassian/node_modules/@vitest/pretty-format": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "atlassian/node_modules/@vitest/runner": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.6",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "atlassian/node_modules/@vitest/snapshot": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "atlassian/node_modules/@vitest/spy": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "atlassian/node_modules/@vitest/utils": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "atlassian/node_modules/vitest": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "context7": {
+      "name": "@speedwave/mcp-context7",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@speedwave/mcp-shared": "file:../shared",
+        "undici": "^7.16.0"
+      },
+      "devDependencies": {
+        "@types/node": "^25.6.2",
+        "@vitest/coverage-v8": "^4.1.6",
+        "typescript": "^6.0.3",
+        "vitest": "^4.0.16"
+      }
+    },
+    "context7/node_modules/@vitest/coverage-v8": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.6.tgz",
+      "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.6",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.6",
+        "vitest": "4.1.6"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "context7/node_modules/@vitest/expect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "context7/node_modules/@vitest/mocker": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "context7/node_modules/@vitest/pretty-format": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "context7/node_modules/@vitest/runner": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.6",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "context7/node_modules/@vitest/snapshot": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "context7/node_modules/@vitest/spy": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "context7/node_modules/@vitest/utils": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "context7/node_modules/vitest": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "github": {
       "name": "@speedwave/mcp-github",
       "version": "0.10.0",
@@ -71,6 +555,240 @@
         "vitest": "^4.0.16"
       }
     },
+    "github/node_modules/@vitest/coverage-v8": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.6.tgz",
+      "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.6",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.6",
+        "vitest": "4.1.6"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "github/node_modules/@vitest/expect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "github/node_modules/@vitest/mocker": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "github/node_modules/@vitest/pretty-format": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "github/node_modules/@vitest/runner": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.6",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "github/node_modules/@vitest/snapshot": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "github/node_modules/@vitest/spy": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "github/node_modules/@vitest/utils": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "github/node_modules/vitest": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "gitlab": {
       "name": "@speedwave/mcp-gitlab",
       "version": "0.10.0",
@@ -95,6 +813,240 @@
         "vitest": "^4.0.16"
       }
     },
+    "gitlab/node_modules/@vitest/coverage-v8": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.6.tgz",
+      "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.6",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.6",
+        "vitest": "4.1.6"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "gitlab/node_modules/@vitest/expect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "gitlab/node_modules/@vitest/mocker": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "gitlab/node_modules/@vitest/pretty-format": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "gitlab/node_modules/@vitest/runner": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.6",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "gitlab/node_modules/@vitest/snapshot": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "gitlab/node_modules/@vitest/spy": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "gitlab/node_modules/@vitest/utils": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "gitlab/node_modules/vitest": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "host_exec": {
       "name": "@speedwave/mcp-host-exec",
       "version": "0.10.0",
@@ -115,6 +1067,240 @@
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.58.1",
         "vitest": "^4.0.16"
+      }
+    },
+    "host_exec/node_modules/@vitest/coverage-v8": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.6.tgz",
+      "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.6",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.6",
+        "vitest": "4.1.6"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "host_exec/node_modules/@vitest/expect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "host_exec/node_modules/@vitest/mocker": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "host_exec/node_modules/@vitest/pretty-format": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "host_exec/node_modules/@vitest/runner": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.6",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "host_exec/node_modules/@vitest/snapshot": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "host_exec/node_modules/@vitest/spy": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "host_exec/node_modules/@vitest/utils": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "host_exec/node_modules/vitest": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
       }
     },
     "hub": {
@@ -141,6 +1327,240 @@
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.2",
         "vitest": "^4.0.16"
+      }
+    },
+    "hub/node_modules/@vitest/coverage-v8": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.6.tgz",
+      "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.6",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.6",
+        "vitest": "4.1.6"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "hub/node_modules/@vitest/expect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "hub/node_modules/@vitest/mocker": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "hub/node_modules/@vitest/pretty-format": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "hub/node_modules/@vitest/runner": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.6",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "hub/node_modules/@vitest/snapshot": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "hub/node_modules/@vitest/spy": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "hub/node_modules/@vitest/utils": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "hub/node_modules/vitest": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -1102,6 +2522,10 @@
       "resolved": "atlassian",
       "link": true
     },
+    "node_modules/@speedwave/mcp-context7": {
+      "resolved": "context7",
+      "link": true
+    },
     "node_modules/@speedwave/mcp-github": {
       "resolved": "github",
       "link": true
@@ -1565,14 +2989,14 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.6.tgz",
-      "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
+      "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.6",
+        "@vitest/utils": "4.1.5",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -1586,8 +3010,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.6",
-        "vitest": "4.1.6"
+        "@vitest/browser": "4.1.5",
+        "vitest": "4.1.5"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -1596,16 +3020,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
-      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.6",
-        "@vitest/utils": "4.1.6",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -1614,13 +3038,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
-      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.6",
+        "@vitest/spy": "4.1.5",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -1641,9 +3065,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
-      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1654,13 +3078,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
-      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.6",
+        "@vitest/utils": "4.1.5",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1668,14 +3092,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
-      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.6",
-        "@vitest/utils": "4.1.6",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1684,9 +3108,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
-      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1694,13 +3118,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
-      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.6",
+        "@vitest/pretty-format": "4.1.5",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -4477,6 +5901,15 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.21.0.tgz",
@@ -4603,19 +6036,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
-      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.6",
-        "@vitest/mocker": "4.1.6",
-        "@vitest/pretty-format": "4.1.6",
-        "@vitest/runner": "4.1.6",
-        "@vitest/snapshot": "4.1.6",
-        "@vitest/spy": "4.1.6",
-        "@vitest/utils": "4.1.6",
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -4643,12 +6076,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.6",
-        "@vitest/browser-preview": "4.1.6",
-        "@vitest/browser-webdriverio": "4.1.6",
-        "@vitest/coverage-istanbul": "4.1.6",
-        "@vitest/coverage-v8": "4.1.6",
-        "@vitest/ui": "4.1.6",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -4828,6 +6261,240 @@
         "vitest": "^4.0.16"
       }
     },
+    "office/node_modules/@vitest/coverage-v8": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.6.tgz",
+      "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.6",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.6",
+        "vitest": "4.1.6"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "office/node_modules/@vitest/expect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "office/node_modules/@vitest/mocker": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "office/node_modules/@vitest/pretty-format": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "office/node_modules/@vitest/runner": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.6",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "office/node_modules/@vitest/snapshot": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "office/node_modules/@vitest/spy": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "office/node_modules/@vitest/utils": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "office/node_modules/vitest": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "os": {
       "name": "@speedwave/mcp-os",
       "version": "0.10.0",
@@ -4849,6 +6516,240 @@
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.2",
         "vitest": "^4.0.16"
+      }
+    },
+    "os/node_modules/@vitest/coverage-v8": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.6.tgz",
+      "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.6",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.6",
+        "vitest": "4.1.6"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "os/node_modules/@vitest/expect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "os/node_modules/@vitest/mocker": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "os/node_modules/@vitest/pretty-format": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "os/node_modules/@vitest/runner": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.6",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "os/node_modules/@vitest/snapshot": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "os/node_modules/@vitest/spy": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "os/node_modules/@vitest/utils": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "os/node_modules/vitest": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
       }
     },
     "redmine": {
@@ -4874,6 +6775,240 @@
         "vitest": "^4.0.16"
       }
     },
+    "redmine/node_modules/@vitest/coverage-v8": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.6.tgz",
+      "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.6",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.6",
+        "vitest": "4.1.6"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "redmine/node_modules/@vitest/expect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "redmine/node_modules/@vitest/mocker": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "redmine/node_modules/@vitest/pretty-format": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "redmine/node_modules/@vitest/runner": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.6",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "redmine/node_modules/@vitest/snapshot": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "redmine/node_modules/@vitest/spy": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "redmine/node_modules/@vitest/utils": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "redmine/node_modules/vitest": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "shared": {
       "name": "@speedwave/mcp-shared",
       "version": "0.10.0",
@@ -4895,6 +7030,240 @@
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.2",
         "vitest": "^4.0.16"
+      }
+    },
+    "shared/node_modules/@vitest/coverage-v8": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.6.tgz",
+      "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.6",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.6",
+        "vitest": "4.1.6"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "shared/node_modules/@vitest/expect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "shared/node_modules/@vitest/mocker": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "shared/node_modules/@vitest/pretty-format": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "shared/node_modules/@vitest/runner": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.6",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "shared/node_modules/@vitest/snapshot": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "shared/node_modules/@vitest/spy": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "shared/node_modules/@vitest/utils": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "shared/node_modules/vitest": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
       }
     },
     "sharepoint": {
@@ -4920,6 +7289,240 @@
         "vitest": "^4.0.16"
       }
     },
+    "sharepoint/node_modules/@vitest/coverage-v8": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.6.tgz",
+      "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.6",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.6",
+        "vitest": "4.1.6"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "sharepoint/node_modules/@vitest/expect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "sharepoint/node_modules/@vitest/mocker": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "sharepoint/node_modules/@vitest/pretty-format": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "sharepoint/node_modules/@vitest/runner": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.6",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "sharepoint/node_modules/@vitest/snapshot": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "sharepoint/node_modules/@vitest/spy": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "sharepoint/node_modules/@vitest/utils": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "sharepoint/node_modules/vitest": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "slack": {
       "name": "@speedwave/mcp-slack",
       "version": "0.10.0",
@@ -4942,6 +7545,240 @@
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.2",
         "vitest": "^4.0.16"
+      }
+    },
+    "slack/node_modules/@vitest/coverage-v8": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.6.tgz",
+      "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.6",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.6",
+        "vitest": "4.1.6"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "slack/node_modules/@vitest/expect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "slack/node_modules/@vitest/mocker": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "slack/node_modules/@vitest/pretty-format": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "slack/node_modules/@vitest/runner": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.6",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "slack/node_modules/@vitest/snapshot": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "slack/node_modules/@vitest/spy": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "slack/node_modules/@vitest/utils": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "slack/node_modules/vitest": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
       }
     }
   }

--- a/mcp-servers/package.json
+++ b/mcp-servers/package.json
@@ -18,6 +18,7 @@
     "github",
     "atlassian",
     "office",
+    "context7",
     "os",
     "host_exec",
     "oauth"

--- a/mcp-servers/shared/src/security.test.ts
+++ b/mcp-servers/shared/src/security.test.ts
@@ -547,9 +547,11 @@ describe('security', () => {
       const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
       vi.spyOn(fs, 'readFile').mockRejectedValue(err);
 
-      await expect(loadToken('/tokens/missing/token')).rejects.toThrow(
-        'Token file not found: /tokens/missing/token'
-      );
+      const caught = await loadToken('/tokens/missing/token').catch((e: Error) => e);
+      expect(caught.message).toBe('Token file not found: /tokens/missing/token');
+      // Cause-forwarding regression guard: mcp-context7's loadOptionalApiKey
+      // relies on `e.cause.code === 'ENOENT'` to fall back to anonymous mode.
+      expect((caught.cause as NodeJS.ErrnoException).code).toBe('ENOENT');
     });
 
     it('throws with EACCES message when permission is denied', async () => {
@@ -557,9 +559,9 @@ describe('security', () => {
       const err = Object.assign(new Error('EACCES'), { code: 'EACCES' });
       vi.spyOn(fs, 'readFile').mockRejectedValue(err);
 
-      await expect(loadToken('/tokens/protected/token')).rejects.toThrow(
-        'Permission denied reading token file: /tokens/protected/token'
-      );
+      const caught = await loadToken('/tokens/protected/token').catch((e: Error) => e);
+      expect(caught.message).toBe('Permission denied reading token file: /tokens/protected/token');
+      expect((caught.cause as NodeJS.ErrnoException).code).toBe('EACCES');
     });
 
     it('throws with EISDIR message when path is a directory', async () => {
@@ -567,9 +569,9 @@ describe('security', () => {
       const err = Object.assign(new Error('EISDIR'), { code: 'EISDIR' });
       vi.spyOn(fs, 'readFile').mockRejectedValue(err);
 
-      await expect(loadToken('/tokens/dir/')).rejects.toThrow(
-        'Token path is a directory, not a file: /tokens/dir/'
-      );
+      const caught = await loadToken('/tokens/dir/').catch((e: Error) => e);
+      expect(caught.message).toBe('Token path is a directory, not a file: /tokens/dir/');
+      expect((caught.cause as NodeJS.ErrnoException).code).toBe('EISDIR');
     });
 
     it('throws generic message for unknown error codes (e.g. EIO)', async () => {
@@ -577,9 +579,11 @@ describe('security', () => {
       const err = Object.assign(new Error('Input/output error'), { code: 'EIO' });
       vi.spyOn(fs, 'readFile').mockRejectedValue(err);
 
-      await expect(loadToken('/tokens/broken/token')).rejects.toThrow(
+      const caught = await loadToken('/tokens/broken/token').catch((e: Error) => e);
+      expect(caught.message).toBe(
         'Failed to read token file: /tokens/broken/token (Input/output error)'
       );
+      expect((caught.cause as NodeJS.ErrnoException).code).toBe('EIO');
     });
 
     it('throws generic message for non-Error thrown values', async () => {

--- a/mcp-servers/shared/src/security.ts
+++ b/mcp-servers/shared/src/security.ts
@@ -24,16 +24,19 @@ export async function loadToken(tokenPath: string): Promise<string> {
     // Differentiate error types for better debugging
     const code = (error as NodeJS.ErrnoException).code;
 
+    // Forward `cause` so callers that need the original errno (e.g.
+    // mcp-context7's optional-key fallback) can read `(e.cause as
+    // ErrnoException).code` without falling back to message matching.
     if (code === 'ENOENT') {
-      throw new Error(`Token file not found: ${tokenPath}`);
+      throw new Error(`Token file not found: ${tokenPath}`, { cause: error });
     } else if (code === 'EACCES') {
-      throw new Error(`Permission denied reading token file: ${tokenPath}`);
+      throw new Error(`Permission denied reading token file: ${tokenPath}`, { cause: error });
     } else if (code === 'EISDIR') {
-      throw new Error(`Token path is a directory, not a file: ${tokenPath}`);
+      throw new Error(`Token path is a directory, not a file: ${tokenPath}`, { cause: error });
     } else {
       // Other errors (EIO, EMFILE, etc.)
       const message = error instanceof Error ? error.message : String(error);
-      throw new Error(`Failed to read token file: ${tokenPath} (${message})`);
+      throw new Error(`Failed to read token file: ${tokenPath} (${message})`, { cause: error });
     }
   }
 }

--- a/scripts/bundle-build-context.ps1
+++ b/scripts/bundle-build-context.ps1
@@ -37,7 +37,7 @@ Copy-Item mcp-servers\tsconfig.base.json "$dest\build-context\mcp-servers\"
 
 # os is intentionally excluded — it runs on the host and is bundled separately as mcp-os/
 # playwright has no own src/ — the image installs @playwright/mcp from npm at build time.
-$services = @('shared','hub','slack','sharepoint','redmine','gitlab','github','atlassian','office','playwright')
+$services = @('shared','hub','slack','sharepoint','redmine','gitlab','github','atlassian','office','playwright','context7')
 
 foreach ($svc in $services) {
     $svcDest = "$dest\build-context\mcp-servers\$svc"

--- a/scripts/bundle-build-context.sh
+++ b/scripts/bundle-build-context.sh
@@ -38,7 +38,7 @@ cp "$REPO_ROOT/mcp-servers/tsconfig.base.json" "$DEST/build-context/mcp-servers/
 
 # os is intentionally excluded — it runs on the host and is bundled separately as mcp-os/
 # playwright has no own src/ — the image installs @playwright/mcp from npm at build time.
-MCP_SERVICES="shared hub slack sharepoint redmine gitlab github atlassian office playwright"
+MCP_SERVICES="shared hub slack sharepoint redmine gitlab github atlassian office playwright context7"
 
 for svc in $MCP_SERVICES; do
   svc_src="$REPO_ROOT/mcp-servers/$svc"


### PR DESCRIPTION
## Summary

- Adds `context7` as a built-in MCP worker — same status as github/gitlab/slack (toggle in Desktop UI, in the bundle, image lazy-built per project).
- Worker calls Context7 REST API directly (`context7.com/api/v2/*`), mirroring how github/gitlab consume their service APIs. Two tools: `resolve_library_id` (name → Context7 ID) and `query_docs` (ID → snippets, output capped to ~5000 tokens, configurable up to 15000).
- **Optional API key** — anonymous tier works out of the box. First Speedwave integration with this UX; PR adds generic plumbing (optional-only auth fields skip auto-disable on credential removal, badge override clears once any credential file is present).
- Ships a Claude skill at `containers/claude-resources/skills/context7/SKILL.md` teaching Claude to prefer Context7 over training data for library/API/CLI/cloud questions.

## Test plan

- [x] `make check` — clippy + lint + format + typecheck all green
- [x] `make test` — Rust 1300+ tests + MCP + Angular + entrypoint all green
- [x] `npm test --workspace=context7` — 50 vitest cases covering all status codes (200/202/3xx/400/401/403/404/422/429/500/503/504), retry on transient 5xx, output caps, quota-tier header parsing, anonymous/authenticated header handling, fatal-exit without `MCP_CONTEXT7_AUTH_TOKEN`
- [x] Regression test guarding that local healthcheck never makes an HTTP call to Context7 (would burn anonymous quota at 30s intervals)
- [ ] Manual e2e in Desktop: enable toggle without key → badge "Anonymous", session works; add key → badge gone; remove key → toggle stays enabled, badge returns

## Docs

- `docs/guides/integrations.md` — tabela row + section with tool surface, anonymous vs key, behavior on credential removal
- `docs/architecture/security.md` — new "Third-party services" section documenting what crosses to Upstash (query, libraryName/Id, optional API key, headers, IP) and data-use implications (queries may be retained/used for benchmarking/reranking)

## Follow-ups (not in this PR)

- [SPW-209](https://speedwave.atlassian.net/browse/SPW-209) — SSOT for MCP service registry (eliminate 14-place duplication when adding a new built-in worker)
- [SPW-210](https://speedwave.atlassian.net/browse/SPW-210) — built-in skills are visible even when the integration is off (systemic fix, not per-skill workaround)

[SPW-209]: https://speedwave.atlassian.net/browse/SPW-209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ