### PR TITLE
feat(desktop): remove project from switcher UI (#269)

### DIFF
--- a/crates/speedwave-runtime/src/project.rs
+++ b/crates/speedwave-runtime/src/project.rs
@@ -873,9 +873,21 @@ mod tests {
 
     #[test]
     fn remove_project_missing_errors() {
+        // Exercises the "populated config, name not in list" branch — distinct
+        // from "missing config.json" which load_user_config_from treats as default.
         let tmp = tempfile::tempdir().unwrap();
+        let pd = tmp.path().join("real");
+        std::fs::create_dir_all(&pd).unwrap();
+        let canonical = std::fs::canonicalize(&pd).unwrap();
         let data_dir = tmp.path().join("data");
         std::fs::create_dir_all(&data_dir).unwrap();
+        add_project_with_validated_dir(
+            "real",
+            canonical.clone(),
+            canonical.to_string_lossy().to_string(),
+            &data_dir,
+        )
+        .unwrap();
 
         let result = remove_project_with_data_dir("ghost", &data_dir);
         assert!(result.is_err());
@@ -884,6 +896,9 @@ mod tests {
             err.contains("not found"),
             "expected 'not found', got: {err}"
         );
+        // Sanity: the real project must remain untouched.
+        let cfg = config::load_user_config_from(&data_dir.join("config.json")).unwrap();
+        assert!(cfg.find_project("real").is_some());
     }
 
     #[test]

--- a/crates/speedwave-runtime/src/project.rs
+++ b/crates/speedwave-runtime/src/project.rs
@@ -8,16 +8,21 @@ pub fn cleanup_project_dirs(project: &str) {
 }
 
 /// Best-effort cleanup of project directories under a given data directory.
+/// Subdir set mirrors fs_security's per-project list — when adding state under data_dir/<sub>/<project>/, add it here too.
 fn cleanup_project_dirs_in(project: &str, data_dir: &Path) {
     for sub in &[
         "tokens",
         "compose",
         "context",
         crate::consts::CLAUDE_HOME_SUBDIR,
+        "secrets",
+        "snapshots",
+        crate::consts::OAUTH_SUBDIR,
+        crate::consts::HOST_EXEC_SUBDIR,
     ] {
         let dir = data_dir.join(sub).join(project);
-        if dir.exists() {
-            if let Err(e) = std::fs::remove_dir_all(&dir) {
+        if let Err(e) = std::fs::remove_dir_all(&dir) {
+            if e.kind() != std::io::ErrorKind::NotFound {
                 log::warn!(
                     "cleanup_project_dirs: failed to remove '{}': {e}",
                     dir.display()
@@ -226,6 +231,42 @@ fn add_project_with_validated_dir(
         return Err(e);
     }
 
+    Ok(())
+}
+
+/// Sentinel prefix on the error message when the caller tried to remove the active project.
+/// Stable string — UI may match on it to surface a tailored toast.
+pub const REMOVE_ACTIVE_PROJECT_ERR_PREFIX: &str = "active_project_removal: ";
+
+/// Unregisters a project and cleans its Speedwave-managed dirs. Source tree on disk is not touched.
+pub fn remove_project(name: &str) -> anyhow::Result<()> {
+    config::with_config_lock(|| remove_project_with_data_dir(name, crate::consts::data_dir()))
+}
+
+fn remove_project_with_data_dir(name: &str, data_dir: &Path) -> anyhow::Result<()> {
+    validation::validate_project_name(name)?;
+
+    let config_path = data_dir.join("config.json");
+    let mut user_config = config::load_user_config_from(&config_path)?;
+
+    if user_config.active_project.as_deref() == Some(name) {
+        anyhow::bail!(
+            "{}Cannot remove the active project '{}'. Switch to a different project first.",
+            REMOVE_ACTIVE_PROJECT_ERR_PREFIX,
+            name
+        );
+    }
+
+    let pos = user_config
+        .projects
+        .iter()
+        .position(|p| p.name == name)
+        .ok_or_else(|| anyhow::anyhow!("Project '{}' not found", name))?;
+
+    user_config.projects.remove(pos);
+
+    config::save_user_config_to(&user_config, &config_path)?;
+    cleanup_project_dirs_in(name, data_dir);
     Ok(())
 }
 
@@ -730,6 +771,157 @@ mod tests {
             .join(crate::consts::CLAUDE_HOME_SUBDIR)
             .join("luke-helm")
             .is_dir());
+    }
+
+    // -- remove_project tests --
+
+    #[test]
+    fn remove_project_happy_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir_a = tmp.path().join("a");
+        let dir_b = tmp.path().join("b");
+        std::fs::create_dir_all(&dir_a).unwrap();
+        std::fs::create_dir_all(&dir_b).unwrap();
+        let canon_a = std::fs::canonicalize(&dir_a).unwrap();
+        let canon_b = std::fs::canonicalize(&dir_b).unwrap();
+        let data_dir = tmp.path().join("data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+
+        add_project_with_validated_dir(
+            "alpha",
+            canon_a.clone(),
+            canon_a.to_string_lossy().to_string(),
+            &data_dir,
+        )
+        .unwrap();
+        add_project_with_validated_dir(
+            "beta",
+            canon_b.clone(),
+            canon_b.to_string_lossy().to_string(),
+            &data_dir,
+        )
+        .unwrap();
+
+        // Seed long-lived per-project dirs alongside the ones add_project created.
+        for sub in &[
+            "secrets",
+            "snapshots",
+            crate::consts::OAUTH_SUBDIR,
+            crate::consts::HOST_EXEC_SUBDIR,
+        ] {
+            let d = data_dir.join(sub).join("alpha");
+            std::fs::create_dir_all(&d).unwrap();
+            std::fs::write(d.join("secret"), b"x").unwrap();
+        }
+
+        remove_project_with_data_dir("alpha", &data_dir).unwrap();
+
+        let cfg = config::load_user_config_from(&data_dir.join("config.json")).unwrap();
+        assert!(cfg.find_project("alpha").is_none());
+        assert_eq!(cfg.active_project.as_deref(), Some("beta"));
+        for sub in &[
+            "tokens",
+            "compose",
+            "context",
+            crate::consts::CLAUDE_HOME_SUBDIR,
+            "secrets",
+            "snapshots",
+            crate::consts::OAUTH_SUBDIR,
+            crate::consts::HOST_EXEC_SUBDIR,
+        ] {
+            assert!(
+                !data_dir.join(sub).join("alpha").exists(),
+                "subdir '{sub}/alpha' must be cleaned up"
+            );
+        }
+        assert!(dir_a.exists(), "user's source tree must NOT be deleted");
+    }
+
+    #[test]
+    fn remove_project_rejects_active() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pd = tmp.path().join("proj");
+        std::fs::create_dir_all(&pd).unwrap();
+        let canonical = std::fs::canonicalize(&pd).unwrap();
+        let data_dir = tmp.path().join("data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+
+        add_project_with_validated_dir(
+            "only",
+            canonical.clone(),
+            canonical.to_string_lossy().to_string(),
+            &data_dir,
+        )
+        .unwrap();
+
+        let result = remove_project_with_data_dir("only", &data_dir);
+        let err = result.unwrap_err().to_string();
+        assert!(err.starts_with(REMOVE_ACTIVE_PROJECT_ERR_PREFIX));
+        let cfg = config::load_user_config_from(&data_dir.join("config.json")).unwrap();
+        assert!(cfg.find_project("only").is_some());
+        assert_eq!(cfg.active_project.as_deref(), Some("only"));
+    }
+
+    #[test]
+    fn remove_project_rejects_invalid_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().join("data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+        let result = remove_project_with_data_dir("../escape", &data_dir);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn remove_project_missing_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().join("data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+
+        let result = remove_project_with_data_dir("ghost", &data_dir);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("not found"),
+            "expected 'not found', got: {err}"
+        );
+    }
+
+    #[test]
+    fn remove_project_preserves_other_active_project() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir_a = tmp.path().join("a");
+        let dir_b = tmp.path().join("b");
+        std::fs::create_dir_all(&dir_a).unwrap();
+        std::fs::create_dir_all(&dir_b).unwrap();
+        let canon_a = std::fs::canonicalize(&dir_a).unwrap();
+        let canon_b = std::fs::canonicalize(&dir_b).unwrap();
+        let data_dir = tmp.path().join("data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+
+        add_project_with_validated_dir(
+            "first",
+            canon_a.clone(),
+            canon_a.to_string_lossy().to_string(),
+            &data_dir,
+        )
+        .unwrap();
+        add_project_with_validated_dir(
+            "second",
+            canon_b.clone(),
+            canon_b.to_string_lossy().to_string(),
+            &data_dir,
+        )
+        .unwrap();
+        // After two adds, `second` is active.
+        let cfg = config::load_user_config_from(&data_dir.join("config.json")).unwrap();
+        assert_eq!(cfg.active_project.as_deref(), Some("second"));
+
+        // Removing the non-active project must leave active_project intact.
+        remove_project_with_data_dir("first", &data_dir).unwrap();
+        let cfg = config::load_user_config_from(&data_dir.join("config.json")).unwrap();
+        assert!(cfg.find_project("first").is_none());
+        assert_eq!(cfg.active_project.as_deref(), Some("second"));
+        assert!(data_dir.join("compose").join("second").exists());
     }
 
     #[test]

--- a/desktop/src-tauri/src/containers_cmd.rs
+++ b/desktop/src-tauri/src/containers_cmd.rs
@@ -505,6 +505,23 @@ pub async fn add_project(
     Ok(())
 }
 
+/// Core: compose_down → runtime::remove_project. Extracted for tests; on compose_down
+/// failure the config wipe is skipped so the user can retry.
+pub(crate) fn remove_project_core(
+    name: &str,
+    rt: &speedwave_runtime::runtime::LockedRuntime,
+    remove_fn: &dyn Fn(&str) -> Result<(), String>,
+) -> Result<(), String> {
+    if rt.is_available() {
+        rt.compose_down(name).map_err(|e| {
+            log::error!("remove_project: compose_down('{name}') failed: {e}");
+            format!("Failed to stop containers for '{name}': {e}")
+        })?;
+    }
+    log::info!("remove_project: name={name}");
+    remove_fn(name)
+}
+
 /// Tears down a project's containers, host_exec drain, and unregisters it.
 /// Runtime layer rejects the active project (sentinel-prefixed error for the UI).
 #[tauri::command]
@@ -514,23 +531,13 @@ pub async fn remove_project(
 ) -> Result<(), String> {
     crate::reconcile::teardown_host_exec_for_project(host_exec.inner(), &name);
 
-    let name_clone = name.clone();
     tokio::task::spawn_blocking(move || {
         let rt = speedwave_runtime::runtime::detect_runtime();
-        if rt.is_available() {
-            // Lima/WSL compose_down already force-removes containers and networks on retry,
-            // so the only Err we see here is when the runtime itself is broken — refuse to
-            // wipe config in that case so the user can retry.
-            rt.compose_down(&name_clone).map_err(|e| {
-                log::error!("remove_project: compose_down('{name_clone}') failed: {e}");
-                format!("Failed to stop containers for '{name_clone}': {e}")
-            })?;
-        }
-
-        log::info!("remove_project: name={name_clone}");
-        speedwave_runtime::project::remove_project(&name_clone).map_err(|e| {
-            log::error!("remove_project: error: {e}");
-            e.to_string()
+        remove_project_core(&name, &rt, &|n| {
+            speedwave_runtime::project::remove_project(n).map_err(|e| {
+                log::error!("remove_project: error: {e}");
+                e.to_string()
+            })
         })
     })
     .await
@@ -2265,5 +2272,45 @@ mod tests {
     fn validate_custom_headers_rejects_oversize() {
         let oversize = format!("X-A: {}", "x".repeat(16 * 1024));
         assert!(super::validate_custom_headers(&oversize).is_err());
+    }
+
+    // -- remove_project_core tests --
+
+    use std::cell::RefCell;
+
+    #[test]
+    fn remove_project_core_happy_path() {
+        let (rt, handles) = MockRuntimeBuilder::new().build();
+        let removed = RefCell::new(Vec::<String>::new());
+        let result = remove_project_core("alpha", &rt, &|n| {
+            removed.borrow_mut().push(n.to_string());
+            Ok(())
+        });
+        assert!(result.is_ok());
+        assert_eq!(handles.down_projects(), vec!["alpha"]);
+        assert_eq!(*removed.borrow(), vec!["alpha"]);
+    }
+
+    #[test]
+    fn remove_project_core_compose_down_failure_aborts_remove() {
+        let (rt, _handles) = MockRuntimeBuilder::new()
+            .with_fail_on_down(&["alpha"])
+            .build();
+        let remove_calls = RefCell::new(0u32);
+        let result = remove_project_core("alpha", &rt, &|_| {
+            *remove_calls.borrow_mut() += 1;
+            Ok(())
+        });
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("Failed to stop containers for 'alpha'"),
+            "expected user-facing teardown error, got: {err}"
+        );
+        assert_eq!(
+            *remove_calls.borrow(),
+            0,
+            "runtime project removal must not run after compose_down failure"
+        );
     }
 }

--- a/desktop/src-tauri/src/containers_cmd.rs
+++ b/desktop/src-tauri/src/containers_cmd.rs
@@ -505,6 +505,38 @@ pub async fn add_project(
     Ok(())
 }
 
+/// Tears down a project's containers, host_exec drain, and unregisters it.
+/// Runtime layer rejects the active project (sentinel-prefixed error for the UI).
+#[tauri::command]
+pub async fn remove_project(
+    name: String,
+    host_exec: tauri::State<'_, crate::reconcile::SharedHostExec>,
+) -> Result<(), String> {
+    crate::reconcile::teardown_host_exec_for_project(host_exec.inner(), &name);
+
+    let name_clone = name.clone();
+    tokio::task::spawn_blocking(move || {
+        let rt = speedwave_runtime::runtime::detect_runtime();
+        if rt.is_available() {
+            // Lima/WSL compose_down already force-removes containers and networks on retry,
+            // so the only Err we see here is when the runtime itself is broken — refuse to
+            // wipe config in that case so the user can retry.
+            rt.compose_down(&name_clone).map_err(|e| {
+                log::error!("remove_project: compose_down('{name_clone}') failed: {e}");
+                format!("Failed to stop containers for '{name_clone}': {e}")
+            })?;
+        }
+
+        log::info!("remove_project: name={name_clone}");
+        speedwave_runtime::project::remove_project(&name_clone).map_err(|e| {
+            log::error!("remove_project: error: {e}");
+            e.to_string()
+        })
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
 // ---------------------------------------------------------------------------
 // Container lifecycle commands
 // ---------------------------------------------------------------------------

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -2037,6 +2037,7 @@ fn main() {
             list_projects,
             switch_project,
             containers_cmd::add_project,
+            containers_cmd::remove_project,
             // Health
             get_health,
             // Container logs

--- a/desktop/src/src/app/project-switcher/project-pill.component.ts
+++ b/desktop/src/src/app/project-switcher/project-pill.component.ts
@@ -9,6 +9,7 @@ import {
 } from '@angular/core';
 import { ProjectStateService } from '../services/project-state.service';
 import { UiStateService } from '../services/ui-state.service';
+import { swatchFor } from './project-swatch';
 
 /**
  * Project switcher trigger — the small monogram + name pill rendered in the
@@ -35,7 +36,8 @@ import { UiStateService } from '../services/ui-state.service';
       (click)="ui.toggleProjectSwitcher()"
     >
       <span
-        class="inline-flex h-3.5 w-3.5 items-center justify-center rounded-sm bg-[var(--violet)] text-[8px] font-bold text-[#07090f]"
+        class="inline-flex h-3.5 w-3.5 items-center justify-center rounded-sm text-[8px] font-bold text-[#07090f]"
+        [style.background]="swatch()"
         aria-hidden="true"
         >{{ monogram() }}</span
       >
@@ -50,12 +52,18 @@ export class ProjectPillComponent implements OnInit, OnDestroy {
   /** Active project name — kept in a signal so OnPush re-renders on change. */
   protected readonly projectName = signal<string>('');
 
+  /** Position of the active project in the list — drives the swatch. -1 when no project. */
+  protected readonly activeIndex = signal<number>(-1);
+
   /** First two letters of the active project name, lowercased. Falls back to a dot. */
   protected readonly monogram = computed(() => {
     const name = this.projectName().trim();
     if (!name) return '·';
     return name.slice(0, 2).toLowerCase();
   });
+
+  /** Swatch color matching the same project's row in the switcher dropdown. */
+  protected readonly swatch = computed(() => swatchFor(this.activeIndex()));
 
   private unsubscribe: (() => void) | null = null;
 
@@ -65,10 +73,10 @@ export class ProjectPillComponent implements OnInit, OnDestroy {
     this.unsubscribe = this.projectState.onChange(() => this.refresh());
   }
 
-  /** Pulls the active project name out of the shared state into a local signal. */
   private refresh(): void {
     const name = this.projectState.activeProject ?? '';
     this.projectName.set(name);
+    this.activeIndex.set(this.projectState.projects.findIndex((p) => p.name === name));
   }
 
   /** Tears down the project state subscription. */

--- a/desktop/src/src/app/project-switcher/project-swatch.ts
+++ b/desktop/src/src/app/project-switcher/project-swatch.ts
@@ -1,0 +1,11 @@
+/** SSOT for project swatch color — deterministic by position in the project list. */
+const SWATCH_TOKENS = ['var(--violet)', 'var(--teal)', 'var(--amber)', 'var(--accent)'] as const;
+
+/**
+ * Returns the swatch color for a project at the given list position.
+ * @param index - Zero-based position in the project list; negative values are treated as 0.
+ */
+export function swatchFor(index: number): string {
+  const safe = index < 0 ? 0 : index;
+  return SWATCH_TOKENS[safe % SWATCH_TOKENS.length];
+}

--- a/desktop/src/src/app/project-switcher/project-switcher.component.spec.ts
+++ b/desktop/src/src/app/project-switcher/project-switcher.component.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ProjectSwitcherComponent } from './project-switcher.component';
+import { ProjectSwitcherComponent, cleanRemoveErrorMessage } from './project-switcher.component';
 import { LoggerService } from '../services/logger.service';
 import { TauriService } from '../services/tauri.service';
 import { ProjectStateService } from '../services/project-state.service';
@@ -51,7 +51,7 @@ describe('ProjectSwitcherComponent', () => {
     expect(component.projects()).toEqual([]);
     expect(component.activeProject()).toBeNull();
     expect(component.showAddForm()).toBe(false);
-    expect(component.pendingDeleteId()).toBeNull();
+    expect(component.pendingDeleteName()).toBeNull();
   });
 
   describe('visibility binding (UiStateService.projectSwitcherOpen)', () => {
@@ -309,7 +309,7 @@ describe('ProjectSwitcherComponent', () => {
     it('requestRemove() swaps the row into the confirm prompt', () => {
       component.requestRemove('beta');
       fixture.detectChanges();
-      expect(component.pendingDeleteId()).toBe('beta');
+      expect(component.pendingDeleteName()).toBe('beta');
       expect(
         fixture.nativeElement.querySelector('[data-testid="project-switcher-confirm-beta"]')
       ).not.toBeNull();
@@ -320,7 +320,7 @@ describe('ProjectSwitcherComponent', () => {
       component.requestRemove('beta');
       component.cancelRemove();
       fixture.detectChanges();
-      expect(component.pendingDeleteId()).toBeNull();
+      expect(component.pendingDeleteName()).toBeNull();
       expect(invokeSpy).not.toHaveBeenCalledWith('remove_project', expect.anything());
     });
 
@@ -329,7 +329,7 @@ describe('ProjectSwitcherComponent', () => {
       component.requestRemove('beta');
       await component.confirmRemove('beta');
       expect(invokeSpy).toHaveBeenCalledWith('remove_project', { name: 'beta' });
-      expect(component.pendingDeleteId()).toBeNull();
+      expect(component.pendingDeleteName()).toBeNull();
     });
 
     it('surfaces backend error inline and strips the runtime sentinel prefix', async () => {
@@ -350,10 +350,10 @@ describe('ProjectSwitcherComponent', () => {
       };
       await component.confirmRemove('beta');
       fixture.detectChanges();
-      expect(component.removeErrorName()).toBe('beta');
-      expect(component.removeError()).toBe(
-        "Cannot remove the active project 'beta'. Switch first."
-      );
+      expect(component.removeError()).toEqual({
+        msg: "Cannot remove the active project 'beta'. Switch first.",
+        project: 'beta',
+      });
       const inline = fixture.nativeElement.querySelector(
         '[data-testid="project-switcher-remove-error-beta"]'
       );
@@ -361,18 +361,16 @@ describe('ProjectSwitcherComponent', () => {
       expect(mockLogError).toHaveBeenCalled();
     });
 
-    it('clears pendingDeleteId and removeError when the dropdown closes', () => {
+    it('clears pendingDeleteName and removeError when the dropdown closes', () => {
       component.requestRemove('beta');
-      component.removeError.set('boom');
-      component.removeErrorName.set('beta');
+      component.removeError.set({ msg: 'boom', project: 'beta' });
       ui.closeProjectSwitcher();
       fixture.detectChanges();
-      expect(component.pendingDeleteId()).toBeNull();
+      expect(component.pendingDeleteName()).toBeNull();
       expect(component.removeError()).toBeNull();
-      expect(component.removeErrorName()).toBeNull();
     });
 
-    it('clears pendingDeleteId when the pending project disappears from the list', async () => {
+    it('clears pendingDeleteName when the pending project disappears from the list', async () => {
       component.requestRemove('beta');
       mockTauri.invokeHandler = async (cmd: string) => {
         if (cmd === 'list_projects')
@@ -388,7 +386,7 @@ describe('ProjectSwitcherComponent', () => {
       }>('list_projects');
       component.projects.set(refreshed.projects);
       fixture.detectChanges();
-      expect(component.pendingDeleteId()).toBeNull();
+      expect(component.pendingDeleteName()).toBeNull();
     });
 
     it('does not render trash button or confirm UI on the active row', () => {
@@ -401,5 +399,20 @@ describe('ProjectSwitcherComponent', () => {
       );
       expect(inactiveTrash).not.toBeNull();
     });
+  });
+});
+
+describe('cleanRemoveErrorMessage', () => {
+  it('strips the sentinel prefix', () => {
+    expect(
+      cleanRemoveErrorMessage("active_project_removal: Cannot remove the active project 'beta'.")
+    ).toBe("Cannot remove the active project 'beta'.");
+  });
+
+  it('returns the message unchanged when no sentinel prefix is present', () => {
+    expect(cleanRemoveErrorMessage('Some other backend failure')).toBe(
+      'Some other backend failure'
+    );
+    expect(cleanRemoveErrorMessage('')).toBe('');
   });
 });

--- a/desktop/src/src/app/project-switcher/project-switcher.component.spec.ts
+++ b/desktop/src/src/app/project-switcher/project-switcher.component.spec.ts
@@ -51,7 +51,7 @@ describe('ProjectSwitcherComponent', () => {
     expect(component.projects()).toEqual([]);
     expect(component.activeProject()).toBeNull();
     expect(component.showAddForm()).toBe(false);
-    expect(component.filter()).toBe('');
+    expect(component.pendingDeleteId()).toBeNull();
   });
 
   describe('visibility binding (UiStateService.projectSwitcherOpen)', () => {
@@ -175,7 +175,7 @@ describe('ProjectSwitcherComponent', () => {
     });
   });
 
-  describe('search filter', () => {
+  describe('project list rendering', () => {
     beforeEach(async () => {
       mockTauri.invokeHandler = async (cmd: string) => {
         if (cmd === 'list_projects')
@@ -183,7 +183,6 @@ describe('ProjectSwitcherComponent', () => {
             projects: [
               { name: 'speedwave', dir: '/tmp/sw' },
               { name: 'speedwave-plugins', dir: '/tmp/sw-plugins' },
-              { name: 'speednet-backend', dir: '/tmp/sn-backend' },
               { name: 'experiments', dir: '/tmp/exp' },
             ],
             active_project: 'speedwave',
@@ -193,70 +192,48 @@ describe('ProjectSwitcherComponent', () => {
       await component.ngOnInit();
     });
 
-    it('returns all projects when filter is empty', () => {
-      expect(component.visibleProjects().length).toBe(4);
+    it('returns every project unfiltered', () => {
+      expect(component.visibleProjects().length).toBe(3);
     });
 
-    it('narrows the list by case-insensitive substring match', () => {
-      component.filter.set('PLUGIN');
-      const visible = component.visibleProjects();
-      expect(visible.length).toBe(1);
-      expect(visible[0].project.name).toBe('speedwave-plugins');
-    });
-
-    it('returns an empty list when nothing matches', () => {
-      component.filter.set('zzz');
-      expect(component.visibleProjects()).toEqual([]);
-    });
-
-    it('marks the active project with isActive=true and current pill', () => {
+    it('marks the active project with isActive=true and disables its row', () => {
       ui.toggleProjectSwitcher();
       fixture.detectChanges();
-      const visible = component.visibleProjects();
-      const active = visible.find((v) => v.isActive);
+      const active = component.visibleProjects().find((v) => v.isActive);
       expect(active?.project.name).toBe('speedwave');
-      const pill = fixture.nativeElement.querySelector(
+      const row = fixture.nativeElement.querySelector(
         '[data-testid="project-switcher-item-speedwave"]'
-      );
-      expect(pill).not.toBeNull();
-      expect(pill.textContent).toContain('current');
+      ) as HTMLButtonElement;
+      expect(row).not.toBeNull();
+      expect(row.disabled).toBe(true);
     });
 
-    it('renders an info tooltip glyph for every project row', () => {
+    it('marks the active row with aria-current="true" on the focusable button and an sr-only label', () => {
       ui.toggleProjectSwitcher();
       fixture.detectChanges();
-      // Active row also exposes the info glyph carrying the project directory.
+      const row = fixture.nativeElement.querySelector(
+        '[data-testid="project-switcher-item-speedwave"]'
+      ) as HTMLButtonElement;
+      expect(row.getAttribute('aria-current')).toBe('true');
+      const srOnly = row.querySelector('.sr-only');
+      expect(srOnly?.textContent).toContain('current project');
+      const inactive = fixture.nativeElement.querySelector(
+        '[data-testid="project-switcher-item-speedwave-plugins"]'
+      ) as HTMLButtonElement;
+      expect(inactive.getAttribute('aria-current')).toBeNull();
+    });
+
+    it('renders the info glyph for every project row', () => {
+      ui.toggleProjectSwitcher();
+      fixture.detectChanges();
       const activeInfo = fixture.nativeElement.querySelector(
         '[data-testid="project-switcher-item-info-speedwave"]'
       );
       expect(activeInfo).not.toBeNull();
-      // Non-active row exposes its own info glyph alongside the row button.
       const inactiveInfo = fixture.nativeElement.querySelector(
         '[data-testid="project-switcher-item-info-speedwave-plugins"]'
       );
       expect(inactiveInfo).not.toBeNull();
-    });
-
-    it('shows the empty placeholder when filter has no matches', () => {
-      ui.toggleProjectSwitcher();
-      component.filter.set('nope');
-      fixture.detectChanges();
-      const empty = fixture.nativeElement.querySelector('[data-testid="project-switcher-empty"]');
-      expect(empty).not.toBeNull();
-      expect(empty.textContent).toContain('no projects match');
-    });
-  });
-
-  describe('search input behavior', () => {
-    it('updates the filter signal from the input event', () => {
-      ui.toggleProjectSwitcher();
-      fixture.detectChanges();
-      const input = fixture.nativeElement.querySelector(
-        '[data-testid="project-switcher-search"]'
-      ) as HTMLInputElement;
-      input.value = 'edge';
-      input.dispatchEvent(new Event('input'));
-      expect(component.filter()).toBe('edge');
     });
   });
 
@@ -300,18 +277,129 @@ describe('ProjectSwitcherComponent', () => {
     it('cleans up project settled listener on destroy', async () => {
       await projectState.init();
       await component.ngOnInit();
-
-      // Verify the unsub function exists before destroy
       expect(
         (component as unknown as { unsubProjectSettled: unknown })['unsubProjectSettled']
       ).not.toBeNull();
-
       component.ngOnDestroy();
-
-      // Verify unsub was called and nulled
       expect(
         (component as unknown as { unsubProjectSettled: unknown })['unsubProjectSettled']
       ).toBeNull();
+    });
+  });
+
+  describe('remove project', () => {
+    beforeEach(async () => {
+      mockTauri.invokeHandler = async (cmd: string) => {
+        if (cmd === 'list_projects')
+          return {
+            projects: [
+              { name: 'alpha', dir: '/tmp/alpha' },
+              { name: 'beta', dir: '/tmp/beta' },
+            ],
+            active_project: 'alpha',
+          };
+        return undefined;
+      };
+      await projectState.init();
+      await component.ngOnInit();
+      ui.toggleProjectSwitcher();
+      fixture.detectChanges();
+    });
+
+    it('requestRemove() swaps the row into the confirm prompt', () => {
+      component.requestRemove('beta');
+      fixture.detectChanges();
+      expect(component.pendingDeleteId()).toBe('beta');
+      expect(
+        fixture.nativeElement.querySelector('[data-testid="project-switcher-confirm-beta"]')
+      ).not.toBeNull();
+    });
+
+    it('cancelRemove() restores the row without invoking the backend', () => {
+      const invokeSpy = vi.spyOn(mockTauri, 'invoke');
+      component.requestRemove('beta');
+      component.cancelRemove();
+      fixture.detectChanges();
+      expect(component.pendingDeleteId()).toBeNull();
+      expect(invokeSpy).not.toHaveBeenCalledWith('remove_project', expect.anything());
+    });
+
+    it('confirmRemove() invokes remove_project and clears the pending state', async () => {
+      const invokeSpy = vi.spyOn(mockTauri, 'invoke');
+      component.requestRemove('beta');
+      await component.confirmRemove('beta');
+      expect(invokeSpy).toHaveBeenCalledWith('remove_project', { name: 'beta' });
+      expect(component.pendingDeleteId()).toBeNull();
+    });
+
+    it('surfaces backend error inline and strips the runtime sentinel prefix', async () => {
+      mockTauri.invokeHandler = async (cmd: string) => {
+        if (cmd === 'remove_project')
+          throw new Error(
+            "active_project_removal: Cannot remove the active project 'beta'. Switch first."
+          );
+        if (cmd === 'list_projects')
+          return {
+            projects: [
+              { name: 'alpha', dir: '/tmp/alpha' },
+              { name: 'beta', dir: '/tmp/beta' },
+            ],
+            active_project: 'alpha',
+          };
+        return undefined;
+      };
+      await component.confirmRemove('beta');
+      fixture.detectChanges();
+      expect(component.removeErrorName()).toBe('beta');
+      expect(component.removeError()).toBe(
+        "Cannot remove the active project 'beta'. Switch first."
+      );
+      const inline = fixture.nativeElement.querySelector(
+        '[data-testid="project-switcher-remove-error-beta"]'
+      );
+      expect(inline).not.toBeNull();
+      expect(mockLogError).toHaveBeenCalled();
+    });
+
+    it('clears pendingDeleteId and removeError when the dropdown closes', () => {
+      component.requestRemove('beta');
+      component.removeError.set('boom');
+      component.removeErrorName.set('beta');
+      ui.closeProjectSwitcher();
+      fixture.detectChanges();
+      expect(component.pendingDeleteId()).toBeNull();
+      expect(component.removeError()).toBeNull();
+      expect(component.removeErrorName()).toBeNull();
+    });
+
+    it('clears pendingDeleteId when the pending project disappears from the list', async () => {
+      component.requestRemove('beta');
+      mockTauri.invokeHandler = async (cmd: string) => {
+        if (cmd === 'list_projects')
+          return {
+            projects: [{ name: 'alpha', dir: '/tmp/alpha' }],
+            active_project: 'alpha',
+          };
+        return undefined;
+      };
+      const refreshed = await mockTauri.invoke<{
+        projects: { name: string; dir: string }[];
+        active_project: string;
+      }>('list_projects');
+      component.projects.set(refreshed.projects);
+      fixture.detectChanges();
+      expect(component.pendingDeleteId()).toBeNull();
+    });
+
+    it('does not render trash button or confirm UI on the active row', () => {
+      const activeTrash = fixture.nativeElement.querySelector(
+        '[data-testid="project-switcher-remove-alpha"]'
+      );
+      expect(activeTrash).toBeNull();
+      const inactiveTrash = fixture.nativeElement.querySelector(
+        '[data-testid="project-switcher-remove-beta"]'
+      );
+      expect(inactiveTrash).not.toBeNull();
     });
   });
 });

--- a/desktop/src/src/app/project-switcher/project-switcher.component.ts
+++ b/desktop/src/src/app/project-switcher/project-switcher.component.ts
@@ -5,6 +5,7 @@ import {
   OnDestroy,
   OnInit,
   computed,
+  effect,
   inject,
   signal,
 } from '@angular/core';
@@ -14,16 +15,9 @@ import { ProjectStateService } from '../services/project-state.service';
 import { UiStateService } from '../services/ui-state.service';
 import type { ProjectEntry, ProjectList } from '../models/update';
 import { CreateProjectModalComponent } from '../shared/create-project-modal/create-project-modal.component';
+import { IconComponent } from '../shared/icon.component';
 import { TooltipDirective } from '../shared/tooltip.directive';
-
-/**
- * Color swatches cycled through in the row left-edge tile.
- *
- * The mockup paints up to four projects (violet / teal / amber / accent). The
- * order is deterministic — same project always gets the same color regardless
- * of how the underlying list is sorted.
- */
-const SWATCH_TOKENS = ['var(--violet)', 'var(--teal)', 'var(--amber)', 'var(--accent)'] as const;
+import { swatchFor } from './project-swatch';
 
 /**
  * Project switcher dropdown — toggled from the chat header / command palette.
@@ -35,7 +29,7 @@ const SWATCH_TOKENS = ['var(--violet)', 'var(--teal)', 'var(--amber)', 'var(--ac
  */
 @Component({
   selector: 'app-project-switcher',
-  imports: [CreateProjectModalComponent, TooltipDirective],
+  imports: [CreateProjectModalComponent, IconComponent, TooltipDirective],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     @if (ui.projectSwitcherOpen()) {
@@ -54,63 +48,49 @@ const SWATCH_TOKENS = ['var(--violet)', 'var(--teal)', 'var(--amber)', 'var(--ac
         aria-label="Switch project"
       >
         <div class="rounded border border-[var(--line-strong)] bg-[var(--bg-1)] shadow-2xl">
-          <!-- Header: search input -->
-          <div class="border-b border-[var(--line)] p-2">
-            <div
-              class="flex items-center gap-2 rounded border border-[var(--line)] bg-[var(--bg-2)] px-2 py-1"
-            >
-              <span class="mono text-[11px] text-[var(--ink-mute)]">&gt;</span>
-              <input
-                type="text"
-                class="mono w-full bg-transparent text-[11px] text-[var(--ink)] focus:outline-none"
-                placeholder="search projects..."
-                aria-label="Search projects"
-                data-testid="project-switcher-search"
-                [value]="filter()"
-                (input)="onFilterInput($event)"
-              />
-            </div>
-          </div>
-
           <!-- Body: project rows -->
           <div class="max-h-64 overflow-y-auto p-1">
-            @for (entry of visibleProjects(); track entry.project.name; let i = $index) {
-              @if (entry.isActive) {
-                <div
-                  class="flex items-center gap-1 rounded px-2 py-1.5"
-                  [class]="rowActiveClasses"
-                  [attr.data-testid]="'project-switcher-item-' + entry.project.name"
-                >
+            @for (entry of visibleProjects(); track entry.project.name) {
+              @let pendingDelete = entry.project.name === pendingDeleteId();
+              <div
+                class="group flex items-center gap-1 rounded px-2 py-1.5"
+                [class]="entry.isActive ? rowActiveClasses : rowInactiveClasses"
+              >
+                @if (pendingDelete) {
                   <div
-                    class="mono inline-flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-sm px-0.5 text-[8px] font-bold leading-none text-[#07090f]"
-                    [style.background]="entry.swatch"
-                    aria-hidden="true"
+                    class="flex min-w-0 flex-1 items-center justify-between gap-2"
+                    [attr.data-testid]="'project-switcher-confirm-' + entry.project.name"
+                    role="alertdialog"
+                    aria-label="Confirm remove project"
                   >
-                    {{ entry.project.name.slice(0, 2).toLowerCase() }}
+                    <span class="mono truncate text-[11.5px] text-[var(--ink-dim)]">Sure?</span>
+                    <div class="flex shrink-0 items-center gap-1">
+                      <button
+                        type="button"
+                        class="mono rounded border border-red-500/40 px-2 py-0.5 text-[11px] text-red-300 hover:bg-red-500/10"
+                        [attr.data-testid]="'project-switcher-confirm-yes-' + entry.project.name"
+                        (click)="confirmRemove(entry.project.name)"
+                      >
+                        delete
+                      </button>
+                      <button
+                        type="button"
+                        class="mono rounded border border-[var(--line)] px-2 py-0.5 text-[11px] text-[var(--ink-mute)] hover:text-[var(--ink)]"
+                        [attr.data-testid]="'project-switcher-confirm-no-' + entry.project.name"
+                        (click)="cancelRemove()"
+                      >
+                        cancel
+                      </button>
+                    </div>
                   </div>
-                  <span class="mono flex-1 truncate text-[12px] text-[var(--ink)]">{{
-                    entry.project.name
-                  }}</span>
-                  <span class="pill accent mr-1.5">current</span>
-                  <span
-                    class="mono flex h-3.5 w-3.5 flex-shrink-0 cursor-default select-none items-center justify-center rounded-full border border-[var(--line-strong)] text-[9px] text-[var(--ink-mute)]"
-                    [appTooltip]="entry.project.dir"
-                    placement="top"
-                    [attr.aria-label]="'Project directory: ' + entry.project.dir"
-                    [attr.data-testid]="'project-switcher-item-info-' + entry.project.name"
-                    tabindex="0"
-                    >i</span
-                  >
-                </div>
-              } @else {
-                <div
-                  class="flex items-center gap-1 rounded px-2 py-1.5"
-                  [class]="rowInactiveClasses"
-                >
+                } @else {
                   <button
                     type="button"
                     class="flex min-w-0 flex-1 items-center gap-2 text-left"
+                    [class.cursor-default]="entry.isActive"
                     [attr.data-testid]="'project-switcher-item-' + entry.project.name"
+                    [disabled]="entry.isActive"
+                    [attr.aria-current]="entry.isActive ? 'true' : null"
                     (click)="switchProject(entry.project.name)"
                   >
                     <div
@@ -120,10 +100,28 @@ const SWATCH_TOKENS = ['var(--violet)', 'var(--teal)', 'var(--amber)', 'var(--ac
                     >
                       {{ entry.project.name.slice(0, 2).toLowerCase() }}
                     </div>
-                    <span class="mono truncate text-[12px] text-[var(--ink-dim)]">{{
-                      entry.project.name
-                    }}</span>
+                    <span
+                      class="mono truncate text-[12px]"
+                      [class]="entry.isActive ? 'text-[var(--ink-mute)]' : 'text-[var(--ink-dim)]'"
+                      >{{ entry.project.name }}</span
+                    >
+                    @if (entry.isActive) {
+                      <span class="sr-only">current project</span>
+                    }
                   </button>
+                  @if (!entry.isActive) {
+                    <button
+                      type="button"
+                      class="flex shrink-0 items-center px-1 text-[var(--ink-mute)] opacity-0 hover:text-red-300 focus:opacity-100 group-hover:opacity-100 group-focus-within:opacity-100"
+                      [attr.data-testid]="'project-switcher-remove-' + entry.project.name"
+                      [attr.aria-label]="'Remove project ' + entry.project.name"
+                      appTooltip="Remove from list?"
+                      placement="top"
+                      (click)="requestRemove(entry.project.name)"
+                    >
+                      <app-icon name="trash" class="h-3.5 w-3.5" />
+                    </button>
+                  }
                   <span
                     class="mono flex h-3.5 w-3.5 flex-shrink-0 cursor-default select-none items-center justify-center rounded-full border border-[var(--line-strong)] text-[9px] text-[var(--ink-mute)]"
                     [appTooltip]="entry.project.dir"
@@ -133,6 +131,15 @@ const SWATCH_TOKENS = ['var(--violet)', 'var(--teal)', 'var(--amber)', 'var(--ac
                     tabindex="0"
                     >i</span
                   >
+                }
+              </div>
+              @if (removeError() && entry.project.name === removeErrorName()) {
+                <div
+                  class="mono px-2 pb-1.5 text-[10px] text-red-300"
+                  [attr.data-testid]="'project-switcher-remove-error-' + entry.project.name"
+                  role="alert"
+                >
+                  {{ removeError() }}
                 </div>
               }
             } @empty {
@@ -140,7 +147,7 @@ const SWATCH_TOKENS = ['var(--violet)', 'var(--teal)', 'var(--amber)', 'var(--ac
                 class="mono px-2 py-2 text-[11px] text-[var(--ink-mute)]"
                 data-testid="project-switcher-empty"
               >
-                no projects match
+                no projects
               </div>
             }
           </div>
@@ -182,8 +189,13 @@ export class ProjectSwitcherComponent implements OnInit, OnDestroy {
   /** Whether the shared create-project modal is currently visible. */
   readonly showAddForm = signal<boolean>(false);
 
-  /** Search input value — filters {@link visibleProjects} by case-insensitive substring. */
-  readonly filter = signal('');
+  /** Name of the row pending remove confirmation; `null` when none. */
+  readonly pendingDeleteId = signal<string | null>(null);
+
+  /** Backend error message to surface inline under a row; `null` when none. */
+  readonly removeError = signal<string | null>(null);
+  /** Project name the surfaced error refers to. */
+  readonly removeErrorName = signal<string | null>(null);
 
   /** Tailwind class string for the active row (highlighted bg, no hover-bg). */
   readonly rowActiveClasses = 'bg-[var(--bg-2)]';
@@ -200,6 +212,32 @@ export class ProjectSwitcherComponent implements OnInit, OnDestroy {
   private projectState = inject(ProjectStateService);
   private logger = inject(LoggerService);
   private unsubProjectSettled: (() => void) | null = null;
+
+  /** Registers reactive cleanup of transient pending/error state. */
+  constructor() {
+    // Reset transient pending/error state when the dropdown closes or when
+    // the row disappears from the list — otherwise reopening would render
+    // a stale "Sure?" confirm prompt or an error for a missing project.
+    effect(() => {
+      if (!this.ui.projectSwitcherOpen()) {
+        this.pendingDeleteId.set(null);
+        this.removeError.set(null);
+        this.removeErrorName.set(null);
+      }
+    });
+    effect(() => {
+      const names = new Set(this.projects().map((p) => p.name));
+      const pending = this.pendingDeleteId();
+      if (pending !== null && !names.has(pending)) {
+        this.pendingDeleteId.set(null);
+      }
+      const errName = this.removeErrorName();
+      if (errName !== null && !names.has(errName)) {
+        this.removeError.set(null);
+        this.removeErrorName.set(null);
+      }
+    });
+  }
 
   /** Loads available projects from the backend on initialization. */
   async ngOnInit(): Promise<void> {
@@ -267,36 +305,62 @@ export class ProjectSwitcherComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Updates the search filter signal from the input event.
-   * @param event - The native input event from the search field.
+   * Swaps the row into the confirm prompt.
+   * @param name - The project to mark as pending removal.
    */
-  onFilterInput(event: Event): void {
-    const target = event.target as HTMLInputElement;
-    this.filter.set(target.value);
+  requestRemove(name: string): void {
+    this.pendingDeleteId.set(name);
+    this.removeError.set(null);
+    this.removeErrorName.set(null);
+    this.cdr.markForCheck();
+  }
+
+  /** Dismisses the confirm prompt without removing. */
+  cancelRemove(): void {
+    this.pendingDeleteId.set(null);
+    this.cdr.markForCheck();
   }
 
   /**
-   * Annotates the current `projects` list with the swatch color and the
-   * `isActive` flag, then filters by the search input.
+   * Confirms removal and calls the backend.
+   * @param name - The project to remove.
    */
+  async confirmRemove(name: string): Promise<void> {
+    this.pendingDeleteId.set(null);
+    try {
+      await this.projectState.removeProject(name);
+      this.removeError.set(null);
+      this.removeErrorName.set(null);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.removeError.set(this.cleanRemoveErrorMessage(msg));
+      this.removeErrorName.set(name);
+      this.logger.error(`Failed to remove project: ${msg}`);
+    }
+    this.cdr.markForCheck();
+  }
+
+  /**
+   * Strips the runtime sentinel prefix so the user sees the human-readable message.
+   * @param msg - Raw backend error message that may carry the sentinel prefix.
+   */
+  private cleanRemoveErrorMessage(msg: string): string {
+    const prefix = 'active_project_removal: ';
+    const idx = msg.indexOf(prefix);
+    return idx >= 0 ? msg.slice(idx + prefix.length) : msg;
+  }
+
+  /** Decorates the project list with swatch color and active flag. */
   private projectsWithMeta(): ReadonlyArray<{
     project: ProjectEntry;
     swatch: string;
     isActive: boolean;
   }> {
-    const needle = this.filter().trim().toLowerCase();
-    return this.projects()
-      .map((project, index) => ({
-        project,
-        swatch: SWATCH_TOKENS[index % SWATCH_TOKENS.length],
-        isActive: this.isActive(project),
-      }))
-      .filter(({ project }) =>
-        needle === '' ? true : project.name.toLowerCase().includes(needle)
-      );
-  }
-
-  private isActive(project: ProjectEntry): boolean {
-    return project.name === this.activeProject();
+    const active = this.activeProject();
+    return this.projects().map((project, index) => ({
+      project,
+      swatch: swatchFor(index),
+      isActive: project.name === active,
+    }));
   }
 }

--- a/desktop/src/src/app/project-switcher/project-switcher.component.ts
+++ b/desktop/src/src/app/project-switcher/project-switcher.component.ts
@@ -20,6 +20,22 @@ import { TooltipDirective } from '../shared/tooltip.directive';
 import { swatchFor } from './project-swatch';
 
 /**
+ * Sentinel prefix used by the runtime to mark "active project removal rejected".
+ * Must match crates/speedwave-runtime/src/project.rs::REMOVE_ACTIVE_PROJECT_ERR_PREFIX.
+ */
+const ACTIVE_PROJECT_ERR_PREFIX = 'active_project_removal: ';
+
+/**
+ * Strips the runtime sentinel prefix so the user sees the human-readable message.
+ * Exported for unit testing.
+ * @param msg - Raw backend error message that may carry the sentinel prefix.
+ */
+export function cleanRemoveErrorMessage(msg: string): string {
+  const idx = msg.indexOf(ACTIVE_PROJECT_ERR_PREFIX);
+  return idx >= 0 ? msg.slice(idx + ACTIVE_PROJECT_ERR_PREFIX.length) : msg;
+}
+
+/**
  * Project switcher dropdown — toggled from the chat header / command palette.
  *
  * Visibility is wired to {@link UiStateService.projectSwitcherOpen} so the
@@ -51,7 +67,7 @@ import { swatchFor } from './project-swatch';
           <!-- Body: project rows -->
           <div class="max-h-64 overflow-y-auto p-1">
             @for (entry of visibleProjects(); track entry.project.name) {
-              @let pendingDelete = entry.project.name === pendingDeleteId();
+              @let pendingDelete = entry.project.name === pendingDeleteName();
               <div
                 class="group flex items-center gap-1 rounded px-2 py-1.5"
                 [class]="entry.isActive ? rowActiveClasses : rowInactiveClasses"
@@ -133,13 +149,13 @@ import { swatchFor } from './project-swatch';
                   >
                 }
               </div>
-              @if (removeError() && entry.project.name === removeErrorName()) {
+              @if (removeError()?.project === entry.project.name) {
                 <div
                   class="mono px-2 pb-1.5 text-[10px] text-red-300"
                   [attr.data-testid]="'project-switcher-remove-error-' + entry.project.name"
                   role="alert"
                 >
-                  {{ removeError() }}
+                  {{ removeError()?.msg }}
                 </div>
               }
             } @empty {
@@ -190,12 +206,10 @@ export class ProjectSwitcherComponent implements OnInit, OnDestroy {
   readonly showAddForm = signal<boolean>(false);
 
   /** Name of the row pending remove confirmation; `null` when none. */
-  readonly pendingDeleteId = signal<string | null>(null);
+  readonly pendingDeleteName = signal<string | null>(null);
 
-  /** Backend error message to surface inline under a row; `null` when none. */
-  readonly removeError = signal<string | null>(null);
-  /** Project name the surfaced error refers to. */
-  readonly removeErrorName = signal<string | null>(null);
+  /** Backend error to surface inline under a row; `null` when none. */
+  readonly removeError = signal<{ msg: string; project: string } | null>(null);
 
   /** Tailwind class string for the active row (highlighted bg, no hover-bg). */
   readonly rowActiveClasses = 'bg-[var(--bg-2)]';
@@ -220,21 +234,19 @@ export class ProjectSwitcherComponent implements OnInit, OnDestroy {
     // a stale "Sure?" confirm prompt or an error for a missing project.
     effect(() => {
       if (!this.ui.projectSwitcherOpen()) {
-        this.pendingDeleteId.set(null);
+        this.pendingDeleteName.set(null);
         this.removeError.set(null);
-        this.removeErrorName.set(null);
       }
     });
     effect(() => {
       const names = new Set(this.projects().map((p) => p.name));
-      const pending = this.pendingDeleteId();
+      const pending = this.pendingDeleteName();
       if (pending !== null && !names.has(pending)) {
-        this.pendingDeleteId.set(null);
+        this.pendingDeleteName.set(null);
       }
-      const errName = this.removeErrorName();
-      if (errName !== null && !names.has(errName)) {
+      const err = this.removeError();
+      if (err !== null && !names.has(err.project)) {
         this.removeError.set(null);
-        this.removeErrorName.set(null);
       }
     });
   }
@@ -309,15 +321,14 @@ export class ProjectSwitcherComponent implements OnInit, OnDestroy {
    * @param name - The project to mark as pending removal.
    */
   requestRemove(name: string): void {
-    this.pendingDeleteId.set(name);
+    this.pendingDeleteName.set(name);
     this.removeError.set(null);
-    this.removeErrorName.set(null);
     this.cdr.markForCheck();
   }
 
   /** Dismisses the confirm prompt without removing. */
   cancelRemove(): void {
-    this.pendingDeleteId.set(null);
+    this.pendingDeleteName.set(null);
     this.cdr.markForCheck();
   }
 
@@ -326,28 +337,16 @@ export class ProjectSwitcherComponent implements OnInit, OnDestroy {
    * @param name - The project to remove.
    */
   async confirmRemove(name: string): Promise<void> {
-    this.pendingDeleteId.set(null);
+    this.pendingDeleteName.set(null);
     try {
       await this.projectState.removeProject(name);
       this.removeError.set(null);
-      this.removeErrorName.set(null);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      this.removeError.set(this.cleanRemoveErrorMessage(msg));
-      this.removeErrorName.set(name);
+      this.removeError.set({ msg: cleanRemoveErrorMessage(msg), project: name });
       this.logger.error(`Failed to remove project: ${msg}`);
     }
     this.cdr.markForCheck();
-  }
-
-  /**
-   * Strips the runtime sentinel prefix so the user sees the human-readable message.
-   * @param msg - Raw backend error message that may carry the sentinel prefix.
-   */
-  private cleanRemoveErrorMessage(msg: string): string {
-    const prefix = 'active_project_removal: ';
-    const idx = msg.indexOf(prefix);
-    return idx >= 0 ? msg.slice(idx + prefix.length) : msg;
   }
 
   /** Decorates the project list with swatch color and active flag. */

--- a/desktop/src/src/app/services/project-state.service.ts
+++ b/desktop/src/src/app/services/project-state.service.ts
@@ -403,6 +403,16 @@ export class ProjectStateService {
     await this.tauri.invoke('add_project', { name, dir });
   }
 
+  /**
+   * The ONLY way to remove projects from the frontend.
+   * @param name - The project to remove.
+   */
+  async removeProject(name: string): Promise<void> {
+    await this.tauri.invoke('remove_project', { name });
+    await this.refreshProjectList();
+    this.notifySettled();
+  }
+
   private async setupListeners(): Promise<void> {
     try {
       await this.tauri.listen<{ project: string }>('project_switch_started', (event) => {

--- a/docs/guides/desktop.md
+++ b/docs/guides/desktop.md
@@ -115,6 +115,16 @@ There is no client-side gate on the active model — every provider gets a chanc
 
 The CLI (`speedwave run`, which launches Claude Code's TUI in the container) does **not** yet support image paste — the TUI's native paste reads the host clipboard, which the container cannot see. A host-side clipboard watcher is planned in a separate spike + PR.
 
+## Project switcher
+
+The project pill in the top-right of every view opens the project switcher dropdown — the single entry point for selecting, adding, and removing projects.
+
+- **Switch:** click any inactive row. The active row is rendered disabled (no `current` pill — color and disabled state are the only signals) so it never reads as a clickable target.
+- **Add:** the `+ add project…` footer opens the shared create-project modal.
+- **Remove:** the trash icon appears on inactive rows on hover or keyboard focus. Clicking it swaps the row into an inline **Sure?** confirm with `delete` / `cancel` (same pattern as the conversation-history sidebar). Removing a project unregisters it from `~/.speedwave/config.json`, stops its containers, tears down its host-exec drain, and deletes every per-project subdirectory under `~/.speedwave/` (tokens, compose, context, claude-home, secrets, snapshots, oauth, host-exec). **The user's project files on the host are not touched** — only Speedwave-managed state is removed.
+- The active project cannot be removed; switch to a different one first. The runtime layer enforces this regardless of caller, and the trash icon is hidden on the active row in the UI.
+- If a backend error reaches the UI (compose-down failure, runtime guard), it surfaces inline under the row as a red `role="alert"` message — the config wipe is aborted so the user can retry.
+
 ## System Tray
 
 ## Logs & system health


### PR DESCRIPTION
## Summary
- Adds a trash icon on inactive project rows with an inline "Sure? / delete / cancel" confirm prompt (mirrors the conversations-sidebar pattern).
- Backend tears down host_exec drain + containers + every per-project subdir under `~/.speedwave/` (tokens, compose, context, claude-home, secrets, snapshots, oauth, host-exec) so re-adding a project with the same name does not inherit stale OAuth refresh tokens or audit state.
- The user's source tree on the host (mounted as `/workspace`) is **not** touched.
- Active project guard + `validate_project_name` enforced inside the runtime config lock; errors carry a stable sentinel prefix the UI strips before display.
- Replaces `swatchFor(name, names[])` with `swatchFor(index)` — drops the duplicate `projectNames` signal in `project-pill` and fixes the color desync between the pill and the dropdown row.
- A11y: `aria-current="true"` moved onto the focusable button + sr-only "current project" label; trash button revealed on `group-focus-within` so it is discoverable for sighted keyboard users.
- Removes search input (UX simplification) and the "current" pill (replaced by disabled-state + a11y signals).

Closes #269

## Test plan
- [x] `make check` — clippy + clippy desktop + cargo fmt + Angular ESLint + Angular type-check + MCP
- [x] `make test-rust` — 18/18 in `project::tests` (new: `remove_project_happy_path`, `remove_project_rejects_active`, `remove_project_rejects_invalid_name`, `remove_project_preserves_other_active_project`, `remove_project_missing_errors`)
- [x] `make test-desktop` — 1367/1367
- [x] `make test-angular` — 1901/1901 (project-switcher.component.spec.ts: 24 tests incl. new error-surfacing, sr-only, effect-cleanup, aria-current-on-button)
- [x] `make test-mcp` + `make test-cli` + `make test-entrypoint`
- [ ] Manual: open switcher → trash icon on inactive row → "Sure?" prompt → `delete` removes the project; active row has no trash; cancel/Esc closes prompt cleanly