### PR TITLE
fix(runtime): normalize plugin digest paths to posix on Windows

### DIFF
--- a/crates/speedwave-runtime/src/compose.rs
+++ b/crates/speedwave-runtime/src/compose.rs
@@ -279,9 +279,6 @@ pub fn compose_output_path_in(
     Ok(data_dir.join("compose").join(project).join("compose.yml"))
 }
 
-/// Atomic 0o600 write. Validates network refs in-memory + post-read-back
-/// (catches macOS virtiofs lag; no-op on ext4/NTFS). 0o600 because YAML
-/// may carry `ANTHROPIC_AUTH_TOKEN` (ADR-040).
 #[cfg(test)]
 thread_local! {
     /// Test seam: when set, overrides the post-write read-back with this string
@@ -304,6 +301,9 @@ fn read_back_compose(path: &std::path::Path) -> std::io::Result<String> {
     std::fs::read_to_string(path)
 }
 
+/// Atomic 0o600 write. Validates network refs in-memory + post-read-back
+/// (catches macOS virtiofs lag; no-op on ext4/NTFS). 0o600 because YAML
+/// may carry `ANTHROPIC_AUTH_TOKEN` (ADR-040).
 pub fn save_compose(project: &str, yaml: &str) -> anyhow::Result<()> {
     validate_compose_network_refs(yaml)
         .map_err(|e| anyhow::anyhow!("save_compose: in-memory YAML failed validation: {e}"))?;

--- a/crates/speedwave-runtime/src/signing.rs
+++ b/crates/speedwave-runtime/src/signing.rs
@@ -221,20 +221,45 @@ fn compute_plugin_digest(plugin_dir: &Path) -> anyhow::Result<Vec<u8>> {
     let mut files: Vec<std::path::PathBuf> = Vec::new();
     collect_files_recursive(plugin_dir, &mut files)?;
 
-    // OsStr byte sort matches Python's as_posix() string sort in the sign script.
-    // Path::cmp is component-based: "X/..." < "X.ts", but byte-wise '.' (0x2E) < '/' (0x2F).
-    files.sort_by(|a, b| {
-        let ra = a.strip_prefix(plugin_dir).unwrap_or(a);
-        let rb = b.strip_prefix(plugin_dir).unwrap_or(b);
-        ra.as_os_str().cmp(rb.as_os_str())
-    });
+    // Build (posix_rel_path, file) pairs. The sign script hashes `as_posix()`
+    // paths (forward slashes), so the relative path MUST be normalized to '/'
+    // on every host — on Windows the native separator is '\', which would
+    // both reorder the sort and change the hashed bytes, breaking verification
+    // for any plugin with subdirectories (macOS already uses '/').
+    let mut entries: Vec<(String, &std::path::PathBuf)> = files
+        .iter()
+        .map(|file| {
+            // `collect_files_recursive` only ever yields paths built by joining
+            // `plugin_dir` with `read_dir` entries, so strip_prefix can't fail.
+            // Bail explicitly rather than fall back to the absolute path: that
+            // would fold a `Prefix(C:)`/`RootDir` into the posix string and
+            // silently diverge the digest from the sign script.
+            let rel = file.strip_prefix(plugin_dir).map_err(|_| {
+                anyhow::anyhow!("plugin file is not under plugin_dir: {}", file.display())
+            })?;
+            // A non-UTF-8 component must abort, never be silently dropped.
+            // The sign script's as_posix() includes the file via
+            // surrogateescape, which Rust has no equivalent for — aborting is
+            // safer than silently producing a diverging hash that also lets a
+            // non-UTF-8-named file vanish (collision / hidden-file vector).
+            let posix = rel
+                .components()
+                .map(|c| {
+                    c.as_os_str().to_str().ok_or_else(|| {
+                        anyhow::anyhow!("plugin path is not valid UTF-8: {}", rel.display())
+                    })
+                })
+                .collect::<anyhow::Result<Vec<_>>>()?
+                .join("/");
+            Ok((posix, file))
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+
+    // Byte sort on the posix path matches Python's as_posix() string sort.
+    entries.sort_by(|a, b| a.0.as_bytes().cmp(b.0.as_bytes()));
 
     let mut hasher = Sha256::new();
-    for file in &files {
-        let rel = file
-            .strip_prefix(plugin_dir)
-            .unwrap_or(file)
-            .to_string_lossy();
+    for (rel, file) in &entries {
         // Hash: relative path (length-prefixed) + file contents (length-prefixed).
         // Length prefixes prevent ambiguity between ("ab","cd") and ("a","bcd").
         let rel_bytes = rel.as_bytes();
@@ -611,6 +636,75 @@ mod tests {
         assert_eq!(
             actual, expected,
             "file 'X.ts' must sort BEFORE 'X/<files>' (POSIX byte order, matching Python sign script)"
+        );
+    }
+
+    /// The hashed relative path must always use forward slashes, regardless
+    /// of host OS separator. The sign script hashes `as_posix()` paths, so a
+    /// nested file like `claude-resources/skills/foo.md` must contribute the
+    /// posix string to the digest — never the Windows `\`-separated form.
+    /// This is the regression test for the Windows-only "signature
+    /// verification failed" caused by `to_string_lossy()` emitting native
+    /// separators (macOS already produced '/').
+    #[test]
+    fn test_compute_digest_uses_posix_separators_for_nested_paths() {
+        use sha2::{Digest, Sha256};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        std::fs::create_dir_all(dir.join("claude-resources").join("skills")).unwrap();
+        std::fs::write(
+            dir.join("claude-resources").join("skills").join("foo.md"),
+            b"body",
+        )
+        .unwrap();
+
+        let actual = compute_plugin_digest(dir).unwrap();
+
+        // Expected digest: the relative path hashed with '/' separators,
+        // exactly as the Python sign script's as_posix() would emit it.
+        let mut hasher = Sha256::new();
+        let rel = b"claude-resources/skills/foo.md" as &[u8];
+        let content = b"body" as &[u8];
+        hasher.update((rel.len() as u64).to_le_bytes());
+        hasher.update(rel);
+        hasher.update((content.len() as u64).to_le_bytes());
+        hasher.update(content);
+        let expected = hasher.finalize().to_vec();
+
+        assert_eq!(
+            actual, expected,
+            "nested-path digest must use posix '/' separators on every host"
+        );
+    }
+
+    /// A plugin file whose name is not valid UTF-8 must abort digest
+    /// computation, not be silently skipped. Silent skipping would diverge
+    /// the digest from the sign script's `as_posix()` (which preserves the
+    /// bytes via surrogateescape) and let a non-UTF-8-named file disappear
+    /// from the hash entirely — a collision / hidden-file vector.
+    #[cfg(unix)]
+    #[test]
+    fn test_compute_digest_rejects_non_utf8_filename() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        std::fs::write(dir.join("plugin.json"), r#"{"name":"ok"}"#).unwrap();
+        // 0xFF is never valid UTF-8 — a legal name on ext4 (the container FS),
+        // but APFS/HFS+ reject it at write time ("Illegal byte sequence").
+        // Where the FS won't even store such a name the bug is unreachable,
+        // so skip the assertion there; it still runs on Linux CI.
+        let bad = OsStr::from_bytes(b"bad\xff.md");
+        if std::fs::write(dir.join(bad), b"body").is_err() {
+            return;
+        }
+
+        let err = compute_plugin_digest(dir).expect_err("non-UTF-8 name must abort digest");
+        assert!(
+            err.to_string().contains("not valid UTF-8"),
+            "expected UTF-8 rejection, got: {err}"
         );
     }
 


### PR DESCRIPTION
## Problem

Installing a plugin on **Windows** failed with:

> Plugin signature verification failed. The plugin may have been tampered with.

macOS was unaffected.

## Root cause

`compute_plugin_digest` hashed each file's relative path using `to_string_lossy()`, which emits the **native OS separator**. On Windows that is a backslash, so a plugin file in a subdirectory (e.g. `claude-resources/skills/foo.md`) was hashed as `claude-resources\skills\foo.md` instead of the forward-slash form the Speednet sign script produces via `as_posix()`. The digest diverged → Ed25519 verification failed → every plugin with subdirectories was rejected on Windows. macOS already uses `/`, so it never reproduced. The file sort had the same latent divergence.

## Fix

- Normalize the relative path to `/` (via `Path::components`) **before** both the byte sort and the hash, so the digest is identical on every host and matches the sign script.
- A non-UTF-8 path component now **aborts** digest computation instead of being silently dropped — silent dropping would diverge from the sign script's `surrogateescape` behavior and let a non-UTF-8-named file vanish from the hash (collision / hidden-file vector).
- `strip_prefix` now bails explicitly instead of falling back to the absolute path, making the "every file is under plugin_dir" invariant self-documenting (addresses review feedback).

Verified against the Speednet sign script's algorithm (`as_posix()` + byte sort + `u64`-LE length-prefix framing): byte-identical on macOS for normal trees, so existing signed plugins keep verifying.

## Tests

- `test_compute_digest_uses_posix_separators_for_nested_paths` — golden-value regression: nested path hashes with `/` on every host.
- `test_compute_digest_rejects_non_utf8_filename` (`#[cfg(unix)]`) — non-UTF-8 name aborts the digest (skips where the FS won't store such a name, e.g. APFS).

## Boy Scout

Moved an orphaned doc comment onto `save_compose` (was above a `#[cfg(test)] thread_local!`, producing an `unused_doc_comments` warning).