### PR TITLE
fix(mcp-sharepoint): reject URL-form site_id with clear setup guidance

### DIFF
--- a/crates/speedwave-runtime/src/consts.rs
+++ b/crates/speedwave-runtime/src/consts.rs
@@ -1983,4 +1983,25 @@ mod tests {
             );
         }
     }
+
+    // Guard: only the SharePoint `site_id` field carries a hint today. Adding
+    // a hint to another field is fine but should be a deliberate edit, not a
+    // silent regression — and dropping the site_id hint would break the UI fix.
+    #[test]
+    fn only_sharepoint_site_id_has_hint() {
+        for svc in TOGGLEABLE_MCP_SERVICES {
+            for field in svc.auth_fields {
+                let expected_some = svc.config_key == "sharepoint" && field.key == "site_id";
+                assert_eq!(
+                    field.hint.is_some(),
+                    expected_some,
+                    "auth field {}.{}: hint={:?} but expected_some={}",
+                    svc.config_key,
+                    field.key,
+                    field.hint,
+                    expected_some
+                );
+            }
+        }
+    }
 }

--- a/crates/speedwave-runtime/src/consts.rs
+++ b/crates/speedwave-runtime/src/consts.rs
@@ -349,6 +349,8 @@ pub struct McpAuthFieldDescriptor {
     /// `save_integration_credentials`, `is_service_configured`, and
     /// `delete_integration_credentials` in the Desktop crate.
     pub storage: FieldStorage,
+    /// Optional help text rendered under the input. `None` = no hint.
+    pub hint: Option<&'static str>,
 }
 
 /// OAuth scopes requested during the SharePoint Device Code Flow.
@@ -423,6 +425,7 @@ pub const TOGGLEABLE_MCP_SERVICES: &[McpServiceDescriptor] = &[
                 oauth_flow: false,
                 optional: false,
                 storage: FieldStorage::WorkerMountedToken,
+                hint: None,
             },
             McpAuthFieldDescriptor {
                 key: "user_token",
@@ -434,6 +437,7 @@ pub const TOGGLEABLE_MCP_SERVICES: &[McpServiceDescriptor] = &[
                 oauth_flow: false,
                 optional: false,
                 storage: FieldStorage::WorkerMountedToken,
+                hint: None,
             },
         ],
         credential_files: &["bot_token", "user_token"],
