### PR TITLE
fix(scripts): stage oauth worker in Windows bundle-build-context.ps1

### DIFF
--- a/scripts/bundle-build-context.ps1
+++ b/scripts/bundle-build-context.ps1
@@ -1,5 +1,5 @@
 # bundle-build-context.ps1 — PowerShell equivalent of bundle-build-context.sh
-# Copies container build context, mcp-os, and the host_exec worker into
+# Copies container build context, mcp-os, host_exec, and the oauth worker into
 # desktop\src-tauri\ for Tauri resource bundling.
 #
 # Usage: powershell -File scripts/bundle-build-context.ps1
@@ -14,7 +14,7 @@ $ErrorActionPreference = 'Stop'
 $dest = 'desktop\src-tauri'
 
 # Clean destination
-Remove-Item -Recurse -Force "$dest\build-context","$dest\mcp-os","$dest\host_exec" -ErrorAction SilentlyContinue
+Remove-Item -Recurse -Force "$dest\build-context","$dest\mcp-os","$dest\host_exec","$dest\oauth" -ErrorAction SilentlyContinue
 
 # -- Build context (containers + MCP server sources) --------------------------
 
@@ -70,7 +70,7 @@ foreach ($svc in $services) {
     }
 }
 
-# -- mcp-os + host_exec (host-side TypeScript workers) -----------------------
+# -- mcp-os + host_exec + oauth (host-side TypeScript workers) ---------------
 
 # Stage-Host-Worker <worker-dir-name> <bundle-dir-name>
 #   Mirrors stage_host_worker() in bundle-build-context.sh — stages
@@ -95,5 +95,6 @@ function Stage-Host-Worker {
 
 Stage-Host-Worker -worker os -bundle mcp-os
 Stage-Host-Worker -worker host_exec -bundle host_exec
+Stage-Host-Worker -worker oauth -bundle oauth
 
 Write-Host "Build context bundled into $dest"


### PR DESCRIPTION
## Summary

- `bundle-build-context.ps1` was missing the `Stage-Host-Worker -worker oauth -bundle oauth` call that its bash counterpart performs. Windows builds were therefore missing `desktop/src-tauri/oauth/oauth/dist/index.js`, and Tauri `build.rs` failed with: `Missing bundled asset file: ...\desktop\src-tauri\oauth\oauth\dist\index.js`.
- Mirrors `scripts/bundle-build-context.sh`: oauth added to the clean list, section header, and a new `Stage-Host-Worker` call. Header comment updated.

## Test plan

- [ ] CI: GitHub Actions windows-latest desktop-build green.
- [ ] Re-run `make test-e2e-all` against the Windows VM — Tauri build step should pass (this is how the bug was originally discovered).
- [x] macOS path unaffected — `.sh` already stages oauth; `make test-e2e-all` macOS phases passed (clean install + reinstall) on the same run that surfaced this.