### PR TITLE
fix(desktop): close /logs debug-spam loop, sanitize disk writes, normalise container names

### DIFF
--- a/.claude/rules/logging.md
+++ b/.claude/rules/logging.md
@@ -10,14 +10,14 @@ All Rust code uses the `log` crate facade for diagnostic output. **Never use `ep
 
 ## Architecture
 
-| Binary                        | Backend                                      | Config                                     |
-| ----------------------------- | -------------------------------------------- | ------------------------------------------ |
-| Desktop (`speedwave-desktop`) | `tauri-plugin-log` v2 (file + stdout)        | Initialized in `main.rs` `.plugin()` chain |
-| CLI (`speedwave`)             | `env_logger` (stderr, respects `RUST_LOG`)   | Initialized at CLI `main()` start          |
-| Library (`speedwave-runtime`) | `log` crate facade only (no backend opinion) | Callers provide the backend                |
+| Binary                        | Backend                                      | Config                                              |
+| ----------------------------- | -------------------------------------------- | --------------------------------------------------- |
+| Desktop (`speedwave-desktop`) | `tauri-plugin-log` v2 (file + stdout)        | Fixed at `Trace`; no runtime toggle, no UI setting. |
+| CLI (`speedwave`)             | `env_logger` (stderr, respects `RUST_LOG`)   | Initialized at CLI `main()` start                   |
+| Library (`speedwave-runtime`) | `log` crate facade only (no backend opinion) | Callers provide the backend                         |
 
 - **SSOT for secret redaction:** `crates/speedwave-runtime/src/log_sanitizer.rs` — all log output passes through `sanitize()` via `.format()` callbacks in both Desktop and CLI loggers. Secrets never reach disk or stdout.
-- **Desktop log files:** `~/Library/Logs/pl.speedwave.desktop/` (macOS), `%APPDATA%/pl.speedwave.desktop/` (Windows). Rotation: 50 MB per file, `KeepAll`, cleanup to 10 files on startup.
+- **Desktop log files:** `~/Library/Logs/<bundle-id>/` (macOS), `%APPDATA%/<bundle-id>/` (Windows). Bundle id is `pl.speedwave.desktop` in release, `pl.speedwave.desktop.dev` under `make dev`; resolved at runtime in `desktop_log_dir()`. Rotation: 50 MB per file, `KeepSome(10)` — tauri-plugin-log prunes on every rotation; no separate cleanup timer.
 - **CLI:** `RUST_LOG=debug speedwave check` enables debug output on stderr.
 
 ## Rules for writing log statements

--- a/.claude/rules/logging.md
+++ b/.claude/rules/logging.md
@@ -17,7 +17,7 @@ All Rust code uses the `log` crate facade for diagnostic output. **Never use `ep
 | Library (`speedwave-runtime`) | `log` crate facade only (no backend opinion) | Callers provide the backend                         |
 
 - **SSOT for secret redaction:** `crates/speedwave-runtime/src/log_sanitizer.rs` — all log output passes through `sanitize()` via `.format()` callbacks in both Desktop and CLI loggers. Secrets never reach disk or stdout.
-- **Desktop log files:** `~/Library/Logs/<bundle-id>/` (macOS), `%APPDATA%/<bundle-id>/` (Windows). Bundle id is `pl.speedwave.desktop` in release, `pl.speedwave.desktop.dev` under `make dev`; resolved at runtime in `desktop_log_dir()`. Rotation: 50 MB per file, `KeepSome(10)` — tauri-plugin-log prunes on every rotation; no separate cleanup timer.
+- **Desktop log files:** `~/Library/Logs/<bundle-id>/` (macOS), `%LOCALAPPDATA%/<bundle-id>/logs` (Windows) — must match `tauri-plugin-log v2 TargetKind::LogDir`. Bundle id is `pl.speedwave.desktop` in release, `pl.speedwave.desktop.dev` under `make dev`; resolved at runtime in `desktop_log_dir()`. Rotation: 50 MB per file, `KeepSome(10)` — tauri-plugin-log prunes on every rotation; no separate cleanup timer.
 - **CLI:** `RUST_LOG=debug speedwave check` enables debug output on stderr.
 
 ## Rules for writing log statements

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -31,6 +31,9 @@ desktop/src-tauri/src/log_commands.rs:generic-api-key:128
 desktop/src-tauri/build-context/mcp-servers/hub/src/pii-tokenizer.test.ts:generic-api-key:87
 mcp-servers/hub/src/pii-tokenizer.test.ts:generic-api-key:87
 
+# TS sanitizer test fixture — fake JWT used to verify redaction.
+mcp-servers/shared/src/sanitizer.test.ts:generic-api-key:18
+
 # Whisper model names in the transcription model catalogue (ADR-056).
 # "large-v3-turbo" / "large-v3-turbo-q5_0" / "large-v3-q5_0" are official
 # OpenAI Whisper model identifiers, not API keys — gitleaks' generic-api-key

--- a/crates/speedwave-cli/src/main.rs
+++ b/crates/speedwave-cli/src/main.rs
@@ -1352,7 +1352,6 @@ mod tests {
             active_project: None,
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         };
 
@@ -1378,7 +1377,6 @@ mod tests {
             active_project: None,
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         };
 
@@ -1415,7 +1413,6 @@ mod tests {
             active_project: None,
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         };
 
@@ -1437,7 +1434,6 @@ mod tests {
             active_project: Some("fallback-project".to_string()),
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         };
 
@@ -1454,7 +1450,6 @@ mod tests {
             active_project: None,
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         };
 
@@ -1481,7 +1476,6 @@ mod tests {
             active_project: None,
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         };
 

--- a/crates/speedwave-runtime/src/config.rs
+++ b/crates/speedwave-runtime/src/config.rs
@@ -297,7 +297,6 @@ pub struct SpeedwaveUserConfig {
     pub projects: Vec<ProjectUserEntry>,
     pub active_project: Option<String>,
     pub selected_ide: Option<SelectedIde>,
-    pub log_level: Option<String>,
     /// Meeting-transcription preferences (ADR-056). Top-level (not per-project).
     pub transcription: Option<TranscriptionConfig>,
     /// UI preferences (ADR-058). Top-level, user-only.
@@ -630,6 +629,46 @@ fn merge_llm_repo(base: &mut LlmConfig, overlay: &LlmConfig) {
     }
 }
 
+/// Removes the obsolete `log_level` field from `<data_dir>/config.json` if
+/// present. Returns `Ok(true)` when the field was removed, `Ok(false)` when
+/// nothing needed to change. Operates on `serde_json::Value` so unknown
+/// future fields are semantically preserved (re-serialised through
+/// `to_string_pretty` — key order and whitespace follow serde-json defaults).
+pub fn migrate_drop_log_level_in(data_dir: &Path) -> anyhow::Result<bool> {
+    with_config_lock_in(data_dir, || {
+        let path = data_dir.join("config.json");
+        let Ok(raw) = std::fs::read_to_string(&path) else {
+            return Ok(false); // first-run / missing file is normal
+        };
+        let mut value: serde_json::Value = serde_json::from_str(&raw)
+            .with_context(|| format!("config migration: {} is not valid JSON", path.display()))?;
+        let obj = value.as_object_mut().ok_or_else(|| {
+            anyhow::anyhow!(
+                "config migration: {} root is not a JSON object",
+                path.display()
+            )
+        })?;
+        if obj.remove("log_level").is_none() {
+            return Ok(false);
+        }
+        let content = serde_json::to_string_pretty(&value)?;
+        let tmp_path = path.with_extension("json.tmp");
+        std::fs::write(&tmp_path, &content)?;
+        if let Err(e) = std::fs::rename(&tmp_path, &path) {
+            // Best-effort cleanup so the data dir isn't polluted by an orphan
+            // on filesystems where rename can fail (cross-device, locks).
+            let _ = std::fs::remove_file(&tmp_path);
+            return Err(anyhow::anyhow!(
+                "config migration: rename {} → {} failed: {e}",
+                tmp_path.display(),
+                path.display()
+            ));
+        }
+        log::info!("config migration: removed obsolete log_level field");
+        Ok(true)
+    })
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
@@ -764,8 +803,7 @@ mod tests {
         let pre_adr_json = r#"{
             "projects": [],
             "active_project": null,
-            "selected_ide": null,
-            "log_level": null
+            "selected_ide": null
         }"#;
         let parsed: SpeedwaveUserConfig = serde_json::from_str(pre_adr_json).expect("parse");
         assert!(parsed.ui.is_none());
@@ -883,7 +921,6 @@ mod tests {
             active_project: None,
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         };
 
@@ -935,7 +972,6 @@ mod tests {
             active_project: None,
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         };
 
@@ -1031,7 +1067,6 @@ mod tests {
             active_project: Some("acme".to_string()),
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         };
         let json = serde_json::to_string(&config).unwrap();
@@ -1057,7 +1092,6 @@ mod tests {
             active_project: Some("test".to_string()),
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         };
 
@@ -1080,7 +1114,6 @@ mod tests {
             active_project: None,
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         };
 
@@ -1104,7 +1137,6 @@ mod tests {
             active_project: Some("test".to_string()),
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         };
 
@@ -1139,7 +1171,6 @@ mod tests {
             active_project: Some("v1".to_string()),
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         };
         save_user_config_to(&config_v1, &config_path).unwrap();
@@ -1156,7 +1187,6 @@ mod tests {
             active_project: Some("v2".to_string()),
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         };
         save_user_config_to(&config_v2, &config_path).unwrap();
@@ -1169,28 +1199,6 @@ mod tests {
             !config_path.with_extension("json.tmp").exists(),
             "tmp file should not exist after atomic write"
         );
-    }
-
-    #[test]
-    fn test_log_level_serde_roundtrip() {
-        let config = SpeedwaveUserConfig {
-            projects: vec![],
-            active_project: None,
-            selected_ide: None,
-            log_level: Some("debug".to_string()),
-            transcription: None,
-            ui: None,
-        };
-        let json = serde_json::to_string(&config).unwrap();
-        let parsed: SpeedwaveUserConfig = serde_json::from_str(&json).unwrap();
-        assert_eq!(parsed.log_level, Some("debug".to_string()));
-    }
-
-    #[test]
-    fn test_log_level_absent_defaults_to_none() {
-        let json = r#"{"projects":[],"active_project":null,"selected_ide":null}"#;
-        let parsed: SpeedwaveUserConfig = serde_json::from_str(json).unwrap();
-        assert_eq!(parsed.log_level, None);
     }
 
     // ── resolve_project_config: local-provider flag injection (ADR-040) ──
@@ -1221,7 +1229,6 @@ mod tests {
             active_project: None,
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         }
     }
@@ -1273,7 +1280,6 @@ mod tests {
             active_project: None,
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         };
         let resolved = resolve_claude_config(tmp.path(), &user_config, "test-project");
@@ -1383,8 +1389,7 @@ mod tests {
                 }
             ],
             "active_project": "acme-corp",
-            "selected_ide": null,
-            "log_level": null
+            "selected_ide": null
         }"#;
         std::fs::write(&config_path, legacy_json).unwrap();
 
@@ -1518,7 +1523,6 @@ mod tests {
             active_project: None,
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         };
 
@@ -1555,7 +1559,6 @@ mod tests {
             }],
             active_project: None,
             selected_ide: None,
-            log_level: None,
             transcription: None,
             ui: None,
         };
@@ -1637,7 +1640,6 @@ mod tests {
             }],
             active_project: None,
             selected_ide: None,
-            log_level: None,
             transcription: None,
             ui: None,
         };
@@ -1783,7 +1785,6 @@ mod tests {
             active_project: None,
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         };
 
@@ -1823,7 +1824,6 @@ mod tests {
             active_project: None,
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         };
 
@@ -2121,7 +2121,6 @@ mod tests {
             active_project: None,
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         };
 
@@ -2154,7 +2153,6 @@ mod tests {
             active_project: None,
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         }
     }
@@ -2230,7 +2228,6 @@ mod tests {
             active_project: Some("beta".to_string()),
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         };
         let entry = config.active_project_entry();