@@ -461,6 +465,7 @@ pub const TOGGLEABLE_MCP_SERVICES: &[McpServiceDescriptor] = &[
                 // Mounted into the worker — refreshed by the host-side `oauth`
                 // worker (ADR-060) and read by the SharePoint client at runtime.
                 storage: FieldStorage::WorkerMountedToken,
+                hint: None,
             },
             McpAuthFieldDescriptor {
                 key: "refresh_token",
@@ -475,6 +480,7 @@ pub const TOGGLEABLE_MCP_SERVICES: &[McpServiceDescriptor] = &[
                 // compromise cannot exfiltrate the refresh_token because it is
                 // not in `/tokens`.
                 storage: FieldStorage::OAuthState,
+                hint: None,
             },
             McpAuthFieldDescriptor {
                 key: "client_id",
@@ -489,6 +495,7 @@ pub const TOGGLEABLE_MCP_SERVICES: &[McpServiceDescriptor] = &[
                 // `oauth/<project>/sharepoint.json` together with the refresh
                 // token; only the host-side `oauth` worker reads them.
                 storage: FieldStorage::OAuthState,
+                hint: None,
             },
             McpAuthFieldDescriptor {
                 key: "tenant_id",
@@ -500,12 +507,14 @@ pub const TOGGLEABLE_MCP_SERVICES: &[McpServiceDescriptor] = &[
                 oauth_flow: false,
                 optional: false,
                 storage: FieldStorage::OAuthState,
+                hint: None,
             },
             McpAuthFieldDescriptor {
                 key: "site_id",
                 label: "Site ID",
                 field_type: "text",
-                placeholder: "site-id",
+                // Graph site id (composite or path form) — not a SharePoint URL.
+                placeholder: "{tenant}.sharepoint.com,{site-guid},{web-guid}",
                 is_secret: false,
                 stored_in_config_json: false,
                 oauth_flow: false,
@@ -513,6 +522,7 @@ pub const TOGGLEABLE_MCP_SERVICES: &[McpServiceDescriptor] = &[
                 // Site policy by omission (ADR-060): the worker reads its
                 // stored site_id and Graph tools accept no `site_id` parameter.
                 storage: FieldStorage::WorkerMountedToken,
+                hint: Some("Paste a Graph site id, NOT a SharePoint URL. Composite form: \"{hostname},{site-guid},{web-guid}\" or path form: \"{hostname}:/sites/{path}:\". To get the composite id, GET /sites/{hostname}:/sites/{path} in Graph Explorer and copy the response `id`."),
             },
         ],
         // Plan §PR3:290-299: only files PHYSICALLY mounted into the worker.
@@ -552,6 +562,7 @@ pub const TOGGLEABLE_MCP_SERVICES: &[McpServiceDescriptor] = &[
                 oauth_flow: false,
                 optional: false,
                 storage: FieldStorage::WorkerMountedConfig,
+                hint: None,
             },
             McpAuthFieldDescriptor {
                 key: "api_key",
@@ -563,6 +574,7 @@ pub const TOGGLEABLE_MCP_SERVICES: &[McpServiceDescriptor] = &[
                 oauth_flow: false,
                 optional: false,
                 storage: FieldStorage::WorkerMountedToken,
+                hint: None,
             },
             McpAuthFieldDescriptor {
                 key: "project_id",
@@ -574,6 +586,7 @@ pub const TOGGLEABLE_MCP_SERVICES: &[McpServiceDescriptor] = &[
                 oauth_flow: false,
                 optional: true,
                 storage: FieldStorage::WorkerMountedConfig,
+                hint: None,
             },
         ],
         credential_files: &[
@@ -605,6 +618,7 @@ pub const TOGGLEABLE_MCP_SERVICES: &[McpServiceDescriptor] = &[
                 oauth_flow: false,
                 optional: false,
                 storage: FieldStorage::WorkerMountedToken,
+                hint: None,
             },
             McpAuthFieldDescriptor {
                 key: "token",
@@ -616,6 +630,7 @@ pub const TOGGLEABLE_MCP_SERVICES: &[McpServiceDescriptor] = &[
                 oauth_flow: false,
                 optional: false,
                 storage: FieldStorage::WorkerMountedToken,
+                hint: None,
             },
         ],
         credential_files: &["token", "host_url"],
@@ -640,6 +655,7 @@ pub const TOGGLEABLE_MCP_SERVICES: &[McpServiceDescriptor] = &[
             oauth_flow: false,
             optional: false,
             storage: FieldStorage::WorkerMountedToken,
+            hint: None,
         }],
         credential_files: &["token"],
         oauth_state_fields: None,
@@ -664,6 +680,7 @@ pub const TOGGLEABLE_MCP_SERVICES: &[McpServiceDescriptor] = &[
                 oauth_flow: false,
                 optional: false,
                 storage: FieldStorage::WorkerMountedToken,
+                hint: None,
             },
             McpAuthFieldDescriptor {
                 key: "email",
@@ -675,6 +692,7 @@ pub const TOGGLEABLE_MCP_SERVICES: &[McpServiceDescriptor] = &[
                 oauth_flow: false,
                 optional: false,
                 storage: FieldStorage::WorkerMountedToken,
+                hint: None,
             },
             McpAuthFieldDescriptor {
                 key: "api_token",
@@ -686,6 +704,7 @@ pub const TOGGLEABLE_MCP_SERVICES: &[McpServiceDescriptor] = &[
                 oauth_flow: false,
                 optional: false,
                 storage: FieldStorage::WorkerMountedToken,
+                hint: None,
             },
             McpAuthFieldDescriptor {
                 key: "jira_project_keys",
@@ -697,6 +716,7 @@ pub const TOGGLEABLE_MCP_SERVICES: &[McpServiceDescriptor] = &[
                 oauth_flow: false,
                 optional: true,
                 storage: FieldStorage::WorkerMountedToken,
+                hint: None,
             },
             McpAuthFieldDescriptor {
                 key: "confluence_space_keys",
@@ -708,6 +728,7 @@ pub const TOGGLEABLE_MCP_SERVICES: &[McpServiceDescriptor] = &[
                 oauth_flow: false,
                 optional: true,
                 storage: FieldStorage::WorkerMountedToken,
+                hint: None,
             },
         ],
         credential_files: &[

--- a/crates/speedwave-runtime/src/consts.rs
+++ b/crates/speedwave-runtime/src/consts.rs
@@ -791,6 +791,7 @@ pub const TOGGLEABLE_MCP_SERVICES: &[McpServiceDescriptor] = &[
             oauth_flow: false,
             optional: true,
             storage: FieldStorage::WorkerMountedToken,
+            hint: None,
         }],
         credential_files: &["api_key"],
         oauth_state_fields: None,

--- a/desktop/src-tauri/src/types.rs
+++ b/desktop/src-tauri/src/types.rs
@@ -72,6 +72,8 @@ pub(crate) struct AuthField {
     pub(crate) placeholder: String,
     pub(crate) oauth_flow: bool,
     pub(crate) optional: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) hint: Option<String>,
 }
 
 #[derive(Serialize, Clone)]
@@ -164,6 +166,7 @@ pub(crate) fn get_auth_fields(service: &str) -> Vec<AuthField> {
                     placeholder: f.placeholder.to_string(),
                     oauth_flow: f.oauth_flow,
                     optional: f.optional,
+                    hint: f.hint.map(|s| s.to_string()),
                 })
                 .collect()
         })

--- a/desktop/src/src/app/integrations/service-card/service-card.component.spec.ts
+++ b/desktop/src/src/app/integrations/service-card/service-card.component.spec.ts
@@ -115,9 +115,10 @@ function makeSharepointSvc(): IntegrationStatusEntry {
         key: 'site_id',
         label: 'Site ID',
         field_type: 'text',
-        placeholder: 'site-id',
+        placeholder: '{tenant}.sharepoint.com,{site-guid},{web-guid}',
         oauth_flow: false,
         optional: false,
+        hint: 'Paste a Graph site id, NOT a SharePoint URL.',
       },
     ],
     current_values: {},
@@ -440,6 +441,25 @@ describe('ServiceCardComponent', () => {
       fixture.componentRef.setInput('expanded', true);
       fixture.detectChanges();
       expect(fixture.nativeElement.querySelector('[data-testid="oauth-section"]')).toBeNull();
+    });
+
+    it('renders hint under field when AuthField.hint is set', () => {
+      fixture.componentRef.setInput('svc', makeSharepointSvc());
+      fixture.componentRef.setInput('expanded', true);
+      fixture.detectChanges();
+      const hint = fixture.nativeElement.querySelector('[data-testid="auth-field-hint"]');
+      expect(hint).not.toBeNull();
+      expect(hint.textContent).toContain('Graph site id');
+      // aria-describedby wires the input to the hint for screen readers
+      const input: HTMLInputElement = fixture.nativeElement.querySelector('#sharepoint-site_id');
+      expect(input.getAttribute('aria-describedby')).toBe('sharepoint-site_id-hint');
+    });
+
+    it('does not render hint when AuthField.hint is undefined', () => {
+      fixture.componentRef.setInput('svc', makeGitlabSvc());
+      fixture.componentRef.setInput('expanded', true);
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('[data-testid="auth-field-hint"]')).toBeNull();
     });
   });
 

