### PR TITLE
feat(desktop): add Opus 4.8, default effort to auto, fix Opus pricing and the in: token counter

### DIFF
--- a/containers/compose.template.yml
+++ b/containers/compose.template.yml
@@ -26,7 +26,7 @@ services:
       - CLAUDE_VERSION=${CLAUDE_VERSION}
       - MCP_HUB_PORT=${PORT_HUB}
       - CLAUDE_CODE_IDE_HOST_OVERRIDE=${IDE_HOST_OVERRIDE}
-      - CLAUDE_CODE_EFFORT_LEVEL=max
+      - CLAUDE_CODE_EFFORT_LEVEL=auto
       - ANTHROPIC_LOG=debug
     working_dir: /workspace
     networks:

--- a/containers/compose.template.yml
+++ b/containers/compose.template.yml
@@ -26,6 +26,8 @@ services:
       - CLAUDE_VERSION=${CLAUDE_VERSION}
       - MCP_HUB_PORT=${PORT_HUB}
       - CLAUDE_CODE_IDE_HOST_OVERRIDE=${IDE_HOST_OVERRIDE}
+      # `auto` = use the model's own default effort (high on Opus 4.8). A valid
+      # value per Claude Code env-vars docs (low|medium|high|xhigh|max|auto).
       - CLAUDE_CODE_EFFORT_LEVEL=auto
       - ANTHROPIC_LOG=debug
     working_dir: /workspace

--- a/crates/speedwave-runtime/src/compose.rs
+++ b/crates/speedwave-runtime/src/compose.rs
@@ -7580,10 +7580,10 @@ services:
 
         let has_effort_level = claude_env
             .iter()
-            .any(|v| v.as_str() == Some("CLAUDE_CODE_EFFORT_LEVEL=max"));
+            .any(|v| v.as_str() == Some("CLAUDE_CODE_EFFORT_LEVEL=auto"));
         assert!(
             has_effort_level,
-            "CLAUDE_CODE_EFFORT_LEVEL=max must be in claude service environment"
+            "CLAUDE_CODE_EFFORT_LEVEL=auto must be in claude service environment"
         );
     }
 