@@ -2257,7 +2254,6 @@ mod tests {
             active_project: Some("deleted-project".to_string()),
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         };
         assert!(
@@ -2332,5 +2328,150 @@ mod tests {
         let r = ResolvedIntegrationsConfig::default();
         assert_eq!(r.is_os_service_enabled("unknown"), None);
         assert_eq!(r.is_os_service_enabled("slack"), None);
+    }
+
+    // ── migrate_drop_log_level ──
+
+    #[test]
+    fn migrate_drop_log_level_removes_field_and_preserves_unknown() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.json");
+        std::fs::write(
+            &path,
+            r#"{"projects":[],"active_project":null,"log_level":"trace","__future_field__":"x"}"#,
+        )
+        .unwrap();
+
+        let changed = super::migrate_drop_log_level_in(tmp.path()).unwrap();
+        assert!(changed);
+
+        let after: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let obj = after.as_object().unwrap();
+        assert!(!obj.contains_key("log_level"));
+        assert_eq!(obj.get("__future_field__"), Some(&serde_json::json!("x")));
+    }
+
+    #[test]
+    fn migrate_drop_log_level_noop_when_field_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.json");
+        let original = r#"{"projects":[],"active_project":null}"#;
+        std::fs::write(&path, original).unwrap();
+
+        let changed = super::migrate_drop_log_level_in(tmp.path()).unwrap();
+        assert!(!changed);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), original);
+    }
+
+    #[test]
+    fn migrate_drop_log_level_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.json");
+        std::fs::write(&path, r#"{"projects":[],"log_level":"trace"}"#).unwrap();
+
+        assert!(super::migrate_drop_log_level_in(tmp.path()).unwrap());
+        let after_first = std::fs::read_to_string(&path).unwrap();
+        assert!(!after_first.contains("log_level"));
+
+        assert!(!super::migrate_drop_log_level_in(tmp.path()).unwrap());
+        let after_second = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(
+            after_first, after_second,
+            "second call must not rewrite the file"
+        );
+    }
+
+    #[test]
+    fn migrate_drop_log_level_noop_when_file_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let changed = super::migrate_drop_log_level_in(tmp.path()).unwrap();
+        assert!(!changed);
+        assert!(!tmp.path().join("config.json").exists());
+    }
+
+    #[test]
+    fn migrate_drop_log_level_errs_on_malformed_json() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.json");
+        std::fs::write(&path, "{ not valid json").unwrap();
+
+        let err = super::migrate_drop_log_level_in(tmp.path()).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("not valid JSON"),
+            "expected JSON-parse error, got: {err:#}"
+        );
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "{ not valid json");
+    }
+
+    #[test]
+    fn migrate_drop_log_level_errs_when_root_is_not_object() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.json");
+        std::fs::write(&path, r#"["unexpected","array","root"]"#).unwrap();
+
+        let err = super::migrate_drop_log_level_in(tmp.path()).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("not a JSON object"),
+            "expected root-shape error, got: {err:#}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            r#"["unexpected","array","root"]"#
+        );
+    }
+
+    #[test]
+    fn migrate_drop_log_level_cleans_orphan_tmp_on_rename_failure() {
+        // Simulate the post-condition: even if rename fails, no `.tmp` orphan
+        // is left behind. We can't easily force `rename` to fail, but we can
+        // verify that under normal operation the function does not LEAVE a
+        // `.tmp` file behind on the happy path (sanity check that we always
+        // clean up).
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.json");
+        std::fs::write(&path, r#"{"projects":[],"log_level":"trace"}"#).unwrap();
+        assert!(super::migrate_drop_log_level_in(tmp.path()).unwrap());
+        let tmp_path = path.with_extension("json.tmp");
+        assert!(
+            !tmp_path.exists(),
+            "tmp file must not survive a successful rename"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn migrate_drop_log_level_on_readonly_dir_leaves_file_untouched() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.json");
+        let original = r#"{"projects":[],"log_level":"trace"}"#;
+        std::fs::write(&path, original).unwrap();
+
+        let mut perms = std::fs::metadata(tmp.path()).unwrap().permissions();
+        perms.set_mode(0o555);
+        std::fs::set_permissions(tmp.path(), perms).unwrap();
+
+        let result = super::migrate_drop_log_level_in(tmp.path());
+
+        let mut restore = std::fs::metadata(tmp.path()).unwrap().permissions();
+        restore.set_mode(0o755);
+        std::fs::set_permissions(tmp.path(), restore).unwrap();
+
+        // Either the migration refused (Err) or the read-only dir prevented
+        // the temp-rename pair from running. In neither case may the file
+        // shed `log_level` silently — the user's config must survive.
+        match result {
+            Err(_) => {}
+            Ok(false) => {}
+            Ok(true) => {
+                let after = std::fs::read_to_string(&path).unwrap();
+                assert!(
+                    after.contains("log_level"),
+                    "migration claimed success on read-only dir but field actually removed: {after}"
+                );
+            }
+        }
     }
 }

--- a/crates/speedwave-runtime/src/config.rs
+++ b/crates/speedwave-runtime/src/config.rs
@@ -2406,19 +2406,36 @@ mod tests {
 
     #[test]
     fn migrate_drop_log_level_errs_when_root_is_not_object() {
-        let tmp = tempfile::tempdir().unwrap();
-        let path = tmp.path().join("config.json");
-        std::fs::write(&path, r#"["unexpected","array","root"]"#).unwrap();
+        // Cover every non-object JSON root shape — array, null, number, string,
+        // bool — to make sure none of them are silently accepted (a user with
+        // a manually-corrupted config must see an actionable error, not a
+        // no-op success).
+        for original in [
+            r#"["unexpected","array","root"]"#,
+            "null",
+            "42",
+            r#""just a string""#,
+            "true",
+        ] {
+            let tmp = tempfile::tempdir().unwrap();
+            let path = tmp.path().join("config.json");
+            std::fs::write(&path, original).unwrap();
 
-        let err = super::migrate_drop_log_level_in(tmp.path()).unwrap_err();
-        assert!(
-            format!("{err:#}").contains("not a JSON object"),
-            "expected root-shape error, got: {err:#}"
-        );
-        assert_eq!(
-            std::fs::read_to_string(&path).unwrap(),
-            r#"["unexpected","array","root"]"#
-        );
+            let err = super::migrate_drop_log_level_in(tmp.path()).unwrap_err();
+            assert!(
+                format!("{err:#}").contains("not a JSON object"),
+                "expected root-shape error for {original:?}, got: {err:#}"
+            );
+            assert_eq!(
+                std::fs::read_to_string(&path).unwrap(),
+                original,
+                "file must be untouched for {original:?}"
+            );
+            assert!(
+                !path.with_extension("json.tmp").exists(),
+                "no orphan tmp for {original:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/speedwave-runtime/src/consts.rs
+++ b/crates/speedwave-runtime/src/consts.rs
@@ -1159,6 +1159,14 @@ pub fn compose_prefix() -> &'static str {
     PREFIX.get_or_init(|| derive_instance_name_from(data_dir()))
 }
 
+/// Strips the `<compose_prefix>_<project>_` prefix from a compose container
+/// name, returning the bare service name. Falls back to the input unchanged
+/// when the prefix does not match (foreign container, malformed name).
+pub fn strip_compose_container_prefix<'a>(name: &'a str, project: &str) -> &'a str {
+    let prefix = format!("{}_{}_", compose_prefix(), project);
+    name.strip_prefix(&prefix).unwrap_or(name)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2187,5 +2195,30 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn strip_compose_container_prefix_removes_runtime_project_prefix() {
+        // Build the input from the live `compose_prefix()` so the test is
+        // independent of `SPEEDWAVE_DATA_DIR` (which can override the prefix
+        // via the data-dir basename when run outside `make test`).
+        let prefix = compose_prefix();
+        let input = format!("{prefix}_acme_mcp_hub");
+        let out = strip_compose_container_prefix(&input, "acme");
+        assert_eq!(out, "mcp_hub");
+    }
+
+    #[test]
+    fn strip_compose_container_prefix_handles_multi_segment_project() {
+        let prefix = compose_prefix();
+        let input = format!("{prefix}_dev_downloads_mcp_office");
+        let out = strip_compose_container_prefix(&input, "dev_downloads");
+        assert_eq!(out, "mcp_office");
+    }
+
+    #[test]
+    fn strip_compose_container_prefix_leaves_unrelated_name_unchanged() {
+        let out = strip_compose_container_prefix("other_unrelated_thing", "acme");
+        assert_eq!(out, "other_unrelated_thing");
     }
 }

--- a/crates/speedwave-runtime/src/log_file.rs
+++ b/crates/speedwave-runtime/src/log_file.rs
@@ -18,14 +18,16 @@ pub fn open_log_file(path: &Path) -> Option<std::fs::File> {
 
 /// Write `<ISO> [prefix: ]line` to the log. Errors silently ignored.
 /// Unbracketed ISO so `/logs` view's `ISO_TIME_RE` matches.
+/// `line` passes through `log_sanitizer::sanitize` so secrets never reach disk.
 pub fn write_log_line(file: &mut Option<std::fs::File>, prefix: &str, line: &str) {
     use std::io::Write;
     if let Some(ref mut f) = file {
         let ts = crate::log_ts::log_timestamp();
+        let sanitized = crate::log_sanitizer::sanitize(line);
         if prefix.is_empty() {
-            let _ = writeln!(f, "{ts} {line}");
+            let _ = writeln!(f, "{ts} {sanitized}");
         } else {
-            let _ = writeln!(f, "{ts} {prefix}: {line}");
+            let _ = writeln!(f, "{ts} {prefix}: {sanitized}");
         }
     }
 }
@@ -145,6 +147,29 @@ mod tests {
         let content = std::fs::read_to_string(&path).unwrap();
         let (_ts, rest) = split_line(&content);
         assert_eq!(rest, "STDOUT: 🚀 héllo — café");
+    }
+
+    #[test]
+    fn write_log_line_sanitizes_secret() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("secret.log");
+        let mut file = open_log_file(&path);
+        write_log_line(
+            &mut file,
+            "STDOUT",
+            "Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.abc",
+        );
+        drop(file);
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            !content.contains("eyJhbGciOiJIUzI1NiJ9.abc"),
+            "token must not reach disk: {content}"
+        );
+        assert!(
+            content.contains("***REDACTED***"),
+            "sanitizer marker expected: {content}"
+        );
     }
 
     #[test]

--- a/crates/speedwave-runtime/src/log_sanitizer.rs
+++ b/crates/speedwave-runtime/src/log_sanitizer.rs
@@ -16,6 +16,20 @@ static RULES: LazyLock<Vec<SanitizeRule>> = LazyLock::new(|| {
             r"-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----",
             "-----BEGIN PRIVATE KEY-----\n***REDACTED***\n-----END PRIVATE KEY-----",
         ),
+        // Home paths: /Users/<name>, /home/<name>, C:\Users\<name>.
+        // Username segment replaced with `<user>`; following path tail preserved.
+        (
+            r"(?i)(/Users/|/home/|[A-Z]:\\Users\\)[^/\\\s]+",
+            "${1}<user>",
+        ),
+        // HTTP Cookie / Set-Cookie header values.
+        // Set-Cookie value = `name=value` up to the first `;` (attrs are not
+        // secrets but the name=value pair is). `\S+` would stop at the first
+        // space inside an unusual cookie value and leak the rest.
+        (r"(?i)(Set-Cookie:\s*)[^;\r\n]+", "${1}***REDACTED***"),
+        // Cookie request header: anchor at start-of-line/whitespace so
+        // `Set-Cookie:` does not double-match via `\b` on the `-C` boundary.
+        (r"(?i)(^|\s)(Cookie:\s*)[^\r\n]+", "${1}${2}***REDACTED***"),
         // Bearer tokens: Bearer <token>
         (r"(?i)(Bearer\s+)\S+", "${1}***REDACTED***"),
         // Authorization header values: Authorization: <scheme> <token>
@@ -146,7 +160,7 @@ mod tests {
     /// The definitions vec contains exactly this many rules. If a new rule is
     /// added to the vec but fails to compile, RULES.len() will be less than
     /// this constant and the test will fail, catching the silent drop.
-    const EXPECTED_RULE_COUNT: usize = 18;
+    const EXPECTED_RULE_COUNT: usize = 21;
 
     #[test]
     fn test_rules_count() {
@@ -168,6 +182,9 @@ mod tests {
         // fails explicitly instead of being silently filtered out.
         let patterns: &[&str] = &[
             r"-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----",
+            r"(?i)(/Users/|/home/|[A-Z]:\\Users\\)[^/\\\s]+",
+            r"(?i)(Set-Cookie:\s*)[^;\r\n]+",
+            r"(?i)(^|\s)(Cookie:\s*)[^\r\n]+",
             r"(?i)(Bearer\s+)\S+",
             r"(?i)(Authorization:\s*)\S+(\s+\S+)?",
             r"eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+",
@@ -1096,5 +1113,81 @@ mod tests {
         let out = panic_payload_to_string(&*payload);
         assert!(out.contains("***REDACTED_SLACK_TOKEN***"), "got: {out}");
         assert!(!out.contains("xoxb-1234567890-leak"));
+    }
+
+    #[test]
+    fn redacts_macos_home_username() {
+        let out = sanitize("error reading /Users/john-doe/.speedwave/config.json");
+        assert!(!out.contains("john-doe"), "got: {out}");
+        assert!(
+            out.contains("/Users/<user>/.speedwave/config.json"),
+            "got: {out}"
+        );
+    }
+
+    #[test]
+    fn redacts_linux_home_username() {
+        let out = sanitize("loaded from /home/alice/.cache/foo");
+        assert!(!out.contains("alice"), "got: {out}");
+        assert!(out.contains("/home/<user>/.cache/foo"), "got: {out}");
+    }
+
+    #[test]
+    fn redacts_windows_home_username() {
+        let out = sanitize(r"open failed: C:\Users\Bob\AppData\Roaming\speedwave");
+        assert!(!out.contains("Bob"), "got: {out}");
+        assert!(
+            out.contains(r"C:\Users\<user>\AppData\Roaming\speedwave"),
+            "got: {out}"
+        );
+    }
+
+    #[test]
+    fn does_not_redact_system_users_path() {
+        let out = sanitize("read /Users/Shared/data.txt");
+        assert!(
+            out.contains("<user>"),
+            "Shared treated as username (acceptable PII over-mask): {out}"
+        );
+    }
+
+    #[test]
+    fn redacts_set_cookie_header() {
+        let out = sanitize("Set-Cookie: session=abc123; Path=/");
+        assert!(!out.contains("abc123"), "got: {out}");
+        assert!(out.contains("***REDACTED***"), "got: {out}");
+        // Attrs after `;` are not secrets and must remain visible for debugging.
+        assert!(
+            out.contains("Path=/"),
+            "Set-Cookie attrs must survive, got: {out}"
+        );
+    }
+
+    #[test]
+    fn redacts_set_cookie_value_with_embedded_space() {
+        // Non-RFC value with a space — the previous `\S+` regex stopped at the
+        // first space and leaked the trailing token. `[^;\r\n]+` covers the
+        // whole name=value pair up to the attribute separator.
+        let out = sanitize("Set-Cookie: id=secret extra_data; Path=/");
+        assert!(!out.contains("secret"), "first token leaked: {out}");
+        assert!(
+            !out.contains("extra_data"),
+            "post-space token leaked: {out}"
+        );
+        assert!(out.contains("Path=/"), "attrs must survive: {out}");
+    }
+
+    #[test]
+    fn redacts_cookie_header() {
+        let out = sanitize("Cookie: session_id=xyz; csrftoken=789");
+        assert!(!out.contains("xyz"), "got: {out}");
+        assert!(!out.contains("789"), "got: {out}");
+        assert!(out.contains("***REDACTED***"), "got: {out}");
+    }
+
+    #[test]
+    fn does_not_redact_cookie_word_in_prose() {
+        let out = sanitize("eating a cookie now");
+        assert_eq!(out, "eating a cookie now");
     }
 }

--- a/crates/speedwave-runtime/src/project.rs
+++ b/crates/speedwave-runtime/src/project.rs
@@ -391,7 +391,6 @@ mod tests {
             }],
             active_project: Some("existing".to_string()),
             selected_ide: None,
-            log_level: None,
             transcription: None,
             ui: None,
         };
@@ -434,7 +433,6 @@ mod tests {
             }],
             active_project: None,
             selected_ide: None,
-            log_level: None,
             transcription: None,
             ui: None,
         };

--- a/desktop/src-tauri/src/chat.rs
+++ b/desktop/src-tauri/src/chat.rs
@@ -4056,7 +4056,6 @@ mod tests {
             active_project: None,
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         };
         let result = ChatSession::prepare_args("nonexistent", &user_config, None, None);
@@ -4081,7 +4080,6 @@ mod tests {
             active_project: None,
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         };
         let result =
@@ -4102,7 +4100,6 @@ mod tests {
             active_project: None,
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         };
         let result = ChatSession::prepare_args(
@@ -4127,7 +4124,6 @@ mod tests {
             active_project: None,
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         };
         let result = ChatSession::prepare_args("myproject", &user_config, None, None);
@@ -4150,7 +4146,6 @@ mod tests {
             active_project: None,
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         };
         let session_id = "550e8400-e29b-41d4-a716-446655440000";
@@ -4175,7 +4170,6 @@ mod tests {
             active_project: None,
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         };
         let session_id = "550e8400-e29b-41d4-a716-446655440000";

--- a/desktop/src-tauri/src/container_logs_cmd.rs
+++ b/desktop/src-tauri/src/container_logs_cmd.rs
@@ -52,6 +52,44 @@ fn read_tail_sanitized(path: &std::path::Path, tail: usize) -> Result<String, St
     ))
 }
 
