### PR TITLE
fix(desktop): makensis abort on backtick in firewall.ps1

### DIFF
--- a/desktop/src-tauri/src/installer_hooks.rs
+++ b/desktop/src-tauri/src/installer_hooks.rs
@@ -201,6 +201,19 @@ mod tests {
         );
     }
 
+    #[test]
+    fn materialized_ps1_scripts_contain_no_backtick() {
+        // A backtick is the NSIS FileWrite string delimiter and has no escape,
+        // so a literal backtick truncates the NSIS string and aborts makensis.
+        // The generator rejects such scripts; this guards the SSOT sources.
+        for (name, ps1) in [("sweep.ps1", SWEEP_PS1), ("firewall.ps1", FIREWALL_PS1)] {
+            assert!(
+                !ps1.contains('`'),
+                "{name} contains a backtick — breaks NSIS FileWrite (use splatting)"
+            );
+        }
+    }
+
     // ── WiX fragments: MSI parity ────────────────────────────────────────
 
     #[test]
@@ -338,7 +351,8 @@ mod tests {
             for c in line.chars() {
                 match c {
                     '$' => esc.push_str("$$"),
-                    '`' => esc.push_str("``"),
+                    // Backtick has no NSIS escape; the generator rejects any
+                    // .ps1 containing one, so it never reaches here.
                     '"' => esc.push_str("$\\\""),
                     other => esc.push(other),
                 }

--- a/desktop/src-tauri/windows/firewall.ps1
+++ b/desktop/src-tauri/windows/firewall.ps1
@@ -43,14 +43,18 @@ if ($Mode -eq 'install') {
   try {
     Get-NetFirewallHyperVRule -DisplayName $RuleName -ErrorAction SilentlyContinue |
       Remove-NetFirewallHyperVRule -ErrorAction SilentlyContinue
-    New-NetFirewallHyperVRule `
-      -DisplayName $RuleName `
-      -Direction Inbound `
-      -Action Allow `
-      -VMCreatorId $WslVmCreatorId `
-      -Protocol TCP `
-      -LocalPorts Any `
-      -ErrorAction Stop | Out-Null
+    # Splatting (no backtick line-continuation): a backtick is the NSIS
+    # FileWrite string delimiter and has no escape, so it breaks makensis.
+    $params = @{
+      DisplayName = $RuleName
+      Direction   = 'Inbound'
+      Action      = 'Allow'
+      VMCreatorId = $WslVmCreatorId
+      Protocol    = 'TCP'
+      LocalPorts  = 'Any'
+      ErrorAction = 'Stop'
+    }
+    New-NetFirewallHyperVRule @params | Out-Null
     Write-Status "Hyper-V rule installed for VMCreatorId $WslVmCreatorId"
     exit 0
   } catch {

--- a/desktop/src-tauri/windows/installer-hooks.nsh
+++ b/desktop/src-tauri/windows/installer-hooks.nsh
@@ -169,14 +169,18 @@ Var SpeedwaveDataDirOverride
   FileWrite $0 `  try {$\r$\n`
   FileWrite $0 `    Get-NetFirewallHyperVRule -DisplayName $$RuleName -ErrorAction SilentlyContinue |$\r$\n`
   FileWrite $0 `      Remove-NetFirewallHyperVRule -ErrorAction SilentlyContinue$\r$\n`
-  FileWrite $0 `    New-NetFirewallHyperVRule ``$\r$\n`
-  FileWrite $0 `      -DisplayName $$RuleName ``$\r$\n`
-  FileWrite $0 `      -Direction Inbound ``$\r$\n`
-  FileWrite $0 `      -Action Allow ``$\r$\n`
-  FileWrite $0 `      -VMCreatorId $$WslVmCreatorId ``$\r$\n`
-  FileWrite $0 `      -Protocol TCP ``$\r$\n`
-  FileWrite $0 `      -LocalPorts Any ``$\r$\n`
-  FileWrite $0 `      -ErrorAction Stop | Out-Null$\r$\n`
+  FileWrite $0 `    # Splatting (no backtick line-continuation): a backtick is the NSIS$\r$\n`
+  FileWrite $0 `    # FileWrite string delimiter and has no escape, so it breaks makensis.$\r$\n`
+  FileWrite $0 `    $$params = @{$\r$\n`
+  FileWrite $0 `      DisplayName = $$RuleName$\r$\n`
+  FileWrite $0 `      Direction   = 'Inbound'$\r$\n`
+  FileWrite $0 `      Action      = 'Allow'$\r$\n`
+  FileWrite $0 `      VMCreatorId = $$WslVmCreatorId$\r$\n`
+  FileWrite $0 `      Protocol    = 'TCP'$\r$\n`
+  FileWrite $0 `      LocalPorts  = 'Any'$\r$\n`
+  FileWrite $0 `      ErrorAction = 'Stop'$\r$\n`
+  FileWrite $0 `    }$\r$\n`
+  FileWrite $0 `    New-NetFirewallHyperVRule @params | Out-Null$\r$\n`
   FileWrite $0 `    Write-Status $\"Hyper-V rule installed for VMCreatorId $$WslVmCreatorId$\"$\r$\n`
   FileWrite $0 `    exit 0$\r$\n`
   FileWrite $0 `  } catch {$\r$\n`

--- a/scripts/generate-installer-nsh.sh
+++ b/scripts/generate-installer-nsh.sh
@@ -53,6 +53,14 @@ emit_materialize_macro() {
     exit 1
   fi
 
+  # A backtick is the NSIS FileWrite string delimiter and has no escape, so a
+  # literal backtick in the .ps1 silently truncates the NSIS string and aborts
+  # makensis. Fail loudly here instead. Use splatting, not backtick-continuation.
+  if grep -q '`' "$src"; then
+    echo "ERROR: $src contains a backtick — breaks NSIS FileWrite. Use splatting." >&2
+    exit 1
+  fi
+
   # Strip UTF-8 BOM before embedding — NSIS writes literal bytes, and the
   # materialized .ps1 does not need a BOM (PowerShell handles ASCII fine).
   local stripped
@@ -78,15 +86,13 @@ emit_materialize_macro() {
 
   # Escape each line for NSIS backtick-delimited FileWrite literal:
   #   $  -> $$
-  #   `  -> `` (NSIS backtick doubling inside backtick string)
   #   "  -> $\"  (NSIS escape for double quote)
-  # Backslashes are literal in backtick strings. Line endings emitted as
-  # NSIS escape sequences $\r$\n (Windows line ending).
+  # Backticks are rejected upstream (no NSIS escape exists). Backslashes are
+  # literal in backtick strings. Line endings emitted as $\r$\n.
   local line esc
   while IFS= read -r line || [[ -n "$line" ]]; do
     esc="$line"
     esc="${esc//\$/\$\$}"
-    esc="${esc//\`/\`\`}"
     esc="${esc//\"/\$\\\"}"
     printf '  FileWrite $0 `%s$\\r$\\n`\n' "$esc"
   done < "$stripped"


### PR DESCRIPTION
## Problem

The Windows build fails during NSIS bundling (seen in **Desktop Build CI on #742** and in **Windows E2E** on a real machine):

```
Error in macro SPEEDWAVE_MATERIALIZE_FIREWALL on macroline 54
Error in macro NSIS_HOOK_POSTINSTALL on macroline 1
Error in script "...installer.nsi" on line 6071 -- aborting creation process
failed to bundle project `The system cannot find the file specified. (os error 2)`
```

## Root cause

`firewall.ps1` (new in the v0.13.0 batch) used PowerShell **backtick line-continuation** for `New-NetFirewallHyperVRule`. The generator embeds each `.ps1` line into a **backtick-delimited** NSIS `FileWrite` string — and NSIS has **no escape for a literal backtick**. The first backtick closes the string early, so `makensis` chokes at exactly the first backtick line (firewall macro line 54). `sweep.ps1` was unaffected only because it contains no backticks.

The generator's comment claimed backtick -> double-backtick ("backtick doubling inside backtick string") — that escape does not exist in NSIS; the assumption was simply never exercised until firewall.ps1.

## Fix

- **`firewall.ps1`** — replace backtick-continuation with **splatting** (`@params`); zero backticks. PowerShell parse verified with `pwsh`.
- **`generate-installer-nsh.sh`** — reject any `.ps1` containing a backtick (fail loud at generation instead of emitting broken NSIS); drop the false "backtick doubling" escape.
- **`installer_hooks.rs`** — mirror the escape change in `render_expected_hooks`; add `materialized_ps1_scripts_contain_no_backtick` asserting both `sweep.ps1` and `firewall.ps1` are backtick-free.

## Verification

- installer-hooks.nsh regenerated, no drift (`installer_hooks_nsh_matches_template_plus_generated_macros` passes)
- 20/20 `installer_hooks` tests
- `make check` (clippy 0 warnings, fmt, typecheck, eslint)
- `pwsh` parse of `firewall.ps1`
- macOS E2E in the same run passed 7/7; only Windows failed on this bug.

Blocks the v0.13.0 release (PR #742).