### PR TITLE
refactor(runtime): remove dead code surfaced by build warnings

### DIFF
--- a/crates/speedwave-runtime/src/binary.rs
+++ b/crates/speedwave-runtime/src/binary.rs
@@ -164,8 +164,9 @@ pub fn command(cmd: &str) -> Command {
 /// Applies `CREATE_NO_WINDOW` on Windows to prevent console window flashing.
 /// For interactive TTY commands, use raw `Command::new()` instead.
 pub fn system_command(program: &str) -> Command {
-    #[allow(unused_mut)] // mut needed on Windows for creation_flags()
-    let mut command = Command::new(program);
+    let command = Command::new(program);
+    #[cfg(target_os = "windows")]
+    let mut command = command;
     #[cfg(target_os = "windows")]
     {
         use std::os::windows::process::CommandExt;

--- a/crates/speedwave-runtime/src/build.rs
+++ b/crates/speedwave-runtime/src/build.rs
@@ -288,12 +288,6 @@ pub fn resolve_oauth_script() -> Option<std::path::PathBuf> {
     )
 }
 
-#[cfg(test)]
-fn resolve_oauth_script_with_home(home: Option<PathBuf>) -> Option<std::path::PathBuf> {
-    let dev = repo_dev_path("mcp-servers/oauth/dist/index.js");
-    resolve_worker_script_inner("oauth", &["oauth", "oauth", "dist", "index.js"], home, dev)
-}
-
 /// Build a `<repo-root>/<rel>` path for the dev-tree fallback. `None` when out of tree.
 fn repo_dev_path(rel: &str) -> Option<PathBuf> {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/crates/speedwave-runtime/src/compose.rs
+++ b/crates/speedwave-runtime/src/compose.rs
@@ -8298,10 +8298,10 @@ networks:
         )
         .unwrap();
 
-        let token_path = tmp.path().join("slack-auth-token");
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
+            let token_path = tmp.path().join("slack-auth-token");
             let mode = std::fs::metadata(&token_path).unwrap().permissions().mode();
             assert_eq!(
                 mode & 0o777,

--- a/crates/speedwave-runtime/src/fs_security.rs
+++ b/crates/speedwave-runtime/src/fs_security.rs
@@ -217,26 +217,23 @@ pub(crate) fn collect_security_paths(
     (dirs, files)
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 
-    #[cfg(unix)]
     fn secure_mkdir(path: &std::path::Path) {
         use std::os::unix::fs::PermissionsExt;
         std::fs::create_dir_all(path).unwrap();
         std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700)).unwrap();
     }
 
-    #[cfg(unix)]
     fn get_mode(path: &std::path::Path) -> u32 {
         use std::os::unix::fs::PermissionsExt;
         std::fs::metadata(path).unwrap().permissions().mode() & 0o777
     }
 
     /// Creates a fully populated data dir tree for testing.
-    #[cfg(unix)]
     fn create_test_tree(data_dir: &std::path::Path, correct_perms: bool) {
         let dir_mode = if correct_perms { 0o700 } else { 0o755 };
         let file_mode = if correct_perms { 0o600 } else { 0o644 };
@@ -291,7 +288,6 @@ mod tests {
 
     // ── collect_security_paths ─────────────────────────────────────────
 
-    #[cfg(unix)]
     #[test]
     fn test_collect_security_paths_returns_correct_paths() {
         let tmp = tempfile::tempdir().unwrap();
@@ -357,7 +353,6 @@ mod tests {
 
     // ── ensure_data_dir_permissions_in ─────────────────────────────────
 
-    #[cfg(unix)]
     #[test]
     fn test_ensure_correct_permissions_noop() {
         use std::os::unix::fs::MetadataExt as _;
@@ -383,7 +378,6 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
     #[test]
     fn test_ensure_fixes_wrong_permissions() {
         use std::os::unix::fs::MetadataExt as _;
@@ -434,7 +428,6 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
     #[test]
     fn test_ensure_missing_paths_ok() {
         let tmp = tempfile::tempdir().unwrap();
@@ -442,7 +435,6 @@ mod tests {
         ensure_data_dir_permissions_in(tmp.path(), "proj").unwrap();
     }
 
-    #[cfg(unix)]
     #[test]
     fn test_ensure_skips_symlinks_at_top_level() {
         let tmp = tempfile::tempdir().unwrap();
@@ -463,7 +455,6 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
     #[test]
     fn test_ensure_skips_symlinks_inside_token_dir() {
         use std::os::unix::fs::PermissionsExt;
@@ -505,7 +496,6 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
     #[test]
     fn test_ensure_does_not_fix_uid_mismatch() {
         use std::os::unix::fs::MetadataExt as _;
@@ -535,7 +525,6 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
     #[test]
     fn test_ensure_roundtrip_fixes_then_check_passes() {
         use std::os::unix::fs::{MetadataExt as _, PermissionsExt};

--- a/crates/speedwave-runtime/src/tz.rs
+++ b/crates/speedwave-runtime/src/tz.rs
@@ -1,5 +1,6 @@
 //! Host timezone detection: returns an IANA name for the `TZ` env var injected into every container service.
 
+#[cfg(any(unix, test))]
 use std::path::Path;
 
 /// Returns the host IANA timezone name (e.g. `"Europe/Warsaw"`); warns and returns `"Etc/UTC"` on failure.
@@ -100,6 +101,7 @@ pub(crate) fn windows_to_iana(id: &str) -> Option<&'static str> {
 }
 
 /// Extracts IANA name from a `zoneinfo/...` symlink target (macOS layout).
+#[cfg(any(unix, test))]
 fn extract_zoneinfo_suffix(target: &Path) -> Option<String> {
     let s = target.to_str()?;
     let needle = "zoneinfo/";
@@ -113,6 +115,7 @@ fn extract_zoneinfo_suffix(target: &Path) -> Option<String> {
 }
 
 /// IANA-shape validator: 1–3 segments of `[A-Za-z0-9_+-]`; rejects empty, leading-colon, traversal, absolute.
+#[cfg(any(unix, test))]
 fn is_valid_iana_name(s: &str) -> bool {
     if s.is_empty() {
         return false;

--- a/desktop/src-tauri/src/host_path.rs
+++ b/desktop/src-tauri/src/host_path.rs
@@ -1,9 +1,11 @@
 //! Recovers the user's login-shell `PATH` once at startup for `host_exec` (ADR-054 §PATH).
 
 use std::sync::OnceLock;
+#[cfg(not(windows))]
 use std::time::Duration;
 
 /// How long to wait for `$SHELL -ilc 'printf %s "$PATH"'` before falling back.
+#[cfg(not(windows))]
 const SHELL_PATH_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Cached recovered `PATH`. Populated by [`init_recovered_host_path`] at


### PR DESCRIPTION
## Summary

- **tz.rs / host_path.rs**: cfg-gate two helper functions and one constant that are only reachable on one platform — they emitted `dead_code` warnings when building on the other. Boy Scout fix; these were appearing on every Windows build.
- **build.rs**: delete `resolve_oauth_script_with_home` (`#[cfg(test)]` but never referenced) and **binary.rs**: replace `#[allow(unused_mut)]` in `system_command` with a cfg-gated shadow — CLAUDE.md forbids `#[allow(...)]` to suppress lints.
- **fs_security.rs / compose.rs**: gate the `tests` module with `cfg(all(test, unix))` (every test inside was already `cfg(unix)`) and move `token_path` into the existing `cfg(unix)` block. Removes the unused-import and unused-variable warnings on Windows test builds, plus 8 now-redundant inner `cfg(unix)` attrs.

Net: −11 lines, zero behaviour change.

## Test plan

- [x] `make check` — clippy + fmt + lint pass with 0 warnings
- [x] `make test-rust` — 1442 runtime tests + 1204 desktop tests, all green; audio-transcription tests green
- [x] `cargo build -p speedwave-runtime --target x86_64-pc-windows-msvc` — was emitting 2 dead-code warnings, now clean
- [x] `cargo build -p speedwave-runtime --target x86_64-pc-windows-msvc --tests` — was emitting `unused_imports` + `unused_variables` + `dead_code`, now only the (unrelated) cross-link error remains
- [x] macOS host build (`cargo build -p speedwave-runtime`) — was clean, still clean