### PR TITLE
feat(desktop): delete conversation from history sidebar

### DIFF
--- a/desktop/src-tauri/src/history.rs
+++ b/desktop/src-tauri/src/history.rs
@@ -556,6 +556,26 @@ fn get_project_memory_impl(data_dir: &Path, project: &str) -> anyhow::Result<Str
     }
 }
 
+/// Delete a conversation's JSONL file. Idempotent: a missing file is treated
+/// as success so a double-click on the trash icon doesn't surface an error.
+pub fn delete_conversation(project: &str, session_id: &str) -> anyhow::Result<()> {
+    delete_conversation_impl(consts::data_dir(), project, session_id)
+}
+
+fn delete_conversation_impl(
+    data_dir: &Path,
+    project: &str,
+    session_id: &str,
+) -> anyhow::Result<()> {
+    validate_session_id_impl(session_id)?;
+    let path = sessions_dir_impl(data_dir, project).join(format!("{session_id}.jsonl"));
+    match fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(anyhow::anyhow!("cannot delete session {session_id}: {e}")),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Resume snapshot
 // ---------------------------------------------------------------------------
@@ -1623,5 +1643,62 @@ mod tests {
             Some("claude-opus-4-7"),
             "must pick the model with the highest outputTokens, not the alphabetically first key"
         );
+    }
+
+    // ── delete_conversation ────────────────────────────────────────
+
+    #[test]
+    fn delete_conversation_removes_existing_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = setup_sessions_dir(tmp.path(), "proj");
+        let id = "abcdef01-2345-6789-abcd-ef0123456789";
+        write_session(&dir, id, &[r#"{"type":"user"}"#]);
+        let path = dir.join(format!("{id}.jsonl"));
+        assert!(path.exists());
+
+        delete_conversation_impl(tmp.path(), "proj", id).unwrap();
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn delete_conversation_is_idempotent_when_file_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_sessions_dir(tmp.path(), "proj");
+        let id = "abcdef01-2345-6789-abcd-ef0123456789";
+
+        let result = delete_conversation_impl(tmp.path(), "proj", id);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn delete_conversation_rejects_path_traversal() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_sessions_dir(tmp.path(), "proj");
+
+        let result = delete_conversation_impl(tmp.path(), "proj", "../escape");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn delete_conversation_rejects_empty_session_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_sessions_dir(tmp.path(), "proj");
+
+        let result = delete_conversation_impl(tmp.path(), "proj", "");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn delete_conversation_does_not_touch_other_sessions() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = setup_sessions_dir(tmp.path(), "proj");
+        let id_a = "abcdef01-2345-6789-abcd-ef0123456789";
+        let id_b = "abcdef01-2345-6789-abcd-ef012345678a";
+        write_session(&dir, id_a, &[r#"{"type":"user"}"#]);
+        write_session(&dir, id_b, &[r#"{"type":"user"}"#]);
+
+        delete_conversation_impl(tmp.path(), "proj", id_a).unwrap();
+        assert!(!dir.join(format!("{id_a}.jsonl")).exists());
+        assert!(dir.join(format!("{id_b}.jsonl")).exists());
     }
 }

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -357,6 +357,20 @@ async fn get_conversation(
 }
 
 #[tauri::command]
+async fn delete_conversation(project: String, session_id: String) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || {
+        check_project(&project)?;
+        log::info!("delete_conversation: project={project}");
+        history::delete_conversation(&project, &session_id).map_err(|e| {
+            log::error!("delete_conversation: error: {e}");
+            e.to_string()
+        })
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
 async fn get_project_memory(project: String) -> Result<String, String> {
     tokio::task::spawn_blocking(move || {
         check_project(&project)?;
@@ -1558,7 +1572,8 @@ fn main() {
     // Shared state: IDE Bridge, host-bridged plugins, mcp-os, per-project host_exec
     // workers, per-project oauth workers, auto-check handle.
     let ide_bridge: SharedIdeBridge = Arc::new(Mutex::new(None));
-    let plugin_bridges: SharedPluginBridges = Arc::new(Mutex::new(std::collections::HashMap::new()));
+    let plugin_bridges: SharedPluginBridges =
+        Arc::new(Mutex::new(std::collections::HashMap::new()));
     let mcp_os: SharedMcpOs = Arc::new(Mutex::new(None));
     let host_exec: SharedHostExec = Arc::new(Mutex::new(std::collections::HashMap::new()));
     let oauth: SharedOauth = Arc::new(Mutex::new(std::collections::HashMap::new()));
@@ -2090,6 +2105,7 @@ fn main() {
             // Chat history
             list_conversations,
             get_conversation,
+            delete_conversation,
             get_project_memory,
             resume_conversation,
             // Project management

--- a/desktop/src/src/app/chat/chat.component.html
+++ b/desktop/src/src/app/chat/chat.component.html
@@ -9,6 +9,7 @@
       [currentSessionId]="currentViewSessionId"
       (closed)="ui.closeSidebar()"
       (resumeConversation)="resumeConversation($event.session_id)"
+      (deleteConversation)="deleteConversation($event.session_id)"
     />
 
     <!-- Main column: header + body (messages or transcript) + composer. -->

--- a/desktop/src/src/app/chat/chat.component.spec.ts
+++ b/desktop/src/src/app/chat/chat.component.spec.ts
@@ -395,6 +395,80 @@ describe('ChatComponent', () => {
     });
   });
 
+  // ── deleteConversation ──────────────────────────────────────────────────────
+
+  describe('deleteConversation', () => {
+    it('calls delete_conversation and removes the row locally', async () => {
+      projectState.activeProject = 'test';
+      component.conversations = [
+        { session_id: 's1', timestamp: null, preview: 'a', message_count: 1 },
+        { session_id: 's2', timestamp: null, preview: 'b', message_count: 1 },
+      ];
+      const calls: { cmd: string; args: unknown }[] = [];
+      mockTauri.invokeHandler = async (cmd: string, args: unknown) => {
+        calls.push({ cmd, args });
+        return undefined;
+      };
+
+      await component.deleteConversation('s1');
+
+      expect(calls).toContainEqual({
+        cmd: 'delete_conversation',
+        args: { project: 'test', sessionId: 's1' },
+      });
+      expect(component.conversations.map((c) => c.session_id)).toEqual(['s2']);
+    });
+
+    it('does nothing when no active project', async () => {
+      projectState.activeProject = null;
+      const invokeSpy = vi.spyOn(mockTauri, 'invoke');
+      await component.deleteConversation('s1');
+      expect(invokeSpy).not.toHaveBeenCalled();
+    });
+
+    it('sets historyError when backend fails and keeps the row', async () => {
+      projectState.activeProject = 'test';
+      component.conversations = [
+        { session_id: 's1', timestamp: null, preview: 'a', message_count: 1 },
+      ];
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      mockTauri.invokeHandler = async (cmd: string) => {
+        if (cmd === 'delete_conversation') throw new Error('io error');
+        return undefined;
+      };
+
+      await component.deleteConversation('s1');
+
+      expect(component.historyError).toContain('Failed to delete conversation');
+      expect(component.conversations.length).toBe(1);
+      errorSpy.mockRestore();
+    });
+
+    it('resets live chat when deleting the active session', async () => {
+      projectState.activeProject = 'test';
+      chatState._setState({
+        messages: [],
+        currentBlocks: [],
+        sessionStats: {
+          session_id: 's1',
+          total_cost: 0,
+          context_window_size: null,
+          total_output_tokens: 0,
+        },
+      });
+      component.conversations = [
+        { session_id: 's1', timestamp: null, preview: 'a', message_count: 1 },
+      ];
+      const resetSpy = vi.spyOn(chatState, 'resetForNewConversation');
+      mockTauri.invokeHandler = async () => undefined;
+
+      await component.deleteConversation('s1');
+
+      expect(resetSpy).toHaveBeenCalled();
+      expect(component.conversations).toEqual([]);
+    });
+  });
+
   // ── newConversation ─────────────────────────────────────────────────────────
 
   describe('newConversation', () => {

--- a/desktop/src/src/app/chat/chat.component.ts
+++ b/desktop/src/src/app/chat/chat.component.ts
@@ -405,6 +405,33 @@ export class ChatComponent implements OnInit, OnDestroy {
     }
   }
 
+  /**
+   * Deletes a conversation's transcript file. If the active session is the one
+   * being deleted, we reset live chat too — the underlying JSONL is gone, so
+   * resume/retry would fail.
+   * @param sessionId - session UUID to delete.
+   */
+  async deleteConversation(sessionId: string): Promise<void> {
+    const project = this.projectState.activeProject;
+    if (!project) return;
+    const wasActive = this.currentViewSessionId === sessionId;
+    this.historyError = '';
+    try {
+      await this.tauri.invoke('delete_conversation', { project, sessionId });
+      this.conversations = this.conversations.filter((c) => c.session_id !== sessionId);
+      if (wasActive) {
+        this.optimisticSessionId = null;
+        this.chat.resetForNewConversation();
+        await this.chat.init();
+      }
+    } catch (err) {
+      console.error('[chat] deleteConversation failed:', err);
+      this.historyError = `Failed to delete conversation: ${err}`;
+    } finally {
+      this.cdr.markForCheck();
+    }
+  }
+
   /** Clears all chat + drawer state and re-runs the chat session bootstrap. */
   async newConversation(): Promise<void> {
     this.ui.closeSidebar();

--- a/desktop/src/src/app/chat/conversations-sidebar/conversations-sidebar.component.spec.ts
+++ b/desktop/src/src/app/chat/conversations-sidebar/conversations-sidebar.component.spec.ts
@@ -15,6 +15,7 @@ import type { ConversationSummary } from '../../models/chat';
       [currentSessionId]="currentSessionId"
       (closed)="onClosed()"
       (resumeConversation)="onResume($event)"
+      (deleteConversation)="onDelete($event)"
     />
   `,
 })
@@ -24,12 +25,16 @@ class HostComponent {
   currentSessionId: string | null = null;
   closedCount = 0;
   resumedPayload: ConversationSummary | null = null;
+  deletedPayload: ConversationSummary | null = null;
 
   onClosed(): void {
     this.closedCount += 1;
   }
   onResume(payload: ConversationSummary): void {
     this.resumedPayload = payload;
+  }
+  onDelete(payload: ConversationSummary): void {
+    this.deletedPayload = payload;
   }
 }
 
@@ -200,6 +205,58 @@ describe('ConversationsSidebarComponent', () => {
       expect(row).not.toBeNull();
       row!.click();
       expect(host.resumedPayload?.session_id).toBe('s1');
+    });
+  });
+
+  describe('delete', () => {
+    it('shows the trash button for every row', () => {
+      host.conversations = sample;
+      fixture.detectChanges();
+      expect(q('[data-testid="conversation-delete-s1"]')).not.toBeNull();
+      expect(q('[data-testid="conversation-delete-s2"]')).not.toBeNull();
+      expect(q('[data-testid="conversation-delete-s3"]')).not.toBeNull();
+    });
+
+    it('trash click swaps the row into a confirm prompt; does not emit yet', () => {
+      host.conversations = sample;
+      fixture.detectChanges();
+      (q('[data-testid="conversation-delete-s2"]') as HTMLButtonElement).click();
+      fixture.detectChanges();
+      expect(q('[data-testid="conversation-confirm-s2"]')).not.toBeNull();
+      expect(q('[data-testid="conversation-resume-s2"]')).toBeNull();
+      expect(host.deletedPayload).toBeNull();
+    });
+
+    it('confirm button emits deleteConversation with the row payload', () => {
+      host.conversations = sample;
+      fixture.detectChanges();
+      (q('[data-testid="conversation-delete-s2"]') as HTMLButtonElement).click();
+      fixture.detectChanges();
+      (q('[data-testid="conversation-confirm-yes-s2"]') as HTMLButtonElement).click();
+      expect(host.deletedPayload?.session_id).toBe('s2');
+    });
+
+    it('cancel button reverts to the row without emitting', () => {
+      host.conversations = sample;
+      fixture.detectChanges();
+      (q('[data-testid="conversation-delete-s2"]') as HTMLButtonElement).click();
+      fixture.detectChanges();
+      (q('[data-testid="conversation-confirm-no-s2"]') as HTMLButtonElement).click();
+      fixture.detectChanges();
+      expect(q('[data-testid="conversation-confirm-s2"]')).toBeNull();
+      expect(q('[data-testid="conversation-resume-s2"]')).not.toBeNull();
+      expect(host.deletedPayload).toBeNull();
+    });
+
+    it('only one row can be in confirm state at a time', () => {
+      host.conversations = sample;
+      fixture.detectChanges();
+      (q('[data-testid="conversation-delete-s1"]') as HTMLButtonElement).click();
+      fixture.detectChanges();
+      (q('[data-testid="conversation-delete-s2"]') as HTMLButtonElement).click();
+      fixture.detectChanges();
+      expect(q('[data-testid="conversation-confirm-s1"]')).toBeNull();
+      expect(q('[data-testid="conversation-confirm-s2"]')).not.toBeNull();
     });
   });
 });

--- a/desktop/src/src/app/chat/conversations-sidebar/conversations-sidebar.component.spec.ts
+++ b/desktop/src/src/app/chat/conversations-sidebar/conversations-sidebar.component.spec.ts
@@ -258,5 +258,29 @@ describe('ConversationsSidebarComponent', () => {
       expect(q('[data-testid="conversation-confirm-s1"]')).toBeNull();
       expect(q('[data-testid="conversation-confirm-s2"]')).not.toBeNull();
     });
+
+    it('clears the confirm state when the drawer is closed and reopened', () => {
+      // Drive the child input directly so we can toggle `open` without going
+      // through the host wrapper's separate fixture lifecycle.
+      fixture.destroy();
+      const childFixture = TestBed.createComponent(ConversationsSidebarComponent);
+      childFixture.componentRef.setInput('conversations', sample);
+      childFixture.componentRef.setInput('open', true);
+      childFixture.detectChanges();
+      TestBed.tick();
+      (q('[data-testid="conversation-delete-s2"]') as HTMLButtonElement).click();
+      childFixture.detectChanges();
+      expect(q('[data-testid="conversation-confirm-s2"]')).not.toBeNull();
+
+      childFixture.componentRef.setInput('open', false);
+      childFixture.detectChanges();
+      TestBed.tick();
+      childFixture.componentRef.setInput('open', true);
+      childFixture.detectChanges();
+      TestBed.tick();
+      expect(q('[data-testid="conversation-confirm-s2"]')).toBeNull();
+      expect(q('[data-testid="conversation-resume-s2"]')).not.toBeNull();
+      childFixture.destroy();
+    });
   });
 });

--- a/desktop/src/src/app/chat/conversations-sidebar/conversations-sidebar.component.ts
+++ b/desktop/src/src/app/chat/conversations-sidebar/conversations-sidebar.component.ts
@@ -142,8 +142,9 @@ const BUCKET_ORDER: readonly { key: string; label: string }[] = [
               </div>
               @for (row of group.rows; track row.conv.session_id) {
                 @let active = row.conv.session_id === currentSessionId();
+                @let pendingDelete = row.conv.session_id === pendingDeleteId();
                 <div
-                  class="flex items-stretch border-l-2"
+                  class="group flex items-stretch border-l-2"
                   [class]="
                     active
                       ? 'border-[var(--accent)] bg-[var(--bg-2)]'
@@ -151,25 +152,63 @@ const BUCKET_ORDER: readonly { key: string; label: string }[] = [
                   "
                   data-testid="conversations-sidebar-row"
                 >
-                  <!-- Row click resumes directly — no "view → resume" two-step. -->
-                  <button
-                    type="button"
-                    class="min-w-0 flex-1 px-3 py-2 text-left"
-                    [attr.data-testid]="'conversation-resume-' + row.conv.session_id"
-                    [attr.aria-current]="active ? 'true' : null"
-                    aria-label="Resume conversation"
-                    (click)="resumeConversation.emit(row.conv)"
-                  >
+                  @if (pendingDelete) {
                     <div
-                      class="truncate text-[13px]"
-                      [class]="active ? 'text-[var(--ink)]' : 'text-[var(--ink-dim)]'"
+                      class="flex min-w-0 flex-1 items-center justify-between gap-2 px-3 py-2"
+                      [attr.data-testid]="'conversation-confirm-' + row.conv.session_id"
+                      role="alertdialog"
+                      aria-label="Confirm delete conversation"
                     >
-                      {{ row.preview }}
+                      <span class="mono truncate text-[11.5px] text-[var(--ink-dim)]"> Sure? </span>
+                      <div class="flex shrink-0 items-center gap-1">
+                        <button
+                          type="button"
+                          class="mono rounded border border-red-500/40 px-2 py-0.5 text-[11px] text-red-300 hover:bg-red-500/10"
+                          [attr.data-testid]="'conversation-confirm-yes-' + row.conv.session_id"
+                          (click)="confirmDelete(row.conv)"
+                        >
+                          delete
+                        </button>
+                        <button
+                          type="button"
+                          class="mono rounded border border-[var(--line)] px-2 py-0.5 text-[11px] text-[var(--ink-mute)] hover:text-[var(--ink)]"
+                          [attr.data-testid]="'conversation-confirm-no-' + row.conv.session_id"
+                          (click)="cancelDelete()"
+                        >
+                          cancel
+                        </button>
+                      </div>
                     </div>
-                    <div class="mono mt-0.5 text-[10px] text-[var(--ink-mute)]">
-                      {{ row.conv.message_count }} · {{ row.timestamp }}
-                    </div>
-                  </button>
+                  } @else {
+                    <!-- Row click resumes directly — no "view → resume" two-step. -->
+                    <button
+                      type="button"
+                      class="min-w-0 flex-1 px-3 py-2 text-left"
+                      [attr.data-testid]="'conversation-resume-' + row.conv.session_id"
+                      [attr.aria-current]="active ? 'true' : null"
+                      aria-label="Resume conversation"
+                      (click)="resumeConversation.emit(row.conv)"
+                    >
+                      <div
+                        class="truncate text-[13px]"
+                        [class]="active ? 'text-[var(--ink)]' : 'text-[var(--ink-dim)]'"
+                      >
+                        {{ row.preview }}
+                      </div>
+                      <div class="mono mt-0.5 text-[10px] text-[var(--ink-mute)]">
+                        {{ row.conv.message_count }} · {{ row.timestamp }}
+                      </div>
+                    </button>
+                    <button
+                      type="button"
+                      class="flex shrink-0 items-center px-2 text-[var(--ink-mute)] opacity-0 hover:text-red-300 focus:opacity-100 group-hover:opacity-100"
+                      [attr.data-testid]="'conversation-delete-' + row.conv.session_id"
+                      [attr.aria-label]="'Delete conversation ' + row.preview"
+                      (click)="requestDelete(row.conv)"
+                    >
+                      <app-icon name="trash" class="h-4 w-4" />
+                    </button>
+                  }
                 </div>
               }
             }
@@ -191,9 +230,14 @@ export class ConversationsSidebarComponent {
   readonly closed = output<void>();
   /** Resume `conv` as the live session — emitted on row click (primary action). */
   readonly resumeConversation = output<ConversationSummary>();
+  /** Delete confirmed for `conv`; parent calls the backend + reloads. */
+  readonly deleteConversation = output<ConversationSummary>();
 
   /** Free-text filter applied to the buckets — narrows preview matches case-insensitively. */
   protected readonly query = signal('');
+
+  /** Session id pending confirm; `null` when no row is in the confirm state. */
+  protected readonly pendingDeleteId = signal<string | null>(null);
 
   /** Template containing the drawer content — handed to the CDK overlay portal. */
   protected readonly content = viewChild.required<TemplateRef<unknown>>('content');
@@ -253,6 +297,19 @@ export class ConversationsSidebarComponent {
   protected onQuery(event: Event): void {
     const target = event.target as HTMLInputElement | null;
     this.query.set(target?.value ?? '');
+  }
+
+  protected requestDelete(conv: ConversationSummary): void {
+    this.pendingDeleteId.set(conv.session_id);
+  }
+
+  protected confirmDelete(conv: ConversationSummary): void {
+    this.pendingDeleteId.set(null);
+    this.deleteConversation.emit(conv);
+  }
+
+  protected cancelDelete(): void {
+    this.pendingDeleteId.set(null);
   }
 
   private openOverlay(): void {

--- a/desktop/src/src/app/chat/conversations-sidebar/conversations-sidebar.component.ts
+++ b/desktop/src/src/app/chat/conversations-sidebar/conversations-sidebar.component.ts
@@ -337,6 +337,7 @@ export class ConversationsSidebarComponent {
 
   private closeOverlay(): void {
     if (this.overlayRef === null) return;
+    this.pendingDeleteId.set(null);
     this.overlayRef.dispose();
     this.overlayRef = null;
   }

--- a/desktop/src/src/app/shared/icon.component.ts
+++ b/desktop/src/src/app/shared/icon.component.ts
@@ -26,7 +26,8 @@ export type IconName =
   | 'settings'
   | 'document'
   | 'microphone'
-  | 'refresh';
+  | 'refresh'
+  | 'trash';
 
 /**
  * Inline SVG icon — glyphs taken verbatim from the terminal-minimal mockup
@@ -144,6 +145,12 @@ export type IconName =
           <path
             d="M4 4v5h.582m15.356 2A8.001 8.001 0 0 0 4.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 0 1-15.357-2m15.357 2H15"
           />
+        }
+        @case ('trash') {
+          <path d="M3 6h18" />
+          <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+          <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+          <path d="M10 11v6M14 11v6" />
         }
       }
     </svg>

--- a/docs/guides/desktop.md
+++ b/docs/guides/desktop.md
@@ -84,6 +84,10 @@ claude-opus-4-7 │ CTX ██░░░ 2% │ 116k/1M │ Limit ░░░░░
 
 Settings invalidates the persisted layer by calling `ChatStateService.refreshLlmConfigCache()` after `update_llm_config` settles, so the footer reflects the new model's window immediately rather than waiting for the next session start.
 
+### Conversation history sidebar
+
+Opens with the **History** button in the chat header (or ⌘B). Lists past sessions for the active project, grouped by today / yesterday / older, with a search filter. Clicking a row resumes that session in live chat. The trash icon next to each row (visible on hover) deletes the underlying JSONL transcript file — a one-tap inline confirm asks **Sure?** before the file is removed. Deletion is irreversible; deleting the currently active session resets the chat to a fresh conversation.
+
 ### Stopping a conversation
 
 While Claude is responding, press **Esc** or click the red **Stop** button next to the message input to interrupt the current turn. The partial response is preserved in the conversation history, in-flight tools are stopped, and the input is immediately re-enabled so you can send the next message. **Esc is ignored while an "ask user" question is visible** — answer or dismiss that prompt first; the Stop button still works in that case and will drop the question.


### PR DESCRIPTION
## Summary
- Adds a trash button next to each row in the Conversations drawer (visible on hover). Clicking swaps the row into an inline "Sure?" confirm with delete / cancel buttons — no separate modal.
- New `delete_conversation` Tauri command + `history::delete_conversation` helper that removes the session JSONL file. Path-traversal-safe (reuses the existing UUID validator) and idempotent when the file is already gone.
- If the active live session is the one being deleted, the chat resets and re-initialises so resume/retry don't fail against a missing transcript.

Closes #656.

## Test plan
- [x] `make test-desktop` — 1291 tests pass (incl. 5 new `delete_conversation_*` cases: existing file, missing file, path traversal, empty session id, isolation from other sessions)
- [x] `make test-angular` — 1852 tests pass (incl. 4 new sidebar specs covering trash → confirm → emit, cancel, single-row confirm state, and 4 new chat.component specs covering the happy path, missing project, backend failure keeps row, deleting the active session resets live chat)
- [x] `make check` — clippy, fmt, MCP type-check, ESLint all green
- [x] Manual: delete one of many conversations in the drawer; confirm/cancel both work; active-session delete clears the chat