### PR TITLE
docs(ide-bridge): explain VM catch-all forwarder for 127.0.0.1 binds

### DIFF
--- a/desktop/src-tauri/src/ide_bridge.rs
+++ b/desktop/src-tauri/src/ide_bridge.rs
@@ -1049,13 +1049,11 @@ async fn handle_with_stubs<S>(
 // NAT 192.168.65.1 on Windows).
 //
 // Reaching a 127.0.0.1-only bind from the container works because the host
-// VM (Lima on macOS, WSL2 on Windows) installs a default catch-all forwarder
-// from VM gateway → host loopback. Lima docs: "When no port forwards are
-// explicitly configured, Lima adds a default catch-all rule that forwards
-// all non-privileged ports from loopback addresses." [^1]
-// WSL2: same effect via the host gateway; mirrored networking mode makes
-// it explicit, NAT mode still works for outbound connections from WSL guest
-// to Windows loopback. [^2]
+// VM (Lima on macOS, WSL2 on Windows) installs a default forwarder from VM
+// gateway → host loopback. Lima registers a catch-all rule for non-privileged
+// ports on loopback when no explicit port forwards are configured (impl in
+// `pkg/hostagent/hostagent.go`). [^1] WSL2 reaches the host loopback through
+// the host gateway in both NAT and mirrored networking modes. [^2]
 //
 // [^1]: https://lima-vm.io/docs/config/port/
 // [^2]: https://learn.microsoft.com/en-us/windows/wsl/networking

--- a/desktop/src-tauri/src/ide_bridge.rs
+++ b/desktop/src-tauri/src/ide_bridge.rs
@@ -1051,12 +1051,13 @@ async fn handle_with_stubs<S>(
 // Reaching a 127.0.0.1-only bind from the container works because the host
 // VM (Lima on macOS, WSL2 on Windows) installs a default forwarder from VM
 // gateway → host loopback. Lima registers a catch-all rule for non-privileged
-// ports on loopback when no explicit port forwards are configured (impl in
-// `pkg/hostagent/hostagent.go`). [^1] WSL2 reaches the host loopback through
-// the host gateway in both NAT and mirrored networking modes. [^2]
+// ports on loopback when no explicit port forwards are configured. [^1] [^2]
+// WSL2 reaches the host loopback through the host gateway in both NAT and
+// mirrored networking modes. [^3]
 //
 // [^1]: https://lima-vm.io/docs/config/port/
-// [^2]: https://learn.microsoft.com/en-us/windows/wsl/networking
+// [^2]: https://github.com/lima-vm/lima/blob/master/pkg/hostagent/hostagent.go
+// [^3]: https://learn.microsoft.com/en-us/windows/wsl/networking
 
 async fn run_websocket_on_tcp(
     std_listener: std::net::TcpListener,

--- a/desktop/src-tauri/src/ide_bridge.rs
+++ b/desktop/src-tauri/src/ide_bridge.rs
@@ -680,9 +680,12 @@ impl IdeBridge {
     /// at that point, so we spin up a dedicated background thread with its own
     /// single-threaded Tokio runtime instead of using `tokio::spawn`.
     ///
-    /// The Bridge listens on `127.0.0.1:<port>`. Containers reach it via
-    /// the canonical host gateway alias `host.docker.internal`, resolved
-    /// inside the container by `extra_hosts` to the platform gateway IP.
+    /// The Bridge listens on `127.0.0.1:<port>` on the host. Containers reach
+    /// it via the canonical host gateway alias `host.docker.internal`,
+    /// resolved inside the container by `extra_hosts` to the platform gateway
+    /// IP. The VM (Lima vzNAT on macOS, WSL2 NAT on Windows) provides a
+    /// default catch-all forwarder from gateway → host loopback. See
+    /// `run_websocket_on_tcp` for the full mechanism.
     pub fn start(&mut self) -> anyhow::Result<()> {
         cleanup_stale_lock_files();
         let (tx, _rx) = tokio::sync::broadcast::channel::<()>(1);
@@ -1040,9 +1043,22 @@ async fn handle_with_stubs<S>(
 // WebSocket TCP listener — all platforms
 // ---------------------------------------------------------------------------
 //
-// The Bridge listens on 127.0.0.1. Containers reach the host via the canonical
-// gateway alias `host.docker.internal`, routed to loopback through `extra_hosts`
-// (Lima vzNAT on macOS, WSL2 NAT on Windows).
+// The Bridge listens on 127.0.0.1 on the host. Containers reach it via the
+// canonical gateway alias `host.docker.internal`, routed to the platform
+// gateway IP through `extra_hosts` (Lima vzNAT 192.168.5.2 on macOS, WSL2
+// NAT 192.168.65.1 on Windows).
+//
+// Reaching a 127.0.0.1-only bind from the container works because the host
+// VM (Lima on macOS, WSL2 on Windows) installs a default catch-all forwarder
+// from VM gateway → host loopback. Lima docs: "When no port forwards are
+// explicitly configured, Lima adds a default catch-all rule that forwards
+// all non-privileged ports from loopback addresses." [^1]
+// WSL2: same effect via the host gateway; mirrored networking mode makes
+// it explicit, NAT mode still works for outbound connections from WSL guest
+// to Windows loopback. [^2]
+//
+// [^1]: https://lima-vm.io/docs/config/port/
+// [^2]: https://learn.microsoft.com/en-us/windows/wsl/networking
 
 async fn run_websocket_on_tcp(
     std_listener: std::net::TcpListener,

--- a/docs/guides/ide-bridge.md
+++ b/docs/guides/ide-bridge.md
@@ -69,6 +69,11 @@ All platforms use the canonical gateway alias `host.docker.internal`, injected i
 
 On all platforms, the Bridge binds to `127.0.0.1` only — the port is never exposed to the LAN.
 
+A 127.0.0.1-only bind on the host is still reachable from inside the VM because both Lima and WSL2 install a default forwarder from their gateway → host loopback. Lima registers a catch-all rule for non-privileged ports on loopback when no explicit port forwards are configured ([Lima docs][lima-port]). WSL2 reaches the host loopback through the host gateway in both NAT and mirrored networking modes ([WSL networking][wsl-net]).
+
+[lima-port]: https://lima-vm.io/docs/config/port/
+[wsl-net]: https://learn.microsoft.com/en-us/windows/wsl/networking
+
 ## See Also
 
 - [ADR-007: IDE Bridge as Proxy](../adr/ADR-007-ide-bridge-as-proxy.md)


### PR DESCRIPTION
## Summary

- The existing comments in `ide_bridge.rs` said *"containers reach it via host.docker.internal"* without explaining **why** a 127.0.0.1-only bind on the host is reachable from inside the VM.
- Every plugin author hitting the gateway IP wonders why their localhost-bound dev tools work too. The mechanism is non-obvious — it's Lima's default catch-all rule that forwards gateway → host loopback.
- This PR adds that missing detail to both comment blocks (the `IdeBridge::start` doc and the `WebSocket TCP listener` section), plus references to upstream docs.

No code change. Comments only.

## Test plan

- [ ] `cargo check` passes (verified locally — no rustc errors)
- [ ] `make check` passes in CI