### PR TITLE
fix(runtime): bump Claude Code to 2.1.143

### DIFF
--- a/crates/speedwave-runtime/src/defaults.rs
+++ b/crates/speedwave-runtime/src/defaults.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-pub const CLAUDE_VERSION: &str = "2.1.126";
+pub const CLAUDE_VERSION: &str = "2.1.143";
 /// Path inside the container where entrypoint.sh generates the MCP config.
 pub const MCP_CONFIG_PATH: &str = "/home/speedwave/.claude/mcp-config.json";
 


### PR DESCRIPTION
## Summary
- Bumps `defaults::CLAUDE_VERSION` from 2.1.126 → 2.1.143 (17 upstream patches).
- One-line change; `render_compose` and `build.rs` propagate the SSOT automatically.

## Why
17 patches behind. The upgrade is netto wins for Speedwave:
- 2.1.133: HTTP(S)_PROXY/NO_PROXY/mTLS now honored across the full MCP OAuth flow; refresh-token race fix for parallel sessions sharing per-project credentials.
- 2.1.136: MCP OAuth refresh-token race across multiple servers; `.mcp.json` no longer disappears after `/clear`; corrupt-credentials login loop fix.
- 2.1.139: hooks now run without terminal access; 16 MB SSE body cap (n/a for hub); `CLAUDE_PROJECT_DIR` injected into MCP stdio servers.
- 2.1.141: malformed `.mcp.json` no longer drops sibling MCP servers; 403 on connect now surfaces as "needs auth"; remote MCP token-rotation 401 fix.
- 2.1.142: `MCP_TOOL_TIMEOUT` actually raises the per-request timeout for remote workers (was capped at 60s); fast mode bumped to Opus 4.7 (already latest in `defaults::ANTHROPIC_MODELS`).
- 2.1.143: `.credentials.json` with non-array scopes no longer hangs CLI; stop-hook block cap=8 (no-op for us — `self-review.sh` has its own `stop_hook_active` guard).

No removed flags, no behavior change for our `-p`/stream-json invocation. Bugfixes for `--resume` (emoji-split errors, paths with underscores) are pure upside for Chat UI.

## Audited before bumping
- `containers/claude-resources/hooks/self-review.sh`: pure stdin→stdout JSON, no tty, has `stop_hook_active` loop guard → compatible with 2.1.139 (hooks-without-tty) and 2.1.143 (block cap).
- Plugin manifest contract: Speedwave symlinks `claude-resources/skills/<name>/SKILL.md` via `entrypoint.sh` into user-level `~/.claude/skills/`, doesn't use Claude Code's plugin `skills:` key, so 2.1.136/2.1.142 skills-shadowing changes don't apply.
- Hub `express.json({ limit: '1mb' })` and JSON-RPC-over-HTTP (not SSE) → 16 MB SSE cap is irrelevant.
- `ide_bridge.rs:1257` `"2.1.49"` is a mock-client fixture inside a test of our own `dispatch_method`, not an SSOT — leave as-is.
- All flags used by `desktop/src-tauri/src/chat.rs::build_claude_args` and `defaults::DEFAULT_FLAGS` still exist in 2.1.143.

## Test plan
- [x] `make check` — clippy 0 warnings, rustfmt, prettier, tsc, eslint all green.
- [x] `cargo test -p speedwave-runtime` — `claude_version_is_pinned_semver` and `test_render_compose_claude_version_is_pinned` regression guards both pass with new value.
- [x] `make test` — 1203 desktop tests pass; pre-push hook (`make test`) also passed on the actual push.
- [ ] Smoke test in Desktop after merge: open a project, send a message, verify Chat UI / `--resume` round-trip.