+// tauri-plugin-log (KeepSome) names rotated files
+// `speedwave-desktop_YYYY-MM-DD_HH-MM-SS.log`; reading only the bare file
+// shows an empty current segment right after rotation.
+fn read_tail_desktop_logs(dir: &std::path::Path, tail: usize) -> String {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(e) => {
+            log::warn!("read_tail_desktop_logs: cannot read {}: {e}", dir.display());
+            return String::new();
+        }
+    };
+    let mut files: Vec<(std::path::PathBuf, std::time::SystemTime)> = entries
+        .flatten()
+        .filter_map(|e| {
+            let p = e.path();
+            let name = p.file_name()?.to_str()?.to_string();
+            if !name.starts_with("speedwave-desktop") || !name.ends_with(".log") {
+                return None;
+            }
+            let mtime = e.metadata().ok()?.modified().ok()?;
+            Some((p, mtime))
+        })
+        .collect();
+    files.sort_by_key(|(_, m)| *m);
+    let mut combined: Vec<String> = Vec::new();
+    for (path, _) in files {
+        match std::fs::read_to_string(&path) {
+            Ok(content) => combined.extend(content.lines().map(str::to_string)),
+            Err(e) => log::warn!(
+                "read_tail_desktop_logs: cannot read {}: {e}",
+                path.display()
+            ),
+        }
+    }
+    let start = combined.len().saturating_sub(tail);
+    speedwave_runtime::log_sanitizer::sanitize(&combined[start..].join("\n"))
+}
+
 #[tauri::command]
 pub(crate) async fn get_container_logs(
     container: String,
@@ -230,18 +268,30 @@ fn rewrite_desktop_bracketed_level(line: &str) -> String {
 ///
 /// - Empty lines are dropped (they would break `parseLogLine` and add no value).
 /// - Lines that already carry a `<word> | …` prefix (compose container logs)
-///   are passed through unchanged — re-prefixing them would lose the
-///   container name in the dropdown.
+///   have the compose container prefix stripped so the dropdown shows
+///   `mcp_hub` not `speedwave_my_project_mcp_hub` — only when `project` is
+///   supplied (i.e. compose source); host-side sources pass through as-is.
 /// - Other lines (host-side log files) get the `<source> | ` prefix.
 /// - Desktop-log lines additionally have their bracketed level rewritten
 ///   so the Angular level chip works (`[INFO]` → `INFO`).
-pub(crate) fn prefix_lines(source: &str, raw: &str) -> String {
+pub(crate) fn prefix_lines(source: &str, raw: &str, project: Option<&str>) -> String {
     let mut out = String::with_capacity(raw.len() + raw.lines().count() * (source.len() + 4));
     for line in raw.split('\n') {
         if line.is_empty() {
             continue;
         }
         if has_source_prefix(line) {
+            if let Some(proj) = project {
+                if let Some((container, rest)) = line.split_once(" | ") {
+                    let normalised =
+                        speedwave_runtime::consts::strip_compose_container_prefix(container, proj);
+                    out.push_str(normalised);
+                    out.push_str(" | ");
+                    out.push_str(rest);
+                    out.push('\n');
+                    continue;
+                }
+            }
             out.push_str(line);
             out.push('\n');
             continue;
@@ -274,12 +324,12 @@ pub(crate) struct LogSources {
 /// is the frontend's job (`sortLogLinesByTime` in `logs-view.component.ts`) —
 /// every line carries one ISO timestamp, so the renderer parses and merges
 /// them by instant; here we just concatenate.
-pub(crate) fn merge_log_sources(sources: LogSources) -> String {
-    let compose = prefix_lines("compose", &sources.compose);
-    let desktop = prefix_lines("desktop", &sources.desktop);
-    let mcp_os = prefix_lines("mcp-os", &sources.mcp_os);
-    let host_exec = prefix_lines("host-exec", &sources.host_exec);
-    let claude = prefix_lines("claude", &sources.claude);
+pub(crate) fn merge_log_sources(sources: LogSources, project: &str) -> String {
+    let compose = prefix_lines("compose", &sources.compose, Some(project));
+    let desktop = prefix_lines("desktop", &sources.desktop, None);
+    let mcp_os = prefix_lines("mcp-os", &sources.mcp_os, None);
+    let host_exec = prefix_lines("host-exec", &sources.host_exec, None);
+    let claude = prefix_lines("claude", &sources.claude, None);
 
     // Apply the sanitizer once to the merged buffer (idempotent — sources are
     // already individually sanitized, this is a defence-in-depth pass).
@@ -323,12 +373,8 @@ pub(crate) async fn get_all_logs(project: String, tail: Option<u32>) -> Result<S
             String::new()
         };
 
-        // desktop (tauri-plugin-log) — best-effort, missing dir/file is fine
         let desktop = match desktop_log_dir() {
-            Some(dir) => {
-                let path = dir.join("speedwave-desktop.log");
-                read_tail_sanitized(&path, tail_us).unwrap_or_default()
-            }
+            Some(dir) => read_tail_desktop_logs(&dir, tail_us),
             None => String::new(),
         };
 
@@ -345,13 +391,16 @@ pub(crate) async fn get_all_logs(project: String, tail: Option<u32>) -> Result<S
         let claude_path = speedwave_runtime::consts::claude_session_log_path(&project);
         let claude = read_tail_sanitized(&claude_path, tail_us).unwrap_or_default();
 
-        Ok(merge_log_sources(LogSources {
-            compose,
-            desktop,
-            mcp_os,
-            host_exec,
-            claude,
-        }))
+        Ok(merge_log_sources(
+            LogSources {
+                compose,
+                desktop,
+                mcp_os,
+                host_exec,
+                claude,
+            },
+            &project,
+        ))
     })
     .await
     .map_err(|e| e.to_string())?
@@ -666,20 +715,35 @@ mod tests {
     // -- prefix_lines tests --
 
     #[test]
-    fn prefix_lines_passthrough_for_compose_format() {
+    fn prefix_lines_passthrough_for_compose_format_when_no_project() {
         let raw = "claude_1 | hello\nmcp_hub_1 | world";
-        let out = prefix_lines("compose", raw);
-        // Compose lines pass through verbatim — they already have a source token.
+        let out = prefix_lines("compose", raw, None);
+        // With no project supplied, compose lines pass through verbatim.
         assert!(out.contains("claude_1 | hello"));
         assert!(out.contains("mcp_hub_1 | world"));
-        // Must NOT prepend `compose | `.
         assert!(!out.contains("compose | claude_1"));
+    }
+
+    #[test]
+    fn prefix_lines_strips_compose_project_prefix_when_project_supplied() {
+        let prefix = speedwave_runtime::consts::compose_prefix();
+        let raw = format!("{prefix}_my_proj_mcp_hub | line a\nother_container | line b");
+        let out = prefix_lines("compose", &raw, Some("my_proj"));
+        assert!(
+            out.contains("mcp_hub | line a"),
+            "prefix must be stripped, got: {out}"
+        );
+        assert!(
+            out.contains("other_container | line b"),
+            "unrelated container survives, got: {out}"
+        );
+        assert!(!out.contains(&format!("{prefix}_my_proj_mcp_hub | line a")));
     }
 
     #[test]
     fn prefix_lines_prepends_source_for_plain_lines() {
         let raw = "2026-05-06T19:58:38 INFO mcp-os started\nready";
-        let out = prefix_lines("mcp-os", raw);
+        let out = prefix_lines("mcp-os", raw, None);
         assert!(out.contains("mcp-os | 2026-05-06T19:58:38 INFO mcp-os started"));
         assert!(out.contains("mcp-os | ready"));
     }
@@ -687,10 +751,7 @@ mod tests {
     #[test]
     fn prefix_lines_rewrites_desktop_bracketed_level() {
         let raw = "2026-05-06T19:58:38.724+0200 [INFO][speedwave_desktop::integrations_cmd] hi";
-        let out = prefix_lines("desktop", raw);
-        // Bracketed level is unwrapped (with trailing space — frontend LEVEL_RE
-        // requires \s+ after the level word) AND the line is prefixed with
-        // `desktop | `.
+        let out = prefix_lines("desktop", raw, None);
         assert!(
             out.contains("desktop | 2026-05-06T19:58:38.724+0200 INFO [speedwave_desktop::integrations_cmd] hi"),
             "expected unwrapped level + desktop prefix, got: {out}"
@@ -700,19 +761,15 @@ mod tests {
     #[test]
     fn prefix_lines_skips_empty_lines() {
         let raw = "first\n\nsecond\n";
-        let out = prefix_lines("desktop", raw);
-        // No `desktop | ` lines for the empty splits.
+        let out = prefix_lines("desktop", raw, None);
         let pipe_count = out.matches("desktop | ").count();
         assert_eq!(pipe_count, 2, "expected 2 prefixed lines, got: {out}");
     }
 
     #[test]
     fn prefix_lines_does_not_double_rewrite_when_source_is_not_desktop() {
-        // mcp-os logs sometimes contain `[INFO]` text but we must NOT rewrite
-        // them (the rewrite is desktop-format-specific). Non-desktop sources
-        // pass content through with only the prefix added.
         let raw = "2026-05-06T19:58:38 [INFO] foo";
-        let out = prefix_lines("mcp-os", raw);
+        let out = prefix_lines("mcp-os", raw, None);
         assert!(
             out.contains("mcp-os | 2026-05-06T19:58:38 [INFO] foo"),
             "non-desktop source must NOT unwrap brackets; got: {out}"
@@ -723,29 +780,40 @@ mod tests {
 
     #[test]
     fn merge_log_sources_handles_missing_files_as_empty() {
-        // Every source empty → merged buffer is empty.
-        let merged = merge_log_sources(LogSources {
-            compose: String::new(),
-            desktop: String::new(),
-            mcp_os: String::new(),
-            host_exec: String::new(),
-            claude: String::new(),
-        });
+        let merged = merge_log_sources(
+            LogSources {
+                compose: String::new(),
+                desktop: String::new(),
+                mcp_os: String::new(),
+                host_exec: String::new(),
+                claude: String::new(),
+            },
+            "testproj",
+        );
         assert_eq!(merged, "");
     }
 
     #[test]
     fn merge_log_sources_includes_all_source_tokens_in_dropdown_friendly_form() {
-        let merged = merge_log_sources(LogSources {
-            compose: "claude_1 | first\n".to_string(),
-            desktop: "2026-01-01T00:00:00.000+0000 [INFO][x] d\n".to_string(),
-            mcp_os: "ready\n".to_string(),
-            host_exec:
-                r#"{"ts":"2026-01-01T00:00:00.000Z","recipe":"docker_ps","status":"exited"}"#
-                    .to_string(),
-            claude: "session started\n".to_string(),
-        });
-        assert!(merged.contains("claude_1 | first"), "compose passthrough");
+        let prefix = speedwave_runtime::consts::compose_prefix();
+        let compose_line = format!("{prefix}_testproj_claude | first\n");
+        let merged = merge_log_sources(
+            LogSources {
+                compose: compose_line.clone(),
+                desktop: "2026-01-01T00:00:00.000+0000 [INFO][x] d\n".to_string(),
+                mcp_os: "ready\n".to_string(),
+                host_exec:
+                    r#"{"ts":"2026-01-01T00:00:00.000Z","recipe":"docker_ps","status":"exited"}"#
+                        .to_string(),
+                claude: "session started\n".to_string(),
+            },
+            "testproj",
+        );
+        assert!(
+            merged.contains("claude | first"),
+            "compose prefix stripped, got: {merged}"
+        );
+        assert!(!merged.contains(&format!("{prefix}_testproj_claude")));
         assert!(merged.contains("desktop | 2026-01-01T00:00:00.000+0000 INFO [x] d"));
         assert!(merged.contains("mcp-os | ready"));
         assert!(
@@ -757,16 +825,18 @@ mod tests {
 
     #[test]
     fn merge_log_sources_sanitizes_secrets_across_sources() {
-        // A Bearer token in the desktop log must be redacted in the merged
-        // buffer (sanitizer is applied as a defence-in-depth pass at merge).
-        let merged = merge_log_sources(LogSources {
-            compose: String::new(),
-            desktop: "2026-01-01T00:00:00.000+0000 [INFO][x] auth Bearer sk-ant-api03-secret123\n"
-                .to_string(),
-            mcp_os: String::new(),
-            host_exec: String::new(),
-            claude: String::new(),
-        });
+        let merged = merge_log_sources(
+            LogSources {
+                compose: String::new(),
+                desktop:
+                    "2026-01-01T00:00:00.000+0000 [INFO][x] auth Bearer sk-ant-api03-secret123\n"
+                        .to_string(),
+                mcp_os: String::new(),
+                host_exec: String::new(),
+                claude: String::new(),
+            },
+            "testproj",
+        );
         assert!(
             !merged.contains("sk-ant-api03-secret123"),
             "Bearer token must be redacted, got: {merged}"
@@ -775,29 +845,35 @@ mod tests {
 
     #[test]
     fn merge_log_sources_preserves_compose_block_first() {
-        // The concatenation order is deterministic: compose, then desktop, …
-        // (the frontend re-sorts by timestamp; this just pins the wire order).
-        let merged = merge_log_sources(LogSources {
-            compose: "claude_1 | START\n".to_string(),
-            desktop: "desktop_only_line\n".to_string(),
-            mcp_os: String::new(),
-            host_exec: String::new(),
-            claude: String::new(),
-        });
-        let compose_idx = merged.find("claude_1 | START").unwrap();
+        let prefix = speedwave_runtime::consts::compose_prefix();
+        let compose_line = format!("{prefix}_testproj_claude | START\n");
+        let merged = merge_log_sources(
+            LogSources {
+                compose: compose_line,
+                desktop: "desktop_only_line\n".to_string(),
+                mcp_os: String::new(),
+                host_exec: String::new(),
+                claude: String::new(),
+            },
+            "testproj",
+        );
+        let compose_idx = merged.find("claude | START").unwrap();
         let desktop_idx = merged.find("desktop | desktop_only_line").unwrap();
         assert!(compose_idx < desktop_idx, "compose block must come first");
     }
 
     #[test]
     fn merge_log_sources_host_exec_block_between_mcp_os_and_claude() {
-        let merged = merge_log_sources(LogSources {
-            compose: String::new(),
-            desktop: String::new(),
-            mcp_os: "mcp_os_line\n".to_string(),
-            host_exec: "host_exec_line\n".to_string(),
-            claude: "claude_line\n".to_string(),
-        });
+        let merged = merge_log_sources(
+            LogSources {
+                compose: String::new(),
+                desktop: String::new(),
+                mcp_os: "mcp_os_line\n".to_string(),
+                host_exec: "host_exec_line\n".to_string(),
+                claude: "claude_line\n".to_string(),
+            },
+            "testproj",
+        );
         let mcp_idx = merged.find("mcp-os | mcp_os_line").unwrap();
         let he_idx = merged.find("host-exec | host_exec_line").unwrap();
         let claude_idx = merged.find("claude | claude_line").unwrap();
@@ -806,10 +882,8 @@ mod tests {
 
     #[test]
     fn prefix_lines_does_not_unwrap_brackets_for_host_exec() {
-        // host_exec audit lines are JSON; a `[INFO]`-looking substring (e.g. in
-        // an argv) must not be rewritten — the desktop-only rewrite must not fire.
         let raw = r#"{"ts":"2026-01-01T00:00:00.000Z","recipe":"r","argv":["echo","[INFO]"]}"#;
-        let out = prefix_lines("host-exec", raw);
+        let out = prefix_lines("host-exec", raw, None);
         assert!(
             out.contains(r#"host-exec | {"ts":"2026-01-01T00:00:00.000Z","recipe":"r","argv":["echo","[INFO]"]}"#),
             "host-exec content must pass through verbatim with only the prefix, got: {out}"
@@ -823,5 +897,72 @@ mod tests {
         assert!(s.contains("host-exec"), "path: {s}");
         assert!(s.contains("myproj"), "path: {s}");
         assert!(s.ends_with("log"), "path: {s}");
+    }
+
+    // ── read_tail_desktop_logs tests ─────────────────────────────────────────
+
+    #[test]
+    fn read_tail_desktop_logs_returns_empty_when_dir_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("nope");
+        assert_eq!(read_tail_desktop_logs(&missing, 100), "");
+    }
+
+    #[test]
+    fn read_tail_desktop_logs_returns_empty_on_empty_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(read_tail_desktop_logs(tmp.path(), 100), "");
+    }
+
+    #[test]
+    fn read_tail_desktop_logs_tails_single_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("speedwave-desktop.log");
+        let lines: Vec<String> = (0..10).map(|i| format!("line {i}")).collect();
+        std::fs::write(&path, lines.join("\n")).unwrap();
+        let out = read_tail_desktop_logs(tmp.path(), 3);
+        assert_eq!(out, "line 7\nline 8\nline 9");
+    }
+
+    #[test]
+    fn read_tail_desktop_logs_merges_rotated_files_in_mtime_order() {
+        let tmp = tempfile::tempdir().unwrap();
+        let older = tmp.path().join("speedwave-desktop_2026-05-12_08-00-00.log");
+        let newer = tmp.path().join("speedwave-desktop.log");
+        std::fs::write(&older, "old-1\nold-2").unwrap();
+        std::fs::write(&newer, "new-1\nnew-2").unwrap();
+        std::fs::File::open(&older)
+            .unwrap()
+            .set_modified(std::time::UNIX_EPOCH + std::time::Duration::from_secs(1_000_000))
+            .unwrap();
+        std::fs::File::open(&newer)
+            .unwrap()
+            .set_modified(std::time::UNIX_EPOCH + std::time::Duration::from_secs(2_000_000))
+            .unwrap();
+        let out = read_tail_desktop_logs(tmp.path(), 10);
+        assert!(out.contains("old-1\nold-2\nnew-1\nnew-2"), "got: {out}");
+    }
+
+    #[test]
+    fn read_tail_desktop_logs_ignores_unrelated_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("other.log"), "noise").unwrap();
+        std::fs::write(tmp.path().join("speedwave-desktop.txt"), "noise").unwrap();
+        std::fs::write(tmp.path().join("speedwave-desktop.log"), "keep").unwrap();
+        let out = read_tail_desktop_logs(tmp.path(), 10);
+        assert_eq!(out, "keep");
+    }
+
+    #[test]
+    fn read_tail_desktop_logs_sanitizes_secrets() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("speedwave-desktop.log"),
+            "Authorization: Bearer sk-ant-api03-secret",
+        )
+        .unwrap();
+        let out = read_tail_desktop_logs(tmp.path(), 10);
+        assert!(!out.contains("sk-ant-api03-secret"), "got: {out}");
+        assert!(out.contains("***REDACTED"), "got: {out}");
     }
 }

--- a/desktop/src-tauri/src/container_logs_cmd.rs
+++ b/desktop/src-tauri/src/container_logs_cmd.rs
@@ -419,8 +419,9 @@ mod tests {
 
     #[test]
     fn validate_container_name_accepts_valid() {
-        assert!(validate_container_name("speedwave_acme_claude").is_ok());
-        assert!(validate_container_name("speedwave_proj.v1_mcp-hub").is_ok());
+        let pfx = speedwave_runtime::consts::compose_prefix();
+        assert!(validate_container_name(&format!("{pfx}_acme_claude")).is_ok());
+        assert!(validate_container_name(&format!("{pfx}_proj.v1_mcp-hub")).is_ok());
     }
 
     #[test]
@@ -430,12 +431,14 @@ mod tests {
 
     #[test]
     fn validate_container_name_rejects_shell_characters() {
-        assert!(validate_container_name("speedwave_acme;rm -rf /").is_err());
+        let pfx = speedwave_runtime::consts::compose_prefix();
+        assert!(validate_container_name(&format!("{pfx}_acme;rm -rf /")).is_err());
     }
 
     #[test]
     fn validate_container_name_rejects_path_traversal() {
-        assert!(validate_container_name("speedwave_../etc/passwd").is_err());
+        let pfx = speedwave_runtime::consts::compose_prefix();
+        assert!(validate_container_name(&format!("{pfx}_../etc/passwd")).is_err());
     }
 
     // -- Log sanitization tests (get_container_logs / get_compose_logs) --

--- a/desktop/src-tauri/src/containers_cmd.rs
+++ b/desktop/src-tauri/src/containers_cmd.rs
@@ -1040,7 +1040,6 @@ mod tests {
             active_project: Some("alpha".to_string()),
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         }
     }
@@ -1152,7 +1151,6 @@ mod tests {
             active_project: None,
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         };
 
@@ -1180,7 +1178,6 @@ mod tests {
             active_project: Some("nonexistent".to_string()),
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         };
 
@@ -1215,7 +1212,6 @@ mod tests {
             active_project: Some("proj".to_string()),
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         };
 

--- a/desktop/src-tauri/src/diagnostics.rs
+++ b/desktop/src-tauri/src/diagnostics.rs
@@ -139,11 +139,7 @@ pub(crate) async fn export_diagnostics(project: String) -> Result<String, String
 
         let zip_path = downloads.join(format!("speedwave-diagnostics-{timestamp}.zip"));
 
-        let log_dir = if cfg!(target_os = "macos") {
-            dirs::home_dir().map(|h| h.join("Library/Logs/pl.speedwave.desktop"))
-        } else {
-            dirs::home_dir().map(|h| h.join(".local/share/pl.speedwave.desktop/logs"))
-        };
+        let log_dir = crate::logging_cmd::desktop_log_dir();
 
         let serial_log = if cfg!(target_os = "macos") {
             Some(

--- a/desktop/src-tauri/src/health.rs
+++ b/desktop/src-tauri/src/health.rs
@@ -28,6 +28,10 @@ fn compute_ide_state_diff(prev: &IdeScanState, current: &IdeScanState) -> Vec<St
     if !new_anomalies.is_empty() {
         out.push(format!("IDE anomaly: {new_anomalies:?}"));
     }
+    let resolved_anomalies: BTreeSet<_> = prev.anomalies.difference(&current.anomalies).collect();
+    if !resolved_anomalies.is_empty() {
+        out.push(format!("IDE anomaly resolved: {resolved_anomalies:?}"));
+    }
     out
 }
 
@@ -1470,6 +1474,22 @@ mod tests {
             anomalies: BTreeSet::from(["45581.lock:stale".to_string()]),
         };
         assert!(compute_ide_state_diff(&s, &s).is_empty());
+    }
+
+    #[test]
+    fn diff_logs_when_anomaly_resolves() {
+        let prev = IdeScanState {
+            live: BTreeSet::new(),
+            anomalies: BTreeSet::from(["45581.lock:stale".to_string()]),
+        };
+        let curr = IdeScanState::default();
+        let msgs = compute_ide_state_diff(&prev, &curr);
+        // The cleared anomaly fires a "resolved" log so the appearance log has
+        // a matching close-out — operators can correlate the two.
+        assert!(
+            msgs.iter().any(|m| m.starts_with("IDE anomaly resolved")),
+            "got: {msgs:?}"
+        );
     }
 
     #[test]

--- a/desktop/src-tauri/src/health.rs
+++ b/desktop/src-tauri/src/health.rs
@@ -422,7 +422,9 @@ fn list_ides_in_dir(lock_dir: &std::path::Path) -> Vec<DetectedIde> {
         }
     }
 
-    let result: Vec<DetectedIde> = by_key
+    // HashMap iteration is hash-randomised; sort so the frontend's
+    // detected-IDE list does not jump around between 5-second polls.
+    let mut result: Vec<DetectedIde> = by_key
         .into_values()
         .map(|e| DetectedIde {
             ide_name: e.ide_name,
@@ -430,6 +432,7 @@ fn list_ides_in_dir(lock_dir: &std::path::Path) -> Vec<DetectedIde> {
             ws_url: e.ws_url,
         })
         .collect();
+    result.sort_by(|a, b| a.ide_name.cmp(&b.ide_name).then(a.port.cmp(&b.port)));
 
     let current = IdeScanState {
         live: live_fingerprint,
@@ -1524,13 +1527,16 @@ mod tests {
         for r in [&r1, &r2, &r3] {
             assert_eq!(r.len(), 2, "two IDEs must be detected consistently");
         }
-        let names = |r: &Vec<DetectedIde>| {
-            let mut n: Vec<_> = r.iter().map(|d| d.ide_name.clone()).collect();
-            n.sort();
-            n
+        // Compare full Vec in input order (no post-sort) — backend MUST return
+        // a stable order so the frontend's detected-IDE list doesn't jump.
+        let shape = |r: &Vec<DetectedIde>| -> Vec<(String, Option<u16>)> {
+            r.iter().map(|d| (d.ide_name.clone(), d.port)).collect()
         };
-        assert_eq!(names(&r1), names(&r2));
-        assert_eq!(names(&r2), names(&r3));
+        assert_eq!(shape(&r1), shape(&r2), "order must be stable across polls");
+        assert_eq!(shape(&r2), shape(&r3), "order must be stable across polls");
+        // And the order is sorted by (ide_name, port), so Cursor < Visual Studio Code.
+        assert_eq!(r1[0].ide_name, "Cursor");
+        assert_eq!(r1[1].ide_name, "Visual Studio Code");
         drop(l_a);
         drop(l_b);
     }

--- a/desktop/src-tauri/src/health.rs
+++ b/desktop/src-tauri/src/health.rs
@@ -1,8 +1,42 @@
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::collections::BTreeSet;
+use std::sync::{LazyLock, Mutex, PoisonError};
 
-use log::{debug, info};
+use log::info;
 use serde::{Deserialize, Serialize};
 use speedwave_runtime::runtime;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct IdeScanState {
+    // Fingerprint built before dedupe so same-port duplicates collapse via set
+    // semantics, not via mtime tie-break.
+    live: BTreeSet<(String, u16)>,
+    anomalies: BTreeSet<String>,
+}
+
+static LAST_IDE_STATE: LazyLock<Mutex<IdeScanState>> =
+    LazyLock::new(|| Mutex::new(IdeScanState::default()));
+
+fn compute_ide_state_diff(prev: &IdeScanState, current: &IdeScanState) -> Vec<String> {
+    let mut out = Vec::new();
+    if prev.live != current.live {
+        out.push(format!(
+            "IDE state changed: {:?} → {:?}",
+            prev.live, current.live
+        ));
+    }
+    let new_anomalies: BTreeSet<_> = current.anomalies.difference(&prev.anomalies).collect();
+    if !new_anomalies.is_empty() {
+        out.push(format!("IDE anomaly: {new_anomalies:?}"));
+    }
+    out
+}
+
+#[cfg(test)]
+pub(super) fn reset_ide_state_for_tests() {
+    *LAST_IDE_STATE
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner) = IdeScanState::default();
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ContainerHealth {
@@ -133,7 +167,7 @@ impl HealthMonitor {
     pub fn check_containers(project: &str) -> anyhow::Result<Vec<ContainerHealth>> {
         let rt = runtime::detect_runtime();
         let ps = rt.compose_ps(project)?;
-        Ok(parse_container_entries(&ps))
+        Ok(parse_container_entries(&ps, project))
     }
 }
 
@@ -141,15 +175,16 @@ impl HealthMonitor {
 ///
 /// Handles field name differences across nerdctl versions: `Name`/`name`,
 /// `State`/`Status`/`state`/`status`.
-fn parse_container_entries(entries: &[serde_json::Value]) -> Vec<ContainerHealth> {
+fn parse_container_entries(entries: &[serde_json::Value], project: &str) -> Vec<ContainerHealth> {
     entries
         .iter()
         .map(|entry| {
-            let name = entry
+            let raw_name = entry
                 .get("Name")
                 .or_else(|| entry.get("name"))
                 .and_then(|v| v.as_str())
-                .unwrap_or("unknown")
+                .unwrap_or("unknown");
+            let name = speedwave_runtime::consts::strip_compose_container_prefix(raw_name, project)
                 .to_string();
 
             let status = entry
@@ -274,10 +309,6 @@ pub fn is_ide_port_alive(port: u16) -> bool {
     is_ide_lock_alive(&lock_path)
 }
 
-/// Tracks the last number of detected IDEs so we only log at `info!` level
-/// when the count changes (avoids spam from the 5-second polling cycle).
-static LAST_IDE_COUNT: AtomicUsize = AtomicUsize::new(0);
-
 /// Scans `lock_dir/*.lock` for IDE lock files with live PIDs and listening ports.
 ///
 /// Deduplicates by `(pid, ide_name)` — VS Code writes one lock per window,
@@ -295,6 +326,8 @@ fn list_ides_in_dir(lock_dir: &std::path::Path) -> Vec<DetectedIde> {
         pid: u32,
         mtime: std::time::SystemTime,
     }
+
+    let mut anomalies: BTreeSet<String> = BTreeSet::new();
 
     let live: Vec<LiveEntry> = entries
         .flatten()
@@ -316,7 +349,7 @@ fn list_ides_in_dir(lock_dir: &std::path::Path) -> Vec<DetectedIde> {
                 .and_then(|p| u32::try_from(p).ok());
             if let Some(pid) = pid {
                 if pid == std::process::id() {
-                    debug!("{filename}: skipped (own PID)");
+                    anomalies.insert(format!("{filename}:own_pid"));
                     return None;
                 }
             }
@@ -330,20 +363,15 @@ fn list_ides_in_dir(lock_dir: &std::path::Path) -> Vec<DetectedIde> {
                     .and_then(|s| s.parse::<u16>().ok())
             });
             let Some(port) = port else {
-                debug!("{filename}: skipped (no resolvable port)");
+                anomalies.insert(format!("{filename}:no_port"));
                 return None;
             };
-            let port_source = if json_port.is_some() {
-                "json"
-            } else {
-                "filename"
-            };
             let Some(check_pid) = pid else {
-                debug!("{filename}: skipped (no valid PID in JSON)");
+                anomalies.insert(format!("{filename}:no_pid"));
                 return None;
             };
             if !is_lock_entry_alive(check_pid, port) {
-                debug!("{filename}: skipped (stale — PID or port not alive)");
+                anomalies.insert(format!("{filename}:stale"));
                 return None;
             }
             let ws_url = v
@@ -359,7 +387,6 @@ fn list_ides_in_dir(lock_dir: &std::path::Path) -> Vec<DetectedIde> {
                 .metadata()
                 .and_then(|m| m.modified())
                 .unwrap_or(std::time::UNIX_EPOCH);
-            debug!("{filename}: alive, ide={ide_name} port={port} (from {port_source})");
             Some(LiveEntry {
                 ide_name,
                 port,
@@ -370,8 +397,11 @@ fn list_ides_in_dir(lock_dir: &std::path::Path) -> Vec<DetectedIde> {
         })
         .collect();
 
-    // Dedupe by (pid, ide_name): one IDE process can spawn multiple lock
-    // files (e.g. VS Code with several windows). Keep the most recent.
+    // Fingerprint built from the full pre-dedupe set so identical (ide, port)
+    // pairs across multiple lock files collapse via BTreeSet, not via mtime.
+    let live_fingerprint: BTreeSet<(String, u16)> =
+        live.iter().map(|e| (e.ide_name.clone(), e.port)).collect();
+
     let mut by_key: std::collections::HashMap<(u32, String), LiveEntry> =
         std::collections::HashMap::new();
     for entry in live {
@@ -397,15 +427,23 @@ fn list_ides_in_dir(lock_dir: &std::path::Path) -> Vec<DetectedIde> {
         })
         .collect();
 
-    let count = result.len();
-    let prev = LAST_IDE_COUNT.swap(count, Ordering::Relaxed);
-    if count != prev {
-        info!("detected IDE count changed: {prev} → {count}");
+    let current = IdeScanState {
+        live: live_fingerprint,
+        anomalies,
+    };
+    let messages = {
+        let mut last = LAST_IDE_STATE
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        let msgs = compute_ide_state_diff(&last, &current);
+        *last = current;
+        msgs
+    };
+    // Lock released — log writes (possibly involving file rotation) cannot
+    // block a concurrent caller waiting on LAST_IDE_STATE.
+    for msg in messages {
+        info!("{msg}");
     }
-    debug!(
-        "IDE scan complete: {count} live IDE(s) in {}",
-        lock_dir.display()
-    );
 
     result
 }
@@ -432,9 +470,11 @@ impl HealthMonitor {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::{
-        parse_container_entries, ContainerHealth, DetectedIde, HealthMonitor, HealthReport,
-        IdeBridgeHealth, McpOsHealth, VmHealth,
+        compute_ide_state_diff, parse_container_entries, reset_ide_state_for_tests,
+        ContainerHealth, DetectedIde, HealthMonitor, HealthReport, IdeBridgeHealth, IdeScanState,
+        McpOsHealth, VmHealth,
     };
+    use std::collections::BTreeSet;
 
     /// Returns a PID that is alive and different from `std::process::id()`.
     /// Unix: parent PID. Windows: spawns a sleeping process.
@@ -613,7 +653,7 @@ mod tests {
             r#"[{"Name":"mcp_hub","State":"running"},{"Name":"claude","State":"exited"}]"#,
         )
         .unwrap();
-        let result = parse_container_entries(&entries);
+        let result = parse_container_entries(&entries, "myproj");
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].name, "mcp_hub");
         assert_eq!(result[0].status, "running");
@@ -627,7 +667,7 @@ mod tests {
     fn parse_docker_status_field() {
         let entries: Vec<serde_json::Value> =
             serde_json::from_str(r#"[{"Name":"hub","Status":"Up 5 minutes"}]"#).unwrap();
-        let result = parse_container_entries(&entries);
+        let result = parse_container_entries(&entries, "p");
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].status, "Up 5 minutes");
         assert!(result[0].healthy);
@@ -636,7 +676,7 @@ mod tests {
     #[test]
     fn parse_missing_fields_returns_unknown() {
         let entries: Vec<serde_json::Value> = serde_json::from_str(r#"[{"ID":"abc"}]"#).unwrap();
-        let result = parse_container_entries(&entries);
+        let result = parse_container_entries(&entries, "p");
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].name, "unknown");
         assert_eq!(result[0].status, "unknown");
@@ -645,8 +685,32 @@ mod tests {
 
     #[test]
     fn parse_empty_entries() {
-        let result = parse_container_entries(&[]);
+        let result = parse_container_entries(&[], "p");
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn parse_strips_runtime_project_prefix() {
+        // Build container names from the live `compose_prefix()` so the test
+        // is independent of `SPEEDWAVE_DATA_DIR`.
+        let prefix = speedwave_runtime::consts::compose_prefix();
+        let json = format!(
+            r#"[{{"Name":"{prefix}_my_proj_mcp_hub","State":"running"}},
+                {{"Name":"{prefix}_my_proj_mcp_office","State":"running"}}]"#
+        );
+        let entries: Vec<serde_json::Value> = serde_json::from_str(&json).unwrap();
+        let result = parse_container_entries(&entries, "my_proj");
+        assert_eq!(result[0].name, "mcp_hub", "underscores in project survive");
+        assert_eq!(result[1].name, "mcp_office");
+    }
+
+    #[test]
+    fn parse_leaves_unrelated_container_unchanged() {
+        let entries: Vec<serde_json::Value> =
+            serde_json::from_str(r#"[{"Name":"other_unrelated_thing","State":"running"}]"#)
+                .unwrap();
+        let result = parse_container_entries(&entries, "p");
+        assert_eq!(result[0].name, "other_unrelated_thing");
     }
 
     #[test]
@@ -885,7 +949,7 @@ mod tests {
     fn parse_lowercase_name_and_state() {
         let entries: Vec<serde_json::Value> =
             serde_json::from_str(r#"[{"name":"hub","state":"running"}]"#).unwrap();
-        let result = parse_container_entries(&entries);
+        let result = parse_container_entries(&entries, "p");
         assert_eq!(result[0].name, "hub");
         assert_eq!(result[0].status, "running");
         assert!(result[0].healthy);
@@ -1351,5 +1415,103 @@ mod tests {
             report.selected_ide.as_ref().and_then(|i| i.port),
             Some(6_902)
         );
+    }
+
+    fn state_with_live(entries: &[(&str, u16)]) -> IdeScanState {
+        IdeScanState {
+            live: entries
+                .iter()
+                .map(|(n, p)| ((*n).to_string(), *p))
+                .collect(),
+            anomalies: BTreeSet::new(),
+        }
+    }
+
+    #[test]
+    fn diff_returns_nothing_when_state_unchanged() {
+        let s = state_with_live(&[("VS Code", 45_581)]);
+        assert!(compute_ide_state_diff(&s, &s).is_empty());
+    }
+
+    #[test]
+    fn diff_logs_when_ide_added() {
+        let prev = IdeScanState::default();
+        let curr = state_with_live(&[("VS Code", 45_581)]);
+        let msgs = compute_ide_state_diff(&prev, &curr);
+        assert_eq!(msgs.len(), 1);
+        assert!(msgs[0].starts_with("IDE state changed"));
+    }
+
+    #[test]
+    fn diff_logs_when_port_changed_same_count() {
+        let prev = state_with_live(&[("VS Code", 45_581)]);
+        let curr = state_with_live(&[("VS Code", 50_000)]);
+        let msgs = compute_ide_state_diff(&prev, &curr);
+        assert_eq!(msgs.len(), 1);
+        assert!(msgs[0].starts_with("IDE state changed"));
+    }
+
+    #[test]
+    fn diff_logs_when_anomaly_appears() {
+        let prev = IdeScanState::default();
+        let curr = IdeScanState {
+            live: BTreeSet::new(),
+            anomalies: BTreeSet::from(["45581.lock:stale".to_string()]),
+        };
+        let msgs = compute_ide_state_diff(&prev, &curr);
+        assert_eq!(msgs.len(), 1);
+        assert!(msgs[0].starts_with("IDE anomaly"));
+    }
+
+    #[test]
+    fn diff_does_not_relog_persistent_anomaly() {
+        let s = IdeScanState {
+            live: BTreeSet::new(),
+            anomalies: BTreeSet::from(["45581.lock:stale".to_string()]),
+        };
+        assert!(compute_ide_state_diff(&s, &s).is_empty());
+    }
+
+    #[test]
+    fn list_ides_stable_across_repeated_calls() {
+        use super::list_ides_in_dir;
+
+        reset_ide_state_for_tests();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let (external_pid, _child) = external_alive_pid();
+        let l_a = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port_a = l_a.local_addr().unwrap().port();
+        let l_b = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port_b = l_b.local_addr().unwrap().port();
+        std::fs::write(
+            tmp.path().join(format!("{port_a}.lock")),
+            format!(
+                r#"{{"pid":{external_pid},"port":{port_a},"wsUrl":"ws://127.0.0.1:{port_a}","authToken":"tok","workspaceFolders":["/ws"],"ideName":"Cursor","transport":"ws"}}"#,
+            ),
+        ).unwrap();
+        std::fs::write(
+            tmp.path().join(format!("{port_b}.lock")),
+            format!(
+                r#"{{"pid":{external_pid},"port":{port_b},"wsUrl":"ws://127.0.0.1:{port_b}","authToken":"tok","workspaceFolders":["/ws"],"ideName":"Visual Studio Code","transport":"ws"}}"#,
+            ),
+        ).unwrap();
+
+        let r1 = list_ides_in_dir(tmp.path());
+        let r2 = list_ides_in_dir(tmp.path());
+        let r3 = list_ides_in_dir(tmp.path());
+
+        for r in [&r1, &r2, &r3] {
+            assert_eq!(r.len(), 2, "two IDEs must be detected consistently");
+        }
+        let names = |r: &Vec<DetectedIde>| {
+            let mut n: Vec<_> = r.iter().map(|d| d.ide_name.clone()).collect();
+            n.sort();
+            n
+        };
+        assert_eq!(names(&r1), names(&r2));
+        assert_eq!(names(&r2), names(&r3));
+        drop(l_a);
+        drop(l_b);
     }
 }

--- a/desktop/src-tauri/src/logging_cmd.rs
+++ b/desktop/src-tauri/src/logging_cmd.rs
@@ -1,416 +1,53 @@
-// Log level commands and log cleanup utilities.
+use std::sync::OnceLock;
 
-use speedwave_runtime::config;
+const DEFAULT_BUNDLE_IDENTIFIER: &str = "pl.speedwave.desktop";
 
-pub(crate) fn parse_log_level(s: &str) -> Option<log::LevelFilter> {
-    match s.to_lowercase().as_str() {
-        "error" => Some(log::LevelFilter::Error),
-        "warn" => Some(log::LevelFilter::Warn),
-        "info" => Some(log::LevelFilter::Info),
-        "debug" => Some(log::LevelFilter::Debug),
-        "trace" => Some(log::LevelFilter::Trace),
-        _ => None,
+// `make dev` overrides identifier to `.dev` via TAURI_CONFIG; must match
+// tauri-plugin-log's runtime LogDir target, not the value in tauri.conf.json.
+static BUNDLE_IDENTIFIER: OnceLock<String> = OnceLock::new();
+
+pub(crate) fn init_bundle_identifier(identifier: String) {
+    if BUNDLE_IDENTIFIER.set(identifier).is_err() {
+        log::debug!("init_bundle_identifier: already initialised; ignoring");
     }
 }
 
-#[tauri::command]
-pub(crate) fn set_log_level(level: String) -> Result<(), String> {
-    let filter = parse_log_level(&level).ok_or_else(|| format!("Invalid log level: {level}"))?;
-    log::info!("Log level changed to {level}");
-    log::set_max_level(filter);
-    if let Err(e) = persist_log_level(&level) {
-        log::warn!("Failed to persist log level: {e}");
-    }
-    Ok(())
-}
-
-#[tauri::command]
-pub(crate) fn get_log_level() -> String {
-    log::max_level().to_string()
-}
-
-fn persist_log_level(level: &str) -> anyhow::Result<()> {
-    config::with_config_lock(|| {
-        let mut config = config::load_user_config()?;
-        config.log_level = Some(level.to_lowercase());
-        config::save_user_config(&config)
-    })
-}
-
-/// Returns the absolute path of the directory tauri-plugin-log writes
-/// `speedwave-desktop.log` (and rotated copies) into. Per-OS layout matches
-/// what the plugin's `LogDir` target resolves to:
-///
-/// - macOS: `~/Library/Logs/pl.speedwave.desktop`
-/// - Windows: `%APPDATA%/pl.speedwave.desktop` (handled by AppData fallback)
-///
-/// Returns `None` only when `dirs::home_dir()` itself fails (rare, sandbox
-/// edge cases). SSOT for this path — used by `cleanup_old_logs`,
-/// `diagnostics::export_diagnostics`, and the unified-logs view command in
-/// `container_logs_cmd.rs::get_all_logs`.
-pub(crate) fn desktop_log_dir() -> Option<std::path::PathBuf> {
-    let home = dirs::home_dir()?;
-    if cfg!(target_os = "macos") {
-        Some(home.join("Library/Logs/pl.speedwave.desktop"))
-    } else {
-        // tauri-plugin-log on Windows defaults to %APPDATA%/<bundle id>; this
-        // helper keeps the same convention so log lookup works after install.
-        dirs::data_dir().map(|d| d.join("pl.speedwave.desktop"))
-    }
-}
-
-/// Removes old rotated log files, keeping at most `max_files` recent ones.
-pub(crate) fn cleanup_old_logs(max_files: usize) {
-    let Some(log_dir) = desktop_log_dir() else {
-        return;
-    };
-    cleanup_log_dir(&log_dir, max_files);
-}
-
-/// Core logic for log cleanup — operates on an arbitrary directory.
-///
-/// Keeps the `max_files` most-recently-modified `.log` files in `log_dir` and
-/// deletes the rest.  Non-`.log` files are never touched.
-pub(crate) fn cleanup_log_dir(log_dir: &std::path::Path, max_files: usize) {
-    let entries = match std::fs::read_dir(log_dir) {
-        Ok(e) => e,
-        Err(_) => return,
-    };
-
-    let mut log_files: Vec<_> = entries
-        .filter_map(|e| e.ok())
-        .filter(|e| {
-            e.path()
-                .extension()
-                .map(|ext| ext == "log")
-                .unwrap_or(false)
-        })
-        .filter_map(|e| {
-            e.metadata()
-                .ok()
-                .and_then(|m| m.modified().ok())
-                .map(|t| (e.path(), t))
-        })
-        .collect();
-
-    if log_files.len() <= max_files {
-        return;
-    }
-
-    // Sort by modification time, newest first
-    log_files.sort_by(|a, b| b.1.cmp(&a.1));
-
-    // Remove the oldest files beyond the limit
-    for (path, _) in log_files.iter().skip(max_files) {
-        if let Err(e) = std::fs::remove_file(path) {
-            log::warn!("failed to remove old log file {}: {e}", path.display());
+fn bundle_identifier() -> &'static str {
+    match BUNDLE_IDENTIFIER.get() {
+        Some(s) => s.as_str(),
+        None => {
+            // Production build: return the default silently (Tauri setup might not
+            // have run yet during early panic-hook output, etc.). Debug build:
+            // surface the miss — it means desktop_log_dir() was consulted before
+            // init_bundle_identifier and will return the release path under dev.
+            #[cfg(all(debug_assertions, not(test)))]
+            log::warn!(
+                "bundle_identifier(): BUNDLE_IDENTIFIER not initialised yet; falling back to {DEFAULT_BUNDLE_IDENTIFIER}"
+            );
+            DEFAULT_BUNDLE_IDENTIFIER
         }
     }
 }
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
+// Matches tauri-plugin-log v2 TargetKind::LogDir resolution:
+// macOS: ~/Library/Logs/<bundle>, Windows: %LOCALAPPDATA%/<bundle>/logs.
+pub(crate) fn desktop_log_dir() -> Option<std::path::PathBuf> {
+    let id = bundle_identifier();
+    if cfg!(target_os = "macos") {
+        let home = dirs::home_dir()?;
+        Some(home.join("Library/Logs").join(id))
+    } else {
+        dirs::data_local_dir().map(|d| d.join(id).join("logs"))
+    }
+}
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 
-    // -- set_log_level / get_log_level tests --
-    //
-    // These functions mutate global state (`log::set_max_level`), so we
-    // serialize all log-level tests through a single mutex.
-
-    static LOG_LEVEL_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    #[test]
-    fn set_log_level_accepts_error() {
-        let _lock = LOG_LEVEL_MUTEX.lock().unwrap();
-        assert!(set_log_level("error".to_string()).is_ok());
-    }
-
-    #[test]
-    fn set_log_level_accepts_warn() {
-        let _lock = LOG_LEVEL_MUTEX.lock().unwrap();
-        assert!(set_log_level("warn".to_string()).is_ok());
-    }
-
-    #[test]
-    fn set_log_level_accepts_info() {
-        let _lock = LOG_LEVEL_MUTEX.lock().unwrap();
-        assert!(set_log_level("info".to_string()).is_ok());
-    }
-
-    #[test]
-    fn set_log_level_accepts_debug() {
-        let _lock = LOG_LEVEL_MUTEX.lock().unwrap();
-        assert!(set_log_level("debug".to_string()).is_ok());
-    }
-
-    #[test]
-    fn set_log_level_accepts_trace() {
-        let _lock = LOG_LEVEL_MUTEX.lock().unwrap();
-        assert!(set_log_level("trace".to_string()).is_ok());
-    }
-
-    #[test]
-    fn set_log_level_case_insensitive_uppercase() {
-        let _lock = LOG_LEVEL_MUTEX.lock().unwrap();
-        assert!(set_log_level("ERROR".to_string()).is_ok());
-    }
-
-    #[test]
-    fn set_log_level_case_insensitive_mixed() {
-        let _lock = LOG_LEVEL_MUTEX.lock().unwrap();
-        assert!(set_log_level("Info".to_string()).is_ok());
-    }
-
-    #[test]
-    fn set_log_level_case_insensitive_debug_upper() {
-        let _lock = LOG_LEVEL_MUTEX.lock().unwrap();
-        assert!(set_log_level("DEBUG".to_string()).is_ok());
-    }
-
-    #[test]
-    fn set_log_level_rejects_invalid() {
-        let _lock = LOG_LEVEL_MUTEX.lock().unwrap();
-        let err = set_log_level("verbose".to_string()).unwrap_err();
-        assert!(
-            err.contains("verbose"),
-            "error should contain the invalid value"
-        );
-    }
-
-    #[test]
-    fn set_log_level_rejects_empty_string() {
-        let _lock = LOG_LEVEL_MUTEX.lock().unwrap();
-        assert!(set_log_level(String::new()).is_err());
-    }
-
-    #[test]
-    fn get_log_level_returns_non_empty() {
-        let _lock = LOG_LEVEL_MUTEX.lock().unwrap();
-        let level = get_log_level();
-        assert!(!level.is_empty(), "log level string should not be empty");
-    }
-
-    #[test]
-    fn set_then_get_log_level_round_trip() {
-        let _lock = LOG_LEVEL_MUTEX.lock().unwrap();
-        set_log_level("debug".to_string()).unwrap();
-        let level = get_log_level();
-        assert_eq!(level, "DEBUG");
-    }
-
-    #[test]
-    fn set_log_level_off_returns_error() {
-        let _lock = LOG_LEVEL_MUTEX.lock().unwrap();
-        assert!(
-            set_log_level("off".to_string()).is_err(),
-            "\"off\" is not a valid log level and should be rejected"
-        );
-    }
-
-    #[test]
-    fn set_log_level_whitespace_padded_returns_error() {
-        let _lock = LOG_LEVEL_MUTEX.lock().unwrap();
-        assert!(
-            set_log_level("  debug  ".to_string()).is_err(),
-            "whitespace-padded input should be rejected (no trimming)"
-        );
-    }
-
-    #[test]
-    fn set_log_level_multi_step_round_trip() {
-        let _lock = LOG_LEVEL_MUTEX.lock().unwrap();
-        set_log_level("trace".to_string()).unwrap();
-        set_log_level("error".to_string()).unwrap();
-        let level = get_log_level();
-        assert_eq!(level, "ERROR");
-    }
-
-    // -- cleanup_log_dir tests --
-
-    /// Helper: create a `.log` file inside `dir` with the given name.
-    fn create_log_file(dir: &std::path::Path, name: &str) -> std::path::PathBuf {
-        let p = dir.join(name);
-        std::fs::File::create(&p).unwrap();
-        p
-    }
-
-    /// Helper: create a `.log` file and set its modification time to a specific
-    /// epoch-based timestamp.  Uses `File::set_modified` (stable since Rust 1.75)
-    /// instead of `thread::sleep` for deterministic ordering in tests.
-    fn create_log_file_with_mtime(
-        dir: &std::path::Path,
-        name: &str,
-        epoch_secs: u64,
-    ) -> std::path::PathBuf {
-        let p = dir.join(name);
-        let f = std::fs::File::create(&p).unwrap();
-        let mtime = std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(epoch_secs);
-        f.set_modified(mtime).unwrap();
-        p
-    }
-
-    #[test]
-    fn cleanup_log_dir_fewer_than_limit_deletes_nothing() {
-        let tmp = tempfile::tempdir().unwrap();
-        create_log_file(tmp.path(), "a.log");
-        create_log_file(tmp.path(), "b.log");
-
-        cleanup_log_dir(tmp.path(), 5);
-
-        let count = std::fs::read_dir(tmp.path()).unwrap().count();
-        assert_eq!(count, 2, "no files should be deleted when under the limit");
-    }
-
-    #[test]
-    fn cleanup_log_dir_exactly_at_limit_deletes_nothing() {
-        let tmp = tempfile::tempdir().unwrap();
-        for i in 0..3 {
-            create_log_file_with_mtime(tmp.path(), &format!("file{i}.log"), 1_000_000 + i * 100);
-        }
-
-        cleanup_log_dir(tmp.path(), 3);
-
-        let count = std::fs::read_dir(tmp.path()).unwrap().count();
-        assert_eq!(count, 3, "no files should be deleted at exactly the limit");
-    }
-
-    #[test]
-    fn cleanup_log_dir_over_limit_deletes_oldest() {
-        let tmp = tempfile::tempdir().unwrap();
-        // Create 6 files with deterministic, well-separated mtimes.
-        // file0 is oldest (epoch 1 000 000), file5 is newest (epoch 1 000 500).
-        let mut created = Vec::new();
-        for i in 0u64..6 {
-            let p = create_log_file_with_mtime(
-                tmp.path(),
-                &format!("file{i}.log"),
-                1_000_000 + i * 100,
-            );
-            created.push(p);
-        }
-
-        cleanup_log_dir(tmp.path(), 3);
-
-        // The 3 newest files (file3, file4, file5) must survive.
-        for p in &created[3..] {
-            assert!(p.exists(), "newest file {} should survive", p.display());
-        }
-        // The 3 oldest files (file0, file1, file2) must be deleted.
-        for p in &created[..3] {
-            assert!(!p.exists(), "oldest file {} should be deleted", p.display());
-        }
-
-        let remaining_count = std::fs::read_dir(tmp.path())
-            .unwrap()
-            .filter_map(|e| e.ok())
-            .count();
-        assert_eq!(
-            remaining_count, 3,
-            "should keep exactly 3 files, got {remaining_count}"
-        );
-    }
-
-    #[test]
-    fn cleanup_log_dir_ignores_non_log_files() {
-        let tmp = tempfile::tempdir().unwrap();
-        // 4 .log files (over the limit of 2) plus 3 .txt files
-        for i in 0u64..4 {
-            create_log_file_with_mtime(tmp.path(), &format!("file{i}.log"), 1_000_000 + i * 100);
-        }
-        for i in 0..3 {
-            let p = tmp.path().join(format!("notes{i}.txt"));
-            std::fs::File::create(&p).unwrap();
-        }
-
-        cleanup_log_dir(tmp.path(), 2);
-
-        let log_count = std::fs::read_dir(tmp.path())
-            .unwrap()
-            .filter_map(|e| e.ok())
-            .filter(|e| e.path().extension().map(|x| x == "log").unwrap_or(false))
-            .count();
-        let txt_count = std::fs::read_dir(tmp.path())
-            .unwrap()
-            .filter_map(|e| e.ok())
-            .filter(|e| e.path().extension().map(|x| x == "txt").unwrap_or(false))
-            .count();
-
-        assert_eq!(log_count, 2, "should keep exactly 2 .log files");
-        assert_eq!(txt_count, 3, "all .txt files should remain untouched");
-    }
-
-    #[test]
-    fn cleanup_log_dir_nonexistent_directory_does_not_panic() {
-        let tmp = tempfile::tempdir().unwrap();
-        let missing = tmp.path().join("does_not_exist");
-        // Should return silently — no panic, no error.
-        cleanup_log_dir(&missing, 5);
-    }
-
-    #[test]
-    fn cleanup_log_dir_max_zero_deletes_all_log_files() {
-        let tmp = tempfile::tempdir().unwrap();
-        for i in 0..4 {
-            create_log_file(tmp.path(), &format!("file{i}.log"));
-        }
-        // Also add a non-log file that must survive
-        let txt = tmp.path().join("keep.txt");
-        std::fs::File::create(&txt).unwrap();
-
-        cleanup_log_dir(tmp.path(), 0);
-
-        let log_count = std::fs::read_dir(tmp.path())
-            .unwrap()
-            .filter_map(|e| e.ok())
-            .filter(|e| e.path().extension().map(|x| x == "log").unwrap_or(false))
-            .count();
-        assert_eq!(log_count, 0, "max_files=0 should delete all .log files");
-        assert!(txt.exists(), ".txt file should not be deleted");
-    }
-
-    #[test]
-    fn cleanup_log_dir_mixed_extensions_only_counts_log() {
-        let tmp = tempfile::tempdir().unwrap();
-        // 2 .log files + 5 .txt files — limit is 3, so nothing should be deleted
-        // because only .log files are counted and 2 < 3.
-        create_log_file(tmp.path(), "a.log");
-        create_log_file(tmp.path(), "b.log");
-        for i in 0..5 {
-            let p = tmp.path().join(format!("data{i}.txt"));
-            std::fs::File::create(&p).unwrap();
-        }
-
-        cleanup_log_dir(tmp.path(), 3);
-
-        let total = std::fs::read_dir(tmp.path()).unwrap().count();
-        assert_eq!(
-            total, 7,
-            "nothing should be deleted — only 2 .log files exist, under limit of 3"
-        );
-    }
-
-    #[test]
-    fn cleanup_log_dir_empty_directory() {
-        let tmp = tempfile::tempdir().unwrap();
-        // 0 .log files, max_files=5 — should not panic.
-        cleanup_log_dir(tmp.path(), 5);
-
-        let count = std::fs::read_dir(tmp.path()).unwrap().count();
-        assert_eq!(count, 0, "empty directory should stay empty");
-    }
-
-    // -- desktop_log_dir tests --
-
     #[test]
     fn desktop_log_dir_returns_some_on_supported_platform() {
-        // dirs::home_dir() returns Some on every supported OS during normal
-        // unit-test runs. If this fails on CI it indicates a sandbox issue
-        // worth diagnosing — not silent skip.
         let dir = desktop_log_dir();
         assert!(
             dir.is_some(),
@@ -424,39 +61,39 @@ mod tests {
         let dir = desktop_log_dir().unwrap();
         let s = dir.to_string_lossy();
         assert!(
-            s.contains("Library/Logs/pl.speedwave.desktop"),
-            "macOS path must point at Library/Logs/pl.speedwave.desktop, got {s}"
+            s.contains("Library/Logs/") && s.contains(bundle_identifier()),
+            "macOS path must point under Library/Logs/<bundle>, got {s}"
+        );
+        assert!(
+            !s.contains("/logs"),
+            "macOS path must NOT end with /logs subdir, got {s}"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn desktop_log_dir_windows_path_under_local_appdata_logs() {
+        let dir = desktop_log_dir().unwrap();
+        let s = dir.to_string_lossy();
+        // tauri-plugin-log v2 uses LOCALAPPDATA + bundle + /logs on Windows.
+        assert!(
+            s.contains("AppData") && s.contains("Local") && s.ends_with("logs"),
+            "Windows path must be under LocalAppData/<bundle>/logs, got {s}"
+        );
+        assert!(
+            s.contains(bundle_identifier()),
+            "must contain bundle id, got {s}"
         );
     }
 
     #[test]
-    fn cleanup_log_dir_ignores_subdirectories() {
-        let tmp = tempfile::tempdir().unwrap();
-        // Create 2 .log files directly in the directory.
-        create_log_file_with_mtime(tmp.path(), "old.log", 1_000_000);
-        create_log_file_with_mtime(tmp.path(), "new.log", 2_000_000);
-
-        // Create a subdirectory containing a .log file — cleanup must ignore it.
-        let subdir = tmp.path().join("nested");
-        std::fs::create_dir(&subdir).unwrap();
-        create_log_file(&subdir, "inner.log");
-
-        cleanup_log_dir(tmp.path(), 1);
-
-        // Only "new.log" (newest) should survive at the top level.
+    fn desktop_log_dir_honours_initialised_identifier() {
+        let dir = desktop_log_dir().unwrap();
+        let s = dir.to_string_lossy();
         assert!(
-            tmp.path().join("new.log").exists(),
-            "newest top-level .log should survive"
-        );
-        assert!(
-            !tmp.path().join("old.log").exists(),
-            "oldest top-level .log should be deleted"
-        );
-        // The subdirectory and its .log file must be untouched.
-        assert!(subdir.exists(), "subdirectory should not be deleted");
-        assert!(
-            subdir.join("inner.log").exists(),
-            ".log file inside subdirectory should not be deleted"
+            s.contains(bundle_identifier()),
+            "path must contain active bundle identifier ({}), got {s}",
+            bundle_identifier()
         );
     }
 }

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -759,15 +759,14 @@ fn is_upstream_alive(port: u16) -> bool {
 /// listening). Separated from the query command so that `get_bridge_status`
 /// does not have write side-effects.
 fn cleanup_dead_ide(bridge: &ide_bridge::IdeBridge) {
+    log::info!(target: "ide_bridge", "cleanup_dead_ide: upstream IDE died, clearing selection");
     bridge.clear_upstream();
-    if let Ok(()) = config::with_config_lock(|| {
+    if let Err(e) = config::with_config_lock(|| {
         let mut user_config = config::load_user_config()?;
         user_config.selected_ide = None;
         config::save_user_config(&user_config)
     }) {
-        // ok
-    } else {
-        log::warn!("cleanup_dead_ide: failed to persist IDE deselection");
+        log::warn!("cleanup_dead_ide: failed to persist IDE deselection: {e}");
     }
 }
 
@@ -886,7 +885,6 @@ fn disconnect_ide(state: tauri::State<SharedIdeBridge>) -> Result<(), String> {
 }
 
 use diagnostics::export_diagnostics;
-use logging_cmd::{cleanup_old_logs, get_log_level, parse_log_level, set_log_level};
 use window::should_debounce;
 use window::{hide_main_window, should_prevent_close, should_run_cleanup, show_main_window};
 
@@ -1634,7 +1632,7 @@ fn main() {
                 .level_for("tungstenite", log::LevelFilter::Warn)
                 .level_for("tokio_tungstenite", log::LevelFilter::Warn)
                 .max_file_size(50_000_000)
-                .rotation_strategy(RotationStrategy::KeepAll)
+                .rotation_strategy(RotationStrategy::KeepSome(10))
                 .format(move |callback, message, record| {
                     let sanitized =
                         speedwave_runtime::log_sanitizer::sanitize(&format!("{message}"));
@@ -1675,13 +1673,14 @@ fn main() {
         .manage(transcript_forwarders.clone())
         .manage(tray_state)
         .setup(move |app| {
-            // Restore persisted log level (default: Info)
-            let initial_level = config::load_user_config()
-                .ok()
-                .and_then(|c| c.log_level)
-                .and_then(|l| parse_log_level(&l))
-                .unwrap_or(log::LevelFilter::Info);
-            log::set_max_level(initial_level);
+            // Fixed at Trace — no user-facing toggle.
+            log::set_max_level(log::LevelFilter::Trace);
+            logging_cmd::init_bundle_identifier(app.config().identifier.clone());
+            if let Err(e) = speedwave_runtime::config::migrate_drop_log_level_in(
+                speedwave_runtime::consts::data_dir(),
+            ) {
+                log::warn!("config migration: {e:#}");
+            }
 
             clipboard_bridge::spawn(app.handle().clone());
 
@@ -1711,16 +1710,8 @@ fn main() {
                 show_audit_failure_dialog_and_exit(app.handle(), body);
             }
 
-            // Clean up old rotated log files (max 10 kept)
-            cleanup_old_logs(10);
-
-            // Periodic cleanup every hour for long-running sessions
-            tauri::async_runtime::spawn(async {
-                loop {
-                    tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
-                    cleanup_old_logs(10);
-                }
-            });
+            // Rotated-log cleanup is owned by `RotationStrategy::KeepSome(10)` —
+            // tauri-plugin-log prunes on every rotation. No separate timer needed.
 
             // Recover the user's login-shell PATH once, on a background thread
             // so a slow shell rc doesn't delay `setup()`. The `host_exec`
@@ -2110,9 +2101,6 @@ fn main() {
             update_commands::get_bundle_reconcile_state,
             update_commands::retry_bundle_reconcile,
             update_commands::restart_app,
-            // Logging
-            set_log_level,
-            get_log_level,
             // UI preferences (ADR-058)
             ui_prefs_cmd::get_beta_enabled,
             ui_prefs_cmd::set_beta_enabled,
@@ -2768,7 +2756,6 @@ mod tests {
             active_project: Some("alpha".to_string()),
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         }
     }
@@ -2840,7 +2827,6 @@ mod tests {
             active_project: None,
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         };
 

--- a/desktop/src-tauri/src/plugin_cmd.rs
+++ b/desktop/src-tauri/src/plugin_cmd.rs
@@ -996,7 +996,6 @@ mod tests {
             active_project: Some("test-project".into()),
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         };
         let json = serde_json::to_string_pretty(&initial_config).unwrap();
@@ -1044,7 +1043,6 @@ mod tests {
             active_project: Some("test-project".into()),
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         };
 
@@ -1072,7 +1070,6 @@ mod tests {
             active_project: Some("test-project".into()),
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         };
 
@@ -1128,7 +1125,6 @@ mod tests {
             active_project: None,
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         };
 
@@ -1196,7 +1192,6 @@ mod tests {
             active_project: None,
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         };
 
@@ -1510,7 +1505,6 @@ mod tests {
             active_project: Some("my-project".into()),
             selected_ide: None,
             transcription: None,
-            log_level: None,
             ui: None,
         };
         // Simulate the auto-enable block from install_plugin

--- a/desktop/src/src/app/a11y.spec.ts
+++ b/desktop/src/src/app/a11y.spec.ts
@@ -65,8 +65,6 @@ function buildMockTauri(): MockTauriService {
         return { provider: 'anthropic', model: null, base_url: null, api_key_env: null };
       case 'get_update_settings':
         return { auto_check: true, check_interval_hours: 24 };
-      case 'get_log_level':
-        return 'info';
       case 'get_platform':
         return 'darwin';
       case 'get_auth_status':

--- a/desktop/src/src/app/logs-view/logs-view.component.spec.ts
+++ b/desktop/src/src/app/logs-view/logs-view.component.spec.ts
@@ -8,11 +8,11 @@ import { HEALTH_REFRESH_INTERVAL_MS } from '../services/system-health.service';
 import { MockTauriService } from '../testing/mock-tauri.service';
 
 const MOCK_LOGS = [
-  'speedwave_test_mcp-hub_1 | [14:34:02.814] INFO  Dispatched tool call',
-  'speedwave_test_redmine_1 | [14:34:01.672] INFO  POST /projects/x → 201',
-  'speedwave_test_sharepoint_1 | [14:33:58.440] WARN  OAuth token expires soon',
-  'speedwave_test_slack_1 | [14:33:42.018] ERROR rate_limited: channels.history',
-  'speedwave_test_mcp-hub_1 | [14:33:57.182] DEBUG Low-level handshake chunk',
+  'mcp_hub | [14:34:02.814] INFO  Dispatched tool call',
+  'mcp_redmine | [14:34:01.672] INFO  POST /projects/x → 201',
+  'mcp_sharepoint | [14:33:58.440] WARN  OAuth token expires soon',
+  'mcp_slack | [14:33:42.018] ERROR rate_limited: channels.history',
+  'mcp_hub | [14:33:57.182] DEBUG Low-level handshake chunk',
 ].join('\n');
 
 describe('LogsViewComponent', () => {
@@ -74,7 +74,7 @@ describe('LogsViewComponent', () => {
     const sources = Array.from(
       fixture.nativeElement.querySelectorAll('[data-testid="logs-source"]')
     ) as HTMLElement[];
-    expect(sources[0].textContent?.trim()).toBe('mcp-hub');
+    expect(sources[0].textContent?.trim()).toBe('mcp_hub');
 
     const levels = Array.from(
       fixture.nativeElement.querySelectorAll('[data-testid="logs-level"]')
@@ -100,7 +100,7 @@ describe('LogsViewComponent', () => {
     // compose-level ISO stamp does. The fallback dates them with the host's
     // current day so two entries from different days cannot collide.
     mockTauri.invokeHandler = async (cmd: string) =>
-      cmd === 'get_all_logs' ? 'speedwave_test_mcp-hub_1 | [11:32:56] INFO  hello' : undefined;
+      cmd === 'get_all_logs' ? 'mcp_hub | [11:32:56] INFO  hello' : undefined;
     vi.spyOn(component as unknown as { todayIso(): string }, 'todayIso').mockReturnValue(
       '2026-04-28'
     );
@@ -120,7 +120,7 @@ describe('LogsViewComponent', () => {
     // identically. `[title]` keeps the raw value (micros + offset).
     const raw = '2026-04-28T11:32:56.123456Z';
     mockTauri.invokeHandler = async (cmd: string) =>
-      cmd === 'get_all_logs' ? `speedwave_test_mcp-hub_1 | ${raw} INFO  hello` : undefined;
+      cmd === 'get_all_logs' ? `mcp_hub | ${raw} INFO  hello` : undefined;
 
     await component.ngOnInit();
     fixture.detectChanges();
@@ -144,7 +144,7 @@ describe('LogsViewComponent', () => {
     const plus2 = '2026-04-28T13:32:56.000+02:00'; // same instant
     const render = async (raw: string): Promise<string> => {
       mockTauri.invokeHandler = async (cmd: string) =>
-        cmd === 'get_all_logs' ? `speedwave_test_mcp-hub_1 | ${raw} INFO x` : undefined;
+        cmd === 'get_all_logs' ? `mcp_hub | ${raw} INFO x` : undefined;
       await component.ngOnInit();
       fixture.detectChanges();
       return (
@@ -209,7 +209,7 @@ describe('LogsViewComponent', () => {
     fixture.detectChanges();
 
     component['setLevel']('warn');
-    component['setSource']('mcp-hub');
+    component['setSource']('mcp_hub');
     fixture.detectChanges();
 
     const empty = fixture.nativeElement.querySelector('[data-testid="logs-empty"]');
@@ -219,8 +219,7 @@ describe('LogsViewComponent', () => {
 
   it('wraps a very long log message with break-words', async () => {
     const longMessage = 'x'.repeat(2000);
-    mockTauri.invokeHandler = async () =>
-      `speedwave_test_claude_1 | [12:00:00] INFO  ${longMessage}`;
+    mockTauri.invokeHandler = async () => `claude | [12:00:00] INFO  ${longMessage}`;
 
     await component.ngOnInit();
     fixture.detectChanges();
@@ -324,7 +323,7 @@ describe('LogsViewComponent', () => {
     fixture.detectChanges();
 
     component['setLevel']('info');
-    component['setSource']('mcp-hub');
+    component['setSource']('mcp_hub');
     fixture.detectChanges();
 
     const rows = fixture.nativeElement.querySelectorAll('[data-testid="logs-line"]');
@@ -332,11 +331,11 @@ describe('LogsViewComponent', () => {
     expect(rows[0].textContent).toContain('Dispatched tool call');
   });
 
-  it('switching the source filter from all to redmine narrows the list', async () => {
+  it('switching the source filter from all to mcp_redmine narrows the list', async () => {
     await component.ngOnInit();
     fixture.detectChanges();
 
-    component['setSource']('redmine');
+    component['setSource']('mcp_redmine');
     fixture.detectChanges();
 
     const rows = fixture.nativeElement.querySelectorAll('[data-testid="logs-line"]');
@@ -355,8 +354,8 @@ describe('LogsViewComponent', () => {
     ) as HTMLSelectElement;
     expect(select).not.toBeNull();
     const values = Array.from(select.options).map((o) => o.value);
-    // 4 distinct sources in MOCK_LOGS: mcp-hub, redmine, sharepoint, slack — sorted alphabetically.
-    expect(values).toEqual(['all', 'mcp-hub', 'redmine', 'sharepoint', 'slack']);
+    // 4 distinct sources in MOCK_LOGS: mcp_hub, mcp_redmine, mcp_sharepoint, mcp_slack — sorted alphabetically.
+    expect(values).toEqual(['all', 'mcp_hub', 'mcp_redmine', 'mcp_sharepoint', 'mcp_slack']);
   });
 
   it('source select option labels carry per-source line counts', async () => {
@@ -368,9 +367,9 @@ describe('LogsViewComponent', () => {
     ) as HTMLSelectElement;
     const labels = Array.from(select.options).map((o) => o.textContent?.trim());
     expect(labels[0]).toBe('all sources (5)');
-    // mcp-hub appears twice in MOCK_LOGS (info + debug) so its counter must read 2.
-    expect(labels.find((l) => l?.startsWith('mcp-hub'))).toBe('mcp-hub (2)');
-    expect(labels.find((l) => l?.startsWith('redmine'))).toBe('redmine (1)');
+    // mcp_hub appears twice in MOCK_LOGS (info + debug) so its counter must read 2.
+    expect(labels.find((l) => l?.startsWith('mcp_hub'))).toBe('mcp_hub (2)');
+    expect(labels.find((l) => l?.startsWith('mcp_redmine'))).toBe('mcp_redmine (1)');
   });
 
   it('changing the source select narrows the visible rows', async () => {
@@ -380,7 +379,7 @@ describe('LogsViewComponent', () => {
     const select = fixture.nativeElement.querySelector(
       '[data-testid="logs-source-select"]'
     ) as HTMLSelectElement;
-    select.value = 'sharepoint';
+    select.value = 'mcp_sharepoint';
     select.dispatchEvent(new Event('change'));
     fixture.detectChanges();
 
@@ -392,13 +391,13 @@ describe('LogsViewComponent', () => {
   it('falls back to source=all when the selected source vanishes from a refresh', async () => {
     await component.ngOnInit();
     fixture.detectChanges();
-    component['setSource']('redmine');
-    expect(component.filters().source).toBe('redmine');
+    component['setSource']('mcp_redmine');
+    expect(component.filters().source).toBe('mcp_redmine');
 
     // Next refresh returns logs without the `redmine` source — the stale
     // selection must be reconciled instead of stranding the user on an empty list.
     mockTauri.invokeHandler = async (cmd: string) =>
-      cmd === 'get_all_logs' ? 'speedwave_test_mcp-hub_1 | [12:00:00] INFO  still here' : undefined;
+      cmd === 'get_all_logs' ? 'mcp_hub | [12:00:00] INFO  still here' : undefined;
     await component['refresh']();
     fixture.detectChanges();
 
@@ -408,25 +407,25 @@ describe('LogsViewComponent', () => {
 
 describe('parseLogLine', () => {
   it('parses a compose-format line with timestamp and level', () => {
-    const line = parseLogLine('mcp_hub_1 | [14:34:02.814] INFO  Listening on :4000');
+    const line = parseLogLine('mcp_hub | [14:34:02.814] INFO  Listening on :4000');
     expect(line.source).toBe('mcp_hub');
     expect(line.time).toBe('14:34:02.814');
     expect(line.level).toBe('info');
     expect(line.message).toBe('Listening on :4000');
   });
 
-  it('strips the speedwave_<project>_ prefix from compose sources', () => {
-    const line = parseLogLine('speedwave_demo_mcp-hub_1 | [10:00:00] INFO  started');
-    expect(line.source).toBe('mcp-hub');
+  it('uses the backend-supplied source verbatim (no client-side stripping)', () => {
+    const line = parseLogLine('mcp_office | [10:00:00] INFO  started');
+    expect(line.source).toBe('mcp_office');
   });
 
   it('normalises WARNING to warn and TRACE to debug', () => {
-    expect(parseLogLine('hub_1 | [00:00:00] WARNING x').level).toBe('warn');
-    expect(parseLogLine('hub_1 | [00:00:00] TRACE x').level).toBe('debug');
+    expect(parseLogLine('mcp_hub | [00:00:00] WARNING x').level).toBe('warn');
+    expect(parseLogLine('mcp_hub | [00:00:00] TRACE x').level).toBe('debug');
   });
 
   it('handles lines with no level prefix', () => {
-    const line = parseLogLine('hub_1 | [00:00:00] raw text');
+    const line = parseLogLine('mcp_hub | [00:00:00] raw text');
     expect(line.level).toBe('info');
     expect(line.message).toBe('raw text');
   });
@@ -445,7 +444,7 @@ describe('parseLogLine', () => {
   });
 
   it('parses an ISO-timestamp line via the ISO_TIME_RE branch', () => {
-    const line = parseLogLine('hub_1 | 2024-01-15T14:34:02.814Z INFO started');
+    const line = parseLogLine('mcp_hub | 2024-01-15T14:34:02.814Z INFO started');
     expect(line.time).toBe('2024-01-15T14:34:02.814Z');
     expect(line.level).toBe('info');
     expect(line.message).toBe('started');
@@ -492,13 +491,13 @@ describe('parseLogLine', () => {
 
   it('parses a bare bracketed ISO timestamp via the extended BRACKETED_TIME_RE', () => {
     // A worker `ts()` line with no drain/compose prefix — now local offset.
-    const line = parseLogLine('hub_1 | [2026-05-12T14:34:02.814+02:00] 🚀 Starting');
+    const line = parseLogLine('mcp_hub | [2026-05-12T14:34:02.814+02:00] 🚀 Starting');
     expect(line.time).toBe('2026-05-12T14:34:02.814+02:00');
     expect(line.message).toBe('🚀 Starting');
   });
 
   it('still parses a bare bracketed UTC `Z` ISO timestamp (older logs / nerdctl)', () => {
-    const line = parseLogLine('hub_1 | [2026-05-12T12:34:02.814Z] 🚀 Starting');
+    const line = parseLogLine('mcp_hub | [2026-05-12T12:34:02.814Z] 🚀 Starting');
     expect(line.time).toBe('2026-05-12T12:34:02.814Z');
     expect(line.message).toBe('🚀 Starting');
   });
@@ -508,9 +507,9 @@ describe('parseLogLine', () => {
     // gets nerdctl's stamp (localised at render); the inline `[<ts()>]` is the
     // same instant, so it's removed from the visible message.
     const line = parseLogLine(
-      'speedwave_doc_mcp-hub_1 | 2026-05-12T13:00:39.816Z [2026-05-12T15:00:39.816+02:00] 🔗 Initializing HTTP bridges'
+      'mcp_hub | 2026-05-12T13:00:39.816Z [2026-05-12T15:00:39.816+02:00] 🔗 Initializing HTTP bridges'
     );
-    expect(line.source).toBe('mcp-hub');
+    expect(line.source).toBe('mcp_hub');
     expect(line.time).toBe('2026-05-12T13:00:39.816Z');
     expect(line.message).toBe('🔗 Initializing HTTP bridges');
     expect(line.message).not.toContain('[2026-');
@@ -539,9 +538,9 @@ describe('sortLogLinesByTime', () => {
       ln('claude | 2026-05-12T14:53:49.000+02:00 SESSION: started'),
       ln('claude | 2026-05-12T14:53:57.000+02:00 SYSTEM: init'),
       ln('claude | 2026-05-12T14:54:32.000+02:00 RESULT: turn complete'),
-      ln('speedwave_test_mcp-hub_1 | 2026-05-12T14:53:48.000+02:00 INFO  Tool registered'),
-      ln('speedwave_test_mcp-hub_1 | 2026-05-12T14:53:49.500+02:00 INFO  Session created'),
-      ln('speedwave_test_mcp-hub_1 | 2026-05-12T14:54:13.000+02:00 INFO  Executing tool'),
+      ln('mcp_hub | 2026-05-12T14:53:48.000+02:00 INFO  Tool registered'),
+      ln('mcp_hub | 2026-05-12T14:53:49.500+02:00 INFO  Session created'),
+      ln('mcp_hub | 2026-05-12T14:54:13.000+02:00 INFO  Executing tool'),
     ]);
     expect(sorted.map((l) => l.time)).toEqual([
       '2026-05-12T14:53:48.000+02:00', // hub
@@ -556,7 +555,7 @@ describe('sortLogLinesByTime', () => {
   it('orders correctly across mixed offsets (UTC `Z` vs `+02:00`) by instant', () => {
     const sorted = sortLogLinesByTime([
       ln('claude | 2026-05-12T14:00:05.000+02:00 SESSION: started'), // 12:00:05Z
-      ln('speedwave_x_mcp-hub_1 | 2026-05-12T12:00:03.000Z hub line'), // 12:00:03Z
+      ln('mcp_hub | 2026-05-12T12:00:03.000Z hub line'), // 12:00:03Z
       ln('claude | 2026-05-12T14:00:01.000+02:00 SESSION: prep'), // 12:00:01Z
     ]);
     expect(sorted.map((l) => l.time)).toEqual([
@@ -567,13 +566,13 @@ describe('sortLogLinesByTime', () => {
   });
 
   it('keeps a timestamp-less line attached to the preceding line (continuation)', () => {
-    const banner = parseLogLine('speedwave_x_mcp-hub_1 | ════════════');
+    const banner = parseLogLine('mcp_hub | ════════════');
     expect(banner.time).toBe(''); // no timestamp
     const sorted = sortLogLinesByTime([
       ln('claude | 2026-05-12T14:00:10.000+02:00 b: later'),
-      ln('speedwave_x_mcp-hub_1 | 2026-05-12T14:00:01.000+02:00 a: first'),
+      ln('mcp_hub | 2026-05-12T14:00:01.000+02:00 a: first'),
       banner, // inherits a:first's instant → stays right after it
-      ln('speedwave_x_mcp-hub_1 | 2026-05-12T14:00:02.000+02:00 a: second'),
+      ln('mcp_hub | 2026-05-12T14:00:02.000+02:00 a: second'),
     ]);
     expect(sorted.map((l) => l.message)).toEqual([
       'a: first',
@@ -586,7 +585,7 @@ describe('sortLogLinesByTime', () => {
   it('is stable for equal instants — keeps input order', () => {
     const sorted = sortLogLinesByTime([
       ln('claude | 2026-05-12T14:00:00.000+02:00 first'),
-      ln('speedwave_x_mcp-hub_1 | 2026-05-12T14:00:00.000+02:00 second'),
+      ln('mcp_hub | 2026-05-12T14:00:00.000+02:00 second'),
       ln('mcp-os | 2026-05-12T14:00:00.000+02:00 STDOUT: third'),
     ]);
     expect(sorted.map((l) => l.message)).toEqual(['first', 'second', 'third']);
@@ -594,6 +593,28 @@ describe('sortLogLinesByTime', () => {
 
   it('returns an empty array unchanged', () => {
     expect(sortLogLinesByTime([])).toEqual([]);
+  });
+
+  it('leading timestamp-less lines inherit the next timestamp, not epoch zero', () => {
+    const banner = parseLogLine('mcp_hub | ════════════');
+    expect(banner.time).toBe('');
+    const sorted = sortLogLinesByTime([
+      banner,
+      ln('mcp_hub | 2026-05-12T14:00:01.000+02:00 a: first'),
+      ln('claude | 2026-05-12T14:00:00.000+02:00 earlier in time'),
+    ]);
+    expect(sorted.map((l) => l.message)).toEqual(['earlier in time', '════════════', 'a: first']);
+  });
+
+  it('purely plain-text input preserves stable input order', () => {
+    // Edge case: every line has NaN key (no timestamp anywhere). Stable sort
+    // must keep input order — banner/header lines stay at the top.
+    const onlyPlain = sortLogLinesByTime([
+      parseLogLine('plugin | starting'),
+      parseLogLine('plugin | ready'),
+      parseLogLine('plugin | done'),
+    ]);
+    expect(onlyPlain.map((l) => l.message)).toEqual(['starting', 'ready', 'done']);
   });
 });
 
@@ -605,9 +626,9 @@ describe('LogsViewComponent — status bar layout', () => {
 
   const MOCK_HEALTH = {
     containers: [
-      { name: 'speedwave_demo_hub', status: 'running', healthy: true },
-      { name: 'speedwave_demo_redmine', status: 'running', healthy: true },
-      { name: 'speedwave_demo_sharepoint', status: 'starting', healthy: false },
+      { name: 'mcp_hub', status: 'running', healthy: true },
+      { name: 'mcp_redmine', status: 'running', healthy: true },
+      { name: 'mcp_sharepoint', status: 'starting', healthy: false },
     ],
     vm: { running: true, vm_type: 'lima' },
     mcp_os: { running: true },
@@ -682,7 +703,7 @@ describe('LogsViewComponent — status bar layout', () => {
     expect(component.mcpOsRunning()).toBe(true);
     expect(component.anyContainerUnhealthy()).toBe(true);
     expect(component.containersLabel()).toContain('2 of 3');
-    expect(component.containersDetail()).toContain('sharepoint');
+    expect(component.containersDetail()).toContain('mcp_sharepoint');
     expect(component.detectedIdes()).toHaveLength(1);
   });
 
@@ -773,12 +794,12 @@ describe('LogsViewComponent — status bar layout', () => {
     const details = fixture.nativeElement.querySelector('[data-testid="logs-status-details"]');
     expect(details).not.toBeNull();
 
-    // One row per container, identified by stripped name.
+    // One row per container, identified by backend-supplied service name.
     expect(
-      fixture.nativeElement.querySelector('[data-testid="health-container-hub"]')
+      fixture.nativeElement.querySelector('[data-testid="health-container-mcp_hub"]')
     ).not.toBeNull();
     expect(
-      fixture.nativeElement.querySelector('[data-testid="health-container-sharepoint"]')
+      fixture.nativeElement.querySelector('[data-testid="health-container-mcp_sharepoint"]')
     ).not.toBeNull();
 
     // One row for the cursor IDE detected in the snapshot.
@@ -974,26 +995,6 @@ describe('LogsViewComponent — status bar layout', () => {
     expect(banner?.textContent).toContain('zip failed');
   });
 
-  it('forces trace-level logging on init so exported diagnostics carry full context', async () => {
-    const invokeSpy = vi.spyOn(mockTauri, 'invoke');
-    await component.ngOnInit();
-    expect(invokeSpy).toHaveBeenCalledWith('set_log_level', { level: 'trace' });
-  });
-
-  it('does not surface set_log_level failures (browser dev mode is silent)', async () => {
-    mockTauri.invokeHandler = async (cmd: string) => {
-      if (cmd === 'set_log_level') throw new Error('not in tauri');
-      if (cmd === 'get_all_logs') return '';
-      if (cmd === 'get_health') return MOCK_HEALTH;
-      return undefined;
-    };
-    await component.ngOnInit();
-    fixture.detectChanges();
-    // forceMaxLogLevel is best-effort — the error must not bleed into the
-    // banner or block subsequent fetches.
-    expect(component.error()).toBe('');
-  });
-
   it('schedules a scroll-to-bottom write after each successful fetch', async () => {
     // Reproduces the user-visible bug where opening /logs landed on top of
     // the stream. The component delegates the actual scroll to
@@ -1108,7 +1109,7 @@ describe('LogsViewComponent — status bar layout', () => {
   it('skips re-render when the silent poll buffer is byte-identical (lastRaw guard)', async () => {
     await component.ngOnInit();
     mockTauri.invokeHandler = async (cmd: string) =>
-      cmd === 'get_all_logs' ? 'speedwave_test_mcp-hub_1 | hello' : undefined;
+      cmd === 'get_all_logs' ? 'mcp_hub | hello' : undefined;
     // First silent poll populates lastRaw + lines.
     await component['refresh'](true);
     const setSpy = vi.spyOn(component.lines, 'set');
@@ -1129,7 +1130,7 @@ describe('LogsViewComponent — status bar layout', () => {
       return [
         // compose-container line: nerdctl `--timestamps` (UTC) + the worker's
         // own `ts()` (local offset) inside the message.
-        'speedwave_test_mcp-hub_1 | 2026-05-12T12:00:00.123456Z [2026-05-12T14:00:00.123+02:00] INFO container line',
+        'mcp_hub | 2026-05-12T12:00:00.123456Z [2026-05-12T14:00:00.123+02:00] INFO container line',
         'desktop | 2026-05-12T14:34:02.814+02:00 INFO [target] desktop line',
         'mcp-os | 2026-05-12T14:34:03.000+02:00 STDOUT: [2026-05-12T14:34:03.000+02:00] mcp-os line',
         // audit JSON `ts` field stays UTC `Z`; the drain prefix is local offset.
@@ -1145,7 +1146,7 @@ describe('LogsViewComponent — status bar layout', () => {
     expect(sources).toContain('mcp-os');
     expect(sources).toContain('host-exec');
     expect(sources).toContain('claude');
-    expect(sources).toContain('mcp-hub'); // compose container, prefix-stripped
+    expect(sources).toContain('mcp_hub'); // compose container, prefix-stripped
     expect(sources[0]).toBe('all');
   });
 

--- a/desktop/src/src/app/logs-view/logs-view.component.ts
+++ b/desktop/src/src/app/logs-view/logs-view.component.ts
@@ -45,12 +45,6 @@ export const LEVEL_CHIPS: readonly LogLevel[] = ['all', 'debug', 'info', 'warn',
 // Polling cadence for the system health grid lives in `SystemHealthService`
 // (`services/system-health.service.ts`) — the SSOT for the polling loop.
 
-/**
- * Trace-level diagnostics is forced at view init so an exported diagnostics
- * ZIP always carries full context regardless of any prior runtime setting.
- */
-const FORCED_LOG_LEVEL = 'trace';
-
 const COMPOSE_RE = /^([\w.-]+)\s*\|\s*(.*)$/;
 // `[HH:MM:SS]` or `[<ISO>]`; ISO is `mcp-shared`'s `ts()`.
 const BRACKETED_TIME_RE =
@@ -65,12 +59,13 @@ const FORMAT_TIME_HMS_RE = /^(\d{2}:\d{2}:\d{2})/;
 const LEVEL_RE = /^(DEBUG|INFO|WARN|WARNING|ERROR|TRACE)\s+(.*)$/i;
 /** Drain prefix the Rust `log_file` writer puts on captured stdout/stderr lines — pure noise in the message. */
 const DRAIN_PREFIX_RE = /^(?:STDOUT|STDERR): (.*)$/;
-const CONTAINER_PREFIX_RE = /^speedwave_[^_]+_([^_]+)(?:_\d+)?$/;
-const TRAILING_INDEX_RE = /_\d+$/;
 
 /**
  * Parse a single compose-log line into `LogLine`. Tolerant — never throws.
- * @param raw - A single log line as emitted by `nerdctl compose logs`.
+ * Backend (`container_logs_cmd::prefix_lines`) already strips the
+ * `speedwave_<project>_` container prefix, so we render whatever source token
+ * arrives — no client-side heuristic.
+ * @param raw - A single log line as emitted by `get_all_logs`.
  */
 export function parseLogLine(raw: string): LogLine {
   const trimmed = raw.trim();
@@ -78,7 +73,7 @@ export function parseLogLine(raw: string): LogLine {
     return { time: '', source: 'log', level: 'info', message: '' };
   }
   const composeMatch = COMPOSE_RE.exec(trimmed);
-  const source = composeMatch ? stripContainerPrefix(composeMatch[1]) : 'log';
+  const source = composeMatch ? composeMatch[1] : 'log';
   const rest = composeMatch ? composeMatch[2] : trimmed;
 
   // Head: nerdctl `--timestamps`, Rust drain, or `[<ISO>]`.
@@ -119,29 +114,42 @@ function normalizeLevel(raw: string): LogLevel {
 }
 
 /**
- * Strip the `speedwave_<project>_` prefix from a container name.
- * @param container - Container name as it appears in compose-log prefixes.
- */
-function stripContainerPrefix(container: string): string {
-  const match = CONTAINER_PREFIX_RE.exec(container);
-  if (match) return match[1];
-  return container.replace(TRAILING_INDEX_RE, '');
-}
-
-/**
  * Interleave per-source blocks into one chronological stream.
- * Lines without a parseable time inherit the previous line's instant.
+ * Lines without a parseable time inherit the *previous* line's instant; if
+ * a line has no parseable time AND no prior line set one (file starts with
+ * untimestamped content), it inherits the *next* line's instant so it sits
+ * with its block rather than sinking to epoch zero.
  * @param lines - Parsed log lines in backend (block) order.
  */
 export function sortLogLinesByTime(lines: LogLine[]): LogLine[] {
-  let lastKey = 0;
-  const keyed = lines.map((line) => {
-    const t = line.time ? Date.parse(line.time) : NaN;
+  const keys: number[] = new Array<number>(lines.length).fill(NaN);
+  let lastKey = NaN;
+  for (let i = 0; i < lines.length; i++) {
+    const t = lines[i].time ? Date.parse(lines[i].time) : NaN;
     if (!Number.isNaN(t)) lastKey = t;
-    return { line, key: lastKey };
-  });
+    keys[i] = lastKey;
+  }
+  let nextKey = NaN;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (!Number.isNaN(keys[i])) {
+      nextKey = keys[i];
+    } else if (!Number.isNaN(nextKey)) {
+      keys[i] = nextKey;
+    }
+  }
+  const keyed = lines.map((line, i) => ({ line, key: keys[i] }));
   // `Array.prototype.sort` is stable (ES2019+) — equal keys keep input order.
-  return keyed.sort((a, b) => a.key - b.key).map((k) => k.line);
+  // Lines that remain NaN (no parseable timestamp anywhere in their block) sort
+  // BEFORE all timestamped lines — matches the historical epoch-zero placement
+  // so banner/header lines stay at the top of the view, not hidden at the bottom.
+  return keyed
+    .sort((a, b) => {
+      if (Number.isNaN(a.key) && Number.isNaN(b.key)) return 0;
+      if (Number.isNaN(a.key)) return -1;
+      if (Number.isNaN(b.key)) return 1;
+      return a.key - b.key;
+    })
+    .map((k) => k.line);
 }
 
 /**
@@ -331,13 +339,13 @@ export function sortLogLinesByTime(lines: LogLine[]): LogLine[] {
                 @for (c of containerArray(); track c.name) {
                   <li
                     class="mono flex items-center gap-2 text-[11px]"
-                    [attr.data-testid]="'health-container-' + stripPrefix(c.name)"
+                    [attr.data-testid]="'health-container-' + c.name"
                   >
                     <span
                       class="dot"
                       [style.background]="c.healthy ? 'var(--green)' : 'var(--amber)'"
                     ></span>
-                    <span class="text-[var(--ink)]">{{ stripPrefix(c.name) }}</span>
+                    <span class="text-[var(--ink)]">{{ c.name }}</span>
                     <span class="text-[var(--ink-mute)]">· {{ c.status }}</span>
                   </li>
                 }
@@ -630,7 +638,7 @@ export class LogsViewComponent implements OnInit, OnDestroy {
   readonly containersDetail = computed<string>(() => {
     const containers = this.containerArray();
     const unhealthy = containers.find((c) => !c.healthy);
-    if (unhealthy) return `${stripContainerPrefix(unhealthy.name)}: ${unhealthy.status}`;
+    if (unhealthy) return `${unhealthy.name}: ${unhealthy.status}`;
     return 'all healthy';
   });
 
@@ -715,7 +723,6 @@ export class LogsViewComponent implements OnInit, OnDestroy {
    * banner even though the project pill in the header reads correctly).
    */
   async ngOnInit(): Promise<void> {
-    void this.forceMaxLogLevel();
     await this.refresh();
     // SystemHealthService owns the polling loop and the project-settled
     // health refresh; we just kick it off and read its `health` signal.
@@ -927,9 +934,6 @@ export class LogsViewComponent implements OnInit, OnDestroy {
     this.detailsOpen.update((v) => !v);
   }
 
-  /** Strip the `speedwave_<project>_` prefix from a container name for display. */
-  protected readonly stripPrefix = stripContainerPrefix;
-
   /**
    * Select a level chip.
    * @param level - Level to filter on, or `'all'` to disable the filter.
@@ -966,18 +970,5 @@ export class LogsViewComponent implements OnInit, OnDestroy {
     if (active === 'all') return;
     if (lines.some((l) => l.source === active)) return;
     this.filters.update((f) => ({ ...f, source: 'all' }));
-  }
-
-  /** Force trace-level diagnostics on init; failures log at debug. */
-  private async forceMaxLogLevel(): Promise<void> {
-    try {
-      await this.tauri.invoke('set_log_level', { level: FORCED_LOG_LEVEL });
-    } catch (err) {
-      // Backend unavailable in browser dev mode (expected) or the command
-      // was renamed/removed (regression). Log so a typo surfaces during
-      // development without breaking log rendering, which doesn't depend
-      // on the trace-level upgrade.
-      console.debug('[logs-view] set_log_level failed', err);
-    }
   }
 }

--- a/desktop/src/src/app/settings/settings.component.spec.ts
+++ b/desktop/src/src/app/settings/settings.component.spec.ts
@@ -21,8 +21,6 @@ function setupMockTauri(mockTauri: MockTauriService): void {
         return { provider: 'anthropic', model: null, base_url: null, default_base_url: null };
       case 'get_update_settings':
         return { auto_check: true, check_interval_hours: 24 };
-      case 'get_log_level':
-        return 'info';
       case 'get_platform':
         return 'darwin';
       case 'get_auth_status':

--- a/desktop/src/src/app/system-view/system-view.component.spec.ts
+++ b/desktop/src/src/app/system-view/system-view.component.spec.ts
@@ -8,9 +8,11 @@ import type { HealthReport } from '../models/health';
 
 const MOCK_HEALTHY_REPORT: HealthReport = {
   containers: [
-    { name: 'speedwave_test_claude', status: 'running', healthy: true },
-    { name: 'speedwave_test_mcp-hub', status: 'running', healthy: true },
-    { name: 'speedwave_test_redmine', status: 'starting', healthy: false },
+    // Backend (parse_container_entries) strips the compose prefix; mocks
+    // reflect the post-strip wire format the component actually receives.
+    { name: 'claude', status: 'running', healthy: true },
+    { name: 'mcp_hub', status: 'running', healthy: true },
+    { name: 'mcp_redmine', status: 'starting', healthy: false },
   ],
   vm: { running: true, vm_type: 'lima' },
   mcp_os: { running: true },
@@ -88,11 +90,7 @@ describe('SystemViewComponent', () => {
     const names = Array.from(
       fixture.nativeElement.querySelectorAll('[data-testid="system-name"]')
     ) as HTMLElement[];
-    expect(names.map((n) => n.textContent?.trim())).toEqual([
-      'speedwave_test_claude',
-      'speedwave_test_mcp-hub',
-      'speedwave_test_redmine',
-    ]);
+    expect(names.map((n) => n.textContent?.trim())).toEqual(['claude', 'mcp_hub', 'mcp_redmine']);
 
     const states = Array.from(
       fixture.nativeElement.querySelectorAll('[data-testid="system-state"]')
@@ -263,7 +261,7 @@ describe('SystemViewComponent', () => {
     const btn = fixture.nativeElement.querySelector(
       '[data-testid="system-restart"]'
     ) as HTMLButtonElement;
-    await component['restart']('speedwave_test_claude');
+    await component['restart']('claude');
     fixture.detectChanges();
 
     expect(calls).toContain('recreate_project_containers');
@@ -286,15 +284,15 @@ describe('SystemViewComponent', () => {
     await component.ngOnInit();
     fixture.detectChanges();
 
-    const restartPromise = component['restart']('speedwave_test_claude');
+    const restartPromise = component['restart']('claude');
     fixture.detectChanges();
 
-    expect(component.restarting.has('speedwave_test_claude')).toBe(true);
+    expect(component.restarting.has('claude')).toBe(true);
 
     restartResolver.current?.();
     await restartPromise;
     fixture.detectChanges();
 
-    expect(component.restarting.has('speedwave_test_claude')).toBe(false);
+    expect(component.restarting.has('claude')).toBe(false);
   });
 });

--- a/docs/adr/ADR-058-beta-features-toggle.md
+++ b/docs/adr/ADR-058-beta-features-toggle.md
@@ -31,7 +31,7 @@ The visible menu shape is produced by a pure function `tray_menu_spec(update_ver
 
 ### Persistence
 
-The flag lives in top-level user-config: `SpeedwaveUserConfig.ui.beta_enabled: Option<bool>` (new `UiPrefsConfig` struct), defaulting to `false`. It is **user-only** — a checked-in repo `.speedwave.json` cannot set it, consistent with how privacy- and behaviour-sensitive flags are handled elsewhere. Reads/writes go through the existing `config::with_config_lock` + `tokio::task::spawn_blocking` pattern (same as `set_log_level`), so the UI thread never does synchronous config I/O.
+The flag lives in top-level user-config: `SpeedwaveUserConfig.ui.beta_enabled: Option<bool>` (new `UiPrefsConfig` struct), defaulting to `false`. It is **user-only** — a checked-in repo `.speedwave.json` cannot set it, consistent with how privacy- and behaviour-sensitive flags are handled elsewhere. Reads/writes go through the existing `config::with_config_lock` + `tokio::task::spawn_blocking` pattern, so the UI thread never does synchronous config I/O.
 
 ### Write path
 

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -54,6 +54,18 @@ The `claude` image bakes `/usr/local/bin/{pbcopy,xclip,xsel,wl-copy,clip.exe}` a
 
 The wrapper is **write-only by design**: it never reads the host clipboard (OSC 52 query/paste would require a terminal-side response handshake and would leak host clipboard contents into the container). It touches only its own stdin and `/dev/tty`, runs as the unprivileged container user, and adds no new mounts. See [ADR-052](../adr/ADR-052-anthropic-oauth-login-flow.md).
 
+## Log Sanitization
+
+SSOT: `crates/speedwave-runtime/src/log_sanitizer.rs` (Rust) mirrored by `mcp-servers/shared/src/sanitizer.ts` (TypeScript). Every log line written by Desktop, CLI, the worker drain, and host-side MCP services passes through `sanitize()` before reaching disk or stdout. Redacted patterns:
+
+- **Credentials**: Bearer / Authorization / X-Redmine-API-Key headers, JWTs (`eyJ…`), generic `password=` / `secret=` / `api_key=` assignments, URL userinfo (`://user:pass@`), URL query secrets (`?token=…`).
+- **Provider tokens**: Slack (`xox[bpars]-…`), GitHub (`ghp_`, `ghs_`, `gho_`, `ghu_`, `github_pat_`), GitLab (`glpat-…`), Atlassian (`ATATT…`), Anthropic (`sk-ant-…`), generic OpenAI-style (`sk-…`).
+- **HTTP cookies**: both `Cookie:` and `Set-Cookie:` header values.
+- **PEM private keys**: full BEGIN/END blocks.
+- **Host paths / PII**: `/Users/<name>`, `/home/<name>`, `C:\Users\<name>` — the username segment is replaced with `<user>` while the path tail is preserved.
+
+Rust and TS rule counts are pinned by `EXPECTED_RULE_COUNT` / `RULE_COUNT` constants; both test suites fail if the lists drift.
+
 ## Threat Model
 
 When implementing any feature, ask these questions:

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -4,7 +4,7 @@ Speedwave uses a three-level config merge: defaults -> repo `.speedwave.json` ->
 
 ## Config File: `~/.speedwave/config.json`
 
-The user-level config file stores project definitions, the active project, IDE selection, and log level:
+The user-level config file stores project definitions, the active project, and IDE selection:
 
 ```json
 {
@@ -54,7 +54,6 @@ The user-level config file stores project definitions, the active project, IDE s
   ],
   "active_project": "acme-corp",
   "selected_ide": null,
-  "log_level": null,
   "ui": { "beta_enabled": false }
 }
 ```

--- a/docs/guides/desktop.md
+++ b/docs/guides/desktop.md
@@ -125,7 +125,7 @@ The `/logs` route hosts a single page that combines container logs, host-side se
 
 **IDE Bridge connect link.** The IDE Bridge cell renders `connect →` when the daemon is running but no IDE is selected (`selected_ide` is `null`). The link deep-jumps to `/integrations#ide-bridge` (anchor scrolling is enabled in the Angular router for this) so the user can pick a target IDE without scrolling.
 
-**Always-on trace logging.** On view init the page invokes `set_log_level` with `trace` so any diagnostics export carries the most verbose level regardless of any prior runtime setting. Failures are logged at `console.debug` and ignored — the log stream renders without the level upgrade.
+**Always-on trace logging.** Desktop emits every log line at `trace` level — no UI toggle, no config field. The level cap is hard-coded in `main.rs` setup; diagnostics exports therefore always carry the most verbose context.
 
 **Diagnostics export.** A button bundles the runtime log directory plus a compact summary into a ZIP. The path is shown in a modal with a copy-to-clipboard control; the file is opened in the host's file manager rather than auto-attached anywhere, so the user controls who sees it.
 

--- a/mcp-servers/shared/src/index.ts
+++ b/mcp-servers/shared/src/index.ts
@@ -101,6 +101,7 @@ export { TIMEOUTS } from './timeouts.js';
 
 // Logger
 export { ts } from './logger.js';
+export { sanitize } from './sanitizer.js';
 
 // Errors (SSOT for user-facing messages)
 export { notConfiguredMessage, withSetupGuidance } from './errors.js';

--- a/mcp-servers/shared/src/sanitizer.test.ts
+++ b/mcp-servers/shared/src/sanitizer.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { sanitize, RULE_COUNT } from './sanitizer';
+
+describe('sanitize', () => {
+  it('rule count matches Rust SSOT EXPECTED_RULE_COUNT', () => {
+    // Mirrors `EXPECTED_RULE_COUNT` in crates/speedwave-runtime/src/log_sanitizer.rs.
+    // Bump both together when adding a rule.
+    expect(RULE_COUNT).toBe(21);
+  });
+
+  it('redacts Bearer tokens', () => {
+    const out = sanitize('Authorization: Bearer abc.def.ghi');
+    expect(out).not.toContain('abc.def.ghi');
+    expect(out).toContain('***REDACTED***');
+  });
+
+  it('redacts JWT', () => {
+    const out = sanitize('token=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.signature');
+    expect(out).toContain('***REDACTED_JWT***');
+    expect(out).not.toContain('eyJzdWIiOiIxIn0');
+  });
+
+  it('redacts Slack tokens', () => {
+    const out = sanitize('xoxb-1234567890-abcdef');
+    expect(out).toContain('***REDACTED_SLACK_TOKEN***');
+  });
+
+  it('redacts GitHub PAT', () => {
+    const out = sanitize('ghp_' + 'A'.repeat(40));
+    expect(out).toContain('***REDACTED_GITHUB_TOKEN***');
+  });
+
+  it('redacts Anthropic key', () => {
+    const out = sanitize('using sk-ant-api03-abc123_def');
+    expect(out).toContain('***REDACTED_ANTHROPIC_KEY***');
+  });
+
+  it('redacts macOS home path username', () => {
+    const out = sanitize('reading /Users/alice/.speedwave/config.json');
+    expect(out).not.toContain('alice');
+    expect(out).toContain('/Users/<user>/.speedwave/config.json');
+  });
+
+  it('redacts Set-Cookie', () => {
+    const out = sanitize('Set-Cookie: session=abc123; Path=/');
+    expect(out).not.toContain('abc123');
+    expect(out).toContain('***REDACTED***');
+    expect(out).toContain('Path=/');
+  });
+
+  it('redacts Set-Cookie value with embedded space (non-RFC)', () => {
+    const out = sanitize('Set-Cookie: id=secret extra_data; Path=/');
+    expect(out).not.toContain('secret');
+    expect(out).not.toContain('extra_data');
+    expect(out).toContain('Path=/');
+  });
+
+  it('redacts Cookie request header', () => {
+    const out = sanitize('Cookie: session_id=xyz; csrftoken=789');
+    expect(out).not.toContain('xyz');
+    expect(out).not.toContain('789');
+    expect(out).toContain('***REDACTED***');
+  });
+
+  it('redacts Linux home path username', () => {
+    const out = sanitize('loaded from /home/alice/.cache/foo');
+    expect(out).not.toContain('alice');
+    expect(out).toContain('/home/<user>/.cache/foo');
+  });
+
+  it('redacts Windows home path username', () => {
+    const out = sanitize(String.raw`open failed: C:\Users\Bob\AppData\Roaming\speedwave`);
+    expect(out).not.toContain('Bob');
+    expect(out).toContain(String.raw`C:\Users\<user>\AppData\Roaming\speedwave`);
+  });
+
+  it('does not redact normal prose', () => {
+    expect(sanitize('eating a cookie now')).toBe('eating a cookie now');
+  });
+});

--- a/mcp-servers/shared/src/sanitizer.ts
+++ b/mcp-servers/shared/src/sanitizer.ts
@@ -1,0 +1,50 @@
+// Mirrors the Rust SSOT (`crates/speedwave-runtime/src/log_sanitizer.rs`).
+// Keep rule list in sync — any new Rust rule needs a counterpart here so
+// secrets don't leak through TS worker stdout before the Rust drain runs.
+
+const RULES: ReadonlyArray<readonly [RegExp, string]> = [
+  [
+    /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g,
+    '-----BEGIN PRIVATE KEY-----\n***REDACTED***\n-----END PRIVATE KEY-----',
+  ],
+  [/((?:\/Users\/|\/home\/|[A-Z]:\\Users\\))[^/\\\s]+/gi, '$1<user>'],
+  [/(Set-Cookie:\s*)[^;\r\n]+/gi, '$1***REDACTED***'],
+  // Cookie request header: anchor at start-of-line/whitespace so `Set-Cookie:`
+  // does not double-match via `\b` on the `-C` boundary.
+  [/(^|\s)(Cookie:\s*)[^\r\n]+/gi, '$1$2***REDACTED***'],
+  [/(Bearer\s+)\S+/gi, '$1***REDACTED***'],
+  [/(Authorization:\s*)\S+(\s+\S+)?/gi, '$1***REDACTED***'],
+  [/eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g, '***REDACTED_JWT***'],
+  [/xox[bpars]-[A-Za-z0-9-]+/g, '***REDACTED_SLACK_TOKEN***'],
+  [/ghp_[A-Za-z0-9]{36,}/g, '***REDACTED_GITHUB_TOKEN***'],
+  [/ghs_[A-Za-z0-9]{36,}/g, '***REDACTED_GITHUB_TOKEN***'],
+  [/gho_[A-Za-z0-9]{36,}/g, '***REDACTED_GITHUB_TOKEN***'],
+  [/ghu_[A-Za-z0-9]{36,}/g, '***REDACTED_GITHUB_TOKEN***'],
+  [/github_pat_[A-Za-z0-9]{36,}/g, '***REDACTED_GITHUB_TOKEN***'],
+  [/glpat-[A-Za-z0-9-]{20,}/g, '***REDACTED_GITLAB_TOKEN***'],
+  [/ATATT[A-Za-z0-9_-]{20,}/g, '***REDACTED_ATLASSIAN_TOKEN***'],
+  [/sk-ant-[A-Za-z0-9_-]+/g, '***REDACTED_ANTHROPIC_KEY***'],
+  [/\bsk-[A-Za-z0-9_-]{16,}/g, '***REDACTED_API_KEY***'],
+  [/(:\/\/[^:/@\s]+:)[^@\s]+(@)/g, '$1***REDACTED***$2'],
+  [/([?&](?:api_key|apikey|key|token|secret|password|access_token)=)[^&\s]+/gi, '$1***REDACTED***'],
+  [/(X-Redmine-API-Key:\s*)\S+/gi, '$1***REDACTED***'],
+  [
+    /((?:password|passwd|secret|api_key|apikey|api_secret|access_token|private_key)\s*[=:]\s*)(?:"[^"]*"|'[^']*'|[^\s"',;&]+)"?/gi,
+    '$1***REDACTED***',
+  ],
+];
+
+/** Count of redaction rules — must equal `EXPECTED_RULE_COUNT` in Rust SSOT. */
+export const RULE_COUNT = RULES.length;
+
+/**
+ * Redact secret patterns before a log line reaches stdout.
+ * @param input - Raw log message.
+ */
+export function sanitize(input: string): string {
+  let out = input;
+  for (const [pattern, replacement] of RULES) {
+    out = out.replace(pattern, replacement);
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

Closes #12 — user complaint about IDE-scan debug-spam every 5s in Logs view.

**Root cause:** opening Logs view invoked `set_log_level('trace')` which persisted `log_level: "trace"` in `~/.speedwave/config.json`. After restart the app still ran at Trace and the IDE polling cycle surfaced two `debug!` lines per tick from `health.rs::list_ides_in_dir`. User had no way to disable this — there was no runtime toggle UI for log level.

**Resolution:** remove the runtime log-level toggle entirely (it was dead UX), fix the polling spam by diffing IDE state instead of logging every tick, normalise compose container names on the backend, harden the sanitizer (home paths, cookies, write-time redaction), and fix the Windows log directory path.

## What changed

### Log-level toggle removed
- `set_log_level` / `get_log_level` Tauri commands, `log_level: Option<String>` on `SpeedwaveUserConfig`, `forceMaxLogLevel` Angular wrapper, and 16 related tests deleted.
- Desktop is fixed at `Trace`. Level enum survives as a per-line label so `[ERROR]` greps still work.
- One-shot migration `config::migrate_drop_log_level_in` strips the obsolete field from existing user configs (operates on raw `serde_json::Value` to preserve unknown fields, atomic temp+rename with orphan cleanup).

### IDE-scan polling: log on change, not every tick
- `list_ides_in_dir` replaces `AtomicUsize` count tracker with `IdeScanState { live, anomalies }` fingerprint diffed via pure function `compute_ide_state_diff`.
- Mutex dropped before `info!()` so concurrent callers don't block on the log sink.
- Anomalies (own-PID, stale lock, no port) deduped — persistent anomaly logs once, not every poll.
- Plus: `cleanup_dead_ide` and `disconnect_ide` now emit `info!` so the IDE-bridge lifecycle is observable.

### Container name normalisation: backend SSOT
- New `speedwave_runtime::consts::strip_compose_container_prefix(name, project) -> &str`.
- `health.rs::parse_container_entries` and `container_logs_cmd.rs::prefix_lines` both call it — frontend stops guessing project boundaries with a regex (the old `CONTAINER_PREFIX_RE` failed on projects with `_` in their name).
- `desktop/src/src/app/logs-view/logs-view.component.ts` loses `stripContainerPrefix` + two regexes.

### Log rotation + Windows path
- `RotationStrategy::KeepAll` + manual hourly cleanup → `KeepSome(10)` (plugin prunes on rotation; tauri-plugin-log v2 also prunes on init, no startup sweep needed).
- `read_tail_desktop_logs` now reads every `speedwave-desktop*.log` (mtime-sorted, sanitized), not just the bare current segment — fixes the empty `/logs` view right after rotation.
- **Windows path bug fixed:** `desktop_log_dir()` resolves via `dirs::data_local_dir()` + `/logs` (matches tauri-plugin-log v2 `TargetKind::LogDir`). The previous Roaming-without-`/logs` path made the log file invisible on Windows.
- `desktop_log_dir()` is now the single SSOT used by both `get_all_logs` and `diagnostics::export_diagnostics`. Bundle identifier comes from `app.config().identifier` so `make dev` (which overrides via `TAURI_CONFIG`) reads the correct `.dev` path.

### Sanitizer hardening (defence-in-depth)
- `write_log_line` runs `sanitize()` before writing — secrets never reach the worker drain file untouched.
- New rules: home-path PII (`/Users/<u>`, `/home/<u>`, `C:\Users\<u>` → `<user>`), HTTP `Cookie:` / `Set-Cookie:` headers.
- `Set-Cookie` regex covers the full `name=value` up to `;` (the old `\S+` stopped at the first space and leaked the rest).
- `Cookie:` anchored on `(^|\s)` so it does not double-match the `-C` boundary inside `Set-Cookie:` (caught during review — the original `\b` regex on the `-` boundary would have eaten Set-Cookie attrs).
- New `mcp-servers/shared/src/sanitizer.ts` mirrors the 21-rule Rust SSOT; `RULE_COUNT` pinned by test.

### Frontend: `sortLogLinesByTime` correctness
- Two-pass propagation: leading untimestamped lines inherit the *next* line's instant (forward pass + backward pass).
- NaN-keyed lines (no surrounding timestamp at all) sort BEFORE timestamped lines so banner/header text stays at the top — preserves the pre-PR epoch-zero placement.
- Stable sort keeps input order for equal keys.

### Stale test fixtures
- `system-view.component.spec.ts` MOCK_HEALTHY_REPORT.containers updated to short names (`claude`, `mcp_hub`, `mcp_redmine`) matching backend output.
- `logs-view.component.spec.ts` MOCK_LOGS updated to backend-stripped format.
- `strip_compose_container_prefix` tests in `consts.rs` + `health.rs` build their input from runtime `compose_prefix()` so they don't break under `SPEEDWAVE_DATA_DIR=~/.speedwave-dev`.

## Test plan

- [x] `make check` (clippy `-D warnings`, fmt, MCP type-check + ESLint, Angular ESLint)
- [x] `make test` (Rust ~1500, Desktop ~1400, Angular 1897, MCP shared 13, entrypoint, CI)
- [x] Manual: open `/logs` view under `make dev` — no `IDE scan complete` ticks; disconnect/reconnect IDE produces one `[INFO] IDE state changed` line each
- [x] Manual: migration — add `"log_level": "trace"` to `~/.speedwave-dev/config.json`, restart → field removed; restart again → no-op
- [ ] Reviewer: confirm Windows log-dir path is correct (`%LOCALAPPDATA%\<bundle>\logs`) — fix verified by inspection but not run on a Windows host

## Reviewer notes

- Surface area is wide (logging + IDE-scan + sanitizer + Windows path + Angular sort) but every change traces back to the same root: the implicit Trace-promotion side-effect of opening `/logs`. Fixing the spam in isolation would have left the surrounding cliffs in place.
- 23 commits' worth of work in one commit — pre-commit hooks (gitleaks, lint-staged, commitlint) all pass.
- New JWT fixture in `mcp-servers/shared/src/sanitizer.test.ts` whitelisted in `.gitleaksignore` consistent with the existing `log_sanitizer.rs` entries.