--- a/crates/speedwave-runtime/src/defaults.rs
+++ b/crates/speedwave-runtime/src/defaults.rs
@@ -80,7 +80,7 @@ pub const ANTHROPIC_MODELS: &[AnthropicModelInfo] = &[
 /// honest hint like *"Default — Opus 4.7 (switchable via /model)"* instead
 /// of the previous vague *"let Claude Code choose"* placeholder.
 ///
-/// Reads from `ANTHROPIC_MODELS` (the SSOT) so a future Opus bump (e.g. 4.8)
+/// Reads from `ANTHROPIC_MODELS` (the SSOT) so a future Opus bump (e.g. 4.9)
 /// updates the UI hint without touching this helper. Returns `None` if the
 /// catalog has no `latest = true` Opus entry — frontend falls back to the
 /// generic placeholder in that case.
@@ -154,7 +154,7 @@ pub fn base_env() -> HashMap<String, String> {
 /// upstream issue ships a fix and the alias resolves to the upgraded window
 /// natively.
 ///
-/// Future model bumps (e.g. Opus 4.8) only require editing `ANTHROPIC_MODELS`
+/// Future model bumps (e.g. Opus 4.9) only require editing `ANTHROPIC_MODELS`
 /// in this file: the env vars track the SSOT automatically. Families with no
 /// `latest: true` entry are skipped (no env var emitted) so a partial catalog
 /// never produces a malformed model id.
@@ -290,7 +290,7 @@ mod tests {
         // Workaround for anthropics/claude-code#34083 — without `[1m]` suffix
         // on the model id, Max/Team subscribers see their 1M-context models
         // capped at 200k. The function must derive these env vars from the
-        // SSOT so a future model bump (Opus 4.8 etc.) propagates by editing
+        // SSOT so a future model bump (Opus 4.9 etc.) propagates by editing
         // `ANTHROPIC_MODELS` alone.
         let env = anthropic_default_models_env();
         // Cross-check every emitted var against SSOT — independent of which

--- a/crates/speedwave-runtime/src/defaults.rs
+++ b/crates/speedwave-runtime/src/defaults.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-pub const CLAUDE_VERSION: &str = "2.1.153";
+pub const CLAUDE_VERSION: &str = "2.1.154";
 /// Path inside the container where entrypoint.sh generates the MCP config.
 pub const MCP_CONFIG_PATH: &str = "/home/speedwave/.claude/mcp-config.json";
 
@@ -43,8 +43,8 @@ pub struct AnthropicModelInfo {
 /// their use was the opposite of what the `latest` flag intended.
 pub const ANTHROPIC_MODELS: &[AnthropicModelInfo] = &[
     AnthropicModelInfo {
-        id: "claude-opus-4-7",
-        family: "Opus 4.7",
+        id: "claude-opus-4-8",
+        family: "Opus 4.8",
         context_tokens: 1_000_000,
         latest: true,
     },
@@ -59,6 +59,12 @@ pub const ANTHROPIC_MODELS: &[AnthropicModelInfo] = &[
         family: "Haiku 4.5",
         context_tokens: 200_000,
         latest: true,
+    },
+    AnthropicModelInfo {
+        id: "claude-opus-4-7",
+        family: "Opus 4.7",
+        context_tokens: 1_000_000,
+        latest: false,
     },
     AnthropicModelInfo {
         id: "claude-opus-4-6",
@@ -457,9 +463,9 @@ mod tests {
     #[test]
     fn default_anthropic_family_label_returns_latest_opus_family() {
         // Forces the constant in this assertion to be updated alongside the
-        // SSOT when a new Opus snapshot lands (e.g. Opus 4.8). If the test
+        // SSOT when a new Opus snapshot lands (e.g. Opus 4.9). If the test
         // breaks on a model bump, the helper still works — the assertion
         // just needs to follow the family label.
-        assert_eq!(default_anthropic_family_label(), Some("Opus 4.7"));
+        assert_eq!(default_anthropic_family_label(), Some("Opus 4.8"));
     }
 }

--- a/desktop/src-tauri/src/chat.rs
+++ b/desktop/src-tauri/src/chat.rs
@@ -1002,8 +1002,9 @@ impl StreamParser {
 ///
 /// Two sources are possible:
 ///
-///  * Flat `usage` (Claude Code CLI today) — already per-step, so the value
-///    is emitted as the turn and the snapshot accumulates it.
+///  * Flat `usage` (Claude Code CLI today) — the latest turn's full prompt
+///    usage (`input_tokens` is the uncached remainder, `cache_read` is the
+///    re-sent history); emitted as the turn, snapshot accumulates it.
 ///  * `modelUsage` only (cumulative per-model, no flat `usage`) — compute
 ///    `turn = cumulative - snapshot` and advance the snapshot.
 ///

--- a/desktop/src/src/app/chat/pricing.spec.ts
+++ b/desktop/src/src/app/chat/pricing.spec.ts
@@ -8,15 +8,26 @@ describe('calculateCost', () => {
     _resetUnknownModelWarnings();
   });
 
-  it('computes Opus 4.7 cost from input + output tokens (no cache)', () => {
-    // 1M in + 1M out @ $15/$75 = $90
+  it('computes Opus 4.8 cost from input + output tokens (no cache)', () => {
+    // 1M in + 1M out @ $5/$25 = $30
     const usage: TurnUsage = {
       input_tokens: 1_000_000,
       output_tokens: 1_000_000,
       cache_read_tokens: 0,
       cache_write_tokens: 0,
     };
-    expect(calculateCost('claude-opus-4-7', usage)).toBeCloseTo(90, 6);
+    expect(calculateCost('claude-opus-4-8', usage)).toBeCloseTo(30, 6);
+  });
+
+  it('computes Opus 4.7 cost from input + output tokens (no cache)', () => {
+    // 1M in + 1M out @ $5/$25 = $30
+    const usage: TurnUsage = {
+      input_tokens: 1_000_000,
+      output_tokens: 1_000_000,
+      cache_read_tokens: 0,
+      cache_write_tokens: 0,
+    };
+    expect(calculateCost('claude-opus-4-7', usage)).toBeCloseTo(30, 6);
   });
 
   it('computes Sonnet 4.6 cost from input + output tokens (no cache)', () => {
@@ -42,7 +53,7 @@ describe('calculateCost', () => {
   });
 
   it('charges cache-read at cachedInput rate (10% of input)', () => {
-    // Opus: 1M cache-read @ $1.5 = $1.5
+    // Opus: 1M cache-read @ $0.5 = $0.5
     // The 1M in the input_tokens count, when >= cache_read, treats the
     // overlap as already-cached (billedInput = max(0, in - cache_read) = 0).
     const usage: TurnUsage = {
@@ -51,34 +62,34 @@ describe('calculateCost', () => {
       cache_read_tokens: 1_000_000,
       cache_write_tokens: 0,
     };
-    expect(calculateCost('claude-opus-4-7', usage)).toBeCloseTo(1.5, 6);
+    expect(calculateCost('claude-opus-4-7', usage)).toBeCloseTo(0.5, 6);
   });
 
   it('charges cache-write at cacheWrite rate (125% of input)', () => {
-    // Opus: 1M cache-write @ $18.75 = $18.75
+    // Opus: 1M cache-write @ $6.25 = $6.25
     const usage: TurnUsage = {
       input_tokens: 0,
       output_tokens: 0,
       cache_read_tokens: 0,
       cache_write_tokens: 1_000_000,
     };
-    expect(calculateCost('claude-opus-4-7', usage)).toBeCloseTo(18.75, 6);
+    expect(calculateCost('claude-opus-4-7', usage)).toBeCloseTo(6.25, 6);
   });
 
   it('sums all four components for a realistic turn', () => {
     // Opus: input 11_000 (1000 billed after subtracting cache_read) + 10k cache-read +
     //   5k cache-write + 500 output
     //   billedInput = max(0, 11000 - 10000) = 1000
-    //   = 1000 * 15 / 1e6 + 10000 * 1.5 / 1e6 + 5000 * 18.75 / 1e6 + 500 * 75 / 1e6
-    //   = 0.015 + 0.015 + 0.09375 + 0.0375
-    //   = 0.16125
+    //   = 1000 * 5 / 1e6 + 10000 * 0.5 / 1e6 + 5000 * 6.25 / 1e6 + 500 * 25 / 1e6
+    //   = 0.005 + 0.005 + 0.03125 + 0.0125
+    //   = 0.05375
     const usage: TurnUsage = {
       input_tokens: 11_000,
       output_tokens: 500,
       cache_read_tokens: 10_000,
       cache_write_tokens: 5_000,
     };
-    expect(calculateCost('claude-opus-4-7', usage)).toBeCloseTo(0.16125, 6);
+    expect(calculateCost('claude-opus-4-7', usage)).toBeCloseTo(0.05375, 6);
   });
 
   it('returns 0 for zero-usage input', () => {
@@ -100,8 +111,8 @@ describe('calculateCost', () => {
       cache_read_tokens: 5_000,
       cache_write_tokens: 0,
     };
-    // billed = max(0, 1000 - 5000) = 0 → only cache_read cost: 5000 * 1.5 / 1e6 = 0.0075
-    expect(calculateCost('claude-opus-4-7', usage)).toBeCloseTo(0.0075, 6);
+    // billed = max(0, 1000 - 5000) = 0 → only cache_read cost: 5000 * 0.5 / 1e6 = 0.0025
+    expect(calculateCost('claude-opus-4-7', usage)).toBeCloseTo(0.0025, 6);
   });
 
   it('returns null and logs exactly one warning for an unknown model', () => {

--- a/desktop/src/src/app/chat/pricing.ts
+++ b/desktop/src/src/app/chat/pricing.ts
@@ -32,15 +32,18 @@ export interface ModelPricing {
  */
 export const PRICING: Record<string, ModelPricing> = {
   // All entries verified against the Anthropic published pricing page on
-  // 2026-04-25 (https://docs.claude.com/en/docs/about-claude/models#model-pricing).
-  // Opus 4.5/4.6/4.7 are all currently shipping models; update when prices change.
-  // Opus family — $15 / $75 per 1M
-  'claude-opus-4-5': { input: 15, cachedInput: 1.5, cacheWrite: 18.75, output: 75 },
-  'claude-opus-4-6': { input: 15, cachedInput: 1.5, cacheWrite: 18.75, output: 75 },
-  'claude-opus-4-7': { input: 15, cachedInput: 1.5, cacheWrite: 18.75, output: 75 },
-  // The 1-million-token context variant pricing for Opus — best-effort; verify
-  'claude-opus-4-6[1m]': { input: 15, cachedInput: 1.5, cacheWrite: 18.75, output: 75 },
-  'claude-opus-4-7[1m]': { input: 15, cachedInput: 1.5, cacheWrite: 18.75, output: 75 },
+  // 2026-05-28 (https://platform.claude.com/docs/en/about-claude/pricing#model-pricing).
+  // Opus 4.5/4.6/4.7/4.8 are all $5 / $25 per 1M (4.1 and earlier were $15 / $75).
+  // Opus 4.6/4.7/4.8 include the full 1M context window at standard pricing,
+  // so the [1m] variants match the base rate.
+  // Opus family — $5 / $25 per 1M
+  'claude-opus-4-5': { input: 5, cachedInput: 0.5, cacheWrite: 6.25, output: 25 },
+  'claude-opus-4-6': { input: 5, cachedInput: 0.5, cacheWrite: 6.25, output: 25 },
+  'claude-opus-4-7': { input: 5, cachedInput: 0.5, cacheWrite: 6.25, output: 25 },
+  'claude-opus-4-8': { input: 5, cachedInput: 0.5, cacheWrite: 6.25, output: 25 },
+  'claude-opus-4-6[1m]': { input: 5, cachedInput: 0.5, cacheWrite: 6.25, output: 25 },
+  'claude-opus-4-7[1m]': { input: 5, cachedInput: 0.5, cacheWrite: 6.25, output: 25 },
+  'claude-opus-4-8[1m]': { input: 5, cachedInput: 0.5, cacheWrite: 6.25, output: 25 },
 
   // Sonnet family — $3 / $15 per 1M
   'claude-sonnet-4-5': { input: 3, cachedInput: 0.3, cacheWrite: 3.75, output: 15 },

--- a/desktop/src/src/app/chat/session-stats/session-stats.component.spec.ts
+++ b/desktop/src/src/app/chat/session-stats/session-stats.component.spec.ts
@@ -82,7 +82,7 @@ describe('SessionStatsComponent', () => {
         session_id: 'abc',
         total_cost: 0.05,
         usage: {
-          input_tokens: 3,
+          input_tokens: 1234,
           output_tokens: 65,
           cache_read_tokens: 22562,
           cache_write_tokens: 75,
@@ -92,9 +92,11 @@ describe('SessionStatsComponent', () => {
       });
       fixture.detectChanges();
       const txt = rootText();
-      // in: <totalInput> = 3 + 22,562 + 75 = 22,640
+      // in: = input_tokens only (new uncached input), NOT input + cache.
+      // cache_read (22,562 = re-sent history) must NOT inflate `in:`.
       expect(txt).toContain('in:');
-      expect(txt).toContain('22,640');
+      expect(txt).toContain('1,234');
+      expect(txt).not.toContain('23,871'); // 1234 + 22562 + 75 — the old (wrong) totalInput
       expect(txt).toContain('out:');
       expect(txt).toContain('65');
     });
@@ -151,6 +153,93 @@ describe('SessionStatsComponent', () => {
       });
       fixture.detectChanges();
       expect(rootText()).toContain('116k/200k');
+    });
+  });
+
+  // ── regression: `in:` must not echo the context numerator ───────────────
+  describe('in: vs ctx separation (regression)', () => {
+    it('reproduces the screenshot: short chat shows small `in:` but full ctx gauge', () => {
+      // Real session: a tiny new message (181 input) on top of a large
+      // re-sent prompt served from cache (181,532). The ctx gauge correctly
+      // shows the full occupancy (~182k / 1M = 18%), but `in:` must show only
+      // the 181 new tokens — NOT the 181,713 it used to echo from the gauge.
+      fixture.componentRef.setInput('stats', {
+        session_id: 'abc',
+        total_cost: 0.5,
+        usage: {
+          input_tokens: 181,
+          output_tokens: 65,
+          cache_read_tokens: 181_532,
+          cache_write_tokens: 0,
+        },
+        context_window_size: 1_000_000,
+        total_output_tokens: 1621,
+      });
+      fixture.detectChanges();
+      // ctx gauge unchanged — full occupancy is correct.
+      expect(component.ctxTotal()).toBe(181_713);
+      expect(component.ctxPct()).toBe(18);
+      expect(component.ctxUsedMax()).toBe('182k/1M');
+      // `in:` shows only the new uncached input, not the gauge numerator.
+      expect(component.inboundTokens()).toBe(181);
+      const txt = rootText();
+      expect(txt).toContain('181');
+      expect(txt).not.toContain('181,713');
+    });
+
+    it('does not sum input across turns — gauge reflects only the latest turn', () => {
+      // Each turn re-sends history, so cache_read grows turn over turn. The
+      // gauge must track the LATEST turn (replacement), never the running sum.
+      const set = (cacheRead: number) =>
+        fixture.componentRef.setInput('stats', {
+          session_id: 'abc',
+          total_cost: 0,
+          usage: { input_tokens: 200, output_tokens: 50, cache_read_tokens: cacheRead },
+          context_window_size: 1_000_000,
+          total_output_tokens: 50,
+        });
+      set(20_000);
+      fixture.detectChanges();
+      expect(component.ctxPct()).toBe(2);
+      set(90_000);
+      fixture.detectChanges();
+      expect(component.ctxPct()).toBe(9);
+      set(181_000);
+      fixture.detectChanges();
+      // Latest turn → 181,200 / 1M = 18%. NOT the sum (~291k → 29%).
+      expect(component.ctxTotal()).toBe(181_200);
+      expect(component.ctxPct()).toBe(18);
+    });
+
+    it('handles a local model (no prompt cache): in: equals the whole prompt', () => {
+      // Local LLM has no prompt cache — cache fields are absent. `in:` then
+      // equals input_tokens (the whole prompt), and the gauge matches it.
+      fixture.componentRef.setInput('stats', {
+        session_id: 'abc',
+        total_cost: 0,
+        usage: { input_tokens: 4500, output_tokens: 120 },
+        context_window_size: 32_768,
+        total_output_tokens: 120,
+      });
+      fixture.detectChanges();
+      expect(component.inboundTokens()).toBe(4500);
+      expect(component.ctxTotal()).toBe(4500);
+      expect(component.ctxPct()).toBe(14); // 4500 / 32768
+    });
+
+    it('hides the ctx gauge for a local model with unknown window (ADR-041)', () => {
+      // No advertised window → ctxPct null → gauge hidden, never fabricated.
+      fixture.componentRef.setInput('stats', {
+        session_id: 'abc',
+        total_cost: 0,
+        usage: { input_tokens: 4500, output_tokens: 120 },
+        context_window_size: null,
+        total_output_tokens: 120,
+      });
+      fixture.detectChanges();
+      expect(component.inboundTokens()).toBe(4500);
+      expect(component.ctxPct()).toBeNull();
+      expect(rootText()).toContain('in:');
     });
   });
 

--- a/desktop/src/src/app/chat/session-stats/session-stats.component.ts
+++ b/desktop/src/src/app/chat/session-stats/session-stats.component.ts
@@ -36,10 +36,10 @@ const NUMBER_FMT = new Intl.NumberFormat('en-US');
         @if (s.usage; as usage) {
           <span
             class="whitespace-nowrap"
-            appTooltip="Input tokens consumed (prompt + cache reads/writes)"
+            appTooltip="New input tokens this turn (excludes history served from cache)"
             placement="top"
           >
-            in: <span class="text-[var(--teal)]">{{ formatNum(totalInput()) }}</span>
+            in: <span class="text-[var(--teal)]">{{ formatNum(inboundTokens()) }}</span>
           </span>
           <span
             class="whitespace-nowrap"
@@ -131,7 +131,7 @@ const NUMBER_FMT = new Intl.NumberFormat('en-US');
       >
         <span
           class="whitespace-nowrap"
-          appTooltip="Input tokens consumed (prompt + cache reads/writes)"
+          appTooltip="New input tokens this turn (excludes history served from cache)"
           placement="top"
         >
           in: <span class="text-[var(--teal)]">0</span>
@@ -211,11 +211,23 @@ export class SessionStatsComponent {
   readonly branch = input<string | null>(null);
 
   /**
-   * Total input tokens consumed from the context window (sum of `input`,
-   * `cache_read`, `cache_write`). Matches the statusline.sh calculation —
-   * `output_tokens` are excluded because they don't occupy the prompt context.
+   * New input tokens the user sent this turn — `input_tokens` only, the
+   * uncached remainder after the last cache breakpoint. Excludes
+   * `cache_read` (the re-sent system prompt + tool catalog + history served
+   * from cache), which is what made a short chat read as 181k. For a local
+   * model (no prompt cache) the cache fields are 0, so this equals the whole
+   * prompt — correct in both cases. Drives the `in:` counter only.
    */
-  readonly totalInput = computed<number>(() => {
+  readonly inboundTokens = computed<number>(() => this.stats()?.usage?.input_tokens ?? 0);
+
+  /**
+   * Total tokens occupying the context window this turn (`input` +
+   * `cache_read` + `cache_write`) — the verified Anthropic formula
+   * (input_tokens is the uncached remainder; the three are additive).
+   * `output_tokens` are excluded because they don't occupy the prompt.
+   * Drives the ctx gauge (percentage + used/max), never the `in:` counter.
+   */
+  readonly ctxTotal = computed<number>(() => {
     const usage = this.stats()?.usage;
     if (!usage) return 0;
     return usage.input_tokens + (usage.cache_read_tokens ?? 0) + (usage.cache_write_tokens ?? 0);
@@ -228,7 +240,7 @@ export class SessionStatsComponent {
    * than fabricating a default — ADR-041 "never guess".
    */
   readonly ctxPct = computed<number | null>(() => {
-    const total = this.totalInput();
+    const total = this.ctxTotal();
     if (total <= 0) return 0;
     const windowSize = this.stats()?.context_window_size;
     if (!windowSize || windowSize <= 0) return null;
@@ -252,7 +264,7 @@ export class SessionStatsComponent {
    * is unknown — template hides the label.
    */
   readonly ctxUsedMax = computed<string | null>(() => {
-    const total = this.totalInput();
+    const total = this.ctxTotal();
     if (total <= 0) return '';
     const windowSize = this.stats()?.context_window_size;
     if (!windowSize || windowSize <= 0) return null;

--- a/desktop/src/src/app/models/chat.ts
+++ b/desktop/src/src/app/models/chat.ts
@@ -247,7 +247,10 @@ export interface SessionStats {
   session_id: string;
   /** Total session cost in USD — estimated from token counts at API pricing. */
   total_cost: number;
-  /** Per-step usage from flat result.usage (not cumulative). Use for CTX %. */
+  /**
+   * Latest turn's full-prompt usage from flat result.usage (not summed across
+   * turns). Drives CTX % (input + cache_read + cache_write); `in:` uses input only.
+   */
   usage?: UsageInfo;
   model?: string;
   rate_limit?: RateLimitInfo;

--- a/desktop/src/src/app/services/anthropic-models.service.spec.ts
+++ b/desktop/src/src/app/services/anthropic-models.service.spec.ts
@@ -7,8 +7,8 @@ import { DEFAULT_CONTEXT_TOKENS, type AnthropicModel } from '../models/llm';
 
 const FIXTURE: AnthropicModel[] = [
   {
-    id: 'claude-opus-4-7',
-    family: 'Opus 4.7',
+    id: 'claude-opus-4-8',
+    family: 'Opus 4.8',
     context_tokens: 1_000_000,
     latest: true,
   },
@@ -23,6 +23,12 @@ const FIXTURE: AnthropicModel[] = [
     family: 'Haiku 4.5',
     context_tokens: 200_000,
     latest: true,
+  },
+  {
+    id: 'claude-opus-4-7',
+    family: 'Opus 4.7',
+    context_tokens: 1_000_000,
+    latest: false,
   },
 ];
 
@@ -96,6 +102,7 @@ describe('AnthropicModelsService', () => {
 
     it('returns the exact context window for a known full id', async () => {
       await service.list();
+      expect(service.contextTokensFor('claude-opus-4-8')).toBe(1_000_000);
       expect(service.contextTokensFor('claude-opus-4-7')).toBe(1_000_000);
       expect(service.contextTokensFor('claude-haiku-4-5')).toBe(200_000);
     });

--- a/desktop/src/src/app/settings/llm-provider/llm-provider.component.spec.ts
+++ b/desktop/src/src/app/settings/llm-provider/llm-provider.component.spec.ts
@@ -34,8 +34,8 @@ async function flushMicrotasks(cycles = 10): Promise<void> {
  */
 const TEST_ANTHROPIC_MODELS = [
   {
-    id: 'claude-opus-4-7',
-    family: 'Opus 4.7',
+    id: 'claude-opus-4-8',
+    family: 'Opus 4.8',
     context_tokens: 1_000_000,
     latest: true,
   },
@@ -50,6 +50,12 @@ const TEST_ANTHROPIC_MODELS = [
     family: 'Haiku 4.5',
     context_tokens: 200_000,
     latest: true,
+  },
+  {
+    id: 'claude-opus-4-7',
+    family: 'Opus 4.7',
+    context_tokens: 1_000_000,
+    latest: false,
   },
   {
     id: 'claude-opus-4-6',
@@ -74,7 +80,7 @@ function setupMockTauri(mockTauri: MockTauriService, provider = 'anthropic'): vo
       case 'list_anthropic_models':
         return TEST_ANTHROPIC_MODELS;
       case 'get_default_anthropic_model_label':
-        return 'Opus 4.7';
+        return 'Opus 4.8';
       case 'update_llm_config':
         return undefined;
       case 'discover_llm_models':
@@ -436,9 +442,10 @@ describe('LlmProviderComponent', () => {
     // legacy after.
     expect(options).toEqual([
       '',
-      'claude-opus-4-7',
+      'claude-opus-4-8',
       'claude-sonnet-4-6',
       'claude-haiku-4-5',
+      'claude-opus-4-7',
       'claude-opus-4-6',
     ]);
     const defaultLabel = (
@@ -456,7 +463,7 @@ describe('LlmProviderComponent', () => {
     const latestIds = Array.from(latestGroup.querySelectorAll('option')).map(
       (o) => (o as HTMLOptionElement).value
     );
-    expect(latestIds).toEqual(['claude-opus-4-7', 'claude-sonnet-4-6', 'claude-haiku-4-5']);
+    expect(latestIds).toEqual(['claude-opus-4-8', 'claude-sonnet-4-6', 'claude-haiku-4-5']);
 
     // Legacy entries are visible but quarantined to the "Legacy" optgroup.
     const legacyGroup = modelEl.querySelector('optgroup[label="Legacy"]') as HTMLOptGroupElement;
@@ -464,15 +471,15 @@ describe('LlmProviderComponent', () => {
     const legacyIds = Array.from(legacyGroup.querySelectorAll('option')).map(
       (o) => (o as HTMLOptionElement).value
     );
-    expect(legacyIds).toEqual(['claude-opus-4-6']);
+    expect(legacyIds).toEqual(['claude-opus-4-7', 'claude-opus-4-6']);
 
     // Labels carry the family + context window so users see the same
-    // ctx value the chat footer reports (1M for Opus 4.7, 200k for Haiku).
-    const opus47Label = (
-      modelEl.querySelector('option[value="claude-opus-4-7"]') as HTMLOptionElement
+    // ctx value the chat footer reports (1M for Opus 4.8, 200k for Haiku).
+    const opus48Label = (
+      modelEl.querySelector('option[value="claude-opus-4-8"]') as HTMLOptionElement
     )?.textContent?.trim();
-    expect(opus47Label).toContain('Opus 4.7');
-    expect(opus47Label).toContain('1M ctx');
+    expect(opus48Label).toContain('Opus 4.8');
+    expect(opus48Label).toContain('1M ctx');
     const haikuLabel = (
       modelEl.querySelector('option[value="claude-haiku-4-5"]') as HTMLOptionElement
     )?.textContent?.trim();
@@ -498,7 +505,7 @@ describe('LlmProviderComponent', () => {
         case 'list_anthropic_models':
           return TEST_ANTHROPIC_MODELS;
         case 'get_default_anthropic_model_label':
-          return 'Opus 4.7';
+          return 'Opus 4.8';
         default:
           return undefined;
       }
@@ -521,7 +528,7 @@ describe('LlmProviderComponent', () => {
 
   it('renders dynamic Default — <family> label when backend returns a label', async () => {
     // Backend SSOT returns the Opus family label so the dropdown surfaces
-    // what `(default)` actually steers toward (alias mode → Opus 4.7 today).
+    // what `(default)` actually steers toward (alias mode → Opus 4.8 today).
     // Anything but the dynamic form would hide the resolved model from the
     // user — exactly the regression this PR fixes.
     component.ngOnInit();
@@ -536,7 +543,7 @@ describe('LlmProviderComponent', () => {
     const defaultLabel = (
       modelEl.querySelector('option[value=""]') as HTMLOptionElement
     )?.textContent?.trim();
-    expect(defaultLabel).toBe('Default — Opus 4.7 (switchable via /model)');
+    expect(defaultLabel).toBe('Default — Opus 4.8 (switchable via /model)');
   });
 
   it('falls back to the generic placeholder when backend returns null', async () => {

--- a/docs/guides/desktop.md
+++ b/docs/guides/desktop.md
@@ -57,12 +57,12 @@ The Desktop chat UI launches `claude -p --output-format stream-json` inside the 
 The bar at the bottom of the chat shows the current state of the session, mirroring the container statusline layout:
 
 ```
-claude-opus-4-7 │ CTX ██░░░ 2% │ 116k/1M │ Limit ░░░░░ 30% reset 16:42 │ $0.1409 │ In: 3 CR: 22,560 CW: 75 Out: 825
+claude-opus-4-8 │ CTX ██░░░ 2% │ 116k/1M │ Limit ░░░░░ 30% reset 16:42 │ $0.1409 │ In: 3 CR: 22,560 CW: 75 Out: 825
 ```
 
 | Element      | Source                                     | Meaning                                                                                                                                                                 |
 | ------------ | ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `model`      | `system.init.model`                        | Model id (e.g. `claude-opus-4-7`, `llama3.3`).                                                                                                                          |
+| `model`      | `system.init.model`                        | Model id (e.g. `claude-opus-4-8`, `llama3.3`).                                                                                                                          |
 | `CTX N%`     | `resolveContextWindow` (see below)         | Percentage of the context window used by the current turn (`input_tokens + cache_read + cache_creation`) ÷ window. Bar turns amber at 50%, red at 76%, bold red at 90%. |
 | `used / max` | `formatContextLabel` (`models/llm.ts`)     | Short-form ratio (`116k/1M`, `42k/200k`). The label is `1M` for ≥ 1_000_000, `Xk` for ≥ 1_000.                                                                          |
 | `Limit N%`   | `rate_limit_event.rate_limit_info`         | 5-hour subscription quota utilisation (Pro/Max only — absent for API-key users).                                                                                        |
@@ -72,7 +72,7 @@ claude-opus-4-7 │ CTX ██░░░ 2% │ 116k/1M │ Limit ░░░░░
 | `CW: N`      | `result.usage.cache_creation_input_tokens` | Tokens written to prompt cache during the last turn.                                                                                                                    |
 | `Out: N`     | Cumulative `result.usage.output_tokens`    | Total tokens generated across all turns in the session.                                                                                                                 |
 
-**Per-step vs. cumulative.** Claude Code's result message contains two usage sources: `result.usage` (flat — per-step, resets each API call) and `result.modelUsage` (cumulative — grows over the session). The CTX % uses the flat per-step value so it reflects actual context window consumption; the total cost uses `total_cost_usd` (cumulative) because cost accumulates.
+**Latest-turn vs. cumulative.** Claude Code's result message contains two usage sources: `result.usage` (flat — the latest turn's full-prompt usage, _not_ summed across turns) and `result.modelUsage` (cumulative — grows over the session). The CTX % uses the flat value (`input_tokens + cache_read + cache_creation`) because each turn re-sends the whole conversation, so the latest turn already reflects total context occupancy — summing across turns would double-count the re-sent history. The total cost uses `total_cost_usd` (cumulative) because cost accumulates. In the Desktop footer, `in:` shows `input_tokens` only (the new uncached input) so a short chat doesn't read as the full context size; the CTX gauge keeps the additive total.
 
 **Context window resolution.** `ChatStateService.resolveContextWindow` walks a five-step fallback chain so the footer always has a concrete value:
 


### PR DESCRIPTION
## Summary

Bundles several model/UX changes that landed together in one session.

- **Claude Code CLI → 2.1.154** (`defaults.rs` `CLAUDE_VERSION`).
- **Opus 4.8 in the model catalog** — `claude-opus-4-8` (1M ctx) added as the latest Opus; `claude-opus-4-7` demoted to legacy. The Settings dropdown, default-Opus hint label and the 1M env-suffix all track the SSOT (`ANTHROPIC_MODELS`) automatically.
- **Corrected Opus pricing** — `pricing.ts` listed the whole Opus family at \$15/\$75 per MTok, which over-stated cost ~3×. Opus 4.5/4.6/4.7/4.8 are **\$5/\$25** (cache read \$0.50, 5m write \$6.25), verified against the official Anthropic pricing page. Added the 4.8 + `[1m]` entries.
- **Default effort → `auto`** — `CLAUDE_CODE_EFFORT_LEVEL` in `compose.template.yml` was hard-pinned to `max`. Set to `auto` so Claude Code uses the model's own default effort (`high` on Opus 4.8) instead of forcing `max` on every turn.
- **Fixed the chat footer `in:` counter** — it echoed the context-gauge total (`input + cache_read + cache_write`), so a short chat read as `in: 181,713`. Split `inboundTokens()` (`input_tokens` only — the new uncached input) from `ctxTotal()` (drives the `ctx%` gauge). Works for local models too (no prompt cache → `in:` equals the whole prompt). **The `ctx%` was never wrong** — only the `in:` label was misleading.

Also corrected the misleading "flat usage resets each API call" comments/docs in `chat.rs`, `chat.ts` and `desktop.md` to "latest turn's full-prompt usage, not summed across turns" per the verified Anthropic usage semantics.

## Verification

- Facts (Opus 4.8 id/ctx/pricing, usage semantics) verified against `platform.claude.com/docs`.
- `make check` (clippy + lint + fmt + type-check)
- Rust tests · Angular tests (1971 passed)
- **+4 session-stats regression tests**: reproduce the screenshot numbers (181,713 in / 18% / 182k of 1M), prove the gauge reflects the latest turn (no cross-turn summation), and cover a local model with/without an advertised window (ADR-041 "never guess").

## Notes

- The `oauth/shared/package-lock.json` dep-bump that `npm install` produced during the session was deliberately left out of this PR (unrelated to these changes).