### PR TITLE
fix(runtime): stop flooding the log with wsl.exe fallback-to-PATH debug lines

### DIFF
--- a/crates/speedwave-runtime/src/binary.rs
+++ b/crates/speedwave-runtime/src/binary.rs
@@ -20,11 +20,17 @@ const PATH_SEP: char = ':';
 const ALWAYS_SYSTEM_COMMANDS: &[&str] = &["wsl.exe", "powershell.exe", "cmd.exe"];
 
 /// `true` if `cmd` is a never-bundled Windows OS command (case-insensitive).
+/// Matches on the file name, so an absolute path (e.g. the
+/// `C:\Windows\System32\wsl.exe` that `reset_vm` builds) is recognised too.
 #[cfg(windows)]
 fn is_always_system_command(cmd: &str) -> bool {
+    let name = std::path::Path::new(cmd)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(cmd);
     ALWAYS_SYSTEM_COMMANDS
         .iter()
-        .any(|c| c.eq_ignore_ascii_case(cmd))
+        .any(|c| c.eq_ignore_ascii_case(name))
 }
 
 /// Resolves the path to a binary command.
@@ -301,9 +307,13 @@ pub(crate) mod tests {
         assert!(is_always_system_command("WSL.EXE"));
         assert!(is_always_system_command("powershell.exe"));
         assert!(is_always_system_command("cmd.exe"));
+        // Absolute path (reset_vm builds C:\Windows\System32\wsl.exe).
+        assert!(is_always_system_command("C:\\Windows\\System32\\wsl.exe"));
+        assert!(is_always_system_command("C:\\Windows\\System32\\WSL.EXE"));
         assert!(!is_always_system_command("limactl"));
         assert!(!is_always_system_command("nerdctl"));
         assert!(!is_always_system_command("node"));
+        assert!(!is_always_system_command("C:\\bundle\\limactl.exe"));
     }
 
     // Suppression must not change resolution — wsl.exe still resolves to the bare name.

--- a/crates/speedwave-runtime/src/binary.rs
+++ b/crates/speedwave-runtime/src/binary.rs
@@ -12,6 +12,19 @@ const PATH_SEP: char = ';';
 #[cfg(not(windows))]
 const PATH_SEP: char = ':';
 
+/// Commands that are always provided by the OS and are never bundled, so the
+/// "falling back to system PATH" debug log is noise for them (e.g. `wsl.exe`
+/// is called on every health poll).
+const ALWAYS_SYSTEM_COMMANDS: &[&str] = &["wsl.exe", "powershell.exe", "cmd.exe"];
+
+/// `true` if `cmd` is a never-bundled OS command (case-insensitive), so the
+/// fallback-to-PATH debug log should be suppressed for it.
+fn is_always_system_command(cmd: &str) -> bool {
+    ALWAYS_SYSTEM_COMMANDS
+        .iter()
+        .any(|c| c.eq_ignore_ascii_case(cmd))
+}
+
 /// Resolves the path to a binary command.
 ///
 /// Lima (macOS), Node.js, and the native macOS CLI helpers (`reminders-cli`,
@@ -70,10 +83,12 @@ pub fn resolve_binary(cmd: &str) -> String {
             return top_level.to_string_lossy().to_string();
         }
 
-        log::debug!(
-            "bundled binary not found for '{}', falling back to system PATH",
-            cmd
-        );
+        if !is_always_system_command(cmd) {
+            log::debug!(
+                "bundled binary not found for '{}', falling back to system PATH",
+                cmd
+            );
+        }
     }
     cmd.to_string()
 }
@@ -268,6 +283,30 @@ pub(crate) mod tests {
 
         env::set_var(BUNDLE_RESOURCES_ENV, tmp.path().to_string_lossy().as_ref());
         assert_eq!(resolve_binary("unknown-cmd"), "unknown-cmd");
+        env::remove_var(BUNDLE_RESOURCES_ENV);
+    }
+
+    // Never-bundled OS commands are recognised (case-insensitive) so the
+    // fallback debug log is suppressed; everything else still logs.
+    #[test]
+    fn always_system_commands_recognised() {
+        assert!(is_always_system_command("wsl.exe"));
+        assert!(is_always_system_command("WSL.EXE"));
+        assert!(is_always_system_command("powershell.exe"));
+        assert!(is_always_system_command("cmd.exe"));
+        assert!(!is_always_system_command("limactl"));
+        assert!(!is_always_system_command("nerdctl"));
+        assert!(!is_always_system_command("node"));
+    }
+
+    // The suppression must not change resolution behaviour — wsl.exe still
+    // resolves to the bare name (system PATH) as before.
+    #[test]
+    fn resolve_binary_wsl_still_returns_bare_name() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        env::set_var(BUNDLE_RESOURCES_ENV, tmp.path().to_string_lossy().as_ref());
+        assert_eq!(resolve_binary("wsl.exe"), "wsl.exe");
         env::remove_var(BUNDLE_RESOURCES_ENV);
     }
 

--- a/crates/speedwave-runtime/src/binary.rs
+++ b/crates/speedwave-runtime/src/binary.rs
@@ -12,13 +12,15 @@ const PATH_SEP: char = ';';
 #[cfg(not(windows))]
 const PATH_SEP: char = ':';
 
-/// Commands that are always provided by the OS and are never bundled, so the
-/// "falling back to system PATH" debug log is noise for them (e.g. `wsl.exe`
-/// is called on every health poll).
+/// Windows OS commands that are never bundled, so the "falling back to system
+/// PATH" debug log is noise for them (`wsl.exe` is called on every health poll).
+/// Windows-only on purpose: on macOS resolving one of these is a real misconfig
+/// worth logging, so suppression must not apply there.
+#[cfg(windows)]
 const ALWAYS_SYSTEM_COMMANDS: &[&str] = &["wsl.exe", "powershell.exe", "cmd.exe"];
 
