### PR TITLE
ci(claude): allow @claude for trusted collaborators

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   claude:
     if: |
-      contains(fromJSON('["slawomir-it"]'), github.actor) && (
+      contains(fromJSON('["slawomir-it", "kamilparczewski", "Alwox"]'), github.actor) && (
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||


### PR DESCRIPTION
## Summary

Adds `kamilparczewski` and `Alwox` to the `github.actor` allowlist in `.github/workflows/claude.yml`, so they can invoke Claude Code by writing `@claude ...` in:

- issue comments
- PR review comments
- PR reviews
- issue bodies / titles

This works for their fork PRs too — the relevant events (`issue_comment`, `pull_request_review_comment`, `pull_request_review`, `issues`) fire in the **main-repo context**, so org secrets are injected normally regardless of where the underlying PR branch lives.

## What this does NOT change

- **`claude-code-review.yml`** (auto-review on PR open/sync) is untouched — still scoped to `slawomir-it` on main-repo PRs. Fork PRs from trusted collaborators do **not** auto-review; they must request a review via an `@claude` comment.
- **Build/CI secrets** (Tauri signing etc.) for fork PRs are still blocked by GitHub platform policy — this PR doesn't touch that.

## Threat model

Trusted collaborators currently get the **default** Claude tool set (Edit, Write, Bash) when invoked — explicitly accepted as a trust decision. Tightening tool access (read-only `--allowedTools` mirroring `claude-code-review.yml`) is a possible follow-up if needed.

## Test plan

- [ ] After merge: have @kamilparczewski post \`@claude /code-review\` on PR #735 — verify the workflow runs.
- [ ] After merge: have @Alwox post an `@claude` comment on any open PR/issue — verify the workflow runs.