### PR TITLE
fix(security): batch — Windows shell ban-list + Windows build CI fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
         working-directory: mcp-servers
         run: |
           (cd shared && npx tsc)
-          for ws in hub slack sharepoint redmine gitlab os; do
+          for ws in hub slack sharepoint redmine gitlab os atlassian context7 github host_exec oauth office playwright; do
             echo "tsc --noEmit $ws"
             (cd "$ws" && npx tsc --noEmit)
           done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,8 @@ jobs:
         working-directory: mcp-servers
         run: |
           (cd shared && npx tsc)
-          for ws in hub slack sharepoint redmine gitlab os atlassian context7 github host_exec oauth office playwright; do
+          # `playwright` is a Container-built bridge worker — no TS sources, no tsconfig.
+          for ws in hub slack sharepoint redmine gitlab os atlassian context7 github host_exec oauth office; do
             echo "tsc --noEmit $ws"
             (cd "$ws" && npx tsc --noEmit)
           done

--- a/crates/speedwave-runtime/src/consts.rs
+++ b/crates/speedwave-runtime/src/consts.rs
@@ -69,8 +69,9 @@ pub const HOST_EXEC_PARAM_PATTERN_MAX_LEN: usize = 4096;
 /// Banned `exec` basenames (shell / eval launchers).
 /// SSOT; case-insensitive. See ADR-054 §"Hard ban on direct shell/eval launchers".
 /// Windows interpreters (`powershell`, `cmd`, `pwsh`, `cscript`, `wscript`,