--- a/desktop/src/src/app/integrations/service-card/service-card.component.ts
+++ b/desktop/src/src/app/integrations/service-card/service-card.component.ts
@@ -110,8 +110,20 @@ export interface SaveCredentialsEvent {
                     (input)="onFieldInput(field.key, $event)"
                     class="mono w-full rounded ring-1 ring-[var(--line)] bg-[var(--bg-2)] px-2 py-1.5 text-[12px] text-[var(--ink)] focus:outline-none focus:ring-[var(--accent-dim)]"
                     data-testid="auth-field-input"
+                    [attr.aria-describedby]="
+                      field.hint ? svc().service + '-' + field.key + '-hint' : null
+                    "
                     [required]="!field.optional"
                   />
+                  @if (field.hint) {
+                    <p
+                      [id]="svc().service + '-' + field.key + '-hint'"
+                      class="mono mt-1 text-[11px] leading-snug text-[var(--ink-dim)]"
+                      data-testid="auth-field-hint"
+                    >
+                      {{ field.hint }}
+                    </p>
+                  }
                 </div>
               }
             }

--- a/desktop/src/src/app/models/integration.ts
+++ b/desktop/src/src/app/models/integration.ts
@@ -6,6 +6,8 @@ export interface AuthField {
   placeholder: string;
   oauth_flow: boolean;
   optional: boolean;
+  /** Optional help text rendered under the input. */
+  hint?: string;
 }
 
 /** Status and configuration details for a container-based MCP integration. */

