### PR TITLE
fix(runtime): propagate host TERM into interactive container exec

### DIFF
--- a/containers/Containerfile.claude
+++ b/containers/Containerfile.claude
@@ -25,6 +25,7 @@ RUN apt-get update -o Acquire::Retries=3 && \
         ca-certificates \
         curl \
         git \
+        ncurses-term \
         tzdata \
         wget \
     && rm -rf /var/lib/apt/lists/*

--- a/crates/speedwave-runtime/src/runtime/lima.rs
+++ b/crates/speedwave-runtime/src/runtime/lima.rs
@@ -1445,9 +1445,8 @@ mod tests {
         ];
 
         // Pin TERM so the interactive prefix is deterministic — container_exec
-        // now propagates the host's real TERM. Restored at the end.
-        let prev_term = std::env::var("TERM").ok();
-        std::env::set_var("TERM", "xterm-256color");
+        // now propagates the host's real TERM. Guard restores it on drop.
+        let _term_guard = crate::runtime::TermGuard::set("xterm-256color");
         let term_env = crate::runtime::resolved_term_env();
 
         for args in nasty_args {
@@ -1509,11 +1508,6 @@ mod tests {
                 .chain(args.iter().copied())
                 .collect();
             assert_quoting_roundtrips(&remote_cmd, &expected, "container_exec_piped");
-        }
-
-        match prev_term {
-            Some(v) => std::env::set_var("TERM", v),
-            None => std::env::remove_var("TERM"),
         }
     }
 

--- a/crates/speedwave-runtime/src/runtime/lima.rs
+++ b/crates/speedwave-runtime/src/runtime/lima.rs
@@ -1445,12 +1445,13 @@ mod tests {
         ];
 
         // Pin TERM so the interactive prefix is deterministic — container_exec
-        // now propagates the host's real TERM.
+        // now propagates the host's real TERM. Restored at the end.
+        let prev_term = std::env::var("TERM").ok();
         std::env::set_var("TERM", "xterm-256color");
+        let term_env = crate::runtime::resolved_term_env();
 
         for args in nasty_args {
             let path_env = format!("PATH={}", consts::CONTAINER_PATH);
-            let term_env = crate::runtime::resolved_term_env();
             let interactive_prefix: Vec<&str> = vec![
                 "sudo",
                 "nerdctl",
@@ -1508,6 +1509,11 @@ mod tests {
                 .chain(args.iter().copied())
                 .collect();
             assert_quoting_roundtrips(&remote_cmd, &expected, "container_exec_piped");
+        }
+
+        match prev_term {
+            Some(v) => std::env::set_var("TERM", v),
+            None => std::env::remove_var("TERM"),
         }
     }
 

--- a/crates/speedwave-runtime/src/runtime/lima.rs
+++ b/crates/speedwave-runtime/src/runtime/lima.rs
@@ -461,6 +461,9 @@ impl ContainerRuntime for LimaRuntime {
     fn container_exec(&self, container: &str, cmd: &[&str]) -> Command {
         let vm = consts::lima_vm_name();
         let path_env = format!("PATH={}", consts::CONTAINER_PATH);
+        // Propagate the host's real TERM so Claude Code can negotiate the
+        // keyboard protocol (Shift+Enter) instead of seeing a forced xterm.
+        let term_env = super::resolved_term_env();
 
         // Both transports below (direct SSH, `limactl shell`) round-trip the
         // remote command through a POSIX shell on the VM side, so every
@@ -474,7 +477,7 @@ impl ContainerRuntime for LimaRuntime {
             "exec",
             "-it",
             "-e",
-            "TERM=xterm-256color",
+            term_env.as_str(),
             "-e",
             "COLORTERM=truecolor",
             "-e",
@@ -1415,6 +1418,7 @@ mod tests {
     /// into `bash -nc` (syntax check, no execution) for every transport
     /// and asserts the parser accepts it.
     #[test]
+    #[serial_test::serial(env_term)]
     fn test_container_exec_remote_cmd_survives_shell_roundtrip() {
         // Pull the smallest set of nasty inputs that historically bit us:
         // - parens, em-dash, periods (the local-LLM identity prompt)
@@ -1440,15 +1444,20 @@ mod tests {
             &["sh", "-c", r#"echo "hello \"world\"""#],
         ];
 
+        // Pin TERM so the interactive prefix is deterministic — container_exec
+        // now propagates the host's real TERM.
+        std::env::set_var("TERM", "xterm-256color");
+
         for args in nasty_args {
             let path_env = format!("PATH={}", consts::CONTAINER_PATH);
+            let term_env = crate::runtime::resolved_term_env();
             let interactive_prefix: Vec<&str> = vec![
                 "sudo",
                 "nerdctl",
                 "exec",
                 "-it",
                 "-e",
-                "TERM=xterm-256color",
+                term_env.as_str(),
                 "-e",
                 "COLORTERM=truecolor",
                 "-e",

--- a/crates/speedwave-runtime/src/runtime/mod.rs
+++ b/crates/speedwave-runtime/src/runtime/mod.rs
@@ -1011,6 +1011,21 @@ pub(crate) fn detect_runtime_inner() -> Box<dyn ContainerRuntime> {
     compile_error!("Speedwave requires macOS or Windows");
 }
 
+/// Default `TERM` used when the host advertises nothing usable.
+pub(crate) const FALLBACK_TERM: &str = "xterm-256color";
+
+/// Builds the `TERM=<value>` arg for interactive `nerdctl exec`, propagating the
+/// host terminal's real `TERM` so Claude Code can negotiate the keyboard protocol
+/// (e.g. Shift+Enter). Falls back to `xterm-256color` when `TERM` is unset, empty,
+/// or `dumb`.
+pub(crate) fn resolved_term_env() -> String {
+    let term = std::env::var("TERM")
+        .ok()
+        .filter(|t| !t.is_empty() && t != "dumb")
+        .unwrap_or_else(|| FALLBACK_TERM.to_string());
+    format!("TERM={term}")
+}
+
 #[cfg(test)]
 pub(crate) mod test_support {
     use super::CommandRunner;
@@ -2172,6 +2187,46 @@ services:
         assert!(is_propagation_error(&anyhow::anyhow!(
             "INVALID COMPOSE PROJECT: ..."
         )));
+    }
+
+    /// Env mutation here is gated `#[serial(env_term)]` so no other test
+    /// reads/writes `TERM` concurrently. Restores the prior value.
+    fn with_term<F: FnOnce()>(value: Option<&str>, f: F) {
+        let prev = std::env::var("TERM").ok();
+        match value {
+            Some(v) => std::env::set_var("TERM", v),
+            None => std::env::remove_var("TERM"),
+        }
+        f();
+        match prev {
+            Some(v) => std::env::set_var("TERM", v),
+            None => std::env::remove_var("TERM"),
+        }
+    }
+
+    #[test]
+    #[serial_test::serial(env_term)]
+    fn resolved_term_env_propagates_real_term() {
+        with_term(Some("xterm-kitty"), || {
+            assert_eq!(resolved_term_env(), "TERM=xterm-kitty");
+        });
+        with_term(Some("xterm-ghostty"), || {
+            assert_eq!(resolved_term_env(), "TERM=xterm-ghostty");
+        });
+    }
+
+    #[test]
+    #[serial_test::serial(env_term)]
+    fn resolved_term_env_falls_back_when_unusable() {
+        with_term(None, || {
+            assert_eq!(resolved_term_env(), format!("TERM={FALLBACK_TERM}"));
+        });
+        with_term(Some(""), || {
+            assert_eq!(resolved_term_env(), format!("TERM={FALLBACK_TERM}"));
+        });
+        with_term(Some("dumb"), || {
+            assert_eq!(resolved_term_env(), format!("TERM={FALLBACK_TERM}"));
+        });
     }
 }
 

--- a/crates/speedwave-runtime/src/runtime/mod.rs
+++ b/crates/speedwave-runtime/src/runtime/mod.rs
@@ -1026,6 +1026,30 @@ pub(crate) fn resolved_term_env() -> String {
     format!("TERM={term}")
 }
 
+/// Test-only RAII guard: pins `TERM` to `value` and restores the prior value on
+/// drop — even on panic/unwind. Pair with `#[serial_test::serial(env_term)]`.
+#[cfg(test)]
+pub(crate) struct TermGuard(Option<String>);
+
+#[cfg(test)]
+impl TermGuard {
+    pub(crate) fn set(value: &str) -> Self {
+        let prev = std::env::var("TERM").ok();
+        std::env::set_var("TERM", value);
+        Self(prev)
+    }
+}
+
+#[cfg(test)]
+impl Drop for TermGuard {
+    fn drop(&mut self) {
+        match &self.0 {
+            Some(v) => std::env::set_var("TERM", v),
+            None => std::env::remove_var("TERM"),
+        }
+    }
+}
+
 #[cfg(test)]
 pub(crate) mod test_support {
     use super::CommandRunner;
@@ -2190,18 +2214,14 @@ services:
     }
 
     /// Env mutation here is gated `#[serial(env_term)]` so no other test
-    /// reads/writes `TERM` concurrently. Restores the prior value.
+    /// reads/writes `TERM` concurrently. The `TermGuard` restores the prior
+    /// value on drop, even if `f` panics.
     fn with_term<F: FnOnce()>(value: Option<&str>, f: F) {
-        let prev = std::env::var("TERM").ok();
-        match value {
-            Some(v) => std::env::set_var("TERM", v),
-            None => std::env::remove_var("TERM"),
+        let _guard = TermGuard::set(value.unwrap_or(""));
+        if value.is_none() {
+            std::env::remove_var("TERM");
         }
         f();
-        match prev {
-            Some(v) => std::env::set_var("TERM", v),
-            None => std::env::remove_var("TERM"),
-        }
     }
 
     #[test]

--- a/crates/speedwave-runtime/src/runtime/wsl.rs
+++ b/crates/speedwave-runtime/src/runtime/wsl.rs
@@ -1196,9 +1196,8 @@ mod tests {
         ];
 
         // Pin TERM so the interactive prefix is deterministic — container_exec
-        // now propagates the host's real TERM. Restored at the end.
-        let prev_term = std::env::var("TERM").ok();
-        std::env::set_var("TERM", "xterm-256color");
+        // now propagates the host's real TERM. Guard restores it on drop.
+        let _term_guard = crate::runtime::TermGuard::set("xterm-256color");
         let term_env = crate::runtime::resolved_term_env();
 
         for args in nasty_args {
@@ -1252,11 +1251,6 @@ mod tests {
                 .chain(args.iter().copied())
                 .collect();
             assert_quoting_roundtrips(&remote_cmd, &expected, "container_exec_piped");
-        }
-
-        match prev_term {
-            Some(v) => std::env::set_var("TERM", v),
-            None => std::env::remove_var("TERM"),
         }
     }
 

--- a/crates/speedwave-runtime/src/runtime/wsl.rs
+++ b/crates/speedwave-runtime/src/runtime/wsl.rs
@@ -1196,12 +1196,13 @@ mod tests {
         ];
 
         // Pin TERM so the interactive prefix is deterministic — container_exec
-        // now propagates the host's real TERM.
+        // now propagates the host's real TERM. Restored at the end.
+        let prev_term = std::env::var("TERM").ok();
         std::env::set_var("TERM", "xterm-256color");
+        let term_env = crate::runtime::resolved_term_env();
 
         for args in nasty_args {
             let path_env = format!("PATH={}", consts::CONTAINER_PATH);
-            let term_env = crate::runtime::resolved_term_env();
             let interactive_prefix: Vec<&str> = vec![
                 "nerdctl",
                 "exec",
@@ -1251,6 +1252,11 @@ mod tests {
                 .chain(args.iter().copied())
                 .collect();
             assert_quoting_roundtrips(&remote_cmd, &expected, "container_exec_piped");
+        }
+
+        match prev_term {
+            Some(v) => std::env::set_var("TERM", v),
+            None => std::env::remove_var("TERM"),
         }
     }
 

--- a/crates/speedwave-runtime/src/runtime/wsl.rs
+++ b/crates/speedwave-runtime/src/runtime/wsl.rs
@@ -482,12 +482,15 @@ impl ContainerRuntime for WslRuntime {
         // arguments containing `(`, `)`, `'`, etc. break remote bash.
         let distro = self.distro();
         let path_env = format!("PATH={}", consts::CONTAINER_PATH);
+        // Propagate the host's real TERM so Claude Code can negotiate the
+        // keyboard protocol (Shift+Enter) instead of seeing a forced xterm.
+        let term_env = super::resolved_term_env();
         let nerdctl_argv: Vec<&str> = [
             "nerdctl",
             "exec",
             "-it",
             "-e",
-            "TERM=xterm-256color",
+            term_env.as_str(),
             "-e",
             "COLORTERM=truecolor",
             "-e",
@@ -1178,6 +1181,7 @@ mod tests {
     /// `wsl.exe` joins everything after `--` and execs through bash inside the
     /// distro, so prompts with `(`, `'`, backticks must shell-quote correctly.
     #[test]
+    #[serial_test::serial(env_term)]
     fn test_container_exec_remote_cmd_survives_shell_roundtrip() {
         let nasty_args: &[&[&str]] = &[
             &[
@@ -1191,14 +1195,19 @@ mod tests {
             &["sh", "-c", r#"echo "hello \"world\"""#],
         ];
 
+        // Pin TERM so the interactive prefix is deterministic — container_exec
+        // now propagates the host's real TERM.
+        std::env::set_var("TERM", "xterm-256color");
+
         for args in nasty_args {
             let path_env = format!("PATH={}", consts::CONTAINER_PATH);
+            let term_env = crate::runtime::resolved_term_env();
             let interactive_prefix: Vec<&str> = vec![
                 "nerdctl",
                 "exec",
                 "-it",
                 "-e",
-                "TERM=xterm-256color",
+                term_env.as_str(),
                 "-e",
                 "COLORTERM=truecolor",
                 "-e",


### PR DESCRIPTION
## Problem

Running `claude` via the `speedwave` CLI in a CSI-u-capable terminal (iTerm2, Kitty, WezTerm, Ghostty), **Shift+Enter submitted the message instead of inserting a newline**. Running `claude` directly in the same terminal worked.

## Root cause

The interactive exec chain — `ssh -t` / `wsl.exe` → `nerdctl exec -it` → `claude` — hardcoded `TERM=xterm-256color`, overwriting the host terminal's real `TERM`. Claude Code gates its keyboard-protocol negotiation (Kitty `CSI u`, which disambiguates Shift+Enter from Enter) on the terminal it sees. With the real terminal identity erased, the negotiation never lit up and Shift+Enter collapsed to a bare `\r` — identical to Enter.

Confirmed empirically: with this fix, Shift+Enter inserts a newline in iTerm2 via `speedwave`.

## Fix

- New shared helper `runtime::resolved_term_env()` reads the host's real `$TERM` (fallback `xterm-256color` when unset/empty/`dumb`); used by both `lima.rs` and `wsl.rs` (DRY — the literal previously appeared in two files).
- Ship `ncurses-term` in the claude image so propagated terminfo names (`xterm-kitty`, `xterm-ghostty`, …) resolve to real entries instead of degrading curses rendering.
- Non-interactive piped path is untouched (no TTY, no negotiation) and keeps a fixed `TERM`.

## Per-terminal limits

Terminals that don't implement CSI-u — **Apple Terminal.app** and classic Windows conhost/PowerShell, and current stock Windows Terminal — physically cannot send a distinct Shift+Enter (VT100 `0x0d` for both Enter and Shift+Enter), so this is a no-op there. That is a terminal limitation, not a speedwave one; `Ctrl+J` and `Option+Enter` remain the universal newline fallbacks. Upstream confirms Apple Terminal Shift+Enter is unsupported and "not planned": [anthropics/claude-code#2946](https://github.com/anthropics/claude-code/issues/2946).

## Tests

- `resolved_term_env_propagates_real_term`, `resolved_term_env_falls_back_when_unusable` (happy + edge + fallback paths)
- Updated argv pin tests in `lima.rs` / `wsl.rs` (serialized on `env_term`)
- All runtime tests pass; clippy + fmt clean