### PR TITLE
fix(ci): strip MSYS2 backslash escape from sha256sum output

### DIFF
--- a/scripts/lib/fetch-sherpa-onnx-md.sh
+++ b/scripts/lib/fetch-sherpa-onnx-md.sh
@@ -53,7 +53,9 @@ fi
 if command -v shasum >/dev/null 2>&1; then
   ACTUAL="$(shasum -a 256 "$ARCHIVE_PATH" | awk '{print $1}')"
 else
-  ACTUAL="$(sha256sum "$ARCHIVE_PATH" | awk '{print $1}')"
+  # MSYS2 sha256sum (Git Bash on windows-latest) prefixes the hash with `\`
+  # when the path contained backslashes — strip it so the compare matches.
+  ACTUAL="$(sha256sum "$ARCHIVE_PATH" | awk '{ sub(/^\\/, "", $1); print $1 }')"
 fi
 
 if [ "$EXPECTED" != "$ACTUAL" ]; then


### PR DESCRIPTION
## Summary

Follow-up to PR #697. The Windows `Desktop Build` post-merge on `dev` (run [26086519265](https://github.com/speednet-software/speedwave/actions/runs/26086519265)) failed the SHA256 verification with:

```
SHA256 mismatch for sherpa-onnx-v1.13.2-win-x64-static-MD-Release-lib.tar.bz2:
  expected 5a7d35d55020ae85d620550796dce89e1fd0b1f046d7bfbed8d4522dd143b145
  got     \5a7d35d55020ae85d620550796dce89e1fd0b1f046d7bfbed8d4522dd143b145
                ^ stray leading backslash
```

The hash bytes match. The corruption is a leading `\` prefix.

### Root cause

MSYS2 `sha256sum` (Git Bash on `windows-latest`) follows GNU coreutils' escape convention: when the path argument contains backslashes, it prefixes the **entire hash line** with `\` and emits the path with literal backslash escapes:

```
$ sha256sum D:\a\_temp\sherpa.tar.bz2
\5a7d35... D:\\a\\_temp\\sherpa.tar.bz2
```

The fetch script's `awk '{print $1}'` captured `\5a7d35...` as the hash, which never matched upstream `5a7d35...` from `checksum.txt`. The bug only surfaced on `windows-latest` runners — local macOS uses `shasum -a 256`, which is the BSD variant and doesn't escape.

### Fix

`scripts/lib/fetch-sherpa-onnx-md.sh`: strip a single leading backslash from `$1` with `awk sub()`. Harmless on non-MSYS2 platforms (no leading `\` → no-op).

## Test plan

Local:
- [x] `shellcheck scripts/lib/fetch-sherpa-onnx-md.sh` — clean
- [x] Awk strip tested against simulated MSYS2 output (`\<hash>` → `<hash>`) and normal output (unchanged)

CI (definition of "fixed"):
- [ ] Post-merge `Desktop Build` on `dev` → Windows job passes the SHA verification and proceeds to the cargo build
- [ ] Windows full Tauri build links cleanly (the actual CRT-alignment goal from PR #697)

This unblocks the v0.11.0 release (PR #696).