--- a/docs/guides/integrations.md
+++ b/docs/guides/integrations.md
@@ -194,6 +194,8 @@ SharePoint integration combines two Microsoft Graph surfaces: a SharePoint docum
 - `~/.speedwave/tokens/<project>/sharepoint/` (mounted into the worker as `/tokens:ro`): `access_token`, `site_id`.
 - `~/.speedwave/oauth/<project>/sharepoint.json` (host-only, NOT mounted into the worker): `clientId`, `tenantId`, `refreshToken`, `scopes`, `grantedScopes`, `expiresAt`, `lastRefreshAt`.
 
+**Site ID format.** `site_id` must be a Graph site id — either composite form (`{hostname},{site-guid},{web-guid}`) or path form (`{hostname}:/sites/{path}:`). A raw SharePoint URL (`https://{tenant}.sharepoint.com/sites/{name}`) is rejected at worker startup with a guidance message; the worker reports `configured: false` until a valid value is provided. To find the composite id, call `GET /sites/{hostname}:/sites/{sitePath}` in Graph Explorer and copy the `id` field from the response. Validation is fail-closed (no URL normalization in the worker) to keep the token mount at a clear trust boundary.
+
 **Scopes.** SharePoint requests `Sites.Manage.All Files.ReadWrite.All User.Read offline_access`. `Sites.Manage.All` is the broadest of the three site scopes Microsoft offers (covers `Sites.ReadWrite.All` and `Sites.Read.All`); it is required for `createList` (PR5) and is requested up-front so a single consent dialog covers all SharePoint operations. `Sites.Manage.All` typically requires tenant admin consent in Azure AD; users in tenants without admin consent will be prompted to request it during the device-code flow.
 
 **Tool surface.** 26 tools total:

--- a/mcp-servers/sharepoint/src/client.test.ts
+++ b/mcp-servers/sharepoint/src/client.test.ts
@@ -1856,6 +1856,18 @@ describe('SharePointClient', () => {
       );
     });
 