-/// `mshta`, `wsl`) are banned alongside Unix shells: each accepts a
-/// `-Command`/`-c`/script argument that executes arbitrary code.
+/// `mshta`, `wsl`) are banned alongside Unix shells: each accepts an inline
+/// command or script argument (`-Command`/`/c`/script path) that executes
+/// arbitrary code.
 pub const HOST_EXEC_SHELL_LAUNCHERS: &[&str] = &[
     "bash",
     "sh",

--- a/crates/speedwave-runtime/src/consts.rs
+++ b/crates/speedwave-runtime/src/consts.rs
@@ -68,9 +68,31 @@ pub const HOST_EXEC_PARAM_PATTERN_MAX_LEN: usize = 4096;
 
 /// Banned `exec` basenames (shell / eval launchers).
 /// SSOT; case-insensitive. See ADR-054 §"Hard ban on direct shell/eval launchers".
+/// Windows interpreters (`powershell`, `cmd`, `pwsh`, `cscript`, `wscript`,
+/// `mshta`, `wsl`) are banned alongside Unix shells: each accepts a
+/// `-Command`/`-c`/script argument that executes arbitrary code.
 pub const HOST_EXEC_SHELL_LAUNCHERS: &[&str] = &[
-    "bash", "sh", "zsh", "dash", "ksh", "fish", "eval", "env", "xargs", "find", "ssh", "sshpass",
-    "busybox", "toybox",
+    "bash",
+    "sh",
+    "zsh",
+    "dash",
+    "ksh",
+    "fish",
+    "eval",
+    "env",
+    "xargs",
+    "find",
+    "ssh",
+    "sshpass",
+    "busybox",
+    "toybox",
+    "powershell",
+    "cmd",
+    "pwsh",
+    "cscript",
+    "wscript",
+    "mshta",
+    "wsl",
 ];
 
 /// Meta-tools banned only with a *bare* `{param}` argv element.

--- a/crates/speedwave-runtime/src/host_exec.rs
+++ b/crates/speedwave-runtime/src/host_exec.rs
@@ -545,6 +545,20 @@ mod tests {
             "busybox",
             "toybox",
             "/bin/busybox",
+            // Windows interpreters — same threat surface (-Command / -c / script arg).
+            "powershell",
+            "powershell.exe",
+            "pwsh",
+            "PWSH.EXE",
+            "cmd",
+            "cmd.exe",
+            "CMD",
+            "cscript",
+            "wscript",
+            "mshta",
+            "wsl",
+            "wsl.exe",
+            r"C:\Windows\System32\powershell.exe",
         ] {
             let err = validate_host_exec_config(&cfg(vec![recipe("x", sh, &["-c", "{cmd}"])]))
                 .unwrap_err()

--- a/crates/speedwave-runtime/src/host_exec_process.rs
+++ b/crates/speedwave-runtime/src/host_exec_process.rs
@@ -271,8 +271,12 @@ fn apply_child_env(cmd: &mut Command, host_path: &str, env: &dyn EnvSource) {
     cmd.env("PATH", host_path);
 
     // HOME on Unix; on Windows USERPROFILE is the equivalent (forwarded above).
+    // Forward only when set — HOME="" makes Node.js `os.homedir()` return ""
+    // and breaks anything resolving ~/.npm, ~/.cache, etc.
     #[cfg(not(target_os = "windows"))]
-    cmd.env("HOME", env.var("HOME").unwrap_or_default());
+    if let Some(home) = env.var("HOME") {
+        cmd.env("HOME", home);
+    }
 
     if let Some(res) = env.var(consts::BUNDLE_RESOURCES_ENV) {
         if !res.is_empty() {

--- a/crates/speedwave-runtime/src/plugin.rs
+++ b/crates/speedwave-runtime/src/plugin.rs
@@ -54,13 +54,12 @@ pub struct PluginManifest {
     pub slug: String,
     pub version: String,
     pub description: String,
-    /// DEPRECATED — ignored by compose emitter since ADR-038.
-    ///
-    /// All workers (built-in and plugin) now listen on the same internal
-    /// port ([`consts::PORT_WORKER`]). Kept `Option<u16>` for backward
-    /// compatibility with already-signed plugin manifests; setting a non-zero
-    /// value merely emits a warning at compose render time.
-    #[serde(default)]
+    /// Ignored by the compose emitter — all workers listen on
+    /// [`consts::PORT_WORKER`] (ADR-038). Field kept `Option<u16>` so already-signed
+    /// plugin manifests still deserialize; a non-zero value emits a warning at
+    /// compose render time. `#[serde(skip_serializing)]` so new manifests don't
+    /// include it.
+    #[serde(default, skip_serializing)]
     pub port: Option<u16>,
     #[serde(default)]
     pub image_tag: Option<String>,

--- a/desktop/src-tauri/src/mcp_os_process.rs
+++ b/desktop/src-tauri/src/mcp_os_process.rs
@@ -1589,7 +1589,7 @@ srv.listen(0, '127.0.0.1', () => {
     }
 
     #[test]
-    fn apply_child_env_defaults_path_and_home_to_empty_when_missing() {
+    fn apply_child_env_defaults_path_to_empty_when_missing_and_omits_home() {
         let mut cmd = Command::new("/bin/true");
         let env = FakeEnv(&[]);
 
@@ -1601,11 +1601,12 @@ srv.listen(0, '127.0.0.1', () => {
             Some(""),
             "PATH must always be set on the child, even if empty"
         );
+        // HOME="" makes Node.js os.homedir() return "" and breaks ~/.npm,
+        // ~/.cache, etc. — better to leave HOME unset than poison it.
         #[cfg(not(target_os = "windows"))]
-        assert_eq!(
-            captured.get("HOME").map(String::as_str),
-            Some(""),
-            "HOME must always be set on Unix children, even if empty"
+        assert!(
+            captured.get("HOME").is_none(),
+            "HOME must be omitted on Unix children when not set on the host"
         );
     }
 

--- a/desktop/src-tauri/src/mcp_os_process.rs
+++ b/desktop/src-tauri/src/mcp_os_process.rs
@@ -310,10 +310,12 @@ fn apply_child_env(cmd: &mut Command, env: &dyn EnvSource) {
 
     // HOME is set on Unix (macOS/Linux) but typically not on Windows, where
     // USERPROFILE is the equivalent. Setting HOME to an empty string on
-    // Windows would break Node.js path resolution (e.g. os.homedir()).
+    // any platform would break Node.js path resolution (e.g. os.homedir()).
     // USERPROFILE is already forwarded via WINDOWS_SYSTEM_ENV_VARS above.
     #[cfg(not(target_os = "windows"))]
-    cmd.env("HOME", env.var("HOME").unwrap_or_default());
+    if let Some(home) = env.var("HOME") {
+        cmd.env("HOME", home);
+    }
 
     // Production mode: forward resource directory so mcp-os resolves native
     // CLI binaries from the bundled .app/Contents/Resources/ layout instead
@@ -910,7 +912,9 @@ srv.listen(0, '127.0.0.1', () => {
             .env_clear()
             .env("PATH", std::env::var("PATH").unwrap_or_default());
         #[cfg(not(target_os = "windows"))]
-        cmd.env("HOME", std::env::var("HOME").unwrap_or_default());
+        if let Ok(home) = std::env::var("HOME") {
+            cmd.env("HOME", home);
+        }
         let result = cmd
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::null())
@@ -1129,7 +1133,9 @@ process.stdout.write(JSON.stringify({ leaked }));
 
         cmd.env("PATH", std::env::var("PATH").unwrap_or_default());
         #[cfg(not(target_os = "windows"))]
-        cmd.env("HOME", std::env::var("HOME").unwrap_or_default());
+        if let Ok(home) = std::env::var("HOME") {
+            cmd.env("HOME", home);
+        }
         let result = cmd
             .env("PORT", "0")
             .env("MCP_OS_AUTH_TOKEN", "test-token")

--- a/desktop/src-tauri/src/mcp_os_process.rs
+++ b/desktop/src-tauri/src/mcp_os_process.rs
@@ -309,8 +309,8 @@ fn apply_child_env(cmd: &mut Command, env: &dyn EnvSource) {
     cmd.env("PATH", env.var("PATH").unwrap_or_default());
 
     // HOME is set on Unix (macOS/Linux) but typically not on Windows, where
-    // USERPROFILE is the equivalent. Setting HOME to an empty string on
-    // any platform would break Node.js path resolution (e.g. os.homedir()).
+    // USERPROFILE is the equivalent. Setting HOME to an empty string on Unix
+    // would break Node.js path resolution (e.g. os.homedir()).
     // USERPROFILE is already forwarded via WINDOWS_SYSTEM_ENV_VARS above.
     #[cfg(not(target_os = "windows"))]
     if let Some(home) = env.var("HOME") {

--- a/scripts/lib/fetch-sherpa-onnx-md.sh
+++ b/scripts/lib/fetch-sherpa-onnx-md.sh
@@ -70,7 +70,7 @@ echo "SHA256 verified (${ACTUAL})" >&2
 # path like `D:\a\...` as `user@host:path` SSH form. The drive letter is fine
 # in the working directory, just not in the archive argument.
 rm -rf "${OUT_ROOT:?}/${EXTRACTED_TOP}"
-(cd "$OUT_ROOT" && tar -xjf "$(basename "$ARCHIVE_PATH")")
+(cd "$OUT_ROOT" && tar -xjf "$ARCHIVE")
 
 if [ ! -d "$LIB_DIR" ] || [ ! -f "${LIB_DIR}/sherpa-onnx-c-api.lib" ]; then
   echo "::error::extraction produced no lib/ with sherpa-onnx-c-api.lib at ${LIB_DIR}" >&2

--- a/scripts/lib/fetch-sherpa-onnx-md.sh
+++ b/scripts/lib/fetch-sherpa-onnx-md.sh
@@ -64,9 +64,13 @@ if [ "$EXPECTED" != "$ACTUAL" ]; then
 fi
 echo "SHA256 verified (${ACTUAL})" >&2
 
-# Extract under OUT_ROOT — tarball top-level is ${EXTRACTED_TOP}/
+# Extract under OUT_ROOT — tarball top-level is ${EXTRACTED_TOP}/.
+# `cd $OUT_ROOT` + relative archive name keeps the drive-letter colon out of
+# tar's argv: MSYS2 tar (Git Bash on windows-latest) parses a `:` in a native
+# path like `D:\a\...` as `user@host:path` SSH form. The drive letter is fine
+# in the working directory, just not in the archive argument.
 rm -rf "${OUT_ROOT:?}/${EXTRACTED_TOP}"
-tar -xjf "$ARCHIVE_PATH" -C "$OUT_ROOT"
+(cd "$OUT_ROOT" && tar -xjf "$(basename "$ARCHIVE_PATH")")
 
 if [ ! -d "$LIB_DIR" ] || [ ! -f "${LIB_DIR}/sherpa-onnx-c-api.lib" ]; then
   echo "::error::extraction produced no lib/ with sherpa-onnx-c-api.lib at ${LIB_DIR}" >&2


### PR DESCRIPTION
## Summary

Bundles six small fixes that address (a) the remaining Windows desktop-build blocker after PR #697/#699 and (b) the open items from claude[bot] reviews of PR #696. Single PR rather than six because they share a release window and CI cycle.

### Commits (squash will collapse)

1. **`fix(ci):` MSYS2 tar drive-letter parse** (`e14d4146`)
   Post-merge Windows desktop-build on `dev` (run [26091109486](https://github.com/speednet-software/speedwave/actions/runs/26091109486)) failed at extraction with `tar (child): Cannot connect to D: resolve failed` — MSYS2 tar parses `:` in `D:\a\_temp\...\sherpa.tar.bz2` as SSH `user@host:path`. Fix: `cd $OUT_ROOT && tar -xjf $(basename …)` keeps the drive-letter colon out of argv. Cross-platform (`--force-local` would work but is GNU-tar only).

2. **`fix(security):` Windows shell ban-list** (`1d7a9062`)
   `HOST_EXEC_SHELL_LAUNCHERS` only covered Unix shells. Linux dropped (ADR-059), Windows first-class → a plugin recipe `exec="powershell" args=["-Command","{cmd}"]` passed validation, exposing arbitrary code execution via a bare param. Adds `powershell`, `cmd`, `pwsh`, `cscript`, `wscript`, `mshta`, `wsl`. Test `rejects_shell_launcher_exec` extended with case variants and a fully-qualified Windows path.

3. **`fix(runtime):` don't forward empty `HOME`** (`0c15e90f`)
   `cmd.env("HOME", env.var("HOME").unwrap_or_default())` writes `HOME=""` when unset, making Node.js `os.homedir()` return `""` and breaking `~/.npm`/`~/.cache`/etc. Switch to `if let Some(home) = …` in 4 sites (host_exec_process.rs + mcp_os_process.rs prod + 2 test helpers).

4. **`style(runtime):` rewrite `port` DEPRECATED comment** (`32f4332c`)
   Project rule: "NEVER leave @deprecated comments". `plugin.PluginManifest.port` had `/// DEPRECATED — …`. Rewritten as backward-compat note + `#[serde(skip_serializing)]` so new manifests don't include it (input deserialization unchanged).

5. **`ci:` extend tsc loop to new MCP workers** (`cab0f1e4`)
   `test.yml` fast tsc step iterated `hub slack sharepoint redmine gitlab os` only. Adds `atlassian context7 github host_exec oauth office playwright`. One-line change.

6. **`test(desktop):` update `apply_child_env` test** (`84488e56`)
   `apply_child_env_defaults_path_and_home_to_empty_when_missing` asserted the old contract (`HOME=""`). Renamed + flipped to expect HOME absent — matches commit #3 above. Should have been bundled into #3; separate commit only because CLAUDE.md forbids interactive rebase.

## Test plan

Local:
- [x] `make check` — clean
- [x] `cargo test -p speedwave-runtime --lib host_exec::tests::rejects_shell_launcher_exec` — passes
- [x] `cargo test -p speedwave-runtime --lib plugin` — 181 passed
- [x] `cargo test mcp_os_process::tests::apply_child_env` — 5 passed
- [x] `make test` — exit 0 (pre-push hook)
- [x] Smoke test fetch-sherpa-onnx-md.sh with new `cd && tar` — extracts correctly on macOS bsdtar

CI:
- [ ] PR CI green (macOS matrix only — Windows desktop-build runs only on push to dev)
- [ ] After merge: push run `Desktop Build` on `dev` → **Windows job green** (canonical CRT-alignment + MSYS2 fix validator)

Once Windows is green on `dev`, PR #696 (`dev → main`) clears for v0.11.0 after dismissing the false-positive CodeQL alert on `main.rs:1259` (`log::error!` output passes through `log_sanitizer::sanitize()` — confirmed by claude[bot] in PR #696 review).

Addresses items 2,3,4,5,6 from claude[bot] PR #696 reviews. Item 1 (CodeQL alert) will be dismissed separately.