-/// `true` if `cmd` is a never-bundled OS command (case-insensitive), so the
-/// fallback-to-PATH debug log should be suppressed for it.
+/// `true` if `cmd` is a never-bundled Windows OS command (case-insensitive).
+#[cfg(windows)]
 fn is_always_system_command(cmd: &str) -> bool {
     ALWAYS_SYSTEM_COMMANDS
         .iter()
@@ -83,7 +85,11 @@ pub fn resolve_binary(cmd: &str) -> String {
             return top_level.to_string_lossy().to_string();
         }
 
-        if !is_always_system_command(cmd) {
+        #[cfg(windows)]
+        let should_log = !is_always_system_command(cmd);
+        #[cfg(not(windows))]
+        let should_log = true;
+        if should_log {
             log::debug!(
                 "bundled binary not found for '{}', falling back to system PATH",
                 cmd
@@ -287,7 +293,8 @@ pub(crate) mod tests {
     }
 
     // Never-bundled OS commands are recognised (case-insensitive) so the
-    // fallback debug log is suppressed; everything else still logs.
+    // fallback debug log is suppressed; everything else still logs. Windows-only.
+    #[cfg(windows)]
     #[test]
     fn always_system_commands_recognised() {
         assert!(is_always_system_command("wsl.exe"));
@@ -299,8 +306,8 @@ pub(crate) mod tests {
         assert!(!is_always_system_command("node"));
     }
 
-    // The suppression must not change resolution behaviour — wsl.exe still
-    // resolves to the bare name (system PATH) as before.
+    // Suppression must not change resolution — wsl.exe still resolves to the bare name.
+    #[cfg(windows)]
     #[test]
     fn resolve_binary_wsl_still_returns_bare_name() {
         let _guard = ENV_LOCK.lock().unwrap();
@@ -413,11 +420,12 @@ pub(crate) mod tests {
         let home = lima_home();
         assert!(home.is_some());
         let path = home.unwrap();
-        let path_str = path.to_string_lossy();
+        // Compare path components (separator-agnostic): on Windows the path uses
+        // `\`, so a string `ends_with(".speedwave/lima")` would wrongly fail.
         assert!(
-            path_str.ends_with(".speedwave/lima"),
+            path.ends_with(std::path::Path::new(".speedwave").join("lima")),
             "expected path ending with .speedwave/lima, got: {}",
-            path_str
+            path.display()
         );
     }
 
@@ -435,11 +443,11 @@ pub(crate) mod tests {
             .expect("LIMA_HOME env should be set for limactl");
 
         let value = lima_home_env.1.expect("LIMA_HOME should have a value");
-        let value_str = value.to_string_lossy();
+        // Separator-agnostic (Windows uses `\`): compare path components.
         assert!(
-            value_str.ends_with(".speedwave/lima"),
+            std::path::Path::new(value).ends_with(std::path::Path::new(".speedwave").join("lima")),
             "LIMA_HOME should end with .speedwave/lima, got: {}",
-            value_str
+            value.to_string_lossy()
         );
     }
 


### PR DESCRIPTION
## Problem

The desktop log is flooded with identical lines, several per second:

```
[DEBUG][speedwave_runtime::binary] bundled binary not found for 'wsl.exe', falling back to system PATH
```

`resolve_binary` emits this `debug!` on every bundled-binary miss. But `wsl.exe` (and `powershell.exe` / `cmd.exe`) are **never bundled** — they're always resolved via the system PATH by design. Since the container health-poll invokes `wsl.exe` roughly every 3 seconds (plus the wsl.conf read/write/probe paths), the log fills with noise that drowns out real diagnostics.

Observed on a live Windows install (every ~3–5s, indefinitely).

## Fix

Add a small `#[cfg(windows)]` allowlist of never-bundled OS commands (`is_always_system_command`) and skip the fallback `debug!` for them. Matches on the path's file name, so an absolute `C:\Windows\System32\wsl.exe` (built by `reset_vm`) is recognised too. **Resolution behaviour is unchanged** — they still return the command for PATH lookup; only the log line is suppressed. On macOS the log fires unconditionally (resolving `wsl.exe` there would be a real misconfiguration worth seeing). Every other binary still logs its miss.

## Bonus: fix pre-existing Windows-broken binary tests

`lima_home_returns_expected_path` and `command_limactl_sets_lima_home_env` asserted `ends_with(".speedwave/lima")` with a forward slash, which fails on Windows (`\`) and poisons the shared `ENV_LOCK`, cascading ~16 binary tests into `PoisonError`. Now compared via `Path::ends_with` (separator-agnostic). Verified on Windows: binary tests pass, 0 failed.

## Tests

- `always_system_commands_recognised` — `wsl.exe`/`WSL.EXE`/`powershell.exe`/`cmd.exe` and the absolute `C:\Windows\System32\wsl.exe` matched; `limactl`/`nerdctl`/`node`/`C:\bundle\limactl.exe` not. (`#[cfg(windows)]`)
- `resolve_binary_wsl_still_returns_bare_name` — suppression does not change resolution. (`#[cfg(windows)]`)

Pure `speedwave-runtime` (cross-platform); host: 27 binary tests pass, fmt + clippy clean. Windows: binary tests 0 failed.

## Note

There is a known follow-up: the cleaner fix is to route never-bundled OS binaries through `binary::system_command()` from `RealRunner::prepare_command` rather than via the allowlist in `resolve_binary` (tracked internally). Also: the pre-push `make test-rust` intermittently flakes on an unrelated `compose::tests` env race (a fix is tracked internally) — this diff is `binary.rs`-only and its tests pass on both host and Windows.