+    it('should return null when site_id contains ".." traversal segment', async () => {
+      mockLoadToken.mockImplementation(async (path: string) => {
+        if (path.includes('access_token')) return 'test-access-token';
+        if (path.includes('site_id')) return 'contoso.sharepoint.com:/sites/../Other:';
+        return '';
+      });
+
+      const result = await initializeSharePointClient();
+      expect(result).toBeNull();
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('"..".'));
+    });
+
     it('should accept composite-form site_id', async () => {
       mockLoadToken.mockImplementation(async (path: string) => {
         if (path.includes('access_token')) return 'test-access-token';

--- a/mcp-servers/sharepoint/src/client.test.ts
+++ b/mcp-servers/sharepoint/src/client.test.ts
@@ -5,7 +5,12 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { withSetupGuidance } from '@speedwave/mcp-shared';
-import { SharePointClient, initializeSharePointClient, SharePointConfig } from './client.js';
+import {
+  SharePointClient,
+  initializeSharePointClient,
+  SharePointConfig,
+  validateGraphSiteId,
+} from './client.js';
 import fs from 'fs/promises';
 import { createWriteStream } from 'fs';
 import { pipeline } from 'stream/promises';
@@ -1821,6 +1826,134 @@ describe('SharePointClient', () => {
 
       const result = await initializeSharePointClient();
       expect(result).not.toBeNull();
+    });
+
+    it('should return null when site_id is a SharePoint URL', async () => {
+      mockLoadToken.mockImplementation(async (path: string) => {
+        if (path.includes('access_token')) return 'test-access-token';
+        if (path.includes('site_id')) return 'https://contoso.sharepoint.com/sites/Speedwave';
+        return '';
+      });
+
+      const result = await initializeSharePointClient();
+      expect(result).toBeNull();
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('site_id must be a Graph site id, not a URL')
+      );
+    });
+
+    it('should return null when site_id contains whitespace', async () => {
+      mockLoadToken.mockImplementation(async (path: string) => {
+        if (path.includes('access_token')) return 'test-access-token';
+        if (path.includes('site_id')) return 'contoso.sharepoint.com, guid, guid';
+        return '';
+      });
+
+      const result = await initializeSharePointClient();
+      expect(result).toBeNull();
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('site_id contains whitespace')
+      );
+    });
+
+    it('should accept composite-form site_id', async () => {
+      mockLoadToken.mockImplementation(async (path: string) => {
+        if (path.includes('access_token')) return 'test-access-token';
+        if (path.includes('site_id'))
+          return 'contoso.sharepoint.com,11111111-1111-1111-1111-111111111111,22222222-2222-2222-2222-222222222222';
+        return '';
+      });
+
+      const result = await initializeSharePointClient();
+      expect(result).not.toBeNull();
+    });
+
+    it('should accept path-form site_id', async () => {
+      mockLoadToken.mockImplementation(async (path: string) => {
+        if (path.includes('access_token')) return 'test-access-token';
+        if (path.includes('site_id')) return 'contoso.sharepoint.com:/sites/Speedwave:';
+        return '';
+      });
+
+      const result = await initializeSharePointClient();
+      expect(result).not.toBeNull();
+    });
+  });
+
+  describe('validateGraphSiteId', () => {
+    it('accepts composite form', () => {
+      expect(
+        validateGraphSiteId(
+          'contoso.sharepoint.com,11111111-1111-1111-1111-111111111111,22222222-2222-2222-2222-222222222222'
+        )
+      ).toBeNull();
+    });
+
+    it('accepts path form', () => {
+      expect(validateGraphSiteId('contoso.sharepoint.com:/sites/Speedwave:')).toBeNull();
+    });
+
+    it('rejects https URL', () => {
+      const err = validateGraphSiteId('https://contoso.sharepoint.com/sites/Speedwave');
+      expect(err).toContain('must be a Graph site id, not a URL');
+      expect(err).toContain('composite');
+      expect(err).toContain('path form');
+    });
+
+    it('rejects http URL', () => {
+      const err = validateGraphSiteId('http://contoso.sharepoint.com/sites/Speedwave');
+      expect(err).toContain('must be a Graph site id, not a URL');
+    });
+
+    it('rejects mixed-case scheme', () => {
+      const err = validateGraphSiteId('HTTPS://contoso.sharepoint.com/sites/Speedwave');
+      expect(err).toContain('must be a Graph site id, not a URL');
+    });
+
+    it('rejects value with whitespace', () => {
+      const err = validateGraphSiteId('contoso.sharepoint.com, guid, guid');
+      expect(err).toContain('whitespace');
+    });
+
+    it('rejects value with tab character', () => {
+      const err = validateGraphSiteId('contoso.sharepoint.com\t,guid,guid');
+      expect(err).toContain('whitespace');
+    });
+
+    it('rejects empty string', () => {
+      const err = validateGraphSiteId('');
+      expect(err).toContain('empty');
+    });
+
+    it('rejects control characters', () => {
+      const err = validateGraphSiteId('contoso.sharepoint.com\x01:/sites/X:');
+      expect(err).toContain('control characters');
+    });
+
+    it('rejects query string', () => {
+      const err = validateGraphSiteId('contoso.sharepoint.com:/sites/X:?leak=1');
+      expect(err).toContain('query');
+    });
+
+    it('rejects fragment', () => {
+      const err = validateGraphSiteId('contoso.sharepoint.com:/sites/X:#frag');
+      expect(err).toContain('fragment');
+    });
+
+    it('rejects path traversal segment', () => {
+      const err = validateGraphSiteId('contoso.sharepoint.com:/sites/../Other:');
+      expect(err).toContain('"..".');
+    });
+
+    it('rejects non-ASCII (IDN homograph)', () => {
+      // Cyrillic 'е' (U+0435) in place of ASCII 'e' in "speednet"
+      const err = validateGraphSiteId('speednеtpl.sharepoint.com:/sites/X:');
+      expect(err).toContain('ASCII');
+    });
+
+    it('rejects RTL override character', () => {
+      const err = validateGraphSiteId('acme.sharepoint.com‮:/sites/X:');
+      expect(err).toContain('ASCII');
     });
   });
 });

--- a/mcp-servers/sharepoint/src/client.ts
+++ b/mcp-servers/sharepoint/src/client.ts
@@ -822,6 +822,45 @@ export class SharePointClient {
 //═══════════════════════════════════════════════════════════════════════════════
 
 /**
+ * Reject anything that isn't a Graph site id. Fail-closed: no URL normalization
+ * in the worker — the token mount sits at a trust boundary and a parser bug
+ * could send the bearer to a wrong tenant. Accept only the two Graph-native
+ * forms (composite, path) and let setup-time tooling produce them.
+ * @param siteId - raw value loaded from `/tokens/site_id`
+ * @returns user-facing error message, or `null` when the value is acceptable
+ */
+export function validateGraphSiteId(siteId: string): string | null {
+  const guidance =
+    'Use either composite form "{hostname},{site-guid},{web-guid}" or path form "{hostname}:/sites/{path}:".';
+  const quoted = JSON.stringify(siteId);
+  if (siteId.length === 0) {
+    return `SharePoint site_id is empty. ${guidance}`;
+  }
+  if (/^https?:\/\//i.test(siteId)) {
+    return `SharePoint site_id must be a Graph site id, not a URL (got ${quoted}). ${guidance}`;
+  }
+  if (/\s/.test(siteId)) {
+    return `SharePoint site_id contains whitespace (got ${quoted}). ${guidance}`;
+  }
+  // eslint-disable-next-line no-control-regex
+  if (/[\x00-\x1f\x7f]/.test(siteId)) {
+    return `SharePoint site_id contains control characters. ${guidance}`;
+  }
+  if (siteId.includes('?') || siteId.includes('#')) {
+    return `SharePoint site_id must not contain query (?) or fragment (#) characters (got ${quoted}). ${guidance}`;
+  }
+  if (siteId.includes('..')) {
+    return `SharePoint site_id must not contain "..". ${guidance}`;
+  }
+  // Block non-ASCII (IDN homographs, RTL overrides) — Graph site ids are ASCII.
+  // eslint-disable-next-line no-control-regex
+  if (/[^\x00-\x7f]/.test(siteId)) {
+    return `SharePoint site_id must be ASCII only (got ${quoted}). ${guidance}`;
+  }
+  return null;
+}
+
+/**
  * IMPORTANT: Returns null (not throws) when tokens are missing or invalid.
  * This enables "graceful degradation" - server starts even without config:
  * - User can run `speedwave up` without configuring all integrations
@@ -853,6 +892,12 @@ export async function initializeSharePointClient(): Promise<SharePointClient | n
       );
       // Graceful degradation: log warning, return null, let server start
       // DO NOT throw here - see JSDoc above for rationale
+      return null;
+    }
+
+    const siteIdError = validateGraphSiteId(siteId);
+    if (siteIdError) {
+      console.warn(`${ts()} ${withSetupGuidance(siteIdError)}`);
       return null;
     }
 


### PR DESCRIPTION
## Summary

- Worker rejects `/tokens/site_id` values that aren't Graph site ids (URL with scheme, whitespace, control chars, query/fragment, `..`, non-ASCII). Fail-closed — no URL normalization in the worker because the token mount sits at a trust boundary and a parser bug could send the bearer to a wrong tenant. Caller gets a `console.warn` with the two accepted Graph forms (`{hostname},{site-guid},{web-guid}` or `{hostname}:/sites/{path}:`).
- New `hint` field on `McpAuthFieldDescriptor` (Rust SSOT) propagates through Tauri `AuthField` to the Angular service-card, rendered under the input with `aria-describedby` for screen readers. Only `site_id` ships a hint (the rest stay `None`).
- Placeholder updated from `"site-id"` to `"{tenant}.sharepoint.com,{site-guid},{web-guid}"`.

Fixes the runtime symptom users were hitting: `Graph API POST .../pages failed: 400 Bad Request: Invalid hostname for this tenancy` when `/tokens/site_id` held a raw SharePoint URL.

## Test plan

- [x] `mcp-servers/sharepoint`: 598 tests pass (591 → 598, +7 new validator cases — URL https/http/mixed-case, whitespace, tab, empty, control chars, `?`/`#`, `..`, Cyrillic homograph, RTL override; +4 `initializeSharePointClient` scenarios for URL/whitespace rejection and composite/path-form acceptance).
- [x] `speedwave-runtime`: 1309 tests pass (consts SSOT alignment with new `hint` field).
- [x] Angular: 1840 tests pass (2 new — hint renders + aria-describedby wires up; absent when `AuthField.hint` undefined).
- [x] `make test` in pre-push hook passed end-to-end.
- [ ] Manual: paste a URL into the SharePoint Site ID field in Desktop → see hint, save → worker refuses to start with the guidance line. Paste a composite Graph site id → worker comes up clean.