### PR TITLE
fix: resolve project from selector, harden compose YAML + restart prompt, isolate & parallelize tests

### DIFF
--- a/.claude/rules/local-llm.md
+++ b/.claude/rules/local-llm.md
@@ -28,7 +28,7 @@ Whether you are adding a feature, fixing a bug, or refactoring something adjacen
 The full table lives in ADR-040. Two rules when modifying it:
 
 - **`ANTHROPIC_MODEL` is primary**, `ANTHROPIC_CUSTOM_MODEL_OPTION` is supplementary. Without `ANTHROPIC_MODEL` Claude Code falls back to the account-tier default and the UI lies about which model is running. Don't drop one and keep the other.
-- **`ANTHROPIC_DEFAULT_{SONNET,OPUS,HAIKU}_MODEL` is forbidden.** It silently remaps built-in aliases to the local model and leaves three misleading Anthropic names in `/model`. Choose explicit naming over silent remapping.
+- **`ANTHROPIC_DEFAULT_{SONNET,OPUS,HAIKU}_MODEL` is forbidden in the LOCAL-provider branch.** Pointing an alias at a local model silently remaps built-in aliases and leaves three misleading Anthropic names in `/model` — choose explicit naming over silent remapping. The Anthropic-provider branch is the deliberate exception: it pins each alias to _its own_ Anthropic model (Opus stays Opus) and appends the documented `[1m]` 1M-context suffix (anthropics/claude-code#34083 workaround in `defaults.rs::anthropic_default_models_env`). That neither remaps nor misleads, so it is allowed. Any env value carrying YAML flow indicators (`[ ] { } ,`, e.g. `[1m]`) is re-quoted by `compose::harden_env_scalar_quoting` so nerdctl's strict Go YAML parser accepts it — never hand-emit such a value unquoted.
 
 ## SSRF policy (host-side)
 

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,11 @@ export SPEEDWAVE_DATA_DIR
 
 LIMA_VERSION := $(shell cat .lima-version 2>/dev/null || echo 2.0.2)
 
+# bats runs serially. `--jobs N` is unsafe here: bundle-build-context.bats mutates
+# shared repo paths (mcp-servers/{os,shared}/dist) that cannot be tempdir-isolated,
+# so concurrent siblings in one file race and fail. The suites are small; the real
+# parallelism win is lane-level (separate task), not per-file bats jobs.
+
 # Hard floor: dev/test must never run against the production data dir, even if a
 # user exported SPEEDWAVE_DATA_DIR=~/.speedwave (the `?=` default above only
 # applies when it is unset). A data dir whose basename is exactly `.speedwave` is
@@ -57,6 +62,7 @@ guard-not-prod-data-dir:
         build-runtime build-cli build-desktop build-tauri build-mcp build-angular \
         build-native-macos build-os-cli bundle-native-assets bundle-static-licenses verify-bundled-assets \
         test-rust test-transcription test-cli test-desktop test-angular test-mcp test-os test-swift test-e2e test-entrypoint test-ci test-desktop-build \
+        test-build-phase test-rust-run test-angular-run test-mcp-run test-desktop-build-run test-desktop-run test-desktop-group-run test-run-lanes \
         test-e2e-desktop _e2e-macos _e2e-windows test-e2e-all setup-e2e-vms \
         check-clippy check-desktop-clippy check-angular check-mcp check-fmt \
         check-mcp-lint check-angular-lint check-all \
@@ -187,7 +193,22 @@ all: build
 build: build-runtime build-cli build-os-cli build-mcp build-angular
 	@echo "\n✅ All builds complete"
 
-test: guard-not-prod-data-dir test-rust test-angular test-mcp test-entrypoint test-desktop-config test-desktop-build test-desktop test-ci
+# build-once + parallel-run. CI never calls this aggregate (it calls standalone
+# test-X targets, which keep their own build prereqs and are left untouched).
+# Phase 1 (sequential): guard + test-build-phase stage every shared artifact
+#   exactly once, so no two lanes ever build the same dist/target concurrently.
+# Phase 2 (parallel): a recursive `$(MAKE) -jN test-run-lanes` fans out the
+#   pure run-only lanes. test-mcp-run + test-desktop-build-run + test-desktop-run
+#   are grouped SERIAL (they share-mutate mcp-servers/*/dist via
+#   bundle-build-context.sh reads + bundle-build-context.bats's --ci rebuild —
+#   the same footgun that broke bats --jobs). A failing lane fails the whole
+#   `make test`: each `$(MAKE)` is its own recipe line, and the sub-make runs
+#   without -k, so the first non-zero exit aborts. Override fan-out width with
+#   `make test TEST_LANES_JOBS=N`.
+TEST_LANES_JOBS ?= 4
+test: guard-not-prod-data-dir
+	@"$(MAKE)" test-build-phase
+	@"$(MAKE)" -j$(TEST_LANES_JOBS) test-run-lanes
 	@echo "\n✅ All tests passed"
 
 check: check-clippy check-desktop-clippy check-fmt check-mcp check-mcp-lint check-angular-lint
@@ -320,12 +341,89 @@ build-angular:
 
 # ── Rust tests ───────────────────────────────────────────────────────────────
 
+# Run a cargo command ($(1)) against an isolated throwaway data dir, then clean
+# up. Each run gets its OWN dir so tests never touch the shared production
+# ~/.speedwave and parallel worktrees never collide. We capture the `mktemp -d`
+# result DIRECTLY and guard it (`|| exit 1`), then put the data dir UNDER it —
+# so cleanup always removes the captured dir, never a path derived via dirname.
+# (A `mktemp -d` that returns empty must not let cleanup expand to `rm -rf /`.)
+# The basename `speedwave-test` is regex-valid (^[a-z][a-z0-9-]{0,63}$) — a bare
+# `mktemp -d` basename (tmp.XXXX) is NOT and would panic instance-name
+# derivation. With isolation the suite is parallel-safe, so the old
+# `--test-threads=1` cap is gone.
+define RUN_CARGO_ISOLATED
+	d=$$(mktemp -d) || exit 1; mkdir -p "$$d/speedwave-test"; \
+	  SPEEDWAVE_DATA_DIR="$$d/speedwave-test" $(1); \
+	  rc=$$?; rm -rf "$$d"; exit $$rc
+endef
+
+# ── Aggregate-only parallel infrastructure (used ONLY by `make test`) ─────────
+# CI invokes the standalone test-X targets, which keep their own build prereqs.
+# These build-once + run-only variants exist so the aggregate can build shared
+# artifacts ONCE (sequentially) then fan the run phases out in parallel.
+
+# Sequential build phase: every shared build the run lanes need, once, in
+# dependency order. Mirrors the build-side of test-desktop (the heaviest lane)
+# so its run variant can assume everything is staged. NOT used by CI.
+test-build-phase: generate-installer-nsh build-cli build-angular build-mcp build-os-cli
+	@if [ "$$(uname)" = "Darwin" ] && [ ! -s desktop/src-tauri/lima/bin/limactl ]; then "$(MAKE)" download-lima; fi
+	@if [ "$(OS)" = "Windows_NT" ] && [ ! -s desktop/src-tauri/wsl/nerdctl-full.tar.gz ]; then "$(MAKE)" download-wsl-resources; fi
+	@if [ ! -s desktop/src-tauri/nodejs/bin/node ] && [ ! -s desktop/src-tauri/nodejs/node.exe ]; then "$(MAKE)" download-nodejs; fi
+	@bash scripts/bundle-build-context.sh
+	@if [ "$$(uname)" = "Darwin" ]; then "$(MAKE)" bundle-native-assets; fi
+	@mkdir -p desktop/src-tauri/cli
+ifeq ($(OS),Windows_NT)
+	@cp target/debug/speedwave.exe desktop/src-tauri/cli/speedwave.exe
+else
+	@cp target/debug/speedwave desktop/src-tauri/cli/speedwave
+	@chmod +x desktop/src-tauri/cli/speedwave
+endif
+	@"$(MAKE)" verify-bundled-assets
+	@echo "✅ Build phase complete"
+
+# Pure run-only lanes — NO build prereqs (test-build-phase staged everything).
+test-rust-run:
+	$(call RUN_CARGO_ISOLATED,cargo test -p speedwave-runtime -p speedwave-cli)
+	"$(MAKE)" test-transcription
+	@echo "✅ Rust tests passed"
+
+test-angular-run: test-angular
+
+test-mcp-run:
+	cd mcp-servers && $(NPM) test
+	@echo "✅ MCP server tests passed"
+
+test-desktop-build-run:
+	@command -v bats >/dev/null 2>&1 || { echo "❌ bats not found. Install: brew install bats-core"; exit 1; }
+	bats _tests/desktop/desktop-build.bats _tests/desktop/bundle-build-context.bats \
+	  _tests/desktop/guard-prod-data-dir.bats _tests/desktop/verify-bundled-assets.bats \
+	  _tests/desktop/sign-bundled-binaries.bats _tests/desktop/release-workflow-signing.bats \
+	  _tests/desktop/info-plist.bats _tests/desktop/entitlements-reminders.bats
+	@echo "✅ Desktop build tests passed"
+
+test-desktop-run:
+	$(call RUN_CARGO_ISOLATED,sh -c 'cd desktop/src-tauri && cargo test')
+	@echo "✅ Desktop tests passed"
+
+# Serial group: every lane that touches REAL repo paths. test-desktop-run's
+# bundle-build-context.sh READS mcp-servers/*/dist; bundle-build-context.bats's
+# `--ci` test (in test-desktop-build-run) transiently RENAMES + rebuilds those
+# same dirs; test-mcp-run consumes them. Concurrent = the bats --jobs footgun,
+# so run these three back-to-back. Each `$(MAKE)` is its own command — first
+# non-zero exit aborts the recipe, so failures propagate.
+test-desktop-group-run:
+	@"$(MAKE)" test-mcp-run
+	@"$(MAKE)" test-desktop-build-run
+	@"$(MAKE)" test-desktop-run
+
+# The fan-out set parallelized by `make test`. Everything here is mutually
+# shared-path-safe after test-build-phase; the one lane that touches real repo
+# paths is the serial test-desktop-group-run.
+test-run-lanes: test-rust-run test-angular-run test-entrypoint \
+                test-desktop-config test-ci test-desktop-group-run
+
 test-rust:
-	@# Tests share `consts::data_dir()` (~/.speedwave/); several of them write
-	@# into `~/.speedwave/secrets/<project>/` or read mcp-os state files.
-	@# Parallel cargo-test threads race on those paths and surface `os error 2`
-	@# from `render_compose`. Run serially to keep the suite deterministic.
-	SPEEDWAVE_DATA_DIR= cargo test -p speedwave-runtime -p speedwave-cli -- --test-threads=1
+	$(call RUN_CARGO_ISOLATED,cargo test -p speedwave-runtime -p speedwave-cli)
 	@# The `audio-transcription` feature (host-side meeting transcription, ADR-056)
 	@# is off by default — the CLI never enables it — so the default run above
 	@# doesn't compile the `transcription` module. Test it explicitly here.
@@ -339,9 +437,8 @@ test-transcription:
 	@# The rest of the crate (compose, plugin, build, …) is identical with or
 	@# without the feature and is already exercised by `test-rust`. Without the
 	@# `transcription::` filter, cargo re-runs the whole suite a second time
-	@# (~100 compose tests at ~5s each under `--test-threads=1`), which alone
-	@# blows past the 15-minute CI job budget.
-	SPEEDWAVE_DATA_DIR= cargo test -p speedwave-runtime --features audio-transcription transcription:: -- --test-threads=1
+	@# (~100 compose tests at ~5s each), which alone blows past the CI job budget.
+	$(call RUN_CARGO_ISOLATED,cargo test -p speedwave-runtime --features audio-transcription transcription::)
 	@echo "✅ audio-transcription tests passed"
 
 test-cli:
@@ -363,7 +460,7 @@ else
 	@chmod +x desktop/src-tauri/cli/speedwave
 endif
 	@"$(MAKE)" verify-bundled-assets
-	cd desktop/src-tauri && SPEEDWAVE_DATA_DIR= cargo test
+	$(call RUN_CARGO_ISOLATED,sh -c 'cd desktop/src-tauri && cargo test')
 	@echo "✅ Desktop tests passed"
 
 # ── Angular tests ───────────────────────────────────────────────────────────
@@ -388,12 +485,13 @@ test-os: build-mcp
 # Tests that need a real matplotlib render self-skip on too-new Python interpreters.
 test-mcp-office-py:
 	@PY=$$(command -v python3.12 || command -v python3.11 || command -v python3); \
-	echo "  building office Python test venv ($$PY)..."; \
-	rm -rf .office-test-venv && "$$PY" -m venv .office-test-venv; \
-	.office-test-venv/bin/pip install -q --upgrade pip; \
-	.office-test-venv/bin/pip install -q -r mcp-servers/office/requirements.txt pytest; \
-	.office-test-venv/bin/python -m pytest mcp-servers/office/scripts -q; \
-	rm -rf .office-test-venv
+	VENV="$${TMPDIR:-/tmp}/office-test-venv-$$$$"; \
+	echo "  building office Python test venv ($$PY) at $$VENV..."; \
+	"$$PY" -m venv --clear "$$VENV"; \
+	"$$VENV/bin/pip" install -q --upgrade pip; \
+	"$$VENV/bin/pip" install -q -r mcp-servers/office/requirements.txt pytest; \
+	"$$VENV/bin/python" -m pytest mcp-servers/office/scripts -q; \
+	rm -rf "$$VENV"
 	@echo "✅ Office Python script tests passed"
 
 # ── Coverage ─────────────────────────────────────────────────────────────────
@@ -442,35 +540,27 @@ test-e2e-plugin-tamper-release: build-cli-release
 
 test-entrypoint:
 	@command -v bats >/dev/null 2>&1 || { echo "❌ bats not found. Install: brew install bats-core"; exit 1; }
-	bats _tests/entrypoint/entrypoint.bats
-	bats _tests/entrypoint/install-claude.bats
-	bats _tests/entrypoint/statusline.bats
-	bats _tests/entrypoint/osc52-copy.bats
+	bats _tests/entrypoint/entrypoint.bats _tests/entrypoint/install-claude.bats \
+	  _tests/entrypoint/statusline.bats _tests/entrypoint/osc52-copy.bats
 	@echo "✅ Entrypoint tests passed"
 
 test-ci:
 	@command -v bats >/dev/null 2>&1 || { echo "❌ bats not found. Install: brew install bats-core"; exit 1; }
-	bats _tests/ci/validate-pr-title-main.bats
-	bats _tests/ci/plan-loop-context.bats
+	bats _tests/ci/validate-pr-title-main.bats _tests/ci/plan-loop-context.bats
 	@echo "✅ CI workflow tests passed"
 
 test-desktop-build: build-angular build-mcp
 	@command -v bats >/dev/null 2>&1 || { echo "❌ bats not found. Install: brew install bats-core"; exit 1; }
-	bats _tests/desktop/desktop-build.bats
-	bats _tests/desktop/bundle-build-context.bats
-	bats _tests/desktop/guard-prod-data-dir.bats
-	bats _tests/desktop/verify-bundled-assets.bats
-	bats _tests/desktop/sign-bundled-binaries.bats
-	bats _tests/desktop/release-workflow-signing.bats
-	bats _tests/desktop/info-plist.bats
-	bats _tests/desktop/entitlements-reminders.bats
+	bats _tests/desktop/desktop-build.bats _tests/desktop/bundle-build-context.bats \
+	  _tests/desktop/guard-prod-data-dir.bats _tests/desktop/verify-bundled-assets.bats \
+	  _tests/desktop/sign-bundled-binaries.bats _tests/desktop/release-workflow-signing.bats \
+	  _tests/desktop/info-plist.bats _tests/desktop/entitlements-reminders.bats
 	@echo "✅ Desktop build tests passed"
 
 # Fast config validation — stable, runs in `make test`.
 test-desktop-config:
 	@command -v bats >/dev/null 2>&1 || { echo "❌ bats not found. Install: brew install bats-core"; exit 1; }
-	bats _tests/desktop/updater-config.bats
-	bats _tests/desktop/version-consistency.bats
+	bats _tests/desktop/updater-config.bats _tests/desktop/version-consistency.bats
 	@echo "✅ Desktop config tests passed"
 
 # Release gate — uses gh shim, CI-only. NOT in `make test` to prevent shim
@@ -530,9 +620,11 @@ _e2e-run:
 	@pkill -f 'mcp-os.*index.js' 2>/dev/null || true
 	@pkill -9 -f limactl 2>/dev/null || true
 	@sleep 1
-	@rm -rf /tmp/speedwave-e2e-project /tmp/speedwave-e2e-project-2
-	@mkdir -p /tmp/speedwave-e2e-project /tmp/speedwave-e2e-project-2
-	@E2E_BAK=$$SPEEDWAVE_DATA_DIR.e2e-bak; \
+	@E2E_PROJECT_DIR="$${TMPDIR:-/tmp}/speedwave-e2e-project-$$$$"; \
+	E2E_SECOND_PROJECT_DIR="$$E2E_PROJECT_DIR-2"; \
+	rm -rf "$$E2E_PROJECT_DIR" "$$E2E_SECOND_PROJECT_DIR"; \
+	mkdir -p "$$E2E_PROJECT_DIR" "$$E2E_SECOND_PROJECT_DIR"; \
+	E2E_BAK=$$SPEEDWAVE_DATA_DIR.e2e-bak; \
 	backup_dir() { \
 		if [ -d "$$1" ]; then rm -rf "$$2"; mv "$$1" "$$2"; fi; \
 	}; \
@@ -552,11 +644,12 @@ _e2e-run:
 		if [ "$$(uname)" = "Darwin" ]; then \
 			restore_dir "$$HOME/Library/Caches/lima" "$$HOME/Library/Caches/lima.e2e-bak"; \
 		fi; \
+		rm -rf "$$E2E_PROJECT_DIR" "$$E2E_SECOND_PROJECT_DIR"; \
 	}; \
 	$(E2E_BINARY) & APP_PID=$$!; \
 	trap "kill $$APP_PID 2>/dev/null; restore_state" EXIT; \
 	for i in $$(seq 1 30); do curl -sf http://127.0.0.1:4445/status >/dev/null 2>&1 && break; sleep 1; done; \
-	cd desktop/e2e && E2E_PROJECT_DIR=/tmp/speedwave-e2e-project E2E_SECOND_PROJECT_DIR=/tmp/speedwave-e2e-project-2 npx wdio run wdio.conf.ts; \
+	cd desktop/e2e && E2E_PROJECT_DIR="$$E2E_PROJECT_DIR" E2E_SECOND_PROJECT_DIR="$$E2E_SECOND_PROJECT_DIR" npx wdio run wdio.conf.ts; \
 	E2E_EXIT=$$?; \
 	kill $$APP_PID 2>/dev/null; \
 	restore_state; \

--- a/_tests/entrypoint/entrypoint.bats
+++ b/_tests/entrypoint/entrypoint.bats
@@ -50,6 +50,11 @@ EOF
 
     # OS_AVAILABLE_SUBS is normally injected by compose.rs from TOGGLEABLE_OS_SERVICES.
     export OS_AVAILABLE_SUBS="reminders,calendar,mail,notes"
+
+    # Per-test health marker under TEST_HOME so parallel runs (bats --jobs)
+    # and concurrent worktrees never collide on a shared /tmp path.
+    # Cleaned up by teardown's rm -rf "$TEST_HOME".
+    export CLAUDE_READY_MARKER="$TEST_HOME/claude-ready"
 }
 
 teardown() {
@@ -119,7 +124,7 @@ EOF
 @test "creates /tmp/claude-ready health marker" {
     run bash "$ENTRYPOINT" true
     [ "$status" -eq 0 ]
-    [ -f /tmp/claude-ready ]
+    [ -f "$CLAUDE_READY_MARKER" ]
 }
 
 # ---------------------------------------------------------------------------
@@ -905,7 +910,7 @@ EOF
         "$ENTRYPOINT" > "$patched"
     run bash "$patched" true
     [ "$status" -eq 0 ]
-    [ -f /tmp/claude-ready ]
+    [ -f "$CLAUDE_READY_MARKER" ]
     # Stderr should carry the warning so operators see the degraded mode.
     [[ "$output" == *"did not respond"* ]]
     rm -f "$patched"

--- a/containers/entrypoint.sh
+++ b/containers/entrypoint.sh
@@ -266,7 +266,7 @@ if [ -z "${SPEEDWAVE_SKIP_HUB_WAIT:-}" ]; then
 fi
 
 # Health check marker
-touch /tmp/claude-ready
+touch "${CLAUDE_READY_MARKER:-/tmp/claude-ready}"
 
 # Execute the passed command (or keep container alive waiting for exec)
 if [ $# -gt 0 ]; then

--- a/crates/speedwave-cli/src/main.rs
+++ b/crates/speedwave-cli/src/main.rs
@@ -25,11 +25,11 @@ enum CliAction {
     PluginDisable { service_id: String, project: String },
     Check,
     Init(Option<String>), // optional explicit project name (default: derive from dir name)
-    Login(Option<String>), // optional --project override (default: resolve from CWD)
-    Logout(Option<String>), // optional --project override (default: resolve from CWD)
+    Login(Option<String>), // optional --project override (default: active project)
+    Logout(Option<String>), // optional --project override (default: active project)
     SelfUpdate,
-    Update,
-    Run, // default: compose_up + exec
+    Update(Option<String>), // optional --project override (default: active project)
+    Run(Option<String>), // optional --project override (default: active project); compose_up + exec
     Help,
 }
 
@@ -44,20 +44,43 @@ fn parse_project_flag(args: &[String], subcommand: &str) -> Result<String, Strin
     ))
 }
 
-/// Parses optional `--project <value>` for `login`/`logout`. The flag itself
-/// is optional; if present it must carry a value. Returns Ok(None) when the
-/// flag is absent.
-fn parse_optional_project_flag(
-    args: &[String],
+/// Parses an optional `--project <value>` / `--project=<value>` flag from the
+/// argv tail that follows a subcommand. `tail` is the slice *after* the
+/// subcommand token (e.g. `args[2..]` for `login`, `args[1..]` for the leading
+/// bare-run form). The only accepted token is the project flag; any other
+/// token — a stray positional, an unknown flag, a second `--project` — is a
+/// hard error. Returns `Ok(None)` when the tail is empty.
+fn parse_optional_project_tail(
+    tail: &[String],
     subcommand: &str,
 ) -> Result<Option<String>, String> {
-    let Some(flag_pos) = args.iter().position(|a| a == "--project") else {
+    let usage = || format!("usage: speedwave {subcommand} [--project <project>]");
+    let mut iter = tail.iter();
+    let Some(first) = iter.next() else {
         return Ok(None);
     };
-    args.get(flag_pos + 1)
-        .cloned()
-        .map(Some)
-        .ok_or_else(|| format!("usage: speedwave {subcommand} [--project <project>]"))
+    let project = if let Some(value) = first.strip_prefix("--project=") {
+        if value.is_empty() {
+            return Err(usage());
+        }
+        value.to_string()
+    } else if first == "--project" {
+        iter.next().cloned().ok_or_else(usage)?
+    } else {
+        return Err(format!("unexpected argument: '{first}'. {}", usage()));
+    };
+    if let Some(extra) = iter.next() {
+        return Err(format!("unexpected argument: '{extra}'. {}", usage()));
+    }
+    Ok(Some(project))
+}
+
+/// Rejects any token beyond `expected_len` for subcommands that take no args.
+fn reject_extra_args(args: &[String], expected_len: usize, usage: &str) -> Result<(), String> {
+    match args.get(expected_len) {
+        Some(extra) => Err(format!("unexpected argument: '{extra}'. usage: {usage}")),
+        None => Ok(()),
+    }
 }
 
 fn parse_action(args: &[String]) -> Result<CliAction, String> {
@@ -68,13 +91,18 @@ fn parse_action(args: &[String]) -> Result<CliAction, String> {
                 let path = args
                     .get(3)
                     .ok_or("usage: speedwave plugin install <zip-path>".to_string())?;
+                reject_extra_args(args, 4, "speedwave plugin install <zip-path>")?;
                 Ok(CliAction::PluginInstall(path.clone()))
             }
-            Some("list") => Ok(CliAction::PluginList),
+            Some("list") => {
+                reject_extra_args(args, 3, "speedwave plugin list")?;
+                Ok(CliAction::PluginList)
+            }
             Some("remove") => {
                 let slug = args
                     .get(3)
                     .ok_or("usage: speedwave plugin remove <slug>".to_string())?;
+                reject_extra_args(args, 4, "speedwave plugin remove <slug>")?;
                 Ok(CliAction::PluginRemove(slug.clone()))
             }
             Some("enable") => {
@@ -99,20 +127,43 @@ fn parse_action(args: &[String]) -> Result<CliAction, String> {
             }
             _ => Err("usage: speedwave plugin [install|list|remove|enable|disable]".to_string()),
         },
-        Some("check") => Ok(CliAction::Check),
+        Some("check") => {
+            reject_extra_args(args, 2, "speedwave check")?;
+            Ok(CliAction::Check)
+        }
         Some("init") => {
             let name = args.get(2).cloned();
+            reject_extra_args(args, 3, "speedwave init [name]")?;
             Ok(CliAction::Init(name))
         }
-        Some("self-update") => Ok(CliAction::SelfUpdate),
-        Some("update") => Ok(CliAction::Update),
-        Some("login") => Ok(CliAction::Login(parse_optional_project_flag(
-            args, "login",
+        Some("self-update") => {
+            reject_extra_args(args, 2, "speedwave self-update")?;
+            Ok(CliAction::SelfUpdate)
+        }
+        Some("update") => Ok(CliAction::Update(parse_optional_project_tail(
+            &args[2..],
+            "update",
         )?)),
-        Some("logout") => Ok(CliAction::Logout(parse_optional_project_flag(
-            args, "logout",
+        Some("login") => Ok(CliAction::Login(parse_optional_project_tail(
+            &args[2..],
+            "login",
         )?)),
-        _ => Ok(CliAction::Run),
+        Some("logout") => Ok(CliAction::Logout(parse_optional_project_tail(
+            &args[2..],
+            "logout",
+        )?)),
+        // A leading flag with no subcommand is the bare-run project override:
+        // `speedwave --project acme` / `speedwave --project=acme`.
+        Some(flag) if flag.starts_with('-') => Ok(CliAction::Run(parse_optional_project_tail(
+            &args[1..],
+            "run",
+        )?)),
+        // A non-flag token that matched no subcommand is a typo, not a silent
+        // `run` — reject it so `speedwave updatte` fails loudly.
+        Some(unknown) => Err(format!(
+            "unknown command: '{unknown}'. Run 'speedwave --help' for usage."
+        )),
+        None => Ok(CliAction::Run(None)),
     }
 }
 
@@ -260,7 +311,7 @@ fn run_rebuild(exe: &std::path::Path) -> anyhow::Result<()> {
         anyhow::bail!(
             "Container image rebuild failed (exit {}). \
              Ensure Speedwave Desktop is running, then run `speedwave update` \
-             in your project directory.",
+             again.",
             status.code().unwrap_or(-1)
         );
     }
@@ -327,12 +378,12 @@ fn print_help() {
 speedwave — run Claude Code in a hardened container per project
 
 USAGE:
-    speedwave                         Start Claude Code for the current project
+    speedwave         [--project <p>] Start Claude Code for the active project (or <p>)
     speedwave check                   Run security + OS prerequisite checks
     speedwave init [name]             Register the current directory as a project
     speedwave login   [--project <p>] Run Anthropic OAuth login (type /login at Claude's prompt)
     speedwave logout  [--project <p>] Delete Claude Code credentials for the project
-    speedwave update                  Rebuild container images for the current bundle
+    speedwave update                  Rebuild container images for the active project
     speedwave self-update             Download the latest speedwave CLI binary
 
     speedwave plugin install <zip>    Install a plugin from a signed ZIP
@@ -342,6 +393,9 @@ USAGE:
     speedwave plugin disable <id> --project <project>   Disable a plugin per-project
 
     speedwave --help | -h | help      Show this help and exit
+
+The active project is the one selected in Speedwave Desktop; `--project <p>`
+overrides it. The working directory does not select the project.
 
 Most commands require Speedwave Desktop to be running. See docs/guides/cli.md.",
     );
@@ -353,7 +407,7 @@ fn runtime_not_available() -> ! {
     eprintln!("1. Open Speedwave.app");
     eprintln!("2. Complete the Setup Wizard");
     eprintln!("3. Start your project");
-    eprintln!("Then run `speedwave` again in your project directory.");
+    eprintln!("Then run `speedwave` again.");
     std::process::exit(1);
 }
 
@@ -485,7 +539,7 @@ fn main() -> anyhow::Result<()> {
     }
 
     // Handle `speedwave update` — rebuild images + recreate containers
-    if action == CliAction::Update {
+    if let CliAction::Update(_) = action {
         let runtime = detect_runtime();
         if !runtime.is_available() {
             runtime_not_available();
@@ -494,7 +548,7 @@ fn main() -> anyhow::Result<()> {
             eprintln!("Failed to load config: {e}");
             std::process::exit(1);
         });
-        let project_name = resolve_project(&user_config)?;
+        let project_name = resolve_action_project(&action, &user_config)?;
         println!("Updating containers for project '{}'...", project_name);
         match update::update_containers(&runtime, &project_name) {
             Ok(result) => {
@@ -514,15 +568,12 @@ fn main() -> anyhow::Result<()> {
     // Handle `speedwave logout` — deletes Claude Code's credential files
     // (~/.claude/.credentials.json and ~/.claude.json) from the per-project
     // CLAUDE_HOME mount. No runtime needed.
-    if let CliAction::Logout(ref project_override) = action {
+    if let CliAction::Logout(_) = action {
         let user_config = config::load_user_config().unwrap_or_else(|e| {
             eprintln!("Failed to load config: {e}");
             std::process::exit(1);
         });
-        let project_name = match project_override {
-            Some(name) => name.clone(),
-            None => resolve_project(&user_config)?,
-        };
+        let project_name = resolve_action_project(&action, &user_config)?;
         validate_project_name(&project_name).map_err(|e| anyhow::anyhow!(e))?;
         let removed = speedwave_runtime::claude_home::remove_claude_credentials(
             consts::data_dir(),
@@ -711,27 +762,29 @@ fn main() -> anyhow::Result<()> {
         std::process::exit(1);
     });
 
-    // `speedwave login --project=foo` overrides CWD-based project resolution
-    // so users can log in from any working directory.
-    let project_name = match &action {
-        CliAction::Login(Some(name)) => name.clone(),
-        _ => resolve_project(&user_config)?,
-    };
+    let project_name = resolve_action_project(&action, &user_config)?;
 
     // Validate project name is safe for container naming
     validate_project_name(&project_name).map_err(|e| anyhow::anyhow!(e))?;
 
-    // Use project dir from config (authoritative), fall back to CWD
-    let project_dir = match user_config.find_project(&project_name) {
-        Some(p) => std::path::PathBuf::from(&p.dir),
-        None => std::env::current_dir().map_err(|e| {
+    // Project dir comes from config (authoritative). resolve_action_project
+    // already rejected an explicit `--project` naming a missing project; an
+    // unresolved name here means a stale active/first entry, which we reject
+    // with a clear error rather than silently mounting the working directory.
+    let project_dir = user_config
+        .find_project(&project_name)
+        .map(|p| std::path::PathBuf::from(&p.dir))
+        .ok_or_else(|| {
+            let available = user_config
+                .projects
+                .iter()
+                .map(|p| p.name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
             anyhow::anyhow!(
-                "project '{}' not found in config and cannot determine current directory: {}",
-                project_name,
-                e
+                "project '{project_name}' not found in config. Available projects: {available}"
             )
-        })?,
-    };
+        })?;
 
     let (resolved, integrations) =
         config::resolve_project_config(&project_dir, &user_config, &project_name);
@@ -997,71 +1050,35 @@ fn maybe_spawn_oauth_worker(
     }
 }
 
-/// Resolves project name from CWD path matching against configured projects.
-/// Falls back to active_project with a warning if no path matches.
-fn resolve_project(user_config: &config::SpeedwaveUserConfig) -> anyhow::Result<String> {
-    if let Ok(cwd) = std::env::current_dir() {
-        return resolve_project_for_cwd(&cwd, user_config);
-    }
-    resolve_project_fallback(user_config)
-}
-
-/// Testable project resolution: matches CWD (or a subdirectory) against
-/// registered project paths using canonicalization and longest-prefix match.
-fn resolve_project_for_cwd(
-    cwd: &Path,
+/// Picks the project an action operates on. An explicit `--project` override
+/// on `run`/`login`/`logout`/`update` wins and must name a real project
+/// (`require_project`); otherwise the active project (Desktop selector) is
+/// used, then the first configured project. The working directory is never
+/// consulted.
+fn resolve_action_project(
+    action: &CliAction,
     user_config: &config::SpeedwaveUserConfig,
 ) -> anyhow::Result<String> {
-    let canonical_cwd = std::fs::canonicalize(cwd).unwrap_or_else(|_| cwd.to_path_buf());
-    let cwd_str = canonical_cwd.to_string_lossy();
-
-    // Exact match — CWD is exactly a project directory
-    for p in &user_config.projects {
-        if let Ok(canonical_dir) = std::fs::canonicalize(&p.dir) {
-            if canonical_dir == canonical_cwd {
-                return Ok(p.name.clone());
-            }
-        } else {
-            eprintln!(
-                "Warning: cannot resolve configured path '{}' for project '{}' — skipping",
-                p.dir, p.name
-            );
+    match action {
+        CliAction::Run(Some(name))
+        | CliAction::Login(Some(name))
+        | CliAction::Logout(Some(name))
+        | CliAction::Update(Some(name)) => {
+            // An explicit `--project` must name a real project. Without this
+            // guard a typo'd name passes syntactic validation and main()
+            // silently mounts the working directory instead (defect #6).
+            user_config.require_project(name)?;
+            Ok(name.clone())
         }
+        _ => resolve_project_fallback(user_config),
     }
-
-    // Longest-prefix match — CWD is inside a project directory
-    let mut best: Option<(&str, usize)> = None;
-    for p in &user_config.projects {
-        if let Ok(canonical_dir) = std::fs::canonicalize(&p.dir) {
-            let dir_str = canonical_dir.to_string_lossy();
-            let prefix = format!("{}/", dir_str.trim_end_matches('/'));
-            if cwd_str.starts_with(&prefix) {
-                let len = prefix.len();
-                if best.is_none_or(|(_, best_len)| len > best_len) {
-                    best = Some((&p.name, len));
-                }
-            }
-        } else {
-            eprintln!(
-                "Warning: cannot resolve configured path '{}' for project '{}' — skipping",
-                p.dir, p.name
-            );
-        }
-    }
-    if let Some((name, _)) = best {
-        return Ok(name.to_string());
-    }
-
-    // Fallback with warning
-    let result = resolve_project_fallback(user_config)?;
-    eprintln!(
-        "Warning: current directory does not match any registered project. Using '{}'.",
-        result
-    );
-    eprintln!("Hint: run `speedwave init` to register this directory as a project.");
-    Ok(result)
 }
 
+/// Resolves the project to act on when no explicit `--project` was given.
+/// The active project (set by the Desktop selector) is authoritative; the
+/// first configured project is the fallback when none is active. The working
+/// directory is intentionally NOT consulted — the selector is the single
+/// source of truth.
 fn resolve_project_fallback(user_config: &config::SpeedwaveUserConfig) -> anyhow::Result<String> {
     user_config
         .active_project
@@ -1082,7 +1099,7 @@ mod tests {
     #[test]
     fn parse_action_no_args_returns_run() {
         let args = vec!["speedwave".to_string()];
-        assert_eq!(parse_action(&args).unwrap(), CliAction::Run);
+        assert_eq!(parse_action(&args).unwrap(), CliAction::Run(None));
     }
 
     #[test]
@@ -1199,9 +1216,13 @@ mod tests {
     }
 
     #[test]
-    fn parse_action_unknown_command_returns_run() {
-        let args = vec!["speedwave".to_string(), "unknown".to_string()];
-        assert_eq!(parse_action(&args).unwrap(), CliAction::Run);
+    fn parse_action_unknown_command_errors() {
+        let args = vec!["speedwave".to_string(), "updatte".to_string()];
+        let err = parse_action(&args).unwrap_err();
+        assert!(
+            err.contains("unknown command") && err.contains("updatte"),
+            "expected unknown-command error, got: {err}"
+        );
     }
 
     // ── login / logout ─────────────────────────────────────────────────────
@@ -1268,6 +1289,155 @@ mod tests {
             "--project".to_string(),
         ];
         assert!(parse_action(&args).is_err());
+    }
+
+    // ── hardened parser: 6 defects + compatibility ──────────────────────────
+
+    fn argv(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn parse_action_leading_flag_before_subcommand_errors() {
+        // Defect #1: `speedwave --project acme login` must NOT silently run
+        // acme and drop `login`. The leading `--project acme` is consumed as
+        // the bare-run override, then `login` is trailing garbage → error.
+        let args = argv(&["speedwave", "--project", "acme", "login"]);
+        let err = parse_action(&args).unwrap_err();
+        assert!(
+            err.contains("unexpected argument") && err.contains("login"),
+            "expected trailing-garbage error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_action_update_with_project_space_form() {
+        // Defect #3: update now accepts --project (was silently ignored).
+        let args = argv(&["speedwave", "update", "--project", "acme"]);
+        assert_eq!(
+            parse_action(&args).unwrap(),
+            CliAction::Update(Some("acme".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_action_login_equals_form() {
+        // Defect #4: `--project=acme` was silently ignored; now supported.
+        let args = argv(&["speedwave", "login", "--project=acme"]);
+        assert_eq!(
+            parse_action(&args).unwrap(),
+            CliAction::Login(Some("acme".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_action_bare_run_equals_form() {
+        let args = argv(&["speedwave", "--project=acme"]);
+        assert_eq!(
+            parse_action(&args).unwrap(),
+            CliAction::Run(Some("acme".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_action_equals_form_empty_value_errors() {
+        let args = argv(&["speedwave", "login", "--project="]);
+        let err = parse_action(&args).unwrap_err();
+        assert!(err.contains("speedwave login"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_action_login_extra_positional_errors() {
+        // Defect #5: garbage after a valid subcommand is rejected.
+        let args = argv(&["speedwave", "login", "extra", "junk"]);
+        let err = parse_action(&args).unwrap_err();
+        assert!(
+            err.contains("unexpected argument") && err.contains("extra"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_action_login_extra_after_project_value_errors() {
+        let args = argv(&["speedwave", "login", "--project", "acme", "junk"]);
+        let err = parse_action(&args).unwrap_err();
+        assert!(
+            err.contains("unexpected argument") && err.contains("junk"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_action_check_rejects_extra_args() {
+        let args = argv(&["speedwave", "check", "junk"]);
+        let err = parse_action(&args).unwrap_err();
+        assert!(err.contains("speedwave check"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_action_self_update_rejects_extra_args() {
+        let args = argv(&["speedwave", "self-update", "junk"]);
+        assert!(parse_action(&args).is_err());
+    }
+
+    #[test]
+    fn parse_action_init_rejects_extra_args() {
+        let args = argv(&["speedwave", "init", "name", "junk"]);
+        let err = parse_action(&args).unwrap_err();
+        assert!(err.contains("speedwave init"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_action_plugin_install_rejects_extra_args() {
+        let args = argv(&["speedwave", "plugin", "install", "x.zip", "junk"]);
+        assert!(parse_action(&args).is_err());
+    }
+
+    #[test]
+    fn parse_action_compat_desktop_login_project_space_form() {
+        // HARD CONSTRAINT: Desktop generates `speedwave login --project <name>`.
+        let args = argv(&["speedwave", "login", "--project", "My Project"]);
+        assert_eq!(
+            parse_action(&args).unwrap(),
+            CliAction::Login(Some("My Project".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_action_compat_bare_run_with_project() {
+        // HARD CONSTRAINT: `speedwave --project acme` → Run(Some).
+        let args = argv(&["speedwave", "--project", "acme"]);
+        assert_eq!(
+            parse_action(&args).unwrap(),
+            CliAction::Run(Some("acme".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_action_compat_bare_run_no_args() {
+        // HARD CONSTRAINT: `speedwave` → Run(None).
+        let args = argv(&["speedwave"]);
+        assert_eq!(parse_action(&args).unwrap(), CliAction::Run(None));
+    }
+
+    #[test]
+    fn parse_action_compat_plugin_enable_shape() {
+        // HARD CONSTRAINT: plugin enable shape unchanged.
+        let args = argv(&[
+            "speedwave",
+            "plugin",
+            "enable",
+            "slack",
+            "--project",
+            "acme",
+        ]);
+        assert_eq!(
+            parse_action(&args).unwrap(),
+            CliAction::PluginEnable {
+                service_id: "slack".to_string(),
+                project: "acme".to_string(),
+            }
+        );
     }
 
     #[test]
@@ -1371,153 +1541,135 @@ mod tests {
         assert!(exec_cmd.contains(&"--strict-mcp-config"));
     }
 
-    #[test]
-    fn test_resolve_project_exact_path_match() {
-        let tmp = tempfile::tempdir().unwrap();
-        let canonical = std::fs::canonicalize(tmp.path()).unwrap();
+    /// Builds a project entry with the given name; dir is irrelevant now that
+    /// resolution ignores CWD, so a fixed placeholder keeps the tests terse.
+    fn proj(name: &str) -> config::ProjectUserEntry {
+        config::ProjectUserEntry {
+            name: name.to_string(),
+            dir: format!("/projects/{name}"),
+            claude: None,
+            integrations: None,
+            plugin_settings: None,
+        }
+    }
 
-        let user_config = config::SpeedwaveUserConfig {
-            projects: vec![config::ProjectUserEntry {
-                name: "my-proj".to_string(),
-                dir: canonical.to_string_lossy().to_string(),
-                claude: None,
-                integrations: None,
-                plugin_settings: None,
-            }],
-            active_project: None,
+    fn config_with(
+        projects: Vec<config::ProjectUserEntry>,
+        active: Option<&str>,
+    ) -> config::SpeedwaveUserConfig {
+        config::SpeedwaveUserConfig {
+            projects,
+            active_project: active.map(str::to_string),
             selected_ide: None,
             transcription: None,
             ui: None,
-        };
-
-        let result = resolve_project_for_cwd(&canonical, &user_config).unwrap();
-        assert_eq!(result, "my-proj");
+        }
     }
 
     #[test]
-    fn test_resolve_project_subdirectory_match() {
-        let tmp = tempfile::tempdir().unwrap();
-        let canonical = std::fs::canonicalize(tmp.path()).unwrap();
-        let sub = canonical.join("src").join("lib");
-        std::fs::create_dir_all(&sub).unwrap();
-
-        let user_config = config::SpeedwaveUserConfig {
-            projects: vec![config::ProjectUserEntry {
-                name: "my-proj".to_string(),
-                dir: canonical.to_string_lossy().to_string(),
-                claude: None,
-                integrations: None,
-                plugin_settings: None,
-            }],
-            active_project: None,
-            selected_ide: None,
-            transcription: None,
-            ui: None,
-        };
-
-        let result = resolve_project_for_cwd(&sub, &user_config).unwrap();
-        assert_eq!(result, "my-proj");
+    fn resolve_fallback_prefers_active_project() {
+        // active_project wins even when it is not first in the list — the
+        // Desktop selector is authoritative.
+        let cfg = config_with(vec![proj("alpha"), proj("beta")], Some("beta"));
+        assert_eq!(resolve_project_fallback(&cfg).unwrap(), "beta");
     }
 
     #[test]
-    fn test_resolve_project_longest_prefix_wins() {
-        let tmp = tempfile::tempdir().unwrap();
-        let root = std::fs::canonicalize(tmp.path()).unwrap();
-        let nested = root.join("apps").join("web");
-        std::fs::create_dir_all(&nested).unwrap();
-        let deep = nested.join("src");
-        std::fs::create_dir_all(&deep).unwrap();
-
-        let user_config = config::SpeedwaveUserConfig {
-            projects: vec![
-                config::ProjectUserEntry {
-                    name: "root-proj".to_string(),
-                    dir: root.to_string_lossy().to_string(),
-                    claude: None,
-                    integrations: None,
-                    plugin_settings: None,
-                },
-                config::ProjectUserEntry {
-                    name: "web-proj".to_string(),
-                    dir: nested.to_string_lossy().to_string(),
-                    claude: None,
-                    integrations: None,
-                    plugin_settings: None,
-                },
-            ],
-            active_project: None,
-            selected_ide: None,
-            transcription: None,
-            ui: None,
-        };
-
-        // CWD inside nested project should match web-proj (longer prefix)
-        let result = resolve_project_for_cwd(&deep, &user_config).unwrap();
-        assert_eq!(result, "web-proj");
+    fn resolve_fallback_uses_first_when_active_none() {
+        let cfg = config_with(vec![proj("alpha"), proj("beta")], None);
+        assert_eq!(resolve_project_fallback(&cfg).unwrap(), "alpha");
     }
 
     #[test]
-    fn test_resolve_project_fallback_to_active() {
-        let user_config = config::SpeedwaveUserConfig {
-            projects: vec![config::ProjectUserEntry {
-                name: "fallback-project".to_string(),
-                dir: "/nonexistent/path/that/wont/match/cwd".to_string(),
-                claude: None,
-                integrations: None,
-                plugin_settings: None,
-            }],
-            active_project: Some("fallback-project".to_string()),
-            selected_ide: None,
-            transcription: None,
-            ui: None,
-        };
-
-        // Use a tempdir as CWD that doesn't match any project
-        let tmp = tempfile::tempdir().unwrap();
-        let result = resolve_project_for_cwd(tmp.path(), &user_config).unwrap();
-        assert_eq!(result, "fallback-project");
+    fn resolve_fallback_errors_when_no_projects() {
+        let cfg = config_with(vec![], None);
+        assert!(resolve_project_fallback(&cfg).is_err());
     }
 
     #[test]
-    fn test_resolve_project_no_projects_errors() {
-        let user_config = config::SpeedwaveUserConfig {
-            projects: vec![],
-            active_project: None,
-            selected_ide: None,
-            transcription: None,
-            ui: None,
+    fn resolve_fallback_ignores_cwd() {
+        // A project dir equal to the real CWD must NOT win over active_project:
+        // resolution never consults the working directory.
+        let cwd = std::env::current_dir().unwrap();
+        let cwd_project = config::ProjectUserEntry {
+            name: "here".to_string(),
+            dir: cwd.to_string_lossy().to_string(),
+            claude: None,
+            integrations: None,
+            plugin_settings: None,
         };
-
-        let tmp = tempfile::tempdir().unwrap();
-        let result = resolve_project_for_cwd(tmp.path(), &user_config);
-        assert!(result.is_err());
+        let cfg = config_with(vec![proj("alpha"), cwd_project], Some("alpha"));
+        assert_eq!(resolve_project_fallback(&cfg).unwrap(), "alpha");
     }
 
     #[test]
-    fn test_resolve_project_trailing_slash_in_config() {
-        let tmp = tempfile::tempdir().unwrap();
-        let canonical = std::fs::canonicalize(tmp.path()).unwrap();
-        // Store with trailing slash — should still match
-        let dir_with_slash = format!("{}/", canonical.to_string_lossy());
+    fn parse_action_project_flag_overrides_run() {
+        let args = vec![
+            "speedwave".to_string(),
+            "--project".to_string(),
+            "beta".to_string(),
+        ];
+        assert_eq!(
+            parse_action(&args).unwrap(),
+            CliAction::Run(Some("beta".to_string()))
+        );
+    }
 
-        let user_config = config::SpeedwaveUserConfig {
-            projects: vec![config::ProjectUserEntry {
-                name: "slashed".to_string(),
-                dir: dir_with_slash,
-                claude: None,
-                integrations: None,
-                plugin_settings: None,
-            }],
-            active_project: None,
-            selected_ide: None,
-            transcription: None,
-            ui: None,
-        };
+    #[test]
+    fn parse_action_project_flag_without_value_errors() {
+        let args = vec!["speedwave".to_string(), "--project".to_string()];
+        assert!(parse_action(&args).is_err());
+    }
 
-        // canonicalize strips trailing slash, so exact match should work
-        // because we canonicalize both sides
-        let result = resolve_project_for_cwd(&canonical, &user_config).unwrap();
-        assert_eq!(result, "slashed");
+    #[test]
+    fn resolve_action_project_uses_run_override() {
+        // `speedwave --project beta` targets beta even when alpha is active.
+        let cfg = config_with(vec![proj("alpha"), proj("beta")], Some("alpha"));
+        let action = CliAction::Run(Some("beta".to_string()));
+        assert_eq!(resolve_action_project(&action, &cfg).unwrap(), "beta");
+    }
+
+    #[test]
+    fn resolve_action_project_bare_run_uses_active() {
+        // Regression guard: bare `speedwave` follows the active project (the
+        // Desktop selector), never the working directory.
+        let cfg = config_with(vec![proj("alpha"), proj("beta")], Some("beta"));
+        let action = CliAction::Run(None);
+        assert_eq!(resolve_action_project(&action, &cfg).unwrap(), "beta");
+    }
+
+    #[test]
+    fn resolve_action_project_login_override_wins() {
+        let cfg = config_with(vec![proj("alpha"), proj("beta")], Some("alpha"));
+        let action = CliAction::Login(Some("beta".to_string()));
+        assert_eq!(resolve_action_project(&action, &cfg).unwrap(), "beta");
+    }
+
+    #[test]
+    fn resolve_action_project_explicit_missing_errors() {
+        // Defect #6: an explicit --project naming a project not in config is a
+        // hard error, not a silent fallback to the working directory.
+        let cfg = config_with(vec![proj("alpha")], Some("alpha"));
+        let action = CliAction::Run(Some("typo".to_string()));
+        let err = resolve_action_project(&action, &cfg).unwrap_err();
+        assert!(
+            err.to_string().contains("not found in config"),
+            "expected not-found error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_action_project_update_override_wins() {
+        let cfg = config_with(vec![proj("alpha"), proj("beta")], Some("alpha"));
+        let action = CliAction::Update(Some("beta".to_string()));
+        assert_eq!(resolve_action_project(&action, &cfg).unwrap(), "beta");
+    }
+
+    #[test]
+    fn resolve_action_project_logout_override_wins() {
+        let cfg = config_with(vec![proj("alpha"), proj("beta")], Some("alpha"));
+        let action = CliAction::Logout(Some("beta".to_string()));
+        assert_eq!(resolve_action_project(&action, &cfg).unwrap(), "beta");
     }
 
     #[test]
@@ -1559,7 +1711,7 @@ mod tests {
     #[test]
     fn parse_action_update() {
         let args = vec!["speedwave".to_string(), "update".to_string()];
-        assert_eq!(parse_action(&args).unwrap(), CliAction::Update);
+        assert_eq!(parse_action(&args).unwrap(), CliAction::Update(None));
     }
 
     #[test]
@@ -1867,9 +2019,9 @@ mod tests {
         // on every installed plugin being trusted. The audit must
         // gate them — a regression that flips any of these to `true`
         // silently disables the runtime-invariant promise.
-        assert!(!skip_plugin_audit(&CliAction::Run));
+        assert!(!skip_plugin_audit(&CliAction::Run(None)));
         assert!(!skip_plugin_audit(&CliAction::Check));
-        assert!(!skip_plugin_audit(&CliAction::Update));
+        assert!(!skip_plugin_audit(&CliAction::Update(None)));
         assert!(!skip_plugin_audit(&CliAction::PluginEnable {
             project: "p".into(),
             service_id: "s".into(),

--- a/crates/speedwave-cli/src/paste_watcher.rs
+++ b/crates/speedwave-cli/src/paste_watcher.rs
@@ -147,6 +147,7 @@ fn set_owner_only(_path: &Path) -> Result<()> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/speedwave-runtime/src/binary.rs
+++ b/crates/speedwave-runtime/src/binary.rs
@@ -427,14 +427,20 @@ pub(crate) mod tests {
 
     #[test]
     fn lima_home_returns_expected_path() {
-        let home = lima_home();
-        assert!(home.is_some());
-        let path = home.unwrap();
-        // Compare path components (separator-agnostic): on Windows the path uses
-        // `\`, so a string `ends_with(".speedwave/lima")` would wrongly fail.
+        // Assert the structural invariant (`<data_dir>/lima`) without naming the
+        // production `data_dir()` singleton: the final component is LIMA_SUBDIR
+        // and a non-empty data-dir parent precedes it. Holds under any isolated
+        // tempdir data dir, and is separator-agnostic (Path tail, not string).
+        let path = lima_home().expect("lima_home should resolve");
         assert!(
-            path.ends_with(std::path::Path::new(".speedwave").join("lima")),
-            "expected path ending with .speedwave/lima, got: {}",
+            path.ends_with(consts::LIMA_SUBDIR),
+            "lima_home should end with {}, got: {}",
+            consts::LIMA_SUBDIR,
+            path.display()
+        );
+        assert!(
+            path.parent().is_some_and(|p| p.file_name().is_some()),
+            "lima_home should have a data-dir parent, got: {}",
             path.display()
         );
     }
@@ -453,10 +459,15 @@ pub(crate) mod tests {
             .expect("LIMA_HOME env should be set for limactl");
 
         let value = lima_home_env.1.expect("LIMA_HOME should have a value");
-        // Separator-agnostic (Windows uses `\`): compare path components.
+        // Structural invariant only (`<data_dir>/lima`), tempdir-safe — no bare
+        // `data_dir()` resolution. `command("limactl")` creates the dir, so the
+        // value is the canonicalized LIMA_HOME; checking the tail is portable
+        // and separator-agnostic (Path tail, not string).
+        let value_path = std::path::Path::new(value);
         assert!(
-            std::path::Path::new(value).ends_with(std::path::Path::new(".speedwave").join("lima")),
-            "LIMA_HOME should end with .speedwave/lima, got: {}",
+            value_path.ends_with(consts::LIMA_SUBDIR),
+            "LIMA_HOME should end with {}, got: {}",
+            consts::LIMA_SUBDIR,
             value.to_string_lossy()
         );
     }

--- a/crates/speedwave-runtime/src/build.rs
+++ b/crates/speedwave-runtime/src/build.rs
@@ -167,6 +167,16 @@ pub fn images_exist(
             return false;
         }
     };
+    images_exist_with_manifest(rt, integrations, &manifest)
+}
+
+/// Core of [`images_exist`] taking an explicit manifest, so tests inject a build
+/// root and never read `SPEEDWAVE_RESOURCES_DIR` or the production marker.
+pub fn images_exist_with_manifest(
+    rt: &super::runtime::LockedRuntime,
+    integrations: &ResolvedIntegrationsConfig,
+    manifest: &crate::bundle::BundleManifest,
+) -> bool {
     enabled_images(integrations).iter().all(|img| {
         let tag = image_ref(img.name, &manifest.bundle_id);
         rt.image_exists(&tag).unwrap_or(false)
@@ -520,6 +530,19 @@ pub fn build_missing_images(
     images: &[&ImageDef],
     bundle_id: &str,
 ) -> anyhow::Result<u32> {
+    let root = resolve_build_root()?;
+    build_missing_images_in(runtime, images, bundle_id, &root)
+}
+
+/// Env-free core of [`build_missing_images`]: takes an explicit build root so
+/// tests never read `SPEEDWAVE_RESOURCES_DIR` or the production `~/.speedwave`
+/// marker.
+pub fn build_missing_images_in(
+    runtime: &crate::runtime::LockedRuntime,
+    images: &[&ImageDef],
+    bundle_id: &str,
+    root: &std::path::Path,
+) -> anyhow::Result<u32> {
     let missing: Vec<&ImageDef> = images
         .iter()
         .copied()
@@ -532,7 +555,7 @@ pub fn build_missing_images(
     if missing.is_empty() {
         return Ok(0);
     }
-    build_images_for_bundle(runtime, &missing, bundle_id)?;
+    build_images_for_bundle_in(runtime, &missing, bundle_id, root)?;
     Ok(missing.len() as u32)
 }
 
@@ -601,7 +624,19 @@ pub fn build_images_for_bundle(
     bundle_id: &str,
 ) -> anyhow::Result<u32> {
     let root = resolve_build_root()?;
-    let vm_root = runtime.prepare_build_context(&root)?;
+    build_images_for_bundle_in(runtime, images, bundle_id, &root)
+}
+
+/// Env-free core of [`build_images_for_bundle`]: takes an explicit build root so
+/// tests never read `SPEEDWAVE_RESOURCES_DIR` or the production `~/.speedwave`
+/// marker. The public no-arg shim resolves the root from env at the call site.
+pub fn build_images_for_bundle_in(
+    runtime: &crate::runtime::LockedRuntime,
+    images: &[&ImageDef],
+    bundle_id: &str,
+    root: &std::path::Path,
+) -> anyhow::Result<u32> {
+    let vm_root = runtime.prepare_build_context(root)?;
     let needs_cleanup = vm_root != root;
 
     let result = try_build_images(runtime, images, &vm_root, bundle_id).or_else(|first_err| {
@@ -955,11 +990,14 @@ mod tests {
     }
 
     /// Builds the full `IMAGES` set, mirroring the old `build_all_images_for_bundle`.
+    /// Takes an explicit build root so no test reads `SPEEDWAVE_RESOURCES_DIR` or
+    /// the production `~/.speedwave` marker.
     fn build_all_for_bundle(
         rt: &crate::runtime::LockedRuntime,
         bundle_id: &str,
+        root: &std::path::Path,
     ) -> anyhow::Result<u32> {
-        build_images_for_bundle(rt, &all_images(), bundle_id)
+        build_images_for_bundle_in(rt, &all_images(), bundle_id, root)
     }
 
     /// Runs the worker pool over the full `IMAGES` set (old `try_build_all`).
@@ -989,7 +1027,10 @@ mod tests {
 
     #[test]
     fn test_images_containerfiles_exist() {
-        let root = resolve_build_root().unwrap();
+        let _guard = crate::binary::tests::ENV_LOCK.lock().unwrap();
+        std::env::remove_var(crate::consts::BUNDLE_RESOURCES_ENV);
+        // None home → dev source tree, never the production ~/.speedwave marker.
+        let root = resolve_build_root_with_home(None).unwrap();
         for img in IMAGES {
             let path = root.join(img.containerfile);
             assert!(
@@ -1003,7 +1044,10 @@ mod tests {
 
     #[test]
     fn test_images_context_dirs_exist() {
-        let root = resolve_build_root().unwrap();
+        let _guard = crate::binary::tests::ENV_LOCK.lock().unwrap();
+        std::env::remove_var(crate::consts::BUNDLE_RESOURCES_ENV);
+        // None home → dev source tree, never the production ~/.speedwave marker.
+        let root = resolve_build_root_with_home(None).unwrap();
         for img in IMAGES {
             let path = root.join(img.context_dir);
             assert!(
@@ -1730,10 +1774,11 @@ mod tests {
             .with_prepare_build_context_root(translated.clone())
             .build();
 
-        // build_images_for_bundle resolves the real build root, then calls
-        // prepare_build_context; the mock returns the translated path.
+        // Explicit fake build root keeps the test off SPEEDWAVE_RESOURCES_DIR and
+        // the production marker; the mock returns the translated path regardless.
+        let (_tmp, root) = create_fake_build_root();
         let bundle_id = "test-bundle";
-        let result = build_all_for_bundle(&rt, bundle_id);
+        let result = build_all_for_bundle(&rt, bundle_id, &root);
         assert!(result.is_ok());
 
         assert!(
@@ -1915,8 +1960,8 @@ mod tests {
             github: true,
             ..ResolvedIntegrationsConfig::default()
         };
-        let (rt, handles) = lazy_build_mock(root, vec![]);
-        let n = build_images_for_bundle(&rt, &enabled_images(&cfg), "b1").unwrap();
+        let (rt, handles) = lazy_build_mock(root.clone(), vec![]);
+        let n = build_images_for_bundle_in(&rt, &enabled_images(&cfg), "b1", &root).unwrap();
         assert_eq!(n, 3);
         let mut built = handles.build_tags();
         built.sort();
@@ -1934,13 +1979,13 @@ mod tests {
     fn test_build_missing_images_skips_present() {
         let (_tmp, root) = create_fake_build_root();
         // claude + mcp-hub already present; mcp-playwright missing.
-        let (rt, handles) = lazy_build_mock(root, vec![IMAGE_CLAUDE, IMAGE_MCP_HUB]);
+        let (rt, handles) = lazy_build_mock(root.clone(), vec![IMAGE_CLAUDE, IMAGE_MCP_HUB]);
         let images: Vec<&ImageDef> = vec![
             image_for_service_key("playwright").unwrap(),
             IMAGES.iter().find(|i| i.name == IMAGE_CLAUDE).unwrap(),
             IMAGES.iter().find(|i| i.name == IMAGE_MCP_HUB).unwrap(),
         ];
-        let n = build_missing_images(&rt, &images, "b1").unwrap();
+        let n = build_missing_images_in(&rt, &images, "b1", &root).unwrap();
         assert_eq!(n, 1, "only the missing playwright image is built");
         assert_eq!(
             handles.build_tags(),
@@ -1951,12 +1996,12 @@ mod tests {
     #[test]
     fn test_build_missing_images_noop_when_all_present() {
         let (_tmp, root) = create_fake_build_root();
-        let (rt, handles) = lazy_build_mock(root, vec![IMAGE_CLAUDE, IMAGE_MCP_HUB]);
+        let (rt, handles) = lazy_build_mock(root.clone(), vec![IMAGE_CLAUDE, IMAGE_MCP_HUB]);
         let images: Vec<&ImageDef> = all_images()
             .into_iter()
             .filter(|i| i.name == IMAGE_CLAUDE || i.name == IMAGE_MCP_HUB)
             .collect();
-        let n = build_missing_images(&rt, &images, "b1").unwrap();
+        let n = build_missing_images_in(&rt, &images, "b1", &root).unwrap();
         assert_eq!(n, 0);
         assert!(handles.build_tags().is_empty());
     }
@@ -1973,9 +2018,9 @@ mod tests {
         );
 
         let (_tmp, build_root) = create_fake_build_root();
-        let (rt, handles) = retry_mock(build_root, fail_on);
+        let (rt, handles) = retry_mock(build_root.clone(), fail_on);
 
-        let result = build_all_for_bundle(&rt, "test-bundle");
+        let result = build_all_for_bundle(&rt, "test-bundle", &build_root);
 
         assert!(result.is_ok(), "retry should succeed, got: {:?}", result);
         assert_eq!(result.unwrap(), image_count);
@@ -2020,9 +2065,9 @@ mod tests {
         );
 
         let (_tmp, build_root) = create_fake_build_root();
-        let (rt, handles) = retry_mock(build_root, fail_on);
+        let (rt, handles) = retry_mock(build_root.clone(), fail_on);
 
-        let result = build_all_for_bundle(&rt, "test-bundle");
+        let result = build_all_for_bundle(&rt, "test-bundle", &build_root);
         assert!(result.is_ok(), "retry should succeed, got: {:?}", result);
         assert_eq!(result.unwrap(), image_count);
 
@@ -2051,9 +2096,9 @@ mod tests {
         }
 
         let (_tmp, build_root) = create_fake_build_root();
-        let (rt, _handles) = retry_mock(build_root, fail_on);
+        let (rt, _handles) = retry_mock(build_root.clone(), fail_on);
 
-        let result = build_all_for_bundle(&rt, "test-bundle");
+        let result = build_all_for_bundle(&rt, "test-bundle", &build_root);
         assert!(result.is_err(), "double disk-full must propagate");
 
         let msg = format!("{:#}", result.unwrap_err());
@@ -2101,9 +2146,9 @@ mod tests {
         );
 
         let (_tmp, build_root) = create_fake_build_root();
-        let (rt, handles) = retry_mock(build_root, fail_on);
+        let (rt, handles) = retry_mock(build_root.clone(), fail_on);
 
-        let result = build_all_for_bundle(&rt, "test-bundle");
+        let result = build_all_for_bundle(&rt, "test-bundle", &build_root);
 
         assert!(result.is_err(), "generic error should not be retried");
         assert!(
@@ -2184,9 +2229,9 @@ mod tests {
         );
 
         let (_tmp, build_root) = create_fake_build_root();
-        let (rt, handles) = retry_mock(build_root, fail_on);
+        let (rt, handles) = retry_mock(build_root.clone(), fail_on);
 
-        let result = build_all_for_bundle(&rt, "test-bundle");
+        let result = build_all_for_bundle(&rt, "test-bundle", &build_root);
 
         assert!(result.is_err(), "second failure should be returned");
         assert!(
@@ -2219,9 +2264,9 @@ mod tests {
         );
 
         let (_tmp, build_root) = create_fake_build_root();
-        let (rt, _handles) = retry_mock(build_root, fail_on);
+        let (rt, _handles) = retry_mock(build_root.clone(), fail_on);
 
-        let result = build_all_for_bundle(&rt, "test-bundle");
+        let result = build_all_for_bundle(&rt, "test-bundle", &build_root);
         assert!(result.is_err());
 
         let err = result.unwrap_err();
@@ -2275,9 +2320,9 @@ mod tests {
         );
 
         let (_tmp, build_root) = create_fake_build_root();
-        let (rt, _handles) = retry_mock(build_root, fail_on);
+        let (rt, _handles) = retry_mock(build_root.clone(), fail_on);
 
-        let result = build_all_for_bundle(&rt, "test-bundle");
+        let result = build_all_for_bundle(&rt, "test-bundle", &build_root);
         assert!(result.is_err());
 
         let err = result.unwrap_err();
@@ -2310,16 +2355,36 @@ mod tests {
             rt
         }
 
+        /// Synthetic manifest so `images_exist_with_manifest` never reads
+        /// `SPEEDWAVE_RESOURCES_DIR` or the production `~/.speedwave` marker. The
+        /// bundle_id is irrelevant — the mock matches on the image name substring.
+        fn fake_manifest() -> crate::bundle::BundleManifest {
+            crate::bundle::BundleManifest {
+                app_version: "0.0.0-test".to_string(),
+                bundle_id: "testbundle".to_string(),
+                build_context_hash: "deadbeef".to_string(),
+                claude_resources_hash: "cafebabe".to_string(),
+            }
+        }
+
         #[test]
         fn test_images_exist_returns_true_when_all_present() {
             let rt = image_check_mock(&[]);
-            assert!(images_exist(&rt, &all_enabled()));
+            assert!(images_exist_with_manifest(
+                &rt,
+                &all_enabled(),
+                &fake_manifest()
+            ));
         }
 
         #[test]
         fn test_images_exist_returns_false_when_any_missing() {
             let rt = image_check_mock(&["speedwave-claude"]);
-            assert!(!images_exist(&rt, &all_enabled()));
+            assert!(!images_exist_with_manifest(
+                &rt,
+                &all_enabled(),
+                &fake_manifest()
+            ));
         }
 
         #[test]
@@ -2330,7 +2395,7 @@ mod tests {
                 slack: true,
                 ..ResolvedIntegrationsConfig::default()
             };
-            assert!(images_exist(&rt, &cfg));
+            assert!(images_exist_with_manifest(&rt, &cfg, &fake_manifest()));
         }
 
         #[test]
@@ -2340,7 +2405,7 @@ mod tests {
                 slack: true,
                 ..ResolvedIntegrationsConfig::default()
             };
-            assert!(!images_exist(&rt, &cfg));
+            assert!(!images_exist_with_manifest(&rt, &cfg, &fake_manifest()));
         }
     }
 
@@ -2838,9 +2903,9 @@ mod tests {
         );
 
         let (_tmp, build_root) = create_fake_build_root();
-        let (rt, handles) = retry_mock(build_root, fail_on);
+        let (rt, handles) = retry_mock(build_root.clone(), fail_on);
 
-        let result = build_all_for_bundle(&rt, "test-bundle");
+        let result = build_all_for_bundle(&rt, "test-bundle", &build_root);
         assert_eq!(result.unwrap(), IMAGES.len() as u32);
 
         assert_eq!(
@@ -2871,9 +2936,9 @@ mod tests {
         );
 
         let (_tmp, build_root) = create_fake_build_root();
-        let (rt, handles) = retry_mock(build_root, fail_on);
+        let (rt, handles) = retry_mock(build_root.clone(), fail_on);
 
-        let result = build_all_for_bundle(&rt, "test-bundle");
+        let result = build_all_for_bundle(&rt, "test-bundle", &build_root);
         assert_eq!(
             result.unwrap(),
             IMAGES.len() as u32,
@@ -2905,9 +2970,9 @@ mod tests {
         }
 
         let (_tmp, build_root) = create_fake_build_root();
-        let (rt, handles) = retry_mock(build_root, fail_on);
+        let (rt, handles) = retry_mock(build_root.clone(), fail_on);
 
-        let result = build_all_for_bundle(&rt, "test-bundle");
+        let result = build_all_for_bundle(&rt, "test-bundle", &build_root);
         assert!(result.is_err(), "exhausting retries must surface the error");
         let msg = format!("{:#}", result.unwrap_err());
         assert!(
@@ -2940,9 +3005,9 @@ mod tests {
         );
 
         let (_tmp, build_root) = create_fake_build_root();
-        let (rt, handles) = retry_mock(build_root, fail_on);
+        let (rt, handles) = retry_mock(build_root.clone(), fail_on);
 
-        let result = build_all_for_bundle(&rt, "test-bundle");
+        let result = build_all_for_bundle(&rt, "test-bundle", &build_root);
         assert_eq!(
             result.unwrap(),
             IMAGES.len() as u32,

--- a/crates/speedwave-runtime/src/bundle.rs
+++ b/crates/speedwave-runtime/src/bundle.rs
@@ -215,7 +215,14 @@ impl BundleReconcilePhase {
 }
 
 pub fn load_current_bundle_manifest() -> anyhow::Result<BundleManifest> {
-    let build_root = build::resolve_build_root()?;
+    load_current_bundle_manifest_from(&build::resolve_build_root()?)
+}
+
+/// Env-free core of [`load_current_bundle_manifest`]: takes an explicit build
+/// root so tests can inject a path and never read the process-global
+/// `SPEEDWAVE_RESOURCES_DIR` (which other tests mutate — see the test-isolation
+/// guard). The public no-arg shim resolves the root from env at the call site.
+pub fn load_current_bundle_manifest_from(build_root: &Path) -> anyhow::Result<BundleManifest> {
     let manifest_path = build_root.join(BUNDLE_MANIFEST_FILE);
     if manifest_path.exists() {
         let data = std::fs::read_to_string(&manifest_path)?;
@@ -224,7 +231,7 @@ pub fn load_current_bundle_manifest() -> anyhow::Result<BundleManifest> {
     generate_bundle_manifest(
         env!("CARGO_PKG_VERSION"),
         crate::defaults::CLAUDE_VERSION,
-        &build_root,
+        build_root,
     )
 }
 

--- a/crates/speedwave-runtime/src/compose.rs
+++ b/crates/speedwave-runtime/src/compose.rs
@@ -225,6 +225,12 @@ pub fn render_compose(
     // Filter services based on integrations config
     yaml = apply_integrations_filter(&yaml, integrations, &network_name)?;
 
+    // Final hardening: re-quote any `environment:` value carrying a YAML flow
+    // indicator (e.g. the `[1m]` 1M-context suffix) that libyaml emits
+    // unquoted but nerdctl's Go YAML parser rejects. Must run last — after
+    // every env-injection pass has contributed its entries.
+    yaml = harden_env_scalar_quoting(&yaml)?;
+
     Ok(yaml)
 }
 
@@ -403,6 +409,86 @@ fn validate_compose_network_refs(yaml: &str) -> anyhow::Result<()> {
         }
     }
     Ok(())
+}
+
+/// YAML flow indicators that are legal inside a *block-context* plain scalar
+/// per the YAML 1.2 spec, so libyaml (serde_yaml_ng's emitter) leaves them
+/// unquoted — but nerdctl's Go YAML parser (gopkg.in/yaml.v3 via compose-go)
+/// rejects them, failing the whole file with `could not find expected ":"`
+/// several lines later. Any env value containing one of these MUST be emitted
+/// as an explicitly quoted scalar. `[`/`]` cover the documented `[1m]`
+/// 1M-context suffix (anthropics/claude-code#34083 workaround); the rest make
+/// the rule general so any future value (`{`, `}`, `,`) is safe too.
+const YAML_PLAIN_UNSAFE_CHARS: &[char] = &['[', ']', '{', '}', ','];
+
+/// True when `entry` (a `KEY=VALUE` env line) would round-trip through every
+/// conformant YAML parser as a plain scalar. When false the caller must emit a
+/// quoted scalar — see [`harden_env_scalar_quoting`].
+fn env_entry_needs_quoting(entry: &str) -> bool {
+    entry.contains(YAML_PLAIN_UNSAFE_CHARS)
+}
+
+/// Final SSOT pass over rendered compose YAML: re-quotes every `environment:`
+/// sequence entry whose value contains a YAML flow indicator that libyaml
+/// emits unquoted but nerdctl's stricter Go parser rejects.
+///
+/// Scoped to `environment:` blocks (tracked by indentation) so it never
+/// touches images, volumes, or networks. The replacement scalar is produced
+/// with `serde_json::to_string`, whose escaping is a valid YAML 1.2
+/// double-quoted scalar (YAML is a JSON superset) — no hand-rolled escaping.
+/// Idempotent: already-quoted entries (those that don't re-parse as a bare
+/// `KEY=VALUE` plain scalar) are left untouched.
+fn harden_env_scalar_quoting(yaml: &str) -> anyhow::Result<String> {
+    let mut out = String::with_capacity(yaml.len());
+    // Indentation (column) of the active `environment:` key, if inside one.
+    let mut env_indent: Option<usize> = None;
+    for line in yaml.split_inclusive('\n') {
+        let body = line.trim_end_matches(['\n', '\r']);
+        let indent = body.len() - body.trim_start().len();
+        let trimmed = body.trim_start();
+
+        // Leaving the active environment block. Compose renders sequence
+        // items at the SAME column as the `environment:` key (`- ITEM`
+        // aligned under `environment:`), so same-indent `- ` lines stay in
+        // the block; any non-sequence line, or a line indented less than the
+        // key, closes it.
+        if let Some(env_col) = env_indent {
+            let is_seq_item = trimmed.starts_with("- ") || trimmed == "-";
+            if !body.trim().is_empty() && (indent < env_col || !is_seq_item) {
+                env_indent = None;
+            }
+        }
+
+        if env_indent.is_none() && trimmed == "environment:" {
+            env_indent = Some(indent);
+            out.push_str(line);
+            continue;
+        }
+
+        if env_indent.is_some() {
+            if let Some(rest) = trimmed.strip_prefix("- ") {
+                let value = rest.trim();
+                // Only touch bare (unquoted) `KEY=VALUE` plain scalars that
+                // carry an unsafe char; quoted/escaped entries are skipped.
+                let is_bare_plain = !value.starts_with('"')
+                    && !value.starts_with('\'')
+                    && !value.starts_with('|')
+                    && !value.starts_with('>');
+                if is_bare_plain && env_entry_needs_quoting(value) {
+                    let prefix = &body[..body.len() - rest.len()];
+                    out.push_str(prefix);
+                    out.push_str(&serde_json::to_string(value)?);
+                    if line.ends_with('\n') {
+                        out.push('\n');
+                    }
+                    continue;
+                }
+            }
+        }
+
+        out.push_str(line);
+    }
+    Ok(out)
 }
 
 fn inject_claude_env(
@@ -3415,6 +3501,88 @@ mod tests {
         let _ = std::fs::remove_dir(&tokens_dir);
     }
 
+    /// Regression for the unquoted `[1m]` 1M-context suffix that nerdctl's Go
+    /// YAML parser rejected with `could not find expected ":"`. The default
+    /// Anthropic provider injects `ANTHROPIC_DEFAULT_OPUS_MODEL=<id>[1m]`; the
+    /// rendered file must (a) re-parse and (b) carry the bracketed entry as a
+    /// quoted scalar so a strict parser accepts it. The pre-existing
+    /// substring/`from_str` tests missed this because serde_yaml_ng's libyaml
+    /// emitter leaves the bracket unquoted and re-reads it without complaint.
+    #[test]
+    #[serial_test::serial(host_addressing)]
+    fn render_compose_quotes_bracketed_model_env_and_round_trips() {
+        let project = format!("render-1m-suffix-{}", std::process::id());
+        let tmp = tempfile::tempdir().unwrap();
+        let project_dir = tmp.path().join("project");
+        std::fs::create_dir_all(&project_dir).unwrap();
+
+        // Default Anthropic provider (no explicit model) — exercises
+        // anthropic_default_models_env(), which emits the `[1m]` suffix.
+        let resolved = ResolvedClaudeConfig {
+            env: crate::defaults::base_env(),
+            flags: default_flags(),
+            llm: LlmConfig {
+                provider: Some("anthropic".to_string()),
+                model: None,
+                base_url: None,
+                context_tokens: None,
+                has_api_key: false,
+                has_custom_headers: false,
+            },
+        };
+
+        let yaml = render_compose(
+            &project,
+            project_dir.to_str().unwrap(),
+            &resolved,
+            &ResolvedIntegrationsConfig::default(),
+            None,
+            &HostBridgesInfo::default(),
+        )
+        .expect("render must succeed");
+
+        // (a) Round-trips through the parser.
+        let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(&yaml)
+            .unwrap_or_else(|e| panic!("rendered compose YAML must re-parse: {e}"));
+        let env = doc["services"]["claude"]["environment"]
+            .as_sequence()
+            .expect("claude.environment must be a sequence");
+        let opus = env
+            .iter()
+            .filter_map(|v| v.as_str())
+            .find(|s| s.starts_with("ANTHROPIC_DEFAULT_OPUS_MODEL="))
+            .expect("ANTHROPIC_DEFAULT_OPUS_MODEL must be present");
+        assert!(
+            opus.ends_with("[1m]"),
+            "1M-context suffix must survive intact, got: {opus:?}"
+        );
+
+        // (b) Across EVERY service, each `environment:` entry that carries a
+        // YAML flow indicator must be a quoted scalar in the RAW serialized
+        // form — the property the Go parser needs and the old tests never
+        // checked. Scope to env values (via the parsed doc) so non-env lines
+        // that legitimately contain flow indicators (e.g. the tmpfs mount
+        // `/tmp:noexec,nosuid,size=512m`) are not mistaken for env entries.
+        let services = doc["services"].as_mapping().expect("services mapping");
+        for (_, svc) in services {
+            let Some(env) = svc.get("environment").and_then(|e| e.as_sequence()) else {
+                continue;
+            };
+            for v in env {
+                let Some(entry) = v.as_str() else { continue };
+                if !env_entry_needs_quoting(entry) {
+                    continue;
+                }
+                let quoted = format!("- {}", serde_json::to_string(entry).unwrap());
+                assert!(
+                    yaml.contains(&quoted),
+                    "env entry {entry:?} carries a flow indicator but is not a quoted \
+                     scalar in the rendered YAML; expected a line containing {quoted:?}"
+                );
+            }
+        }
+    }
+
     /// `Authorization` in a stale `custom_headers` token must not be allowed
     /// to smuggle a header that collides with `ANTHROPIC_AUTH_TOKEN` Bearer.
     /// Mirrors the defensive reject in `build_llm_probe_client_with_auth`.
@@ -3509,6 +3677,85 @@ mod tests {
             .expect("header entry present");
         assert!(header_entry.contains("X-Tenant-ID: foo"));
         assert!(header_entry.contains("X-Subscription-ID: bar"));
+    }
+
+    #[test]
+    fn env_entry_needs_quoting_flags_flow_indicators() {
+        // Happy path: plain values stay plain.
+        assert!(!env_entry_needs_quoting("ANTHROPIC_MODEL=claude-opus-4-8"));
+        assert!(!env_entry_needs_quoting("PORT=4000"));
+        assert!(!env_entry_needs_quoting("TZ=Europe/Warsaw"));
+        // A single `: ` mid-scalar is plain-safe (the Go parser accepts it);
+        // no flow indicator means no quoting.
+        assert!(!env_entry_needs_quoting(
+            "ANTHROPIC_CUSTOM_HEADERS=X-Tenant-ID: foo"
+        ));
+        // …but the multi-header flattened form joins with `, ` — the comma is
+        // a flow indicator, so it must now be quoted too (defends the same
+        // nerdctl-compose breakage the multiline headers fix addressed).
+        assert!(env_entry_needs_quoting(
+            "ANTHROPIC_CUSTOM_HEADERS=X-Tenant-ID: foo, X-Subscription-ID: bar"
+        ));
+        // The reported bug: the `[1m]` 1M-context suffix.
+        assert!(env_entry_needs_quoting(
+            "ANTHROPIC_DEFAULT_OPUS_MODEL=claude-opus-4-8[1m]"
+        ));
+        // General: every flow indicator triggers quoting.
+        for c in ['[', ']', '{', '}', ','] {
+            assert!(
+                env_entry_needs_quoting(&format!("K=a{c}b")),
+                "char {c:?} must require quoting"
+            );
+        }
+    }
+
+    #[test]
+    fn harden_env_scalar_quoting_quotes_bracketed_model_id() {
+        let yaml = "services:\n  claude:\n    environment:\n    \
+                    - ANTHROPIC_DEFAULT_OPUS_MODEL=claude-opus-4-8[1m]\n    \
+                    - ANTHROPIC_MODEL=claude-opus-4-8\nnetworks: {}\n";
+        let hardened = harden_env_scalar_quoting(yaml).unwrap();
+        // The bracketed entry is now an explicit double-quoted scalar.
+        assert!(
+            hardened.contains("- \"ANTHROPIC_DEFAULT_OPUS_MODEL=claude-opus-4-8[1m]\""),
+            "bracketed entry must be double-quoted, got:\n{hardened}"
+        );
+        // The plain entry is untouched (no needless quoting).
+        assert!(
+            hardened.contains("- ANTHROPIC_MODEL=claude-opus-4-8\n"),
+            "plain entry must stay plain, got:\n{hardened}"
+        );
+        // Round-trips, and the value survives intact.
+        let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(&hardened).unwrap();
+        let env = doc["services"]["claude"]["environment"]
+            .as_sequence()
+            .unwrap();
+        assert!(env
+            .iter()
+            .any(|v| v.as_str() == Some("ANTHROPIC_DEFAULT_OPUS_MODEL=claude-opus-4-8[1m]")));
+    }
+
+    #[test]
+    fn harden_env_scalar_quoting_is_idempotent_and_scoped() {
+        // Already-quoted entries and non-environment flow indicators (the
+        // `networks: {}` mapping, an image with no brackets) are untouched;
+        // running twice is a no-op.
+        let yaml = "services:\n  claude:\n    image: registry/x:1\n    environment:\n    \
+                    - \"ALREADY=quoted[1m]\"\n    - PLAIN=ok\n    volumes:\n    \
+                    - /a:/b\nnetworks:\n  net: {}\n";
+        let once = harden_env_scalar_quoting(yaml).unwrap();
+        let twice = harden_env_scalar_quoting(&once).unwrap();
+        assert_eq!(once, twice, "must be idempotent");
+        // Volume mounts contain `:` but no flow indicator — untouched.
+        assert!(once.contains("- /a:/b\n"));
+        // The flow-mapping `net: {}` outside environment is untouched.
+        assert!(once.contains("net: {}"));
+        // Already-quoted bracket entry not re-wrapped.
+        assert!(once.contains("- \"ALREADY=quoted[1m]\""));
+        assert!(
+            !once.contains("\\\""),
+            "no double-escaping of existing quotes"
+        );
     }
 
     fn default_flags() -> Vec<String> {

--- a/crates/speedwave-runtime/src/compose.rs
+++ b/crates/speedwave-runtime/src/compose.rs
@@ -29,9 +29,30 @@ fn str_to_engine_path(path: &str) -> anyhow::Result<String> {
     to_engine_path(std::path::Path::new(path))
 }
 
-/// Returns the tokens directory for a project using `consts::data_dir()`.
-fn resolve_tokens_dir(project_name: &str) -> PathBuf {
-    consts::data_dir().join("tokens").join(project_name)
+/// Returns the tokens directory for a project under an explicit data dir.
+fn resolve_tokens_dir_in(data_dir: &Path, project_name: &str) -> PathBuf {
+    data_dir.join("tokens").join(project_name)
+}
+
+// Test-only override for the bundle build root, so `render_compose_in` resolves
+// the manifest from an injected path instead of the process-global
+// `SPEEDWAVE_RESOURCES_DIR` env var (which other tests mutate). Thread-local so
+// parallel tests don't perturb each other.
+#[cfg(test)]
+thread_local! {
+    static TEST_BUILD_ROOT: std::cell::RefCell<Option<PathBuf>> = const { std::cell::RefCell::new(None) };
+}
+
+/// Resolves the bundle manifest: production reads the env-derived build root;
+/// tests read the injected `TEST_BUILD_ROOT` so they never touch global env.
+fn resolve_bundle_manifest() -> anyhow::Result<bundle::BundleManifest> {
+    #[cfg(test)]
+    {
+        if let Some(root) = TEST_BUILD_ROOT.with(|r| r.borrow().clone()) {
+            return bundle::load_current_bundle_manifest_from(&root);
+        }
+    }
+    bundle::load_current_bundle_manifest()
 }
 
 /// Default compose template embedded at compile time from containers/compose.template.yml (SSOT).
@@ -74,19 +95,42 @@ pub fn render_compose(
     runtime: Option<&crate::runtime::LockedRuntime>,
     bridges: &HostBridgesInfo,
 ) -> anyhow::Result<String> {
+    render_compose_in(
+        consts::data_dir(),
+        project_name,
+        project_dir,
+        resolved_config,
+        integrations,
+        runtime,
+        bridges,
+    )
+}
+
+/// Env-free core of [`render_compose`]: every data-dir-rooted path is derived
+/// from the explicit `data_dir`, so tests pass a tempdir and never touch the
+/// production `~/.speedwave`. The public no-arg shim resolves `data_dir()` from
+/// the global singleton at the call site.
+pub fn render_compose_in(
+    data_dir: &Path,
+    project_name: &str,
+    project_dir: &str,
+    resolved_config: &ResolvedClaudeConfig,
+    integrations: &ResolvedIntegrationsConfig,
+    runtime: Option<&crate::runtime::LockedRuntime>,
+    bridges: &HostBridgesInfo,
+) -> anyhow::Result<String> {
     crate::validation::validate_project_name(project_name)?;
     // Windows: WSL adapter IP can drift; re-detect before it lands in extra_hosts.
     #[cfg(target_os = "windows")]
     invalidate_host_addressing_cache();
-    let data_dir = consts::data_dir();
-    let tokens_dir = resolve_tokens_dir(project_name);
+    let tokens_dir = resolve_tokens_dir_in(data_dir, project_name);
     let claude_home = crate::claude_home::claude_home_dir(data_dir, project_name);
     let resources_dir = data_dir.join("claude-resources");
     let network_name = format!("{}_{}_network", consts::compose_prefix(), project_name);
 
     let port_hub = consts::PORT_BASE;
     let port_worker = consts::PORT_WORKER;
-    let bundle_manifest = bundle::load_current_bundle_manifest()?;
+    let bundle_manifest = resolve_bundle_manifest()?;
 
     let mut yaml = COMPOSE_TEMPLATE.to_string();
     yaml = yaml.replace("${COMPOSE_PREFIX}", consts::compose_prefix());
@@ -167,7 +211,7 @@ pub fn render_compose(
     yaml = inject_claude_env(&yaml, &resolved_config.env)?;
 
     // Handle LLM provider switching
-    yaml = apply_llm_config(&yaml, &resolved_config.llm, project_name)?;
+    yaml = apply_llm_config_in(data_dir, &yaml, &resolved_config.llm, project_name)?;
 
     // Ensure plugin images exist (builds pending and missing) before compose generation.
     // Scoped to plugins enabled for this project — a broken plugin in another project
@@ -205,22 +249,22 @@ pub fn render_compose(
         .as_deref()
         .unwrap_or("anthropic");
     if provider == "anthropic" {
-        yaml = apply_auth_config(&yaml, project_name)?;
+        yaml = apply_auth_config_in(&yaml, project_name, data_dir)?;
     }
 
     // Inject mcp-os config into hub if auth token exists
-    yaml = apply_mcp_os_config(&yaml)?;
+    yaml = apply_mcp_os_config_in(data_dir, &yaml)?;
 
     // Inject host_exec WORKER URL + token if the worker is running (ADR-054). No-op otherwise.
-    yaml = apply_host_exec_config(&yaml, project_name)?;
+    yaml = apply_host_exec_config_in(data_dir, &yaml, project_name)?;
 
     // Inject oauth worker URL + per-service bearer mount into OAuth-consuming worker
     // containers (today: mcp-sharepoint). No-op if the oauth worker is not running
     // for this project (ADR-060). Hub is NOT touched — the oauth worker is internal.
-    yaml = apply_oauth_config(&yaml, project_name)?;
+    yaml = apply_oauth_config_in(data_dir, &yaml, project_name)?;
 
     // Inject per-worker Bearer auth tokens (SEC-035)
-    yaml = apply_worker_auth_tokens(&yaml, project_name, integrations)?;
+    yaml = apply_worker_auth_tokens_in(data_dir, &yaml, project_name, integrations)?;
 
     // Filter services based on integrations config
     yaml = apply_integrations_filter(&yaml, integrations, &network_name)?;
@@ -268,15 +312,11 @@ pub(crate) fn init_secrets_dir_in(
 
 /// Returns the path where the rendered compose file should be saved.
 pub fn compose_output_path(project: &str) -> anyhow::Result<PathBuf> {
-    crate::validation::validate_project_name(project)?;
-    Ok(consts::data_dir()
-        .join("compose")
-        .join(project)
-        .join("compose.yml"))
+    compose_output_path_in(consts::data_dir(), project)
 }
 
-/// Testable variant: resolves compose output path under an explicit data directory.
-#[cfg(test)]
+/// Resolves the compose output path under an explicit data directory — the
+/// env-free core used by `save_compose_in` and by tests.
 pub fn compose_output_path_in(
     data_dir: &std::path::Path,
     project: &str,
@@ -311,10 +351,17 @@ fn read_back_compose(path: &std::path::Path) -> std::io::Result<String> {
 /// (catches macOS virtiofs lag; no-op on ext4/NTFS). 0o600 because YAML
 /// may carry `ANTHROPIC_AUTH_TOKEN` (ADR-040).
 pub fn save_compose(project: &str, yaml: &str) -> anyhow::Result<()> {
+    save_compose_in(consts::data_dir(), project, yaml)
+}
+
+/// Env-free core of [`save_compose`]: writes the per-project compose file under
+/// an explicit `data_dir` so tests use a tempdir and never write the production
+/// `~/.speedwave`. The public no-arg shim resolves `data_dir()` at the call site.
+pub fn save_compose_in(data_dir: &Path, project: &str, yaml: &str) -> anyhow::Result<()> {
     validate_compose_network_refs(yaml)
         .map_err(|e| anyhow::anyhow!("save_compose: in-memory YAML failed validation: {e}"))?;
 
-    let path = compose_output_path(project)?;
+    let path = compose_output_path_in(data_dir, project)?;
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
@@ -582,7 +629,16 @@ fn inject_host_timezone(yaml: &str, tz: &str) -> anyhow::Result<String> {
         .map_err(|e| anyhow::anyhow!("inject_host_timezone: failed to serialize compose YAML: {e}"))
 }
 
-fn apply_llm_config(yaml: &str, llm: &LlmConfig, project: &str) -> anyhow::Result<String> {
+/// Applies LLM provider switching. Local-LLM token reads resolve under the
+/// explicit `data_dir` so callers (and tests) never touch the production
+/// `~/.speedwave/tokens`. The only caller is `render_compose_in`, which
+/// already threads the data dir.
+fn apply_llm_config_in(
+    data_dir: &Path,
+    yaml: &str,
+    llm: &LlmConfig,
+    project: &str,
+) -> anyhow::Result<String> {
     let provider = llm.provider.as_deref().unwrap_or("anthropic");
     if !crate::config::LOCAL_PROVIDERS.contains(&provider) && provider != "anthropic" {
         anyhow::bail!(
@@ -630,7 +686,7 @@ fn apply_llm_config(yaml: &str, llm: &LlmConfig, project: &str) -> anyhow::Resul
             // servers expect *any* non-empty Bearer).
             const DUMMY_TOKEN: &str = "sk-no-key-required";
             let auth_token = if llm.has_api_key {
-                read_local_llm_token_opt(project, "api_key").unwrap_or_else(|| {
+                read_local_llm_token_opt_in(data_dir, project, "api_key").unwrap_or_else(|| {
                     log::warn!("local-llm api_key flagged but unreadable — using dummy");
                     DUMMY_TOKEN.to_string()
                 })
@@ -671,7 +727,9 @@ fn apply_llm_config(yaml: &str, llm: &LlmConfig, project: &str) -> anyhow::Resul
             // defensively (a stale token file must not smuggle a header that
             // would collide with the `ANTHROPIC_AUTH_TOKEN` Bearer).
             if llm.has_custom_headers {
-                if let Some(headers) = read_local_llm_token_opt(project, "custom_headers") {
+                if let Some(headers) =
+                    read_local_llm_token_opt_in(data_dir, project, "custom_headers")
+                {
                     let flattened = headers
                         .lines()
                         .map(str::trim)
@@ -703,7 +761,12 @@ fn apply_llm_config(yaml: &str, llm: &LlmConfig, project: &str) -> anyhow::Resul
 /// file, I/O error, empty content). Callers decide whether to fall back to
 /// a dummy or skip env injection.
 pub fn read_local_llm_token_opt(project: &str, file: &str) -> Option<String> {
-    let path = tokens_path(project, "local-llm", file).ok()?;
+    read_local_llm_token_opt_in(consts::data_dir().as_path(), project, file)
+}
+
+/// Testable variant: resolves the token file under an explicit data directory.
+pub fn read_local_llm_token_opt_in(data_dir: &Path, project: &str, file: &str) -> Option<String> {
+    let path = tokens_path_in(data_dir, project, "local-llm", file).ok()?;
     let content = std::fs::read_to_string(&path).ok()?;
     let trimmed = content.trim_end_matches(['\n', '\r']).to_string();
     if trimmed.is_empty() {
@@ -1091,12 +1154,7 @@ fn apply_plugins_from_verified(
 /// Claude Code itself inside the `CLAUDE_HOME` bind-mount — Speedwave never
 /// reads or writes them. On the host they live at
 /// `<data_dir>/claude-home/<project>/.claude/.credentials.json`. See ADR-052.
-pub fn apply_auth_config(yaml: &str, project: &str) -> anyhow::Result<String> {
-    apply_auth_config_in(yaml, project, consts::data_dir())
-}
-
-/// Testable variant: resolves the legacy API key path under an explicit
-/// data directory.
+/// Resolves the legacy API key path under an explicit data directory.
 pub(crate) fn apply_auth_config_in(
     yaml: &str,
     project: &str,
@@ -1167,12 +1225,15 @@ fn add_service_env_var(
 ///
 /// Hub reads tokens from `/secrets/` files (auth-tokens.ts), not env vars.
 /// Workers read tokens from env vars. This asymmetry is enforced by `check_no_tokens_in_hub`.
-fn apply_worker_auth_tokens(
+/// Creates the per-project secrets dir under an explicit data dir so render
+/// under a tempdir never writes the global `~/.speedwave/secrets`.
+fn apply_worker_auth_tokens_in(
+    data_dir: &std::path::Path,
     yaml: &str,
     project_name: &str,
     integrations: &ResolvedIntegrationsConfig,
 ) -> anyhow::Result<String> {
-    let secrets_dir = init_secrets_dir(project_name)?;
+    let secrets_dir = init_secrets_dir_in(data_dir, project_name)?;
     let plugins = plugin::list_installed_plugins().unwrap_or_default();
     apply_worker_auth_tokens_with_dir(yaml, &secrets_dir, integrations, &plugins)
 }
@@ -1445,8 +1506,9 @@ fn remove_env_from(doc: &mut serde_yaml_ng::Value, service: &str, env_name: &str
 ///   - /secrets/os-auth-token:ro bind-mount (token as file, not env var)
 ///
 /// Claude container is NOT modified — it only sees the hub.
-fn apply_mcp_os_config(yaml: &str) -> anyhow::Result<String> {
-    let data_dir = consts::data_dir();
+/// Resolves the mcp-os lock/token paths under an explicit data dir so render
+/// under a tempdir never reads the global `~/.speedwave`.
+fn apply_mcp_os_config_in(data_dir: &std::path::Path, yaml: &str) -> anyhow::Result<String> {
     let lock_path = data_dir.join(consts::MCP_OS_LOCK_FILE);
     let token_mount_path = data_dir.join(consts::MCP_OS_AUTH_TOKEN_FILE);
     apply_mcp_os_config_with_path(yaml, &token_mount_path, &lock_path)
@@ -1473,8 +1535,13 @@ fn apply_mcp_os_config_with_path(
 }
 
 /// Injects `WORKER_HOST_EXEC_URL` + bearer-token mount into the hub if the worker is up.
-fn apply_host_exec_config(yaml: &str, project: &str) -> anyhow::Result<String> {
-    let state_dir = crate::host_exec::host_exec_project_dir(consts::data_dir(), project);
+/// Resolves the host_exec state paths under an explicit data dir.
+fn apply_host_exec_config_in(
+    data_dir: &std::path::Path,
+    yaml: &str,
+    project: &str,
+) -> anyhow::Result<String> {
+    let state_dir = crate::host_exec::host_exec_project_dir(data_dir, project);
     let lock_path = state_dir.join(consts::PER_PROJECT_LOCK_FILE);
     let token_mount_path = state_dir.join(consts::HOST_EXEC_AUTH_TOKEN_FILE);
     apply_host_exec_config_with_paths(yaml, &token_mount_path, &lock_path)
@@ -1506,8 +1573,12 @@ fn apply_host_exec_config_with_paths(
 /// Per-service bearer: each consumer gets its own bearer at
 /// `/secrets/oauth-auth-token-<config_key>:ro`. The bearer values come from
 /// `<oauth-state-dir>/.bearer-map.json` (bearer → service).
-fn apply_oauth_config(yaml: &str, project: &str) -> anyhow::Result<String> {
-    let state_dir = crate::oauth_process::oauth_project_dir(consts::data_dir(), project);
+fn apply_oauth_config_in(
+    data_dir: &std::path::Path,
+    yaml: &str,
+    project: &str,
+) -> anyhow::Result<String> {
+    let state_dir = crate::oauth_process::oauth_project_dir(data_dir, project);
     let lock_path = state_dir.join(consts::PER_PROJECT_LOCK_FILE);
     let bearer_map_path = state_dir.join(consts::OAUTH_BEARER_MAP_FILE);
     apply_oauth_config_with_paths(yaml, &state_dir, &lock_path, &bearer_map_path)
@@ -2136,7 +2207,7 @@ impl SecurityExpectedPaths {
     }
 
     pub fn compute(project_name: &str, project_dir: &str) -> anyhow::Result<Self> {
-        let tokens_dir = resolve_tokens_dir(project_name);
+        let tokens_dir = resolve_tokens_dir_in(consts::data_dir(), project_name);
         Ok(Self {
             project_engine_path: to_engine_path(std::path::Path::new(project_dir))?,
             tokens_engine_dir: to_engine_path(&tokens_dir)?,
@@ -3409,6 +3480,51 @@ mod tests {
 
     const SECURITY_RULE_COUNT: usize = 31;
 
+    /// Repo root (workspace dir holding `containers/`, `mcp-servers/`), derived
+    /// from this crate's manifest dir — used as the injected bundle build root
+    /// so manifest resolution never reads the process-global env.
+    fn test_build_root() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(Path::parent)
+            .expect("crate manifest dir has a workspace grandparent")
+            .to_path_buf()
+    }
+
+    /// Isolated `render_compose` for tests: roots every data-dir path at the
+    /// caller's `data_dir` (a tempdir) and resolves the bundle manifest from the
+    /// repo build root via `TEST_BUILD_ROOT` — so the test touches neither the
+    /// production `~/.speedwave` nor the global `SPEEDWAVE_RESOURCES_DIR` env.
+    fn render_compose_isolated(
+        data_dir: &Path,
+        project_name: &str,
+        project_dir: &str,
+        resolved_config: &ResolvedClaudeConfig,
+        integrations: &ResolvedIntegrationsConfig,
+        runtime: Option<&crate::runtime::LockedRuntime>,
+        bridges: &HostBridgesInfo,
+    ) -> anyhow::Result<String> {
+        // RAII guard clears the thread-local on scope exit (even on panic), so a
+        // later test reusing this libtest thread never inherits a stale build root.
+        struct BuildRootGuard;
+        impl Drop for BuildRootGuard {
+            fn drop(&mut self) {
+                TEST_BUILD_ROOT.with(|r| *r.borrow_mut() = None);
+            }
+        }
+        TEST_BUILD_ROOT.with(|r| *r.borrow_mut() = Some(test_build_root()));
+        let _guard = BuildRootGuard;
+        render_compose_in(
+            data_dir,
+            project_name,
+            project_dir,
+            resolved_config,
+            integrations,
+            runtime,
+            bridges,
+        )
+    }
+
     /// Render the same compose template via `render_compose` with a local
     /// LLM provider + multi-line custom_headers token, and check the result
     /// re-parses. This is the production code path; if it diverges from
@@ -3417,6 +3533,7 @@ mod tests {
     #[test]
     #[serial_test::serial(host_addressing)]
     fn render_compose_with_multiline_custom_headers_is_valid_yaml() {
+        let data_dir = tempfile::tempdir().unwrap();
         // Use the same locking pattern as the existing token-touching tests
         // — they share a global `~/.speedwave/tokens` namespace and would
         // otherwise race when run in parallel.
@@ -3425,7 +3542,7 @@ mod tests {
         let _guard = LOCK.lock().unwrap_or_else(|e| e.into_inner());
 
         let project = format!("render-multiline-headers-{}", std::process::id());
-        let tokens_dir = ensure_token_dir(&project, "local-llm")
+        let tokens_dir = ensure_token_dir_in(data_dir.path(), &project, "local-llm")
             .expect("ensure_token_dir must succeed in test env");
         std::fs::write(tokens_dir.join("api_key"), "sk-test-key").unwrap();
         std::fs::write(
@@ -3451,7 +3568,8 @@ mod tests {
         };
         let integrations = ResolvedIntegrationsConfig::default();
 
-        let yaml = render_compose(
+        let yaml = render_compose_isolated(
+            data_dir.path(),
             &project,
             project_dir.to_str().unwrap(),
             &resolved,
@@ -3511,6 +3629,7 @@ mod tests {
     #[test]
     #[serial_test::serial(host_addressing)]
     fn render_compose_quotes_bracketed_model_env_and_round_trips() {
+        let data_dir = tempfile::tempdir().unwrap();
         let project = format!("render-1m-suffix-{}", std::process::id());
         let tmp = tempfile::tempdir().unwrap();
         let project_dir = tmp.path().join("project");
@@ -3531,7 +3650,8 @@ mod tests {
             },
         };
 
-        let yaml = render_compose(
+        let yaml = render_compose_isolated(
+            data_dir.path(),
             &project,
             project_dir.to_str().unwrap(),
             &resolved,
@@ -3589,12 +3709,13 @@ mod tests {
     #[test]
     #[serial_test::serial(host_addressing)]
     fn render_compose_strips_authorization_from_custom_headers() {
+        let data_dir = tempfile::tempdir().unwrap();
         use std::sync::Mutex;
         static LOCK: Mutex<()> = Mutex::new(());
         let _guard = LOCK.lock().unwrap_or_else(|e| e.into_inner());
 
         let project = format!("authz-strip-{}", std::process::id());
-        let tokens_dir = ensure_token_dir(&project, "local-llm")
+        let tokens_dir = ensure_token_dir_in(data_dir.path(), &project, "local-llm")
             .expect("ensure_token_dir must succeed in test env");
         std::fs::write(tokens_dir.join("api_key"), "sk-test").unwrap();
         std::fs::write(
@@ -3618,7 +3739,8 @@ mod tests {
                 has_custom_headers: true,
             },
         };
-        let yaml = render_compose(
+        let yaml = render_compose_isolated(
+            data_dir.path(),
             &project,
             project_dir.to_str().unwrap(),
             &resolved,
@@ -3938,6 +4060,7 @@ networks:
 
     #[test]
     fn test_security_check_missing_cap_drop() {
+        let data_dir = tempfile::tempdir().unwrap();
         let yaml = r#"
 version: "3"
 services:
@@ -3951,7 +4074,13 @@ services:
     environment:
       - CLAUDE_VERSION=1.0.3
 "#;
-        let violations = SecurityCheck::run(yaml, "test", &[], &test_expected_paths());
+        let violations = SecurityCheck::run_with_data_dir(
+            yaml,
+            "test",
+            &[],
+            &test_expected_paths(),
+            data_dir.path(),
+        );
         assert!(violations
             .iter()
             .any(|v| v.rule == SecurityRule::CapDropAll));
@@ -3959,6 +4088,7 @@ services:
 
     #[test]
     fn test_security_check_missing_no_new_privileges() {
+        let data_dir = tempfile::tempdir().unwrap();
         let yaml = r#"
 version: "3"
 services:
@@ -3972,7 +4102,13 @@ services:
     environment:
       - CLAUDE_VERSION=1.0.3
 "#;
-        let violations = SecurityCheck::run(yaml, "test", &[], &test_expected_paths());
+        let violations = SecurityCheck::run_with_data_dir(
+            yaml,
+            "test",
+            &[],
+            &test_expected_paths(),
+            data_dir.path(),
+        );
         assert!(violations
             .iter()
             .any(|v| v.rule == SecurityRule::NoNewPrivs));
@@ -3980,6 +4116,7 @@ services:
 
     #[test]
     fn test_security_check_claude_read_only_missing() {
+        let data_dir = tempfile::tempdir().unwrap();
         let yaml = r#"
 version: "3"
 services:
@@ -3994,7 +4131,13 @@ services:
     environment:
       - CLAUDE_VERSION=1.0.3
 "#;
-        let violations = SecurityCheck::run(yaml, "test", &[], &test_expected_paths());
+        let violations = SecurityCheck::run_with_data_dir(
+            yaml,
+            "test",
+            &[],
+            &test_expected_paths(),
+            data_dir.path(),
+        );
         assert!(violations
             .iter()
             .any(|v| v.rule == SecurityRule::ReadOnlyFs && v.container == "claude"));
@@ -4002,6 +4145,7 @@ services:
 
     #[test]
     fn test_security_check_tmpfs_missing() {
+        let data_dir = tempfile::tempdir().unwrap();
         let yaml = r#"
 version: "3"
 services:
@@ -4015,7 +4159,13 @@ services:
     environment:
       - CLAUDE_VERSION=1.0.3
 "#;
-        let violations = SecurityCheck::run(yaml, "test", &[], &test_expected_paths());
+        let violations = SecurityCheck::run_with_data_dir(
+            yaml,
+            "test",
+            &[],
+            &test_expected_paths(),
+            data_dir.path(),
+        );
         assert!(violations
             .iter()
             .any(|v| v.rule == SecurityRule::TmpfsNoexec));
@@ -4023,6 +4173,7 @@ services:
 
     #[test]
     fn test_security_check_tokens_in_claude() {
+        let data_dir = tempfile::tempdir().unwrap();
         let yaml = r#"
 version: "3"
 services:
@@ -4039,7 +4190,13 @@ services:
       - CLAUDE_VERSION=1.0.3
       - SLACK_TOKEN=xoxb-12345
 "#;
-        let violations = SecurityCheck::run(yaml, "test", &[], &test_expected_paths());
+        let violations = SecurityCheck::run_with_data_dir(
+            yaml,
+            "test",
+            &[],
+            &test_expected_paths(),
+            data_dir.path(),
+        );
         assert!(violations
             .iter()
             .any(|v| v.rule == SecurityRule::NoTokensClaude));
@@ -4047,6 +4204,7 @@ services:
 
     #[test]
     fn test_security_check_ports_not_localhost() {
+        let data_dir = tempfile::tempdir().unwrap();
         let yaml = r#"
 version: "3"
 services:
@@ -4062,7 +4220,13 @@ services:
     ports:
       - "0.0.0.0:4000:4000"
 "#;
-        let violations = SecurityCheck::run(yaml, "test", &[], &test_expected_paths());
+        let violations = SecurityCheck::run_with_data_dir(
+            yaml,
+            "test",
+            &[],
+            &test_expected_paths(),
+            data_dir.path(),
+        );
         assert!(violations
             .iter()
             .any(|v| v.rule == SecurityRule::PortsLocalhost));
@@ -4070,6 +4234,7 @@ services:
 
     #[test]
     fn test_security_check_claude_docker_socket() {
+        let data_dir = tempfile::tempdir().unwrap();
         let yaml = r#"
 version: "3"
 services:
@@ -4087,7 +4252,13 @@ services:
     environment:
       - CLAUDE_VERSION=1.0.3
 "#;
-        let violations = SecurityCheck::run(yaml, "test", &[], &test_expected_paths());
+        let violations = SecurityCheck::run_with_data_dir(
+            yaml,
+            "test",
+            &[],
+            &test_expected_paths(),
+            data_dir.path(),
+        );
         assert!(violations
             .iter()
             .any(|v| v.rule == SecurityRule::NoSocketClaude));
@@ -4095,6 +4266,7 @@ services:
 
     #[test]
     fn test_security_check_external_llm_keys_in_claude() {
+        let data_dir = tempfile::tempdir().unwrap();
         let yaml = r#"
 version: "3"
 services:
@@ -4111,7 +4283,13 @@ services:
       - CLAUDE_VERSION=1.0.3
       - OPENAI_API_KEY=sk-12345
 "#;
-        let violations = SecurityCheck::run(yaml, "test", &[], &test_expected_paths());
+        let violations = SecurityCheck::run_with_data_dir(
+            yaml,
+            "test",
+            &[],
+            &test_expected_paths(),
+            data_dir.path(),
+        );
         assert!(violations
             .iter()
             .any(|v| v.rule == SecurityRule::NoExternalLlmKeysClaude));
@@ -4119,6 +4297,7 @@ services:
 
     #[test]
     fn test_security_check_external_llm_keys_covers_major_providers() {
+        let data_dir = tempfile::tempdir().unwrap();
         // Each prefix on its own line — one violation per leaked key. We assert the
         // rule fires for every major third-party LLM vendor, not just the four
         // originally hard-coded.
@@ -4150,7 +4329,13 @@ services:
       - {key}
 "#
             );
-            let violations = SecurityCheck::run(&yaml, "test", &[], &test_expected_paths());
+            let violations = SecurityCheck::run_with_data_dir(
+                &yaml,
+                "test",
+                &[],
+                &test_expected_paths(),
+                data_dir.path(),
+            );
             assert!(
                 violations
                     .iter()
@@ -4162,8 +4347,14 @@ services:
 
     #[test]
     fn test_security_check_invalid_yaml() {
-        let violations =
-            SecurityCheck::run("not: valid: yaml: [[[", "test", &[], &test_expected_paths());
+        let data_dir = tempfile::tempdir().unwrap();
+        let violations = SecurityCheck::run_with_data_dir(
+            "not: valid: yaml: [[[",
+            "test",
+            &[],
+            &test_expected_paths(),
+            data_dir.path(),
+        );
         assert!(violations
             .iter()
             .any(|v| v.rule == SecurityRule::YamlParseError));
@@ -4172,12 +4363,14 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_render_compose_substitution() {
+        let data_dir = tempfile::tempdir().unwrap();
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
             flags: default_flags(),
             llm: LlmConfig::default(),
         };
-        let result = render_compose(
+        let result = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/home/user/projects/test",
             &config,
@@ -4187,8 +4380,11 @@ services:
         );
         assert!(result.is_ok());
         let yaml = result.unwrap();
-        assert!(yaml.contains("speedwave_test-project_claude"));
-        assert!(yaml.contains("speedwave_test-project_mcp_hub"));
+        // Derive the prefix from the SSOT rather than hardcoding "speedwave",
+        // so the test holds whatever data_dir basename the process resolved.
+        let prefix = consts::compose_prefix();
+        assert!(yaml.contains(&format!("{prefix}_test-project_claude")));
+        assert!(yaml.contains(&format!("{prefix}_test-project_mcp_hub")));
         assert!(yaml.contains("/workspace"));
         // ${CLAUDE_MEMORY} must be substituted with a concrete value (e.g. "8g")
         assert!(
@@ -4208,14 +4404,16 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_render_compose_uses_bundle_scoped_image_refs() {
+        let data_dir = tempfile::tempdir().unwrap();
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
             flags: default_flags(),
             llm: LlmConfig::default(),
         };
-        let manifest = bundle::load_current_bundle_manifest().unwrap();
+        let manifest = bundle::load_current_bundle_manifest_from(&test_build_root()).unwrap();
 
-        let yaml = render_compose(
+        let yaml = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/home/user/projects/test",
             &config,
@@ -4269,12 +4467,14 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_rendered_compose_has_sharepoint_workspace_mount() {
+        let data_dir = tempfile::tempdir().unwrap();
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
             flags: default_flags(),
             llm: LlmConfig::default(),
         };
-        let yaml = render_compose(
+        let yaml = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/home/user/projects/test",
             &config,
@@ -4299,6 +4499,7 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_render_compose_playwright_service_present() {
+        let data_dir = tempfile::tempdir().unwrap();
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
             flags: default_flags(),
@@ -4308,7 +4509,8 @@ services:
             playwright: true,
             ..Default::default()
         };
-        let yaml = render_compose(
+        let yaml = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/home/user/projects/test",
             &config,
@@ -4382,6 +4584,7 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_render_compose_office_no_token_mount_workspace_rw_office_network_only() {
+        let data_dir = tempfile::tempdir().unwrap();
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
             flags: default_flags(),
@@ -4391,7 +4594,8 @@ services:
             office: true,
             ..Default::default()
         };
-        let yaml = render_compose(
+        let yaml = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/home/user/projects/test",
             &config,
@@ -4441,6 +4645,7 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_render_compose_playwright_no_token_mount() {
+        let data_dir = tempfile::tempdir().unwrap();
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
             flags: default_flags(),
@@ -4450,7 +4655,8 @@ services:
             playwright: true,
             ..Default::default()
         };
-        let yaml = render_compose(
+        let yaml = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/home/user/projects/test",
             &config,
@@ -4479,6 +4685,7 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_render_compose_playwright_no_workspace_mount() {
+        let data_dir = tempfile::tempdir().unwrap();
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
             flags: default_flags(),
@@ -4488,7 +4695,8 @@ services:
             playwright: true,
             ..Default::default()
         };
-        let yaml = render_compose(
+        let yaml = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/home/user/projects/test",
             &config,
@@ -4518,6 +4726,7 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_playwright_worker_url_in_hub_env() {
+        let data_dir = tempfile::tempdir().unwrap();
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
             flags: default_flags(),
@@ -4527,7 +4736,8 @@ services:
             playwright: true,
             ..Default::default()
         };
-        let yaml = render_compose(
+        let yaml = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/home/user/projects/test",
             &config,
@@ -4556,6 +4766,7 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_render_compose_github_service_present() {
+        let data_dir = tempfile::tempdir().unwrap();
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
             flags: default_flags(),
@@ -4565,7 +4776,8 @@ services:
             github: true,
             ..Default::default()
         };
-        let yaml = render_compose(
+        let yaml = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/home/user/projects/test",
             &config,
@@ -4650,6 +4862,7 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_github_worker_url_in_hub_env() {
+        let data_dir = tempfile::tempdir().unwrap();
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
             flags: default_flags(),
@@ -4659,7 +4872,8 @@ services:
             github: true,
             ..Default::default()
         };
-        let yaml = render_compose(
+        let yaml = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/home/user/projects/test",
             &config,
@@ -4736,12 +4950,14 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_rendered_compose_has_mcp_hub_port() {
+        let data_dir = tempfile::tempdir().unwrap();
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
             flags: default_flags(),
             llm: LlmConfig::default(),
         };
-        let yaml = render_compose(
+        let yaml = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/home/user/projects/test",
             &config,
@@ -4763,6 +4979,7 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_mcp_hub_port_matches_port_base() {
+        let data_dir = tempfile::tempdir().unwrap();
         // MCP_HUB_PORT in the claude container must equal PORT_BASE (hub port).
         // If these drift apart, entrypoint.sh generates wrong mcp-config.json URL.
         let config = ResolvedClaudeConfig {
@@ -4770,7 +4987,8 @@ services:
             flags: default_flags(),
             llm: LlmConfig::default(),
         };
-        let yaml = render_compose(
+        let yaml = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/home/user/projects/test",
             &config,
@@ -4793,12 +5011,14 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_all_workers_use_port_worker() {
+        let data_dir = tempfile::tempdir().unwrap();
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
             flags: default_flags(),
             llm: LlmConfig::default(),
         };
-        let yaml = render_compose(
+        let yaml = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/home/user/projects/test",
             &config,
@@ -4841,12 +5061,14 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_hub_worker_urls_use_port_worker() {
+        let data_dir = tempfile::tempdir().unwrap();
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
             flags: default_flags(),
             llm: LlmConfig::default(),
         };
-        let yaml = render_compose(
+        let yaml = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/home/user/projects/test",
             &config,
@@ -4943,6 +5165,7 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_mcp_hub_port_survives_inject_claude_env() {
+        let data_dir = tempfile::tempdir().unwrap();
         // Regression: inject_claude_env re-parses YAML via serde_yaml_ng.
         // MCP_HUB_PORT must survive the parse → serialize roundtrip.
         let config = ResolvedClaudeConfig {
@@ -4950,7 +5173,8 @@ services:
             flags: default_flags(),
             llm: LlmConfig::default(),
         };
-        let yaml = render_compose(
+        let yaml = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/home/user/projects/test",
             &config,
@@ -5059,6 +5283,7 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_mcp_hub_port_in_claude_service_env() {
+        let data_dir = tempfile::tempdir().unwrap();
         // Verify MCP_HUB_PORT is specifically in the claude service environment,
         // not somewhere else in the compose file.
         let config = ResolvedClaudeConfig {
@@ -5066,7 +5291,8 @@ services:
             flags: default_flags(),
             llm: LlmConfig::default(),
         };
-        let yaml = render_compose(
+        let yaml = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/home/user/projects/test",
             &config,
@@ -5128,12 +5354,14 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_rendered_compose_passes_security_check() {
+        let data_dir = tempfile::tempdir().unwrap();
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
             flags: default_flags(),
             llm: LlmConfig::default(),
         };
-        let yaml = render_compose(
+        let yaml = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/home/user/projects/test",
             &config,
@@ -5357,6 +5585,7 @@ services:
 
     #[test]
     fn test_security_check_ports_integer_rejected() {
+        let data_dir = tempfile::tempdir().unwrap();
         let yaml = r#"
 version: "3"
 services:
@@ -5372,7 +5601,13 @@ services:
     ports:
       - 4000
 "#;
-        let violations = SecurityCheck::run(yaml, "test", &[], &test_expected_paths());
+        let violations = SecurityCheck::run_with_data_dir(
+            yaml,
+            "test",
+            &[],
+            &test_expected_paths(),
+            data_dir.path(),
+        );
         assert!(
             violations
                 .iter()
@@ -5383,6 +5618,7 @@ services:
 
     #[test]
     fn test_security_check_ports_long_form_no_host_ip() {
+        let data_dir = tempfile::tempdir().unwrap();
         let yaml = r#"
 version: "3"
 services:
@@ -5400,7 +5636,13 @@ services:
         published: 4000
         protocol: tcp
 "#;
-        let violations = SecurityCheck::run(yaml, "test", &[], &test_expected_paths());
+        let violations = SecurityCheck::run_with_data_dir(
+            yaml,
+            "test",
+            &[],
+            &test_expected_paths(),
+            data_dir.path(),
+        );
         assert!(
             violations
                 .iter()
@@ -5411,6 +5653,7 @@ services:
 
     #[test]
     fn test_security_check_ports_long_form_with_localhost() {
+        let data_dir = tempfile::tempdir().unwrap();
         let yaml = r#"
 version: "3"
 services:
@@ -5429,7 +5672,13 @@ services:
         host_ip: "127.0.0.1"
         protocol: tcp
 "#;
-        let violations = SecurityCheck::run(yaml, "test", &[], &test_expected_paths());
+        let violations = SecurityCheck::run_with_data_dir(
+            yaml,
+            "test",
+            &[],
+            &test_expected_paths(),
+            data_dir.path(),
+        );
         let port_violations: Vec<_> = violations
             .iter()
             .filter(|v| v.rule == SecurityRule::PortsLocalhost)
@@ -5442,6 +5691,7 @@ services:
 
     #[test]
     fn test_security_check_anthropic_api_key_allowed() {
+        let data_dir = tempfile::tempdir().unwrap();
         let yaml = r#"
 version: "3"
 services:
@@ -5458,7 +5708,13 @@ services:
       - CLAUDE_VERSION=1.0.3
       - ANTHROPIC_API_KEY=sk-ant-12345
 "#;
-        let violations = SecurityCheck::run(yaml, "test", &[], &test_expected_paths());
+        let violations = SecurityCheck::run_with_data_dir(
+            yaml,
+            "test",
+            &[],
+            &test_expected_paths(),
+            data_dir.path(),
+        );
         assert!(
             !violations
                 .iter()
@@ -5470,6 +5726,7 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_render_compose_ollama_provider() {
+        let data_dir = tempfile::tempdir().unwrap();
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
             flags: default_flags(),
@@ -5482,7 +5739,8 @@ services:
                 has_custom_headers: false,
             },
         };
-        let yaml = render_compose(
+        let yaml = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/home/user/projects/test",
             &config,
@@ -5502,6 +5760,7 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_local_provider_requires_model() {
+        let data_dir = tempfile::tempdir().unwrap();
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
             flags: default_flags(),
@@ -5514,7 +5773,8 @@ services:
                 has_custom_headers: false,
             },
         };
-        let result = render_compose(
+        let result = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/home/user/projects/test",
             &config,
@@ -5537,12 +5797,14 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_render_compose_default_anthropic() {
+        let data_dir = tempfile::tempdir().unwrap();
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
             flags: default_flags(),
             llm: LlmConfig::default(), // provider = None → defaults to "anthropic"
         };
-        let yaml = render_compose(
+        let yaml = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/home/user/projects/test",
             &config,
@@ -5597,6 +5859,7 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_ollama_direct_injection() {
+        let data_dir = tempfile::tempdir().unwrap();
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
             flags: default_flags(),
@@ -5609,7 +5872,8 @@ services:
                 has_custom_headers: false,
             },
         };
-        let yaml = render_compose(
+        let yaml = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/home/user/projects/test",
             &config,
@@ -5679,6 +5943,7 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_lmstudio_default_url() {
+        let data_dir = tempfile::tempdir().unwrap();
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
             flags: default_flags(),
@@ -5691,7 +5956,8 @@ services:
                 has_custom_headers: false,
             },
         };
-        let yaml = render_compose(
+        let yaml = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/home/user/projects/test",
             &config,
@@ -5714,6 +5980,7 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_llamacpp_default_url() {
+        let data_dir = tempfile::tempdir().unwrap();
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
             flags: default_flags(),
@@ -5726,7 +5993,8 @@ services:
                 has_custom_headers: false,
             },
         };
-        let yaml = render_compose(
+        let yaml = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/home/user/projects/test",
             &config,
@@ -5749,6 +6017,7 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_unsupported_provider_rejected() {
+        let data_dir = tempfile::tempdir().unwrap();
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
             flags: default_flags(),
@@ -5761,7 +6030,8 @@ services:
                 has_custom_headers: false,
             },
         };
-        let result = render_compose(
+        let result = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/home/user/projects/test",
             &config,
@@ -5780,6 +6050,7 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_custom_provider_rejected_after_removal() {
+        let data_dir = tempfile::tempdir().unwrap();
         // Regression guard: the `custom` provider value was removed end-to-end.
         // Any lingering config that still sets `provider = "custom"` must now
         // fall through to the same unknown-provider path used by any other
@@ -5796,7 +6067,8 @@ services:
                 has_custom_headers: false,
             },
         };
-        let result = render_compose(
+        let result = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/home/user/projects/test",
             &config,
@@ -5832,6 +6104,7 @@ services:
 
     #[test]
     fn test_idempotent_render() {
+        let data_dir = tempfile::tempdir().unwrap();
         let llm = LlmConfig {
             provider: Some("ollama".to_string()),
             model: Some("llama3.3".to_string()),
@@ -5840,8 +6113,9 @@ services:
             has_api_key: false,
             has_custom_headers: false,
         };
-        let result1 = apply_llm_config(COMPOSE_TEMPLATE, &llm, "test-project").unwrap();
-        let result2 = apply_llm_config(&result1, &llm, "test-project").unwrap();
+        let result1 =
+            apply_llm_config_in(data_dir.path(), COMPOSE_TEMPLATE, &llm, "test-project").unwrap();
+        let result2 = apply_llm_config_in(data_dir.path(), &result1, &llm, "test-project").unwrap();
         assert_eq!(
             result1, result2,
             "apply_llm_config must be idempotent (no UUID injection)"
@@ -5943,7 +6217,6 @@ services:
     }
 
     #[test]
-    #[serial_test::serial(host_addressing)]
     fn compose_template_claude_has_canonical_host_gateway_entry() {
         // Static template guard — `claude` and `mcp-playwright` must list the
         // canonical host gateway alias in extra_hosts (ADR-062). Other services
@@ -6198,6 +6471,7 @@ services:
 
     #[test]
     fn test_anthropic_with_model_injects_anthropic_model_env() {
+        let data_dir = tempfile::tempdir().unwrap();
         // Settings → LLM Provider → Model dropdown writes the chosen value
         // into claude.llm.model. compose must translate that into the
         // ANTHROPIC_MODEL env var so Claude Code respects the user's pick
@@ -6211,7 +6485,8 @@ services:
             has_api_key: false,
             has_custom_headers: false,
         };
-        let rendered = apply_llm_config(COMPOSE_TEMPLATE, &llm, "test-project").unwrap();
+        let rendered =
+            apply_llm_config_in(data_dir.path(), COMPOSE_TEMPLATE, &llm, "test-project").unwrap();
         let env = get_claude_env(&rendered);
         assert!(
             env.iter().any(|e| e == "ANTHROPIC_MODEL=claude-sonnet-4-6"),
@@ -6226,6 +6501,7 @@ services:
 
     #[test]
     fn test_anthropic_without_model_does_not_inject_anthropic_model() {
+        let data_dir = tempfile::tempdir().unwrap();
         // Empty/unset model = "let Claude Code pick its default". compose
         // must keep base_env() free of ANTHROPIC_MODEL so the fallback path
         // documented in defaults.rs::base_env_does_not_set_model holds.
@@ -6237,7 +6513,8 @@ services:
             has_api_key: false,
             has_custom_headers: false,
         };
-        let rendered = apply_llm_config(COMPOSE_TEMPLATE, &llm, "test-project").unwrap();
+        let rendered =
+            apply_llm_config_in(data_dir.path(), COMPOSE_TEMPLATE, &llm, "test-project").unwrap();
         let env = get_claude_env(&rendered);
         assert!(
             !env.iter().any(|e| e.starts_with("ANTHROPIC_MODEL=")),
@@ -6254,8 +6531,13 @@ services:
             has_api_key: false,
             has_custom_headers: false,
         };
-        let rendered_blank =
-            apply_llm_config(COMPOSE_TEMPLATE, &llm_blank, "test-project").unwrap();
+        let rendered_blank = apply_llm_config_in(
+            data_dir.path(),
+            COMPOSE_TEMPLATE,
+            &llm_blank,
+            "test-project",
+        )
+        .unwrap();
         let env_blank = get_claude_env(&rendered_blank);
         assert!(
             !env_blank.iter().any(|e| e.starts_with("ANTHROPIC_MODEL=")),
@@ -6265,6 +6547,7 @@ services:
 
     #[test]
     fn test_anthropic_injects_default_alias_env_vars() {
+        let data_dir = tempfile::tempdir().unwrap();
         // Workaround for anthropics/claude-code#34083 — without
         // ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU}_MODEL pointing to the
         // `[1m]` variant, Max/Team subscribers see their 1M models capped
@@ -6279,7 +6562,8 @@ services:
             has_api_key: false,
             has_custom_headers: false,
         };
-        let rendered = apply_llm_config(COMPOSE_TEMPLATE, &llm, "test-project").unwrap();
+        let rendered =
+            apply_llm_config_in(data_dir.path(), COMPOSE_TEMPLATE, &llm, "test-project").unwrap();
         let env = get_claude_env(&rendered);
 
         let expected = crate::defaults::anthropic_default_models_env();
@@ -6298,6 +6582,7 @@ services:
 
     #[test]
     fn test_switching_provider_ollama_to_anthropic() {
+        let data_dir = tempfile::tempdir().unwrap();
         let llm_ollama = LlmConfig {
             provider: Some("ollama".to_string()),
             model: Some("llama3.3".to_string()),
@@ -6308,9 +6593,20 @@ services:
         };
         let llm_anthropic = LlmConfig::default();
 
-        let with_ollama = apply_llm_config(COMPOSE_TEMPLATE, &llm_ollama, "test-project").unwrap();
-        let with_anthropic =
-            apply_llm_config(COMPOSE_TEMPLATE, &llm_anthropic, "test-project").unwrap();
+        let with_ollama = apply_llm_config_in(
+            data_dir.path(),
+            COMPOSE_TEMPLATE,
+            &llm_ollama,
+            "test-project",
+        )
+        .unwrap();
+        let with_anthropic = apply_llm_config_in(
+            data_dir.path(),
+            COMPOSE_TEMPLATE,
+            &llm_anthropic,
+            "test-project",
+        )
+        .unwrap();
 
         let env_ollama = get_claude_env(&with_ollama);
         let env_anthropic = get_claude_env(&with_anthropic);
@@ -6347,6 +6643,7 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_llamacpp_custom_model_option_labels() {
+        let data_dir = tempfile::tempdir().unwrap();
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
             flags: default_flags(),
@@ -6359,7 +6656,8 @@ services:
                 has_custom_headers: false,
             },
         };
-        let yaml = render_compose(
+        let yaml = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/home/user/projects/test",
             &config,
@@ -6379,6 +6677,7 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_lmstudio_custom_model_option_labels() {
+        let data_dir = tempfile::tempdir().unwrap();
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
             flags: default_flags(),
@@ -6391,7 +6690,8 @@ services:
                 has_custom_headers: false,
             },
         };
-        let yaml = render_compose(
+        let yaml = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/home/user/projects/test",
             &config,
@@ -6411,13 +6711,15 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_render_compose_claude_version_is_pinned() {
+        let data_dir = tempfile::tempdir().unwrap();
         // Regression guard: CLAUDE_VERSION must be the pinned semver from defaults.
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
             flags: default_flags(),
             llm: LlmConfig::default(),
         };
-        let result = render_compose(
+        let result = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/home/user/projects/test",
             &config,
@@ -6447,6 +6749,7 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_workspace_mount_is_readwrite() {
+        let data_dir = tempfile::tempdir().unwrap();
         // The workspace must be read-write so Claude can create/edit files.
         // This guards against accidentally adding :ro to the workspace mount.
         let config = ResolvedClaudeConfig {
@@ -6454,7 +6757,8 @@ services:
             flags: default_flags(),
             llm: LlmConfig::default(),
         };
-        let yaml = render_compose(
+        let yaml = render_compose_isolated(
+            data_dir.path(),
             "testproj",
             "/tmp/test",
             &config,
@@ -7341,6 +7645,7 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_render_compose_enables_host_exec_in_hub_when_project_has_it() {
+        let data_dir = tempfile::tempdir().unwrap();
         // End-to-end: render_compose with host_exec enabled puts it in
         // ENABLED_SERVICES. (WORKER_HOST_EXEC_URL is NOT injected here because
         // no worker is running in a test — that's correct: the hub still knows
@@ -7353,7 +7658,8 @@ services:
         };
         let mut integrations = all_enabled_integrations();
         integrations.host_exec = true;
-        let yaml = render_compose(
+        let yaml = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/home/user/projects/test",
             &config,
@@ -7384,6 +7690,7 @@ services:
 
     #[test]
     fn test_security_check_mcp_os_auth_token_forbidden_in_claude() {
+        let data_dir = tempfile::tempdir().unwrap();
         // MCP_OS_AUTH_TOKEN must now trigger a security violation in claude
         // container — it should never be injected there anymore.
         let yaml = r#"
@@ -7402,7 +7709,13 @@ services:
       - CLAUDE_VERSION=1.0.3
       - MCP_OS_AUTH_TOKEN=550e8400-e29b-41d4-a716-446655440000
 "#;
-        let violations = SecurityCheck::run(yaml, "test", &[], &test_expected_paths());
+        let violations = SecurityCheck::run_with_data_dir(
+            yaml,
+            "test",
+            &[],
+            &test_expected_paths(),
+            data_dir.path(),
+        );
         assert!(
             violations
                 .iter()
@@ -7413,6 +7726,7 @@ services:
 
     #[test]
     fn test_security_check_no_tokens_in_hub() {
+        let data_dir = tempfile::tempdir().unwrap();
         // Hub env must not contain TOKEN/KEY/SECRET vars (except WORKER_*_URL).
         let yaml = r#"
 version: "3"
@@ -7431,7 +7745,13 @@ services:
       - WORKER_SLACK_URL=http://mcp-slack:3000
       - SLACK_TOKEN=xoxb-12345
 "#;
-        let violations = SecurityCheck::run(yaml, "test", &[], &test_expected_paths());
+        let violations = SecurityCheck::run_with_data_dir(
+            yaml,
+            "test",
+            &[],
+            &test_expected_paths(),
+            data_dir.path(),
+        );
         assert!(
             violations
                 .iter()
@@ -7442,9 +7762,16 @@ services:
 
     #[test]
     fn test_security_check_hub_worker_urls_allowed() {
+        let data_dir = tempfile::tempdir().unwrap();
         // WORKER_*_URL vars in hub env should pass the security check.
         let yaml = valid_compose_yaml();
-        let violations = SecurityCheck::run(&yaml, "test", &[], &test_expected_paths());
+        let violations = SecurityCheck::run_with_data_dir(
+            &yaml,
+            "test",
+            &[],
+            &test_expected_paths(),
+            data_dir.path(),
+        );
         assert!(
             !violations
                 .iter()
@@ -7455,6 +7782,7 @@ services:
 
     #[test]
     fn test_security_check_missing_user_field() {
+        let data_dir = tempfile::tempdir().unwrap();
         let yaml = r#"
 version: "3"
 services:
@@ -7470,7 +7798,13 @@ services:
     environment:
       - CLAUDE_VERSION=1.0.3
 "#;
-        let violations = SecurityCheck::run(yaml, "test", &[], &test_expected_paths());
+        let violations = SecurityCheck::run_with_data_dir(
+            yaml,
+            "test",
+            &[],
+            &test_expected_paths(),
+            data_dir.path(),
+        );
         assert!(
             violations
                 .iter()
@@ -7481,6 +7815,7 @@ services:
 
     #[test]
     fn test_security_check_wrong_user_value() {
+        let data_dir = tempfile::tempdir().unwrap();
         let yaml = format!(
             r#"
 version: "3"
@@ -7494,7 +7829,13 @@ services:
       - no-new-privileges:true
 "#
         );
-        let violations = SecurityCheck::run(&yaml, "test", &[], &test_expected_paths());
+        let violations = SecurityCheck::run_with_data_dir(
+            &yaml,
+            "test",
+            &[],
+            &test_expected_paths(),
+            data_dir.path(),
+        );
         assert!(
             violations
                 .iter()
@@ -7505,6 +7846,7 @@ services:
 
     #[test]
     fn test_security_check_correct_user_passes() {
+        let data_dir = tempfile::tempdir().unwrap();
         let yaml = format!(
             r#"
 version: "3"
@@ -7519,7 +7861,13 @@ services:
 "#,
             user = container_user()
         );
-        let violations = SecurityCheck::run(&yaml, "test", &[], &test_expected_paths());
+        let violations = SecurityCheck::run_with_data_dir(
+            &yaml,
+            "test",
+            &[],
+            &test_expected_paths(),
+            data_dir.path(),
+        );
         assert!(
             !violations
                 .iter()
@@ -7547,6 +7895,7 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_render_compose_contains_ide_lock_mount() {
+        let data_dir = tempfile::tempdir().unwrap();
         // render_compose must substitute ${IDE_LOCK_DIR} so the claude container
         // has the ide-bridge directory mounted as /home/speedwave/.claude/ide:ro.
         // Read-only — container only reads the lock file; Speedwave host writes it.
@@ -7555,7 +7904,8 @@ services:
             flags: default_flags(),
             llm: LlmConfig::default(),
         };
-        let yaml = render_compose(
+        let yaml = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/home/user/projects/test",
             &config,
@@ -7615,12 +7965,14 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_render_compose_substitutes_container_user() {
+        let data_dir = tempfile::tempdir().unwrap();
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
             flags: vec![],
             llm: crate::config::LlmConfig::default(),
         };
-        let result = render_compose(
+        let result = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/workspace",
             &config,
@@ -7648,12 +8000,14 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_render_compose_substitutes_host_gateway() {
+        let data_dir = tempfile::tempdir().unwrap();
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
             flags: vec![],
             llm: crate::config::LlmConfig::default(),
         };
-        let result = render_compose(
+        let result = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/workspace",
             &config,
@@ -7685,12 +8039,14 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_render_compose_substitutes_ide_host_override() {
+        let data_dir = tempfile::tempdir().unwrap();
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
             flags: vec![],
             llm: crate::config::LlmConfig::default(),
         };
-        let result = render_compose(
+        let result = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/workspace",
             &config,
@@ -7729,13 +8085,15 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_claude_env_has_ide_host_override() {
+        let data_dir = tempfile::tempdir().unwrap();
         // CLAUDE_CODE_IDE_HOST_OVERRIDE must be in the claude service environment.
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
             flags: default_flags(),
             llm: LlmConfig::default(),
         };
-        let yaml = render_compose(
+        let yaml = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/home/user/projects/test",
             &config,
@@ -7766,12 +8124,14 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_claude_env_has_no_flicker() {
+        let data_dir = tempfile::tempdir().unwrap();
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
             flags: default_flags(),
             llm: LlmConfig::default(),
         };
-        let yaml = render_compose(
+        let yaml = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/home/user/projects/test",
             &config,
@@ -7802,12 +8162,14 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_claude_env_has_effort_level() {
+        let data_dir = tempfile::tempdir().unwrap();
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
             flags: default_flags(),
             llm: LlmConfig::default(),
         };
-        let yaml = render_compose(
+        let yaml = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/home/user/projects/test",
             &config,
@@ -7847,6 +8209,7 @@ services:
 
     #[test]
     fn test_security_no_ports_on_each_worker() {
+        let data_dir = tempfile::tempdir().unwrap();
         for name in [
             "claude",
             "mcp-hub",
@@ -7869,7 +8232,13 @@ services:
       - "127.0.0.1:4000:4000"
 "#
             );
-            let violations = SecurityCheck::run(&yaml, "test", &[], &test_expected_paths());
+            let violations = SecurityCheck::run_with_data_dir(
+                &yaml,
+                "test",
+                &[],
+                &test_expected_paths(),
+                data_dir.path(),
+            );
             assert!(
                 violations
                     .iter()
@@ -7881,6 +8250,7 @@ services:
 
     #[test]
     fn test_security_worker_without_ports_passes() {
+        let data_dir = tempfile::tempdir().unwrap();
         let yaml = r#"
 version: "3"
 services:
@@ -7893,7 +8263,13 @@ services:
     environment:
       - PORT=3000
 "#;
-        let violations = SecurityCheck::run(yaml, "test", &[], &test_expected_paths());
+        let violations = SecurityCheck::run_with_data_dir(
+            yaml,
+            "test",
+            &[],
+            &test_expected_paths(),
+            data_dir.path(),
+        );
         assert!(
             !violations
                 .iter()
@@ -7923,6 +8299,7 @@ services:
 
     #[test]
     fn test_security_addon_service_ports_allowed() {
+        let data_dir = tempfile::tempdir().unwrap();
         let yaml = r#"
 version: "3"
 services:
@@ -7935,7 +8312,13 @@ services:
     ports:
       - "127.0.0.1:4006:4006"
 "#;
-        let violations = SecurityCheck::run(yaml, "test", &[], &test_expected_paths());
+        let violations = SecurityCheck::run_with_data_dir(
+            yaml,
+            "test",
+            &[],
+            &test_expected_paths(),
+            data_dir.path(),
+        );
         assert!(
             !violations
                 .iter()
@@ -7947,13 +8330,15 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_render_compose_rejects_invalid_project_name() {
+        let data_dir = tempfile::tempdir().unwrap();
         let resolved = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
             flags: default_flags(),
             llm: LlmConfig::default(),
         };
         let integrations = ResolvedIntegrationsConfig::default();
-        assert!(render_compose(
+        assert!(render_compose_isolated(
+            data_dir.path(),
             "",
             "/tmp/proj",
             &resolved,
@@ -7962,7 +8347,8 @@ services:
             &HostBridgesInfo::default()
         )
         .is_err());
-        assert!(render_compose(
+        assert!(render_compose_isolated(
+            data_dir.path(),
             "../evil",
             "/tmp/proj",
             &resolved,
@@ -7971,7 +8357,8 @@ services:
             &HostBridgesInfo::default()
         )
         .is_err());
-        assert!(render_compose(
+        assert!(render_compose_isolated(
+            data_dir.path(),
             &"a".repeat(64),
             "/tmp/proj",
             &resolved,
@@ -7984,9 +8371,10 @@ services:
 
     #[test]
     fn test_init_secrets_dir_rejects_invalid_name() {
-        assert!(init_secrets_dir("").is_err());
-        assert!(init_secrets_dir("../evil").is_err());
-        assert!(init_secrets_dir(&"a".repeat(64)).is_err());
+        let data_dir = tempfile::tempdir().unwrap();
+        assert!(init_secrets_dir_in(data_dir.path(), "").is_err());
+        assert!(init_secrets_dir_in(data_dir.path(), "../evil").is_err());
+        assert!(init_secrets_dir_in(data_dir.path(), &"a".repeat(64)).is_err());
     }
 
     #[cfg(unix)]
@@ -8027,9 +8415,10 @@ services:
 
     #[test]
     fn test_compose_output_path_rejects_invalid_name() {
-        assert!(compose_output_path("").is_err());
-        assert!(compose_output_path("../evil").is_err());
-        assert!(compose_output_path(&"a".repeat(64)).is_err());
+        let data_dir = tempfile::tempdir().unwrap();
+        assert!(compose_output_path_in(data_dir.path(), "").is_err());
+        assert!(compose_output_path_in(data_dir.path(), "../evil").is_err());
+        assert!(compose_output_path_in(data_dir.path(), &"a".repeat(64)).is_err());
     }
 
     #[test]
@@ -8265,6 +8654,7 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_render_compose_with_mixed_enabled_disabled_end_to_end() {
+        let data_dir = tempfile::tempdir().unwrap();
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
             flags: default_flags(),
@@ -8278,7 +8668,8 @@ services:
         // slack, redmine remain disabled (default)
         // os_reminders, os_mail, os_notes remain disabled (default)
 
-        let result = render_compose(
+        let result = render_compose_isolated(
+            data_dir.path(),
             "test-e2e",
             "/home/user/projects/test",
             &config,
@@ -8481,6 +8872,7 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_render_compose_all_services_have_container_user() {
+        let data_dir = tempfile::tempdir().unwrap();
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
             flags: vec![],
@@ -8499,7 +8891,8 @@ services:
             context7: true,
             ..ResolvedIntegrationsConfig::default()
         };
-        let result = render_compose(
+        let result = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/workspace",
             &config,
@@ -8531,6 +8924,7 @@ services:
 
     #[test]
     fn test_security_check_plugin_no_privileged() {
+        let data_dir = tempfile::tempdir().unwrap();
         let yaml = format!(
             r#"
 version: "3"
@@ -8548,7 +8942,13 @@ services:
 "#,
             user = container_user()
         );
-        let violations = SecurityCheck::run(&yaml, "test", &[], &test_expected_paths());
+        let violations = SecurityCheck::run_with_data_dir(
+            &yaml,
+            "test",
+            &[],
+            &test_expected_paths(),
+            data_dir.path(),
+        );
         assert!(
             violations
                 .iter()
@@ -8559,6 +8959,7 @@ services:
 
     #[test]
     fn test_security_check_plugin_no_host_network() {
+        let data_dir = tempfile::tempdir().unwrap();
         let yaml = format!(
             r#"
 version: "3"
@@ -8576,7 +8977,13 @@ services:
 "#,
             user = container_user()
         );
-        let violations = SecurityCheck::run(&yaml, "test", &[], &test_expected_paths());
+        let violations = SecurityCheck::run_with_data_dir(
+            &yaml,
+            "test",
+            &[],
+            &test_expected_paths(),
+            data_dir.path(),
+        );
         assert!(
             violations.iter().any(
                 |v| v.rule == SecurityRule::PluginNoHostNetwork && v.container == "mcp-presale"
@@ -8641,6 +9048,7 @@ services:
 
     #[test]
     fn test_security_check_plugin_no_extra_volumes() {
+        let data_dir = tempfile::tempdir().unwrap();
         let yaml = format!(
             r#"
 version: "3"
@@ -8662,7 +9070,13 @@ services:
             user = container_user()
         );
         let manifests = vec![test_presale_manifest(plugin::TokenMount::ReadOnly)];
-        let violations = SecurityCheck::run(&yaml, "test", &manifests, &test_expected_paths());
+        let violations = SecurityCheck::run_with_data_dir(
+            &yaml,
+            "test",
+            &manifests,
+            &test_expected_paths(),
+            data_dir.path(),
+        );
         assert!(
             violations
                 .iter()
@@ -8674,9 +9088,16 @@ services:
 
     #[test]
     fn test_security_check_plugin_no_extra_volumes_clean() {
+        let data_dir = tempfile::tempdir().unwrap();
         let yaml = valid_plugin_yaml("ro");
         let manifests = vec![test_presale_manifest(plugin::TokenMount::ReadOnly)];
-        let violations = SecurityCheck::run(&yaml, "test", &manifests, &test_expected_paths());
+        let violations = SecurityCheck::run_with_data_dir(
+            &yaml,
+            "test",
+            &manifests,
+            &test_expected_paths(),
+            data_dir.path(),
+        );
         assert!(
             !violations
                 .iter()
@@ -8687,9 +9108,16 @@ services:
 
     #[test]
     fn test_security_check_plugin_token_mount_mode_ro_violation() {
+        let data_dir = tempfile::tempdir().unwrap();
         let yaml = valid_plugin_yaml("rw");
         let manifests = vec![test_presale_manifest(plugin::TokenMount::ReadOnly)];
-        let violations = SecurityCheck::run(&yaml, "test", &manifests, &test_expected_paths());
+        let violations = SecurityCheck::run_with_data_dir(
+            &yaml,
+            "test",
+            &manifests,
+            &test_expected_paths(),
+            data_dir.path(),
+        );
         assert!(
             violations
                 .iter()
@@ -8701,11 +9129,18 @@ services:
 
     #[test]
     fn test_security_check_plugin_token_mount_mode_rw_pass() {
+        let data_dir = tempfile::tempdir().unwrap();
         let yaml = valid_plugin_yaml("rw");
         let manifests = vec![test_presale_manifest(plugin::TokenMount::ReadWrite {
             justification: "OAuth token refresh".to_string(),
         })];
-        let violations = SecurityCheck::run(&yaml, "test", &manifests, &test_expected_paths());
+        let violations = SecurityCheck::run_with_data_dir(
+            &yaml,
+            "test",
+            &manifests,
+            &test_expected_paths(),
+            data_dir.path(),
+        );
         assert!(
             !violations
                 .iter()
@@ -8716,6 +9151,7 @@ services:
 
     #[test]
     fn test_security_check_plugin_workspace_path_mismatch() {
+        let data_dir = tempfile::tempdir().unwrap();
         let yaml = format!(
             r#"
 version: "3"
@@ -8738,7 +9174,13 @@ services:
             user = container_user()
         );
         let manifests = vec![test_presale_manifest(plugin::TokenMount::ReadOnly)];
-        let violations = SecurityCheck::run(&yaml, "test", &manifests, &test_expected_paths());
+        let violations = SecurityCheck::run_with_data_dir(
+            &yaml,
+            "test",
+            &manifests,
+            &test_expected_paths(),
+            data_dir.path(),
+        );
         assert!(
             violations
                 .iter()
@@ -8749,6 +9191,7 @@ services:
 
     #[test]
     fn test_security_check_plugin_workspace_mount_mode_ro() {
+        let data_dir = tempfile::tempdir().unwrap();
         let yaml = format!(
             r#"
 version: "3"
@@ -8771,7 +9214,13 @@ services:
             user = container_user()
         );
         let manifests = vec![test_presale_manifest(plugin::TokenMount::ReadOnly)];
-        let violations = SecurityCheck::run(&yaml, "test", &manifests, &test_expected_paths());
+        let violations = SecurityCheck::run_with_data_dir(
+            &yaml,
+            "test",
+            &manifests,
+            &test_expected_paths(),
+            data_dir.path(),
+        );
         assert!(
             violations
                 .iter()
@@ -8782,6 +9231,7 @@ services:
 
     #[test]
     fn test_security_check_plugin_token_path_mismatch() {
+        let data_dir = tempfile::tempdir().unwrap();
         let yaml = format!(
             r#"
 version: "3"
@@ -8804,7 +9254,13 @@ services:
             user = container_user()
         );
         let manifests = vec![test_presale_manifest(plugin::TokenMount::ReadOnly)];
-        let violations = SecurityCheck::run(&yaml, "test", &manifests, &test_expected_paths());
+        let violations = SecurityCheck::run_with_data_dir(
+            &yaml,
+            "test",
+            &manifests,
+            &test_expected_paths(),
+            data_dir.path(),
+        );
         assert!(
             violations
                 .iter()
@@ -8815,6 +9271,7 @@ services:
 
     #[test]
     fn test_security_check_plugin_volume_long_form() {
+        let data_dir = tempfile::tempdir().unwrap();
         let yaml = format!(
             r#"
 version: "3"
@@ -8838,7 +9295,13 @@ services:
             user = container_user()
         );
         let manifests = vec![test_presale_manifest(plugin::TokenMount::ReadOnly)];
-        let violations = SecurityCheck::run(&yaml, "test", &manifests, &test_expected_paths());
+        let violations = SecurityCheck::run_with_data_dir(
+            &yaml,
+            "test",
+            &manifests,
+            &test_expected_paths(),
+            data_dir.path(),
+        );
         assert!(
             violations
                 .iter()
@@ -8849,9 +9312,16 @@ services:
 
     #[test]
     fn test_security_check_plugin_manifest_missing() {
+        let data_dir = tempfile::tempdir().unwrap();
         let yaml = valid_plugin_yaml("ro");
         // Pass empty manifests — should detect missing manifest
-        let violations = SecurityCheck::run(&yaml, "test", &[], &test_expected_paths());
+        let violations = SecurityCheck::run_with_data_dir(
+            &yaml,
+            "test",
+            &[],
+            &test_expected_paths(),
+            data_dir.path(),
+        );
         assert!(
             violations
                 .iter()
@@ -9089,6 +9559,7 @@ services:
 
     #[test]
     fn test_security_check_sharepoint_correct_mounts_pass() {
+        let data_dir = tempfile::tempdir().unwrap();
         // ADR-060 / PR3: SharePoint tokens mount is :ro (refresh is delegated to
         // the host-side `oauth` worker). The legacy :rw mount is now a violation
         // — see `test_security_check_sharepoint_rw_now_violates`.
@@ -9112,7 +9583,8 @@ services:
             user = container_user()
         );
         let paths = test_expected_paths();
-        let violations = SecurityCheck::run(&yaml, "test", &[], &paths);
+        let violations =
+            SecurityCheck::run_with_data_dir(&yaml, "test", &[], &paths, data_dir.path());
         let sp_violations: Vec<_> = violations
             .iter()
             .filter(|v| v.rule.is_sharepoint())
@@ -9126,6 +9598,7 @@ services:
 
     #[test]
     fn test_security_check_sharepoint_with_oauth_bearer_mount_passes() {
+        let data_dir = tempfile::tempdir().unwrap();
         // After ADR-060, SharePoint additionally mounts its per-service oauth
         // bearer at `/secrets/oauth-auth-token-sharepoint:ro`. Verify the
         // SharepointNoExtraVolumes allowlist accepts it.
@@ -9150,7 +9623,8 @@ services:
             user = container_user()
         );
         let paths = test_expected_paths();
-        let violations = SecurityCheck::run(&yaml, "test", &[], &paths);
+        let violations =
+            SecurityCheck::run_with_data_dir(&yaml, "test", &[], &paths, data_dir.path());
         let sp_violations: Vec<_> = violations
             .iter()
             .filter(|v| v.rule.is_sharepoint())
@@ -9164,6 +9638,7 @@ services:
 
     #[test]
     fn test_security_check_sharepoint_oauth_bearer_must_be_ro() {
+        let data_dir = tempfile::tempdir().unwrap();
         // ADR-060 / extra_allowed_ro_targets logic: oauth bearer mount must be :ro.
         // A `:rw` mount on that path should fail SharepointNoExtraVolumes.
         let yaml = format!(
@@ -9187,7 +9662,8 @@ services:
             user = container_user()
         );
         let paths = test_expected_paths();
-        let violations = SecurityCheck::run(&yaml, "test", &[], &paths);
+        let violations =
+            SecurityCheck::run_with_data_dir(&yaml, "test", &[], &paths, data_dir.path());
         assert!(
             violations
                 .iter()
@@ -9198,6 +9674,7 @@ services:
 
     #[test]
     fn test_security_check_sharepoint_unrecognised_secret_mount_rejected() {
+        let data_dir = tempfile::tempdir().unwrap();
         // A `/secrets/` mount with a path that is NOT in extra_allowed_ro_targets
         // (e.g. an attempt to mount another service's bearer) must be rejected.
         let yaml = format!(
@@ -9221,7 +9698,8 @@ services:
             user = container_user()
         );
         let paths = test_expected_paths();
-        let violations = SecurityCheck::run(&yaml, "test", &[], &paths);
+        let violations =
+            SecurityCheck::run_with_data_dir(&yaml, "test", &[], &paths, data_dir.path());
         assert!(
             violations
                 .iter()
@@ -9232,6 +9710,7 @@ services:
 
     #[test]
     fn test_security_check_sharepoint_rw_now_violates() {
+        let data_dir = tempfile::tempdir().unwrap();
         // Verifies that the legacy :rw mount (ADR-009) is rejected after the
         // ADR-060 migration: SharePoint no longer needs to write to /tokens.
         let yaml = format!(
@@ -9254,7 +9733,8 @@ services:
             user = container_user()
         );
         let paths = test_expected_paths();
-        let violations = SecurityCheck::run(&yaml, "test", &[], &paths);
+        let violations =
+            SecurityCheck::run_with_data_dir(&yaml, "test", &[], &paths, data_dir.path());
         // ADR-060/PR3 removed `SharepointTokenMountMode`; the universal
         // `PluginTokenMountMode` rule (re-used for built-in workers) is now
         // what catches a SharePoint `:rw` regression.
@@ -9269,6 +9749,7 @@ services:
 
     #[test]
     fn test_security_check_sharepoint_missing_workspace_mount() {
+        let data_dir = tempfile::tempdir().unwrap();
         let yaml = format!(
             r#"
 version: "3"
@@ -9288,7 +9769,8 @@ services:
             user = container_user()
         );
         let paths = test_expected_paths();
-        let violations = SecurityCheck::run(&yaml, "test", &[], &paths);
+        let violations =
+            SecurityCheck::run_with_data_dir(&yaml, "test", &[], &paths, data_dir.path());
         assert!(
             violations
                 .iter()
@@ -9299,6 +9781,7 @@ services:
 
     #[test]
     fn test_security_check_sharepoint_workspace_path_mismatch() {
+        let data_dir = tempfile::tempdir().unwrap();
         let yaml = format!(
             r#"
 version: "3"
@@ -9319,7 +9802,8 @@ services:
             user = container_user()
         );
         let paths = test_expected_paths();
-        let violations = SecurityCheck::run(&yaml, "test", &[], &paths);
+        let violations =
+            SecurityCheck::run_with_data_dir(&yaml, "test", &[], &paths, data_dir.path());
         assert!(
             violations
                 .iter()
@@ -9330,6 +9814,7 @@ services:
 
     #[test]
     fn test_security_check_sharepoint_workspace_mount_mode_ro() {
+        let data_dir = tempfile::tempdir().unwrap();
         let yaml = format!(
             r#"
 version: "3"
@@ -9350,7 +9835,8 @@ services:
             user = container_user()
         );
         let paths = test_expected_paths();
-        let violations = SecurityCheck::run(&yaml, "test", &[], &paths);
+        let violations =
+            SecurityCheck::run_with_data_dir(&yaml, "test", &[], &paths, data_dir.path());
         assert!(
             violations
                 .iter()
@@ -10411,6 +10897,7 @@ networks:
 
     #[test]
     fn test_security_check_plugin_token_ro_when_manifest_rw() {
+        let data_dir = tempfile::tempdir().unwrap();
         use crate::plugin::{PluginManifest, TokenMount};
         let yaml = format!(
             r#"
@@ -10456,7 +10943,13 @@ services:
             host_bridge: None,
             instructions: None,
         };
-        let violations = SecurityCheck::run(&yaml, "test", &[manifest], &test_expected_paths());
+        let violations = SecurityCheck::run_with_data_dir(
+            &yaml,
+            "test",
+            &[manifest],
+            &test_expected_paths(),
+            data_dir.path(),
+        );
         assert!(
             violations
                 .iter()
@@ -10471,6 +10964,7 @@ services:
 
     #[test]
     fn test_security_check_sharepoint_no_extra_volumes() {
+        let data_dir = tempfile::tempdir().unwrap();
         let yaml = format!(
             r#"
 version: "3"
@@ -10489,7 +10983,13 @@ services:
 "#,
             user = container_user()
         );
-        let violations = SecurityCheck::run(&yaml, "test", &[], &test_expected_paths());
+        let violations = SecurityCheck::run_with_data_dir(
+            &yaml,
+            "test",
+            &[],
+            &test_expected_paths(),
+            data_dir.path(),
+        );
         assert!(
             violations
                 .iter()
@@ -11222,12 +11722,14 @@ services:
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_render_compose_propagates_tz_to_all_services() {
+        let data_dir = tempfile::tempdir().unwrap();
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
             flags: default_flags(),
             llm: LlmConfig::default(),
         };
-        let yaml = render_compose(
+        let yaml = render_compose_isolated(
+            data_dir.path(),
             "test-project",
             "/home/user/projects/test",
             &config,
@@ -11310,6 +11812,7 @@ services:
 
     #[test]
     fn test_security_check_oauth_token_allowed() {
+        let data_dir = tempfile::tempdir().unwrap();
         let yaml = r#"
 version: "3"
 services:
@@ -11326,7 +11829,13 @@ services:
       - CLAUDE_VERSION=1.0.3
       - CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-aaaaaaaaaaaaaaaaaaaa
 "#;
-        let violations = SecurityCheck::run(yaml, "test", &[], &test_expected_paths());
+        let violations = SecurityCheck::run_with_data_dir(
+            yaml,
+            "test",
+            &[],
+            &test_expected_paths(),
+            data_dir.path(),
+        );
         assert!(
             !violations
                 .iter()
@@ -11338,6 +11847,7 @@ services:
 
     #[test]
     fn test_security_check_other_token_still_blocked() {
+        let data_dir = tempfile::tempdir().unwrap();
         // Defence-in-depth: allowlist must NOT widen to arbitrary *_TOKEN.
         // MCP_OS_AUTH_TOKEN must remain forbidden in claude container.
         let yaml = r#"
@@ -11356,7 +11866,13 @@ services:
       - CLAUDE_VERSION=1.0.3
       - MCP_OS_AUTH_TOKEN=secret-uuid
 "#;
-        let violations = SecurityCheck::run(yaml, "test", &[], &test_expected_paths());
+        let violations = SecurityCheck::run_with_data_dir(
+            yaml,
+            "test",
+            &[],
+            &test_expected_paths(),
+            data_dir.path(),
+        );
         assert!(
             violations
                 .iter()
@@ -11824,6 +12340,7 @@ services:
 
     #[test]
     fn apply_llm_config_local_provider_renders_with_dummy_when_no_key() {
+        let data_dir = tempfile::tempdir().unwrap();
         let llm = LlmConfig {
             provider: Some("local".to_string()),
             model: Some("my-model".to_string()),
@@ -11832,7 +12349,8 @@ services:
             has_api_key: false,
             has_custom_headers: false,
         };
-        let rendered = apply_llm_config(COMPOSE_TEMPLATE, &llm, "test-project").unwrap();
+        let rendered =
+            apply_llm_config_in(data_dir.path(), COMPOSE_TEMPLATE, &llm, "test-project").unwrap();
         let env = get_claude_env(&rendered);
 
         // Dummy token when has_api_key=false.
@@ -11887,6 +12405,7 @@ services:
 
     #[test]
     fn apply_llm_config_local_uses_default_base_url_when_none() {
+        let data_dir = tempfile::tempdir().unwrap();
         let llm = LlmConfig {
             provider: Some("local".to_string()),
             model: Some("foo".to_string()),
@@ -11895,7 +12414,8 @@ services:
             has_api_key: false,
             has_custom_headers: false,
         };
-        let rendered = apply_llm_config(COMPOSE_TEMPLATE, &llm, "test-project").unwrap();
+        let rendered =
+            apply_llm_config_in(data_dir.path(), COMPOSE_TEMPLATE, &llm, "test-project").unwrap();
         let env = get_claude_env(&rendered);
         let expected = format!("ANTHROPIC_BASE_URL={}", default_base_url("local").unwrap());
         assert!(
@@ -12045,12 +12565,9 @@ services:
     /// abandoned token could silently leak into a future container render.
     #[test]
     fn apply_llm_config_ignores_orphaned_token_when_flag_is_false() {
-        use std::sync::Mutex;
-        static LOCK: Mutex<()> = Mutex::new(());
-        let _guard = LOCK.lock().unwrap();
-
+        let data_dir = tempfile::tempdir().unwrap();
         let project = format!("crash-recovery-{}", std::process::id());
-        let dir = ensure_token_dir(&project, "local-llm")
+        let dir = ensure_token_dir_in(data_dir.path(), &project, "local-llm")
             .expect("ensure_token_dir must succeed in test env");
         let api_key_path = dir.join("api_key");
         // Simulate the orphan: a token written by an interrupted save that
@@ -12067,7 +12584,8 @@ services:
             has_api_key: false,
             has_custom_headers: false,
         };
-        let rendered = apply_llm_config(COMPOSE_TEMPLATE, &llm, &project).unwrap();
+        let rendered =
+            apply_llm_config_in(data_dir.path(), COMPOSE_TEMPLATE, &llm, &project).unwrap();
         let env = get_claude_env(&rendered);
 
         // Critical: dummy, not the orphaned secret.
@@ -12105,15 +12623,9 @@ services:
     ///    regressions that might re-introduce block-literal serialisation).
     #[test]
     fn apply_llm_config_multiline_custom_headers_survives_yaml_roundtrip() {
-        use std::sync::Mutex;
-        // Serialize across test threads — apply_llm_config reads from the
-        // real `tokens_path` which is global state. Each invocation uses a
-        // unique project name so per-project files do not collide.
-        static LOCK: Mutex<()> = Mutex::new(());
-        let _guard = LOCK.lock().unwrap();
-
+        let data_dir = tempfile::tempdir().unwrap();
         let project = format!("custom-headers-roundtrip-{}", std::process::id());
-        let dir = ensure_token_dir(&project, "local-llm")
+        let dir = ensure_token_dir_in(data_dir.path(), &project, "local-llm")
             .expect("ensure_token_dir must succeed in test env");
         let headers_path = dir.join("custom_headers");
         let multiline = "X-Foo: bar\nX-Tenant-ID: acme\nOcp-Apim-Subscription-Key: secret-123";
@@ -12128,7 +12640,8 @@ services:
             has_api_key: false,
             has_custom_headers: true,
         };
-        let rendered = apply_llm_config(COMPOSE_TEMPLATE, &llm, &project).unwrap();
+        let rendered =
+            apply_llm_config_in(data_dir.path(), COMPOSE_TEMPLATE, &llm, &project).unwrap();
 
         // Step 1: the env entry is present as a string.
         let env = get_claude_env(&rendered);
@@ -12318,14 +12831,15 @@ networks:
   speedwave_net:
     driver: bridge
 "#;
-        let err = super::save_compose(&project, yaml).unwrap_err();
+        let data_dir = tempfile::tempdir().unwrap();
+        let err = super::save_compose_in(data_dir.path(), &project, yaml).unwrap_err();
         assert!(
             err.to_string().contains("in-memory YAML failed validation"),
             "expected in-memory diagnostic: {err}"
         );
 
         // Side-effect check: file should NOT have been written.
-        let path = super::compose_output_path(&project).unwrap();
+        let path = super::compose_output_path_in(data_dir.path(), &project).unwrap();
         assert!(
             !path.exists(),
             "compose.yml must not exist after pre-write bail"
@@ -12356,8 +12870,9 @@ networks:
   speedwave_net:
     driver: bridge
 "#;
+        let data_dir = tempfile::tempdir().unwrap();
         super::FORCE_DISK_GARBAGE.with(|c| *c.borrow_mut() = Some(corrupt_yaml.to_string()));
-        let err = super::save_compose(&project, valid_yaml).unwrap_err();
+        let err = super::save_compose_in(data_dir.path(), &project, valid_yaml).unwrap_err();
         assert!(
             err.to_string().contains("disk content failed validation"),
             "expected disk-corruption diagnostic, got: {err}"
@@ -12384,8 +12899,9 @@ networks:
   speedwave_net:
     driver: bridge
 "#;
+        let data_dir = tempfile::tempdir().unwrap();
         super::FORCE_DISK_GARBAGE.with(|c| *c.borrow_mut() = Some(valid_yaml.to_string()));
-        super::save_compose(&project, valid_yaml).unwrap();
+        super::save_compose_in(data_dir.path(), &project, valid_yaml).unwrap();
     }
 
     // ── HostAddressing resolver tests ───────────────────────────────────────

--- a/crates/speedwave-runtime/src/compose.rs
+++ b/crates/speedwave-runtime/src/compose.rs
@@ -484,7 +484,8 @@ fn env_entry_needs_quoting(entry: &str) -> bool {
 /// with `serde_json::to_string`, whose escaping is a valid YAML 1.2
 /// double-quoted scalar (YAML is a JSON superset) — no hand-rolled escaping.
 /// Idempotent: already-quoted entries (those that don't re-parse as a bare
-/// `KEY=VALUE` plain scalar) are left untouched.
+/// `KEY=VALUE` plain scalar) are left untouched. Assumes the renderer emits no
+/// YAML comments inside `environment:` (a same-indent `#` line closes the block).
 fn harden_env_scalar_quoting(yaml: &str) -> anyhow::Result<String> {
     let mut out = String::with_capacity(yaml.len());
     // Indentation (column) of the active `environment:` key, if inside one.
@@ -3534,13 +3535,6 @@ mod tests {
     #[serial_test::serial(host_addressing)]
     fn render_compose_with_multiline_custom_headers_is_valid_yaml() {
         let data_dir = tempfile::tempdir().unwrap();
-        // Use the same locking pattern as the existing token-touching tests
-        // — they share a global `~/.speedwave/tokens` namespace and would
-        // otherwise race when run in parallel.
-        use std::sync::Mutex;
-        static LOCK: Mutex<()> = Mutex::new(());
-        let _guard = LOCK.lock().unwrap_or_else(|e| e.into_inner());
-
         let project = format!("render-multiline-headers-{}", std::process::id());
         let tokens_dir = ensure_token_dir_in(data_dir.path(), &project, "local-llm")
             .expect("ensure_token_dir must succeed in test env");
@@ -3710,10 +3704,6 @@ mod tests {
     #[serial_test::serial(host_addressing)]
     fn render_compose_strips_authorization_from_custom_headers() {
         let data_dir = tempfile::tempdir().unwrap();
-        use std::sync::Mutex;
-        static LOCK: Mutex<()> = Mutex::new(());
-        let _guard = LOCK.lock().unwrap_or_else(|e| e.into_inner());
-
         let project = format!("authz-strip-{}", std::process::id());
         let tokens_dir = ensure_token_dir_in(data_dir.path(), &project, "local-llm")
             .expect("ensure_token_dir must succeed in test env");
@@ -3877,6 +3867,36 @@ mod tests {
         assert!(
             !once.contains("\\\""),
             "no double-escaping of existing quotes"
+        );
+    }
+
+    #[test]
+    fn harden_env_scalar_quoting_reopens_block_for_second_service() {
+        // Two services, each with a bracketed env value separated by the first
+        // service's `networks`/`image` lines: the block must CLOSE after svc-a's
+        // env and RE-OPEN for svc-b's, so both bracketed values get quoted.
+        let yaml = "services:\n  a:\n    environment:\n    \
+                    - MODEL_A=x[1m]\n    image: reg/a:1\n  b:\n    environment:\n    \
+                    - MODEL_B=y[1m]\nnetworks: {}\n";
+        let hardened = harden_env_scalar_quoting(yaml).unwrap();
+        assert!(
+            hardened.contains("- \"MODEL_A=x[1m]\""),
+            "svc-a bracketed entry must be quoted, got:\n{hardened}"
+        );
+        assert!(
+            hardened.contains("- \"MODEL_B=y[1m]\""),
+            "svc-b bracketed entry must be quoted (block re-opened), got:\n{hardened}"
+        );
+        // The intervening non-env line is untouched (block closed before it).
+        assert!(hardened.contains("    image: reg/a:1\n"));
+        let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(&hardened).unwrap();
+        assert_eq!(
+            doc["services"]["a"]["environment"][0].as_str(),
+            Some("MODEL_A=x[1m]")
+        );
+        assert_eq!(
+            doc["services"]["b"]["environment"][0].as_str(),
+            Some("MODEL_B=y[1m]")
         );
     }
 

--- a/crates/speedwave-runtime/src/consts.rs
+++ b/crates/speedwave-runtime/src/consts.rs
@@ -1,6 +1,5 @@
 pub const APP_NAME: &str = "speedwave";
 pub const DATA_DIR_ENV: &str = "SPEEDWAVE_DATA_DIR";
-pub const LIMA_VM_NAME: &str = "speedwave";
 pub const LIMA_SUBDIR: &str = "lima";
 pub const DATA_DIR: &str = ".speedwave";
 /// Per-project Claude Code home directory under the data dir

--- a/crates/speedwave-runtime/src/plugin.rs
+++ b/crates/speedwave-runtime/src/plugin.rs
@@ -2586,7 +2586,10 @@ mod tests {
             "image tag: {yaml}"
         );
         assert!(
-            yaml.contains("speedwave_myproject_mcp_presale"),
+            yaml.contains(&format!(
+                "{}_myproject_mcp_presale",
+                crate::consts::compose_prefix()
+            )),
             "container_name: {yaml}"
         );
         assert!(yaml.contains("read_only: true"), "read_only: {yaml}");
@@ -3338,11 +3341,10 @@ mod tests {
     #[test]
     fn test_peek_plugin_manifest_does_not_install() {
         // Verifies peek does not write into the plugins base directory.
-        // Runs against an isolated tempdir-as-plugins-dir snapshot: even
-        // though peek itself uses the real plugins_base_dir() internally,
-        // it should not touch it (no write paths). We check by counting
-        // entries in a freshly-created tempdir given as a probe — peek
-        // should not write anywhere outside its own scratch tmp.
+        // peek_plugin_manifest only extracts into std::env::temp_dir(), so it
+        // should never touch a plugins dir. We check by counting entries in a
+        // freshly-created tempdir given as a probe — peek should not write
+        // anywhere outside its own scratch tmp.
         let tmp = tempfile::tempdir().unwrap();
         let zip = tmp.path().join("plugin.zip");
         build_test_plugin_zip(&zip, "side-effect-test", true);
@@ -5205,7 +5207,9 @@ mod tests {
 
     #[test]
     fn test_token_dir_returns_correct_path() {
-        let result = token_dir("myproject", "presale").unwrap();
+        // Isolated: build under a tempdir home instead of consts::data_dir().
+        let tmp = tempfile::tempdir().unwrap();
+        let result = token_dir_with_base(tmp.path(), "myproject", "presale");
         let expected_suffix = std::path::Path::new(".speedwave/tokens/myproject/presale");
         assert!(
             result.ends_with(expected_suffix),
@@ -5617,7 +5621,11 @@ mod tests {
 
     #[test]
     fn test_plugin_state_dir_returns_plugin_state_path_for_slug() {
-        let dir = plugin_state_dir("my-plugin");
+        // Isolated: exercise the path logic via the _for variant on a tempdir
+        // so we never resolve consts::data_dir() / the real ~/.speedwave.
+        let tmp = tempfile::tempdir().unwrap();
+        let plugins_dir = tmp.path().join("plugins");
+        let dir = plugin_state_dir_for(&plugins_dir, "my-plugin");
         assert!(
             dir.to_string_lossy().contains("plugin-state"),
             "expected 'plugin-state' in path, got {}",

--- a/crates/speedwave-runtime/src/project.rs
+++ b/crates/speedwave-runtime/src/project.rs
@@ -584,7 +584,7 @@ mod tests {
             "should mention other distro, got: {err}"
         );
         assert!(
-            err.contains("Speedwave"),
+            err.contains(crate::consts::wsl_distro_name()),
             "should mention runtime distro, got: {err}"
         );
         assert!(
@@ -727,7 +727,10 @@ mod tests {
         let canonical = std::fs::canonicalize(&project_dir).unwrap();
         // Use a synthetic UNC-style string for the stored `dir` field — this
         // is what we'd persist on Windows for `\\wsl.localhost\Speedwave\projects\foo`.
-        let unc_canonical_str = r"\\wsl.localhost\Speedwave\projects\foo".to_string();
+        let unc_canonical_str = format!(
+            r"\\wsl.localhost\{}\projects\foo",
+            crate::consts::wsl_distro_name()
+        );
 
         let data_dir = tmp.path().join("data");
         std::fs::create_dir_all(&data_dir).unwrap();
@@ -948,7 +951,10 @@ mod tests {
         let project_dir = tmp.path().join("project");
         std::fs::create_dir_all(&project_dir).unwrap();
         let canonical = std::fs::canonicalize(&project_dir).unwrap();
-        let unc_str = r"\\wsl.localhost\Speedwave\projects\foo".to_string();
+        let unc_str = format!(
+            r"\\wsl.localhost\{}\projects\foo",
+            crate::consts::wsl_distro_name()
+        );
 
         let data_dir = tmp.path().join("data");
         std::fs::create_dir_all(&data_dir).unwrap();

--- a/crates/speedwave-runtime/src/runtime/lima.rs
+++ b/crates/speedwave-runtime/src/runtime/lima.rs
@@ -1304,7 +1304,7 @@ mod tests {
             .with_response(
                 &format!(
                     "limactl list --format {{{{.Status}}}} {}",
-                    consts::LIMA_VM_NAME
+                    consts::lima_vm_name()
                 ),
                 "Running",
             );
@@ -1326,7 +1326,7 @@ mod tests {
             .with_response(
                 &format!(
                     "limactl list --format {{{{.Status}}}} {}",
-                    consts::LIMA_VM_NAME
+                    consts::lima_vm_name()
                 ),
                 "Stopped",
             );
@@ -1349,14 +1349,15 @@ mod tests {
     #[test]
     fn test_ssh_config_path_contains_lima_vm() {
         let path = ssh_config_path().expect("ssh_config_path should succeed");
-        // Compare via Path components — path separators differ across host
-        // OSes (`/` on Unix, `\` on Windows) and a substring check would
-        // false-fail on Windows runners. The semantic claim is "the path
-        // ends with `.speedwave/lima/<vm>/ssh.config`", which Path::ends_with
-        // expresses portably.
+        // Compare via Path components — separators differ across host OSes
+        // (`/` vs `\`) and a substring check would false-fail on Windows.
+        // The semantic claim is the data-dir-relative tail `lima/<vm>/ssh.config`;
+        // asserting only that tail keeps the test tempdir-robust without naming
+        // the production `data_dir()` singleton.
         let vm = consts::lima_vm_name();
-        let expected_tail: std::path::PathBuf =
-            [".speedwave", "lima", vm, "ssh.config"].iter().collect();
+        let expected_tail = std::path::Path::new(consts::LIMA_SUBDIR)
+            .join(vm)
+            .join("ssh.config");
         assert!(
             path.ends_with(&expected_tail),
             "ssh_config_path should end with {:?}, got: {}",
@@ -1787,11 +1788,11 @@ mod tests {
             .with_response(
                 &format!(
                     "limactl list --format {{{{.Status}}}} {}",
-                    consts::LIMA_VM_NAME
+                    consts::lima_vm_name()
                 ),
                 "Stopped",
             )
-            .with_response(&format!("limactl start {}", consts::LIMA_VM_NAME), "");
+            .with_response(&format!("limactl start {}", consts::lima_vm_name()), "");
         let rt = LimaRuntime::with_runner(Box::new(runner));
         assert!(
             !rt.is_available(),
@@ -1810,12 +1811,12 @@ mod tests {
             .with_response(
                 &format!(
                     "limactl list --format {{{{.Status}}}} {}",
-                    consts::LIMA_VM_NAME
+                    consts::lima_vm_name()
                 ),
                 "Stopped",
             )
             .with_error(
-                &format!("limactl start {}", consts::LIMA_VM_NAME),
+                &format!("limactl start {}", consts::lima_vm_name()),
                 "timed out after 120s",
             );
         let rt = LimaRuntime::with_runner(Box::new(runner));
@@ -1935,7 +1936,7 @@ mod tests {
             .with_response(
                 &format!(
                     "limactl list --format {{{{.Status}}}} {}",
-                    consts::LIMA_VM_NAME
+                    consts::lima_vm_name()
                 ),
                 "Running",
             )
@@ -1946,7 +1947,7 @@ mod tests {
         let runner = mock_runner_with_vm_running().with_response(
             &format!(
                 "limactl shell {} -- sudo nerdctl logs --tail 100 speedwave_acme_claude",
-                consts::LIMA_VM_NAME
+                consts::lima_vm_name()
             ),
             "line1\nline2\nline3",
         );
@@ -1996,7 +1997,7 @@ mod tests {
         let runner = mock_runner_with_vm_running().with_response(
             &format!(
                 "limactl shell {} -- sudo nerdctl compose -f {} -p acme logs --timestamps --tail 200",
-                consts::LIMA_VM_NAME,
+                consts::lima_vm_name(),
                 compose_file
             ),
             "hub | started\nclaude | ready",
@@ -2013,7 +2014,7 @@ mod tests {
             .with_response(
                 &format!(
                     "limactl list --format {{{{.Status}}}} {}",
-                    consts::LIMA_VM_NAME
+                    consts::lima_vm_name()
                 ),
                 "Stopped",
             );
@@ -2132,7 +2133,7 @@ mod tests {
             .with_response(
                 &format!(
                     "limactl list --format {{{{.Status}}}} {}",
-                    consts::LIMA_VM_NAME
+                    consts::lima_vm_name()
                 ),
                 "Stopped",
             );
@@ -2252,7 +2253,7 @@ mod tests {
             .with_response(
                 &format!(
                     "limactl list --format {{{{.Status}}}} {}",
-                    consts::LIMA_VM_NAME
+                    consts::lima_vm_name()
                 ),
                 "Stopped",
             );
@@ -2293,7 +2294,7 @@ mod tests {
             .with_response(
                 &format!(
                     "limactl list --format {{{{.Status}}}} {}",
-                    consts::LIMA_VM_NAME
+                    consts::lima_vm_name()
                 ),
                 "Stopped",
             );
@@ -2310,7 +2311,7 @@ mod tests {
         let runner = mock_runner_with_vm_running().with_error(
             &format!(
                 "limactl shell {} -- sudo nerdctl builder prune --all --force",
-                consts::LIMA_VM_NAME
+                consts::lima_vm_name()
             ),
             "buildkit prune failed",
         );
@@ -2346,7 +2347,7 @@ mod tests {
         let runner = mock_runner_with_vm_running().with_response(
             &format!(
                 "limactl shell {} -- sudo nerdctl rmi speedwave-claude:abc123 speedwave-mcp-hub:abc123",
-                consts::LIMA_VM_NAME
+                consts::lima_vm_name()
             ),
             "",
         );
@@ -2360,7 +2361,7 @@ mod tests {
         let runner = mock_runner_with_vm_running().with_error(
             &format!(
                 "limactl shell {} -- sudo nerdctl rmi speedwave-claude:abc123",
-                consts::LIMA_VM_NAME
+                consts::lima_vm_name()
             ),
             "no such image",
         );
@@ -2378,7 +2379,7 @@ mod tests {
         let runner = mock_runner_with_vm_running().with_response(
             &format!(
                 "limactl shell {} -- sudo nerdctl rmi --force speedwave-mcp-example:1.0.0",
-                consts::LIMA_VM_NAME
+                consts::lima_vm_name()
             ),
             "",
         );
@@ -2396,7 +2397,7 @@ mod tests {
             .with_response(
                 &format!(
                     "limactl list --format {{{{.Status}}}} {}",
-                    consts::LIMA_VM_NAME
+                    consts::lima_vm_name()
                 ),
                 "Stopped",
             );
@@ -2416,28 +2417,28 @@ mod tests {
             .with_response(
                 &format!(
                     "limactl shell {} -- sudo systemctl restart containerd",
-                    consts::LIMA_VM_NAME
+                    consts::lima_vm_name()
                 ),
                 "",
             )
             .with_response(
                 &format!(
                     "limactl shell {} -- sudo systemctl restart buildkit",
-                    consts::LIMA_VM_NAME
+                    consts::lima_vm_name()
                 ),
                 "",
             )
             .with_response(
                 &format!(
                     "limactl shell {} -- sudo nerdctl info",
-                    consts::LIMA_VM_NAME
+                    consts::lima_vm_name()
                 ),
                 "containerd running",
             )
             .with_response(
                 &format!(
                     "limactl shell {} -- sudo buildctl debug workers",
-                    consts::LIMA_VM_NAME
+                    consts::lima_vm_name()
                 ),
                 "buildkit ready",
             );
@@ -2451,28 +2452,28 @@ mod tests {
             .with_response(
                 &format!(
                     "limactl shell {} -- sudo systemctl restart containerd",
-                    consts::LIMA_VM_NAME
+                    consts::lima_vm_name()
                 ),
                 "",
             )
             .with_error(
                 &format!(
                     "limactl shell {} -- sudo systemctl restart buildkit",
-                    consts::LIMA_VM_NAME
+                    consts::lima_vm_name()
                 ),
                 "unit not found",
             )
             .with_response(
                 &format!(
                     "limactl shell {} -- sudo nerdctl info",
-                    consts::LIMA_VM_NAME
+                    consts::lima_vm_name()
                 ),
                 "containerd running",
             )
             .with_response(
                 &format!(
                     "limactl shell {} -- sudo buildctl debug workers",
-                    consts::LIMA_VM_NAME
+                    consts::lima_vm_name()
                 ),
                 "buildkit ready",
             );
@@ -2490,7 +2491,7 @@ mod tests {
             .with_response(
                 &format!(
                     "limactl list --format {{{{.Status}}}} {}",
-                    consts::LIMA_VM_NAME
+                    consts::lima_vm_name()
                 ),
                 "Stopped",
             );
@@ -2508,14 +2509,14 @@ mod tests {
             .with_response(
                 &format!(
                     "limactl shell {} -- sudo systemctl restart containerd",
-                    consts::LIMA_VM_NAME
+                    consts::lima_vm_name()
                 ),
                 "",
             )
             .with_error(
                 &format!(
                     "limactl shell {} -- sudo systemctl restart buildkit",
-                    consts::LIMA_VM_NAME
+                    consts::lima_vm_name()
                 ),
                 "some other error",
             );
@@ -2538,12 +2539,12 @@ mod tests {
             .with_response(
                 &format!(
                     "limactl list --format {{{{.Status}}}} {}",
-                    consts::LIMA_VM_NAME
+                    consts::lima_vm_name()
                 ),
                 "Running",
             )
             .with_response(
-                &format!("limactl stop --force {}", consts::LIMA_VM_NAME),
+                &format!("limactl stop --force {}", consts::lima_vm_name()),
                 "",
             );
         let rt = LimaRuntime::with_runner(Box::new(runner));
@@ -2558,7 +2559,7 @@ mod tests {
         let runner = MockRunner::new().with_response(
             &format!(
                 "limactl list --format {{{{.Status}}}} {}",
-                consts::LIMA_VM_NAME
+                consts::lima_vm_name()
             ),
             "Stopped",
         );
@@ -2574,7 +2575,7 @@ mod tests {
         let runner = MockRunner::new().with_response(
             &format!(
                 "limactl list --format {{{{.Status}}}} {}",
-                consts::LIMA_VM_NAME
+                consts::lima_vm_name()
             ),
             "",
         );
@@ -2590,7 +2591,7 @@ mod tests {
         let runner = MockRunner::new().with_response(
             &format!(
                 "limactl list --format {{{{.Status}}}} {}",
-                consts::LIMA_VM_NAME
+                consts::lima_vm_name()
             ),
             "Stopping",
         );
@@ -2606,7 +2607,7 @@ mod tests {
         let runner = MockRunner::new().with_response(
             &format!(
                 "limactl list --format {{{{.Status}}}} {}",
-                consts::LIMA_VM_NAME
+                consts::lima_vm_name()
             ),
             "Creating",
         );
@@ -2623,12 +2624,12 @@ mod tests {
             .with_response(
                 &format!(
                     "limactl list --format {{{{.Status}}}} {}",
-                    consts::LIMA_VM_NAME
+                    consts::lima_vm_name()
                 ),
                 "Running",
             )
             .with_error(
-                &format!("limactl stop --force {}", consts::LIMA_VM_NAME),
+                &format!("limactl stop --force {}", consts::lima_vm_name()),
                 "limactl stop failed",
             );
         let rt = LimaRuntime::with_runner(Box::new(runner));
@@ -2650,12 +2651,12 @@ mod tests {
             .with_response(
                 &format!(
                     "limactl list --format {{{{.Status}}}} {}",
-                    consts::LIMA_VM_NAME
+                    consts::lima_vm_name()
                 ),
                 "  Running  \n",
             )
             .with_response(
-                &format!("limactl stop --force {}", consts::LIMA_VM_NAME),
+                &format!("limactl stop --force {}", consts::lima_vm_name()),
                 "",
             );
         let rt = LimaRuntime::with_runner(Box::new(runner));
@@ -2670,7 +2671,7 @@ mod tests {
         let runner = MockRunner::new().with_error(
             &format!(
                 "limactl list --format {{{{.Status}}}} {}",
-                consts::LIMA_VM_NAME
+                consts::lima_vm_name()
             ),
             "limactl not found",
         );
@@ -2759,7 +2760,7 @@ mod tests {
 
     #[test]
     fn test_ensure_ready_stopping_then_stopped_starts_vm() {
-        let vm = consts::LIMA_VM_NAME;
+        let vm = consts::lima_vm_name();
         let runner = SequencedRunner::new()
             // ensure_ready_inner calls: --version, then list (Stopping), then list (Stopped)
             .with_fallback("limactl --version", "limactl version 1.0.0")
@@ -2777,7 +2778,7 @@ mod tests {
 
     #[test]
     fn test_ensure_ready_stopping_then_running_returns_ok_without_start() {
-        let vm = consts::LIMA_VM_NAME;
+        let vm = consts::lima_vm_name();
         let runner = SequencedRunner::new()
             .with_fallback("limactl --version", "limactl version 1.0.0")
             .with_sequence(

--- a/crates/speedwave-runtime/src/runtime/mod.rs
+++ b/crates/speedwave-runtime/src/runtime/mod.rs
@@ -1153,61 +1153,6 @@ pub(crate) mod test_support {
         }
     }
 
-    /// `CommandRunner` that records every command into a shared `Vec<String>`
-    /// and resolves responses from a pre-seeded `HashMap`. Used by tests that
-    /// need to assert command sequence AND control return values. Previously
-    /// 5 separate inline `struct RecordingRunner` blocks scattered across the
-    /// test module — consolidated here (Rule of Three passed at 5 sites).
-    pub struct TestRecordingRunner {
-        pub commands: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
-        pub responses: std::collections::HashMap<String, anyhow::Result<String>>,
-    }
-
-    impl Default for TestRecordingRunner {
-        fn default() -> Self {
-            Self::new()
-        }
-    }
-
-    impl TestRecordingRunner {
-        pub fn new() -> Self {
-            Self {
-                commands: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
-                responses: std::collections::HashMap::new(),
-            }
-        }
-
-        /// Returns a shared handle to the commands log so callers can keep
-        /// inspecting it after the runner is boxed into a `LockedRuntime`.
-        pub fn commands_handle(&self) -> std::sync::Arc<std::sync::Mutex<Vec<String>>> {
-            std::sync::Arc::clone(&self.commands)
-        }
-
-        pub fn with_response(mut self, key: &str, response: &str) -> Self {
-            self.responses
-                .insert(key.to_string(), Ok(response.to_string()));
-            self
-        }
-
-        pub fn with_error(mut self, key: &str, msg: &str) -> Self {
-            self.responses
-                .insert(key.to_string(), Err(anyhow::anyhow!("{msg}")));
-            self
-        }
-    }
-
-    impl CommandRunner for TestRecordingRunner {
-        fn run(&self, cmd: &str, args: &[&str]) -> anyhow::Result<String> {
-            let key = format!("{} {}", cmd, args.join(" "));
-            self.commands.lock().unwrap().push(key.clone());
-            match self.responses.get(&key) {
-                Some(Ok(val)) => Ok(val.clone()),
-                Some(Err(e)) => Err(anyhow::anyhow!("{e}")),
-                None => Err(anyhow::anyhow!("unexpected command: {key}")),
-            }
-        }
-    }
-
     pub struct SequentialMockRunner {
         pub responses: std::sync::Mutex<std::collections::VecDeque<anyhow::Result<String>>>,
         pub calls: std::sync::Mutex<Vec<(String, Vec<String>, Option<std::time::Duration>)>>,
@@ -1711,8 +1656,11 @@ services:
                 .subsec_nanos()
         );
 
-        // Write compose file at the path that compose_file_path() will resolve
-        // via the OnceLock-cached data_dir() (no HOME manipulation needed).
+        // `force_remove_project_containers` reads the compose file through the
+        // production `compose_file_path()` → OnceLock `data_dir()`; the write and
+        // the read must agree on the same dir, so we deliberately resolve it. The
+        // RAII guard below removes the uniquely-named project subdir afterward.
+        // SSOT-allow: production read path is keyed on the OnceLock data_dir().
         let compose_dir = crate::consts::data_dir().join("compose").join(&project);
         std::fs::create_dir_all(&compose_dir).unwrap();
 

--- a/crates/speedwave-runtime/src/runtime/wsl.rs
+++ b/crates/speedwave-runtime/src/runtime/wsl.rs
@@ -900,8 +900,10 @@ mod tests {
 
     #[test]
     fn test_is_available_distro_exists() {
-        let runner =
-            MockRunner::new().with_response("wsl.exe --list --quiet", "Ubuntu\nSpeedwave\n");
+        let runner = MockRunner::new().with_response(
+            "wsl.exe --list --quiet",
+            &format!("Ubuntu\n{}\n", consts::wsl_distro_name()),
+        );
         let rt = WslRuntime::with_runner(Box::new(runner));
         assert!(rt.is_available());
     }
@@ -923,7 +925,7 @@ mod tests {
     #[test]
     fn test_is_available_handles_utf16le_output() {
         // Real wsl.exe outputs UTF-16LE: "Speedwave\r\n" with each char as 2 bytes
-        let text = "Ubuntu\r\nSpeedwave\r\n";
+        let text = format!("Ubuntu\r\n{}\r\n", consts::wsl_distro_name());
         let mut bytes: Vec<u8> = Vec::new();
         for ch in text.encode_utf16() {
             bytes.extend_from_slice(&ch.to_le_bytes());
@@ -935,7 +937,7 @@ mod tests {
 
     #[test]
     fn test_is_available_handles_utf16le_with_bom() {
-        let text = "Speedwave\r\n";
+        let text = format!("{}\r\n", consts::wsl_distro_name());
         let mut bytes: Vec<u8> = vec![0xFF, 0xFE]; // BOM
         for ch in text.encode_utf16() {
             bytes.extend_from_slice(&ch.to_le_bytes());
@@ -947,7 +949,10 @@ mod tests {
 
     #[test]
     fn test_is_available_distro_with_trailing_null() {
-        let runner = MockRunner::new().with_response("wsl.exe --list --quiet", "Speedwave\0\n");
+        let runner = MockRunner::new().with_response(
+            "wsl.exe --list --quiet",
+            &format!("{}\0\n", consts::wsl_distro_name()),
+        );
         let rt = WslRuntime::with_runner(Box::new(runner));
         assert!(rt.is_available());
     }
@@ -956,7 +961,7 @@ mod tests {
     fn test_is_available_utf16le_non_ascii_distro_before_speedwave() {
         // Non-ASCII distro name before Speedwave — verifies that
         // UTF-16LE is detected even when the first bytes aren't ASCII
-        let text = "\u{5F00}\u{53D1}\r\nSpeedwave\r\n"; // "开发\r\nSpeedwave\r\n"
+        let text = format!("\u{5F00}\u{53D1}\r\n{}\r\n", consts::wsl_distro_name()); // "开发\r\n<distro>\r\n"
         let mut bytes: Vec<u8> = Vec::new();
         for ch in text.encode_utf16() {
             bytes.extend_from_slice(&ch.to_le_bytes());
@@ -968,11 +973,15 @@ mod tests {
 
     #[test]
     fn test_ensure_ready_distro_exists() {
+        let distro = consts::wsl_distro_name();
         let runner = MockRunner::new()
-            .with_response("wsl.exe --list --quiet", "Ubuntu\nSpeedwave\n")
-            .with_response("wsl.exe -d Speedwave -- nerdctl info", "containerd running")
+            .with_response("wsl.exe --list --quiet", &format!("Ubuntu\n{distro}\n"))
             .with_response(
-                "wsl.exe -d Speedwave -- buildctl debug workers",
+                &format!("wsl.exe -d {distro} -- nerdctl info"),
+                "containerd running",
+            )
+            .with_response(
+                &format!("wsl.exe -d {distro} -- buildctl debug workers"),
                 "buildkit ready",
             );
         let rt = WslRuntime::with_runner(Box::new(runner));
@@ -1017,11 +1026,15 @@ mod tests {
 
     #[test]
     fn test_ensure_ready_containerd_not_running() {
+        let distro = consts::wsl_distro_name();
         let runner = MockRunner::new()
-            .with_response("wsl.exe --list --quiet", "Speedwave\n")
-            .with_error("wsl.exe -d Speedwave -- nerdctl info", "connection refused")
+            .with_response("wsl.exe --list --quiet", &format!("{distro}\n"))
             .with_error(
-                "wsl.exe -d Speedwave -- systemctl start containerd",
+                &format!("wsl.exe -d {distro} -- nerdctl info"),
+                "connection refused",
+            )
+            .with_error(
+                &format!("wsl.exe -d {distro} -- systemctl start containerd"),
                 "start failed",
             );
         let rt = WslRuntime::with_runner(Box::new(runner)).with_zero_delay();
@@ -1044,15 +1057,19 @@ mod tests {
 
     #[test]
     fn test_ensure_ready_buildkit_not_running() {
+        let distro = consts::wsl_distro_name();
         let runner = MockRunner::new()
-            .with_response("wsl.exe --list --quiet", "Speedwave\n")
-            .with_response("wsl.exe -d Speedwave -- nerdctl info", "containerd running")
+            .with_response("wsl.exe --list --quiet", &format!("{distro}\n"))
+            .with_response(
+                &format!("wsl.exe -d {distro} -- nerdctl info"),
+                "containerd running",
+            )
             .with_error(
-                "wsl.exe -d Speedwave -- buildctl debug workers",
+                &format!("wsl.exe -d {distro} -- buildctl debug workers"),
                 "connection refused",
             )
             .with_error(
-                "wsl.exe -d Speedwave -- systemctl start buildkit",
+                &format!("wsl.exe -d {distro} -- systemctl start buildkit"),
                 "start failed",
             );
         let rt = WslRuntime::with_runner(Box::new(runner)).with_zero_delay();
@@ -1077,7 +1094,10 @@ mod tests {
     #[test]
     fn test_container_logs() {
         let runner = MockRunner::new().with_response(
-            "wsl.exe -d Speedwave -- nerdctl logs --tail 100 my_container",
+            &format!(
+                "wsl.exe -d {} -- nerdctl logs --tail 100 my_container",
+                consts::wsl_distro_name()
+            ),
             "log output here",
         );
         let rt = WslRuntime::with_runner(Box::new(runner));
@@ -1095,7 +1115,8 @@ mod tests {
         let compose_file = wsl_compose_file_path("acme").unwrap();
         let runner = MockRunner::new().with_response(
             &format!(
-                "wsl.exe -d Speedwave -- nerdctl compose -f {} -p acme logs --timestamps --tail 200",
+                "wsl.exe -d {} -- nerdctl compose -f {} -p acme logs --timestamps --tail 200",
+                consts::wsl_distro_name(),
                 compose_file
             ),
             "hub | started\nclaude | ready",
@@ -1276,18 +1297,18 @@ mod tests {
         // calls) so the mock key matches on Windows runners where the
         // host home dir gets translated to `/mnt/c/...` before being
         // passed into wsl.exe.
+        let distro = consts::wsl_distro_name();
         let compose_file = wsl_compose_file_path("wsl-cleanup-test").unwrap();
         let expected_key = format!(
-            "wsl.exe -d Speedwave -- nerdctl compose -f {} -p wsl-cleanup-test down --remove-orphans",
-            compose_file
+            "wsl.exe -d {distro} -- nerdctl compose -f {compose_file} -p wsl-cleanup-test down --remove-orphans",
         );
         let runner = MockRunner::new()
             .with_response(&expected_key, "")
             .with_response(
-                "wsl.exe -d Speedwave -- nerdctl ps -a --filter label=com.docker.compose.project=wsl-cleanup-test -q",
+                &format!("wsl.exe -d {distro} -- nerdctl ps -a --filter label=com.docker.compose.project=wsl-cleanup-test -q"),
                 "stale-id",
             )
-            .with_response("wsl.exe -d Speedwave -- nerdctl rm -f stale-id", "");
+            .with_response(&format!("wsl.exe -d {distro} -- nerdctl rm -f stale-id"), "");
         let rt = WslRuntime::with_runner(Box::new(runner));
         assert!(rt.compose_down("wsl-cleanup-test").is_ok());
     }
@@ -1296,7 +1317,8 @@ mod tests {
     fn test_compose_up_recreate_includes_force_recreate() {
         let compose_file = wsl_compose_file_path("acme").unwrap();
         let expected_key = format!(
-            "wsl.exe -d Speedwave -- nerdctl compose -f {} -p acme up -d --force-recreate --remove-orphans",
+            "wsl.exe -d {} -- nerdctl compose -f {} -p acme up -d --force-recreate --remove-orphans",
+            consts::wsl_distro_name(),
             compose_file
         );
         let runner = MockRunner::new().with_response(&expected_key, "");
@@ -1308,14 +1330,15 @@ mod tests {
     fn test_compose_validate_runs_nerdctl_compose_config_quiet() {
         let compose_file = wsl_compose_file_path("acme").unwrap();
         let expected_key = format!(
-            "wsl.exe -d Speedwave -- nerdctl compose -f {} -p acme config --quiet",
+            "wsl.exe -d {} -- nerdctl compose -f {} -p acme config --quiet",
+            consts::wsl_distro_name(),
             compose_file
         );
         let runner = MockRunner::new().with_response(&expected_key, "");
         let rt = WslRuntime::with_runner(Box::new(runner));
         assert!(
             rt.compose_validate("acme").is_ok(),
-            "compose_validate must emit `wsl.exe -d Speedwave -- nerdctl compose -f <file> -p acme config --quiet`"
+            "compose_validate must emit `wsl.exe -d <distro> -- nerdctl compose -f <file> -p acme config --quiet`"
         );
     }
 
@@ -1401,16 +1424,18 @@ mod tests {
 
     #[test]
     fn test_is_wsl_unc_path_modern_form() {
-        let info = is_wsl_unc_path(r"\\wsl.localhost\Speedwave\workspace\foo").unwrap();
-        assert_eq!(info.distro, "Speedwave");
+        let distro = consts::wsl_distro_name();
+        let info = is_wsl_unc_path(&format!(r"\\wsl.localhost\{distro}\workspace\foo")).unwrap();
+        assert_eq!(info.distro, distro);
         assert_eq!(info.rest, "workspace/foo");
         assert!(info.is_runtime_distro());
     }
 
     #[test]
     fn test_is_wsl_unc_path_legacy_form() {
-        let info = is_wsl_unc_path(r"\\wsl$\Speedwave\workspace").unwrap();
-        assert_eq!(info.distro, "Speedwave");
+        let distro = consts::wsl_distro_name();
+        let info = is_wsl_unc_path(&format!(r"\\wsl$\{distro}\workspace")).unwrap();
+        assert_eq!(info.distro, distro);
         assert_eq!(info.rest, "workspace");
         assert!(info.is_runtime_distro());
     }
@@ -1488,34 +1513,46 @@ mod tests {
 
     #[test]
     fn test_windows_to_wsl_path_wsl_localhost_own_distro() {
-        let result =
-            windows_to_wsl_path(Path::new(r"\\wsl.localhost\Speedwave\workspace\foo")).unwrap();
+        let distro = consts::wsl_distro_name();
+        let result = windows_to_wsl_path(Path::new(&format!(
+            r"\\wsl.localhost\{distro}\workspace\foo"
+        )))
+        .unwrap();
         assert_eq!(result, PathBuf::from("/workspace/foo"));
     }
 
     #[test]
     fn test_windows_to_wsl_path_wsl_dollar_own_distro() {
-        let result = windows_to_wsl_path(Path::new(r"\\wsl$\Speedwave\workspace")).unwrap();
+        let distro = consts::wsl_distro_name();
+        let result =
+            windows_to_wsl_path(Path::new(&format!(r"\\wsl$\{distro}\workspace"))).unwrap();
         assert_eq!(result, PathBuf::from("/workspace"));
     }
 
     #[test]
     fn test_windows_to_wsl_path_canonicalized_wsl_unc() {
-        // \\?\UNC\wsl.localhost\Speedwave\foo (what canonicalize() may return on Windows)
+        // \\?\UNC\wsl.localhost\<distro>\foo (what canonicalize() may return on Windows)
+        let distro = consts::wsl_distro_name();
         let result =
-            windows_to_wsl_path(Path::new(r"\\?\UNC\wsl.localhost\Speedwave\foo")).unwrap();
+            windows_to_wsl_path(Path::new(&format!(r"\\?\UNC\wsl.localhost\{distro}\foo")))
+                .unwrap();
         assert_eq!(result, PathBuf::from("/foo"));
     }
 
     #[test]
     fn test_windows_to_wsl_path_canonicalized_wsl_dollar() {
-        let result = windows_to_wsl_path(Path::new(r"\\?\UNC\wsl$\Speedwave\foo")).unwrap();
+        let distro = consts::wsl_distro_name();
+        let result =
+            windows_to_wsl_path(Path::new(&format!(r"\\?\UNC\wsl$\{distro}\foo"))).unwrap();
         assert_eq!(result, PathBuf::from("/foo"));
     }
 
     #[test]
     fn test_windows_to_wsl_path_case_insensitive_distro() {
-        let result = windows_to_wsl_path(Path::new(r"\\wsl.localhost\speedwave\foo")).unwrap();
+        // Lowercased distro name must still match the runtime distro.
+        let distro = consts::wsl_distro_name().to_lowercase();
+        let result =
+            windows_to_wsl_path(Path::new(&format!(r"\\wsl.localhost\{distro}\foo"))).unwrap();
         assert_eq!(result, PathBuf::from("/foo"));
     }
 
@@ -1523,7 +1560,9 @@ mod tests {
     fn test_windows_to_wsl_path_mixed_slashes_in_rest() {
         // After splitting on backslash for distro extraction, mixed slashes
         // within the rest must still normalize to forward slashes.
-        let result = windows_to_wsl_path(Path::new(r"\\wsl.localhost\Speedwave\foo\bar")).unwrap();
+        let distro = consts::wsl_distro_name();
+        let result =
+            windows_to_wsl_path(Path::new(&format!(r"\\wsl.localhost\{distro}\foo\bar"))).unwrap();
         assert_eq!(result, PathBuf::from("/foo/bar"));
     }
 
@@ -1531,7 +1570,9 @@ mod tests {
     fn test_windows_to_wsl_path_wsl_localhost_bare_root_returns_slash() {
         // Pure path translator returns "/" for bare root distro paths.
         // Rejection of "/" as a project dir is enforced in project::add_project.
-        let result = windows_to_wsl_path(Path::new(r"\\wsl.localhost\Speedwave\")).unwrap();
+        let distro = consts::wsl_distro_name();
+        let result =
+            windows_to_wsl_path(Path::new(&format!(r"\\wsl.localhost\{distro}\"))).unwrap();
         assert_eq!(result, PathBuf::from("/"));
     }
 
@@ -1899,8 +1940,11 @@ mod tests {
 
     #[test]
     fn test_system_prune_calls_nerdctl_in_wsl() {
-        let runner = MockRunner::new()
-            .with_response("wsl.exe -d Speedwave -- nerdctl system prune --force", "");
+        let distro = consts::wsl_distro_name();
+        let runner = MockRunner::new().with_response(
+            &format!("wsl.exe -d {distro} -- nerdctl system prune --force"),
+            "",
+        );
         let rt = WslRuntime::with_runner(Box::new(runner));
         assert!(
             rt.system_prune().is_ok(),
@@ -1911,7 +1955,10 @@ mod tests {
     #[test]
     fn test_system_prune_propagates_error() {
         let runner = MockRunner::new().with_error(
-            "wsl.exe -d Speedwave -- nerdctl system prune --force",
+            &format!(
+                "wsl.exe -d {} -- nerdctl system prune --force",
+                consts::wsl_distro_name()
+            ),
             "prune failed",
         );
         let rt = WslRuntime::with_runner(Box::new(runner));
@@ -1923,7 +1970,10 @@ mod tests {
     #[test]
     fn test_prune_buildkit_cache_calls_nerdctl_in_wsl() {
         let runner = MockRunner::new().with_response(
-            "wsl.exe -d Speedwave -- nerdctl builder prune --all --force",
+            &format!(
+                "wsl.exe -d {} -- nerdctl builder prune --all --force",
+                consts::wsl_distro_name()
+            ),
             "",
         );
         let rt = WslRuntime::with_runner(Box::new(runner));
@@ -1936,7 +1986,10 @@ mod tests {
     #[test]
     fn test_prune_buildkit_cache_propagates_error() {
         let runner = MockRunner::new().with_error(
-            "wsl.exe -d Speedwave -- nerdctl builder prune --all --force",
+            &format!(
+                "wsl.exe -d {} -- nerdctl builder prune --all --force",
+                consts::wsl_distro_name()
+            ),
             "prune failed",
         );
         let rt = WslRuntime::with_runner(Box::new(runner));
@@ -2003,7 +2056,8 @@ mod tests {
     fn test_build_image_passes_build_args() {
         let version = crate::defaults::CLAUDE_VERSION;
         let expected_key = format!(
-            "wsl.exe -d Speedwave -- nerdctl build -t my-image:latest -f /ctx/Containerfile --build-arg CLAUDE_VERSION={} /ctx",
+            "wsl.exe -d {} -- nerdctl build -t my-image:latest -f /ctx/Containerfile --build-arg CLAUDE_VERSION={} /ctx",
+            consts::wsl_distro_name(),
             version
         );
         let runner = MockRunner::new().with_response(&expected_key, "");
@@ -2054,16 +2108,20 @@ mod tests {
 
     #[test]
     fn test_ensure_ready_handles_utf16le_output() {
-        let text = "Ubuntu\r\nSpeedwave\r\n";
+        let distro = consts::wsl_distro_name();
+        let text = format!("Ubuntu\r\n{distro}\r\n");
         let mut bytes: Vec<u8> = Vec::new();
         for ch in text.encode_utf16() {
             bytes.extend_from_slice(&ch.to_le_bytes());
         }
         let runner = MockRunner::new()
             .with_raw_response("wsl.exe --list --quiet", bytes)
-            .with_response("wsl.exe -d Speedwave -- nerdctl info", "containerd running")
             .with_response(
-                "wsl.exe -d Speedwave -- buildctl debug workers",
+                &format!("wsl.exe -d {distro} -- nerdctl info"),
+                "containerd running",
+            )
+            .with_response(
+                &format!("wsl.exe -d {distro} -- buildctl debug workers"),
                 "buildkit ready",
             );
         let rt = WslRuntime::with_runner(Box::new(runner));
@@ -2141,7 +2199,7 @@ mod tests {
 
     #[test]
     fn test_decode_wsl_output_utf16le_distro_name_matches_after_trim() {
-        let text = "Speedwave\r\n";
+        let text = format!("{}\r\n", consts::wsl_distro_name());
         let mut bytes: Vec<u8> = vec![0xFF, 0xFE];
         for ch in text.encode_utf16() {
             bytes.extend_from_slice(&ch.to_le_bytes());
@@ -2160,7 +2218,7 @@ mod tests {
 
     #[test]
     fn test_decode_wsl_output_utf16le_without_bom_distro_name_matches() {
-        let text = "Ubuntu\r\nSpeedwave\r\n";
+        let text = format!("Ubuntu\r\n{}\r\n", consts::wsl_distro_name());
         let mut bytes: Vec<u8> = Vec::new();
         for ch in text.encode_utf16() {
             bytes.extend_from_slice(&ch.to_le_bytes());
@@ -2271,18 +2329,16 @@ mod tests {
 
     #[test]
     fn test_ensure_ready_recovers_buildkit_after_retries() {
+        let distro = consts::wsl_distro_name();
         // buildctl: fast-path fails, then 3 retry failures, then succeeds on 4th retry
         let runner = KeyedSequentialMockRunner::new()
-            .with_responses(
-                "wsl.exe --list --quiet",
-                vec![Ok("Speedwave\n".to_string())],
-            )
+            .with_responses("wsl.exe --list --quiet", vec![Ok(format!("{distro}\n"))])
             // containerd: fast-path OK
             .with_responses(
-                "wsl.exe -d Speedwave -- nerdctl info",
+                &format!("wsl.exe -d {distro} -- nerdctl info"),
                 vec![Ok("containerd running".to_string())],
             )
-            .with_responses("wsl.exe -d Speedwave -- buildctl debug workers", {
+            .with_responses(&format!("wsl.exe -d {distro} -- buildctl debug workers"), {
                 let mut v: Vec<anyhow::Result<String>> = Vec::new();
                 // Fast-path check fails
                 v.push(Err(anyhow::anyhow!("connection refused")));
@@ -2297,7 +2353,7 @@ mod tests {
             // If the code used "buildkitd", this mock wouldn't match and the test
             // would panic with "unexpected command".
             .with_responses(
-                "wsl.exe -d Speedwave -- systemctl start buildkit",
+                &format!("wsl.exe -d {distro} -- systemctl start buildkit"),
                 vec![Ok(String::new())],
             );
 
@@ -2312,14 +2368,12 @@ mod tests {
 
     #[test]
     fn test_ensure_ready_recovers_containerd_after_retries() {
+        let distro = consts::wsl_distro_name();
         let runner = KeyedSequentialMockRunner::new()
-            .with_responses(
-                "wsl.exe --list --quiet",
-                vec![Ok("Speedwave\n".to_string())],
-            )
+            .with_responses("wsl.exe --list --quiet", vec![Ok(format!("{distro}\n"))])
             // containerd: fast-path fails, start succeeds, 1st retry fails, 2nd retry OK
             .with_responses(
-                "wsl.exe -d Speedwave -- nerdctl info",
+                &format!("wsl.exe -d {distro} -- nerdctl info"),
                 vec![
                     Err(anyhow::anyhow!("connection refused")),
                     Err(anyhow::anyhow!("connection refused")),
@@ -2327,12 +2381,12 @@ mod tests {
                 ],
             )
             .with_responses(
-                "wsl.exe -d Speedwave -- systemctl start containerd",
+                &format!("wsl.exe -d {distro} -- systemctl start containerd"),
                 vec![Ok(String::new())],
             )
             // buildkitd: fast-path OK
             .with_responses(
-                "wsl.exe -d Speedwave -- buildctl debug workers",
+                &format!("wsl.exe -d {distro} -- buildctl debug workers"),
                 vec![Ok("buildkit ready".to_string())],
             );
 
@@ -2347,6 +2401,7 @@ mod tests {
 
     #[test]
     fn test_ensure_ready_fails_after_max_retries_with_diagnostics() {
+        let distro = consts::wsl_distro_name();
         let max = consts::WSL_SERVICE_CHECK_MAX_RETRIES;
 
         // buildctl fails on all attempts (fast-path + max retries)
@@ -2359,20 +2414,17 @@ mod tests {
         }
 
         let runner = KeyedSequentialMockRunner::new()
+            .with_responses("wsl.exe --list --quiet", vec![Ok(format!("{distro}\n"))])
             .with_responses(
-                "wsl.exe --list --quiet",
-                vec![Ok("Speedwave\n".to_string())],
-            )
-            .with_responses(
-                "wsl.exe -d Speedwave -- nerdctl info",
+                &format!("wsl.exe -d {distro} -- nerdctl info"),
                 vec![Ok("containerd running".to_string())],
             )
             .with_responses(
-                "wsl.exe -d Speedwave -- buildctl debug workers",
+                &format!("wsl.exe -d {distro} -- buildctl debug workers"),
                 buildctl_responses,
             )
             .with_responses(
-                "wsl.exe -d Speedwave -- systemctl start buildkit",
+                &format!("wsl.exe -d {distro} -- systemctl start buildkit"),
                 vec![Err(anyhow::anyhow!("unit not found"))],
             );
 
@@ -2411,12 +2463,22 @@ mod tests {
 
     #[test]
     fn test_restart_container_engine_ok() {
+        let distro = consts::wsl_distro_name();
         let runner = MockRunner::new()
-            .with_response("wsl.exe -d Speedwave -- systemctl restart containerd", "")
-            .with_response("wsl.exe -d Speedwave -- systemctl restart buildkit", "")
-            .with_response("wsl.exe -d Speedwave -- nerdctl info", "containerd running")
             .with_response(
-                "wsl.exe -d Speedwave -- buildctl debug workers",
+                &format!("wsl.exe -d {distro} -- systemctl restart containerd"),
+                "",
+            )
+            .with_response(
+                &format!("wsl.exe -d {distro} -- systemctl restart buildkit"),
+                "",
+            )
+            .with_response(
+                &format!("wsl.exe -d {distro} -- nerdctl info"),
+                "containerd running",
+            )
+            .with_response(
+                &format!("wsl.exe -d {distro} -- buildctl debug workers"),
                 "buildkit ready",
             );
         let rt = WslRuntime::with_runner(Box::new(runner)).with_zero_delay();
@@ -2426,7 +2488,10 @@ mod tests {
     #[test]
     fn test_restart_container_engine_propagates_containerd_error() {
         let runner = MockRunner::new().with_error(
-            "wsl.exe -d Speedwave -- systemctl restart containerd",
+            &format!(
+                "wsl.exe -d {} -- systemctl restart containerd",
+                consts::wsl_distro_name()
+            ),
             "restart failed",
         );
         let rt = WslRuntime::with_runner(Box::new(runner)).with_zero_delay();
@@ -2437,15 +2502,22 @@ mod tests {
 
     #[test]
     fn test_restart_container_engine_buildkit_unit_not_found_still_polls() {
+        let distro = consts::wsl_distro_name();
         let runner = MockRunner::new()
-            .with_response("wsl.exe -d Speedwave -- systemctl restart containerd", "")
+            .with_response(
+                &format!("wsl.exe -d {distro} -- systemctl restart containerd"),
+                "",
+            )
             .with_error(
-                "wsl.exe -d Speedwave -- systemctl restart buildkit",
+                &format!("wsl.exe -d {distro} -- systemctl restart buildkit"),
                 "Failed to restart buildkit.service: Unit not found.",
             )
-            .with_response("wsl.exe -d Speedwave -- nerdctl info", "containerd running")
             .with_response(
-                "wsl.exe -d Speedwave -- buildctl debug workers",
+                &format!("wsl.exe -d {distro} -- nerdctl info"),
+                "containerd running",
+            )
+            .with_response(
+                &format!("wsl.exe -d {distro} -- buildctl debug workers"),
                 "buildkit ready",
             );
         let rt = WslRuntime::with_runner(Box::new(runner)).with_zero_delay();
@@ -2457,10 +2529,14 @@ mod tests {
 
     #[test]
     fn test_restart_container_engine_propagates_buildkit_error() {
+        let distro = consts::wsl_distro_name();
         let runner = MockRunner::new()
-            .with_response("wsl.exe -d Speedwave -- systemctl restart containerd", "")
+            .with_response(
+                &format!("wsl.exe -d {distro} -- systemctl restart containerd"),
+                "",
+            )
             .with_error(
-                "wsl.exe -d Speedwave -- systemctl restart buildkit",
+                &format!("wsl.exe -d {distro} -- systemctl restart buildkit"),
                 "Failed to restart buildkit.service: some other error",
             );
         let rt = WslRuntime::with_runner(Box::new(runner)).with_zero_delay();
@@ -2474,12 +2550,22 @@ mod tests {
 
     #[test]
     fn test_restart_container_engine_not_ready_after_retries() {
+        let distro = consts::wsl_distro_name();
         let runner = MockRunner::new()
-            .with_response("wsl.exe -d Speedwave -- systemctl restart containerd", "")
-            .with_response("wsl.exe -d Speedwave -- systemctl restart buildkit", "")
-            .with_error("wsl.exe -d Speedwave -- nerdctl info", "connection refused")
+            .with_response(
+                &format!("wsl.exe -d {distro} -- systemctl restart containerd"),
+                "",
+            )
+            .with_response(
+                &format!("wsl.exe -d {distro} -- systemctl restart buildkit"),
+                "",
+            )
             .with_error(
-                "wsl.exe -d Speedwave -- buildctl debug workers",
+                &format!("wsl.exe -d {distro} -- nerdctl info"),
+                "connection refused",
+            )
+            .with_error(
+                &format!("wsl.exe -d {distro} -- buildctl debug workers"),
                 "connection refused",
             );
         let rt = WslRuntime::with_runner(Box::new(runner)).with_zero_delay();

--- a/crates/speedwave-runtime/src/transcription/mod.rs
+++ b/crates/speedwave-runtime/src/transcription/mod.rs
@@ -124,17 +124,24 @@ mod tests {
 
     #[test]
     fn dirs_are_under_the_data_dir() {
-        let data = crate::consts::data_dir();
-        assert!(
-            transcripts_dir().starts_with(data),
-            "transcripts dir must be under data_dir"
+        // Structural invariant only — both dirs share one data-dir parent and
+        // end with their subdir. Asserted without naming the production
+        // `data_dir()` singleton, so it holds under any isolated tempdir.
+        let transcripts = transcripts_dir();
+        let models = models_dir();
+        assert!(transcripts.ends_with(crate::consts::TRANSCRIPTS_SUBDIR));
+        assert!(models.ends_with(crate::consts::MODELS_SUBDIR));
+        assert_eq!(
+            transcripts.parent(),
+            models.parent(),
+            "both dirs must live directly under the same data_dir"
         );
         assert!(
-            models_dir().starts_with(data),
-            "models dir must be under data_dir"
+            transcripts
+                .parent()
+                .is_some_and(|p| p.file_name().is_some()),
+            "data-dir parent must be non-empty"
         );
-        assert!(transcripts_dir().ends_with(crate::consts::TRANSCRIPTS_SUBDIR));
-        assert!(models_dir().ends_with(crate::consts::MODELS_SUBDIR));
     }
 
     #[test]

--- a/crates/speedwave-runtime/tests/no_raw_data_dir_in_tests.rs
+++ b/crates/speedwave-runtime/tests/no_raw_data_dir_in_tests.rs
@@ -1,0 +1,183 @@
+//! Drift detector: test code must never resolve the production data dir via
+//! `consts::data_dir()`. Tests pass an explicit tempdir to the `_in` variants
+//! (or set `SPEEDWAVE_DATA_DIR` to a tempdir in a dedicated integration binary).
+//! Bypass an individual line with `// SSOT-allow: <reason>`.
+//!
+//! KNOWN LIMITATION (cannot be fixed statically): this scanner only catches a
+//! *literal* `consts::data_dir()` token inside test code. It cannot catch
+//! TRANSITIVE resolution — a test that calls a no-arg production fn (e.g.
+//! `compose::init_secrets_dir(project)`) which internally resolves
+//! `consts::data_dir()`. The runtime guard `prod_data_dir_untouched.rs` is the
+//! backstop for those cases: it env-isolates the data dir and asserts the real
+//! `~/.speedwave` is untouched after a representative smoke, catching transitive
+//! leaks this static scan is blind to.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::{Path, PathBuf};
+
+fn walk_rs(root: &Path, out: &mut Vec<PathBuf>) {
+    let dir = match std::fs::read_dir(root) {
+        Ok(d) => d,
+        Err(_) => return,
+    };
+    for entry in dir.flatten() {
+        let path = entry.path();
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if path.is_dir() {
+            if name == "target" || name.starts_with(".") {
+                continue;
+            }
+            walk_rs(&path, out);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+fn manifest_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("workspace root")
+        .parent()
+        .expect("repo root")
+        .to_path_buf()
+}
+
+/// The bare-`data_dir()` resolutions forbidden inside test regions. Each is the
+/// production OnceLock-backed singleton that maps to the real `~/.speedwave`.
+/// Ordered longest-first so a qualified form (`crate::consts::…`) is reported
+/// once, not also as the `consts::…` substring it contains.
+const PATTERNS: &[&str] = &[
+    "speedwave_runtime::consts::data_dir()",
+    "crate::consts::data_dir()",
+    "consts::data_dir()",
+];
+
+/// True when `#[cfg(test)]` / `#[cfg(any(test...` guards a test *module*
+/// (the next item is `mod`), not a test-only production helper (`fn`/`pub fn`).
+/// A `data_dir()` call in a `#[cfg(test)]`-gated *helper* runs in
+/// production-shaped code and is legitimate; one inside `mod tests` is not.
+fn cfg_test_guards_a_module(lines: &[&str], cfg_idx: usize) -> bool {
+    for l in lines.iter().skip(cfg_idx + 1) {
+        let l = l.trim_start();
+        if l.is_empty() || l.starts_with("//") || l.starts_with("#[") {
+            continue;
+        }
+        return l.starts_with("mod ")
+            || l.starts_with("pub mod ")
+            || l.starts_with("pub(crate) mod ");
+    }
+    false
+}
+
+fn is_in_test_module(lines: &[&str], idx: usize) -> bool {
+    // Walk backwards for the nearest enclosing test marker: `mod tests {`,
+    // `#[test]`, or a `#[cfg(test)]` that guards a `mod` (not a helper fn).
+    for i in (0..idx).rev() {
+        let l = lines[i].trim_start();
+        if l.starts_with("mod tests") || l.starts_with("#[test]") {
+            return true;
+        }
+        if (l.starts_with("#[cfg(test)]") || l.starts_with("#[cfg(any(test"))
+            && cfg_test_guards_a_module(lines, i)
+        {
+            return true;
+        }
+        // Closing brace of a sibling top-level item — stop scanning back.
+        if l == "}" && lines[i].starts_with('}') {
+            return false;
+        }
+    }
+    false
+}
+
+/// A file living under a `tests/` directory is a cargo *integration-test
+/// binary*: the WHOLE file is test code (there is no production codepath in an
+/// integration binary). A bare `data_dir()` in a free helper fn there — not
+/// only under `#[test]`/`mod tests` — still runs in the test process and can
+/// touch the real `~/.speedwave`. So for these files we treat any line as a
+/// test region and rely solely on the comment / `// SSOT-allow:` filters.
+fn is_integration_test_file(rel_str: &str) -> bool {
+    rel_str.contains("/tests/")
+}
+
+fn has_allow_marker(line: &str, prev: Option<&&str>) -> bool {
+    line.contains("// SSOT-allow:") || prev.is_some_and(|p| p.contains("// SSOT-allow:"))
+}
+
+/// Integration-test binaries that legitimately set `SPEEDWAVE_DATA_DIR` to a
+/// tempdir and then resolve the OnceLock once, to exercise the env-var wiring
+/// itself. These are the only sanctioned bare-`data_dir()` call sites in tests.
+///
+/// This drift detector's own source is self-excluded: it carries the literal
+/// `consts::data_dir()` token in `PATTERNS` as *data*, not as a call.
+const ALLOWLISTED_FILES: &[&str] = &[
+    "crates/speedwave-runtime/tests/apply_transaction_behaviour.rs",
+    "crates/speedwave-runtime/tests/data_dir_integration.rs",
+    "crates/speedwave-runtime/tests/no_raw_data_dir_in_tests.rs",
+];
+
+#[test]
+fn no_raw_data_dir_in_test_regions() {
+    let root = manifest_root();
+    let crates_root = root.join("crates");
+    let desktop_src = root.join("desktop").join("src-tauri").join("src");
+    // Integration-test binaries for the Desktop crate: whole-file test code,
+    // same as the runtime crate's own `tests/` binaries.
+    let desktop_tests = root.join("desktop").join("src-tauri").join("tests");
+
+    let mut files = Vec::new();
+    walk_rs(&crates_root, &mut files);
+    walk_rs(&desktop_src, &mut files);
+    walk_rs(&desktop_tests, &mut files);
+
+    let mut violations: Vec<String> = Vec::new();
+    for file in &files {
+        let rel = file.strip_prefix(&root).unwrap_or(file);
+        let rel_str = rel.to_string_lossy().replace('\\', "/");
+        if ALLOWLISTED_FILES.iter().any(|f| rel_str == *f) {
+            continue;
+        }
+        let content = match std::fs::read_to_string(file) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let lines: Vec<&str> = content.lines().collect();
+        let whole_file_is_test = is_integration_test_file(&rel_str);
+        for (idx, line) in lines.iter().enumerate() {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("//") {
+                continue;
+            }
+            let prev = if idx > 0 { lines.get(idx - 1) } else { None };
+            if has_allow_marker(line, prev) {
+                continue;
+            }
+            // Longest-first; report each line once (a qualified form contains
+            // the shorter `consts::data_dir()` substring).
+            if let Some(pat) = PATTERNS.iter().find(|p| line.contains(**p)) {
+                // In an integration-test binary the whole file is test code; in
+                // a `src/` file only genuine test regions (`#[test]`/`mod tests`)
+                // are forbidden — a `#[cfg(test)]` helper is production-shaped.
+                if whole_file_is_test || is_in_test_module(&lines, idx) {
+                    violations.push(format!(
+                        "{}:{}: matches {pat:?}\n  > {}",
+                        rel.display(),
+                        idx + 1,
+                        line.trim_end()
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "found {} bare `data_dir()` call(s) inside test regions — pass an explicit \
+         tempdir to the `_in` variant (or add a `// SSOT-allow: <reason>` marker):\n\n{}",
+        violations.len(),
+        violations.join("\n\n")
+    );
+}

--- a/crates/speedwave-runtime/tests/prod_data_dir_untouched.rs
+++ b/crates/speedwave-runtime/tests/prod_data_dir_untouched.rs
@@ -1,0 +1,102 @@
+//! Runtime backstop for the static scanner (`no_raw_data_dir_in_tests.rs`):
+//! a representative data-dir-rooted smoke must never touch the production
+//! `~/.speedwave`. This is the ONLY guard that catches *transitive* leaks — a
+//! test calling a no-arg production fn that internally resolves
+//! `consts::data_dir()` — which the static scan is structurally blind to.
+//!
+//! Design (why this is robust, not OnceLock-fragile):
+//! The real invariant is "production `~/.speedwave` is untouched", NOT
+//! "`data_dir()` resolves to the tempdir". So the smoke drives the **`_in`
+//! variants** with an explicit tempdir and never asserts on the OnceLock. We
+//! still point `SPEEDWAVE_DATA_DIR` at the tempdir as defense-in-depth (any
+//! *transitive* bare-`data_dir()` a future addition introduces also lands in
+//! the tempdir on the first resolution), but no assertion DEPENDS on that
+//! resolution order. Consequently this binary is safe to grow a second test:
+//! the prod-untouched invariant holds regardless of which test resolves the
+//! OnceLock first.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::PathBuf;
+use std::time::SystemTime;
+
+use speedwave_runtime::{compose, consts};
+
+/// Minimal compose YAML with a resolvable network ref — `save_compose_in`
+/// validates network refs in-memory and on read-back, so the document must be
+/// internally consistent.
+const VALID_YAML: &str = "version: '3'\nnetworks:\n  default:\n    driver: bridge\nservices:\n  app:\n    image: nginx\n    networks:\n      - default\n";
+
+/// `SPEEDWAVE_DATA_DIR` basename must match `^[a-z][a-z0-9-]{0,63}$`
+/// (`consts::derive_instance_name_from`). `tempfile`'s own basenames start with
+/// a dot and mix case, so we nest a regex-valid child under an outer tempdir.
+fn regex_valid_data_dir() -> (tempfile::TempDir, PathBuf) {
+    let outer = tempfile::tempdir().expect("tempdir");
+    let child = outer.path().join("speedwave-prod-untouched");
+    std::fs::create_dir(&child).expect("create child data dir");
+    (outer, child)
+}
+
+/// `None` if the path does not exist (the strongest assertion — production was
+/// never created); otherwise `Some(mtime)`.
+fn snapshot(path: &std::path::Path) -> Option<SystemTime> {
+    std::fs::metadata(path).ok().and_then(|m| m.modified().ok())
+}
+
+#[test]
+#[serial_test::serial]
+fn representative_smoke_does_not_touch_prod_data_dir() {
+    let prod = dirs::home_dir().expect("home dir").join(consts::DATA_DIR);
+
+    // Record production state BEFORE the smoke. Missing is the strongest
+    // assertion; if a developer happens to have a real install, we fall back
+    // to an mtime-unchanged check.
+    let before_exists = prod.exists();
+    let before_mtime = snapshot(&prod);
+
+    let (_outer, tmp_data_dir) = regex_valid_data_dir();
+
+    // Defense-in-depth only: routes any *transitive* bare-`data_dir()` into the
+    // tempdir too. The assertions below do NOT depend on this resolving (the
+    // smoke uses the explicit-`data_dir` `_in` variants), so the OnceLock
+    // ordering is irrelevant to correctness — that is what makes this binary
+    // safe to extend with additional tests.
+    std::env::set_var(consts::DATA_DIR_ENV, &tmp_data_dir);
+
+    // Representative smoke: a real, data-dir-rooted filesystem write
+    // (`save_compose_in` creates `compose/<project>/` and writes the file) plus
+    // a path-resolution op — both via the explicit-`data_dir` `_in` variants,
+    // so every path derives from the tempdir, never from the OnceLock.
+    let project = "prod-untouched-smoke";
+    compose::save_compose_in(&tmp_data_dir, project, VALID_YAML).expect("save_compose_in");
+    let compose_path =
+        compose::compose_output_path_in(&tmp_data_dir, project).expect("compose_output_path_in");
+
+    // The smoke must have written under the tempdir, never under production.
+    assert!(
+        compose_path.starts_with(&tmp_data_dir),
+        "compose path {compose_path:?} escaped the tempdir {tmp_data_dir:?}"
+    );
+    assert!(
+        compose_path.is_file(),
+        "smoke did not write the compose file at {compose_path:?}"
+    );
+
+    // Production must be untouched: still absent (strongest), or — if it
+    // pre-existed on this machine — its mtime must be unchanged.
+    let after_exists = prod.exists();
+    let after_mtime = snapshot(&prod);
+
+    if !before_exists {
+        assert!(
+            !after_exists,
+            "production data dir {prod:?} was CREATED by the smoke — isolation regressed"
+        );
+    } else {
+        assert_eq!(
+            before_mtime, after_mtime,
+            "production data dir {prod:?} mtime CHANGED ({before_mtime:?} -> {after_mtime:?}) \
+             — the smoke wrote into the real install"
+        );
+    }
+}

--- a/desktop/src-tauri/src/chat.rs
+++ b/desktop/src-tauri/src/chat.rs
@@ -1224,7 +1224,13 @@ pub fn build_claude_args(
 
 /// Build the container name for a project's Claude container.
 pub fn claude_container_name(project: &str) -> String {
-    format!("{}_{}_claude", consts::compose_prefix(), project)
+    claude_container_name_with_prefix(consts::compose_prefix(), project)
+}
+
+/// Parameterised by `prefix` so unit tests avoid the `consts::compose_prefix()`
+/// `OnceLock`, which resolves the process-global `data_dir()` basename.
+fn claude_container_name_with_prefix(prefix: &str, project: &str) -> String {
+    format!("{prefix}_{project}_claude")
 }
 
 /// Build the stream-json `control_request` payload for an interrupt.
@@ -3264,13 +3270,15 @@ mod tests {
 
     #[test]
     fn claude_container_name_uses_compose_prefix() {
-        let name = claude_container_name("myproject");
+        // Use the `_with_prefix` variant with the fixed `COMPOSE_PREFIX` literal
+        // so the test does not depend on the process-global `data_dir()` basename.
+        let name = claude_container_name_with_prefix(consts::COMPOSE_PREFIX, "myproject");
         assert_eq!(name, format!("{}_myproject_claude", consts::COMPOSE_PREFIX));
     }
 
     #[test]
     fn claude_container_name_format_is_prefix_project_claude() {
-        let name = claude_container_name("acme-corp");
+        let name = claude_container_name_with_prefix(consts::COMPOSE_PREFIX, "acme-corp");
         assert_eq!(name, "speedwave_acme-corp_claude");
     }
 

--- a/desktop/src-tauri/src/container_logs_cmd.rs
+++ b/desktop/src-tauri/src/container_logs_cmd.rs
@@ -24,7 +24,17 @@ fn validate_container_name(container: &str) -> Result<(), String> {
 /// Parse the project name from a Claude container name.
 /// Expected format: `{compose_prefix()}_{project}_claude`.
 fn parse_claude_project(container: &str) -> Result<String, String> {
-    let prefix = format!("{}_", speedwave_runtime::consts::compose_prefix());
+    parse_claude_project_with_prefix(speedwave_runtime::consts::compose_prefix(), container)
+}
+
+/// Parameterised by `compose_prefix` so unit tests avoid the
+/// `consts::compose_prefix()` `OnceLock`, which resolves the process-global
+/// `data_dir()` basename.
+fn parse_claude_project_with_prefix(
+    compose_prefix: &str,
+    container: &str,
+) -> Result<String, String> {
+    let prefix = format!("{compose_prefix}_");
     let without_prefix = container
         .strip_prefix(&prefix)
         .ok_or_else(|| "Not a claude container".to_string())?;
@@ -548,35 +558,56 @@ mod tests {
     }
 
     // -- Claude session logs: project parsing from container name --
+    //
+    // Tests use the `_with_prefix` variant with the fixed `COMPOSE_PREFIX`
+    // literal so they do not depend on the process-global `data_dir()` basename.
 
     #[test]
     fn parse_project_from_claude_container() {
-        let project = parse_claude_project("speedwave_myproject_claude").unwrap();
+        let project = parse_claude_project_with_prefix(
+            speedwave_runtime::consts::COMPOSE_PREFIX,
+            "speedwave_myproject_claude",
+        )
+        .unwrap();
         assert_eq!(project, "myproject");
     }
 
     #[test]
     fn parse_project_from_dotted_container_name() {
-        let project = parse_claude_project("speedwave_proj.v1_claude").unwrap();
+        let project = parse_claude_project_with_prefix(
+            speedwave_runtime::consts::COMPOSE_PREFIX,
+            "speedwave_proj.v1_claude",
+        )
+        .unwrap();
         assert_eq!(project, "proj.v1");
     }
 
     #[test]
     fn parse_project_rejects_non_claude_container() {
-        let result = parse_claude_project("speedwave_myproject_mcp-hub");
+        let result = parse_claude_project_with_prefix(
+            speedwave_runtime::consts::COMPOSE_PREFIX,
+            "speedwave_myproject_mcp-hub",
+        );
         assert!(result.is_err(), "non-claude container should be rejected");
     }
 
     #[test]
     fn parse_project_rejects_missing_prefix() {
-        let result = parse_claude_project("other_myproject_claude");
+        let result = parse_claude_project_with_prefix(
+            speedwave_runtime::consts::COMPOSE_PREFIX,
+            "other_myproject_claude",
+        );
         assert!(result.is_err(), "missing prefix should be rejected");
     }
 
     #[test]
     fn parse_project_validates_extracted_project() {
         // Container with ".." in project name → check_project rejects it
-        let project = parse_claude_project("speedwave_.._claude").unwrap();
+        let project = parse_claude_project_with_prefix(
+            speedwave_runtime::consts::COMPOSE_PREFIX,
+            "speedwave_.._claude",
+        )
+        .unwrap();
         let result = crate::types::check_project(&project);
         assert!(
             result.is_err(),
@@ -586,7 +617,11 @@ mod tests {
 
     #[test]
     fn parse_project_dotted_name_passes_check_project() {
-        let project = parse_claude_project("speedwave_proj.v1_claude").unwrap();
+        let project = parse_claude_project_with_prefix(
+            speedwave_runtime::consts::COMPOSE_PREFIX,
+            "speedwave_proj.v1_claude",
+        )
+        .unwrap();
         let result = crate::types::check_project(&project);
         assert!(
             result.is_ok(),

--- a/desktop/src-tauri/src/integrations_cmd.rs
+++ b/desktop/src-tauri/src/integrations_cmd.rs
@@ -515,14 +515,14 @@ pub fn set_integration_enabled(
 // ---------------------------------------------------------------------------
 
 /// Resolves the absolute path to a native macOS CLI binary.
-///
-/// Production: `BUNDLE_RESOURCES_ENV` → `<dir>/<binary-name>`
-/// Dev: `CARGO_MANIFEST_DIR` → `../../native/macos/<pkg>/.build/release/<binary-name>`
-///
-/// No fallback to Resources/ subdir — `BUNDLE_RESOURCES_ENV` is always set by
-/// Desktop `main.rs` in production.
+/// `resources_dir` is `Some(<BUNDLE_RESOURCES_ENV dir>)` in production (set by
+/// main.rs); `None` selects the dev fallback `CARGO_MANIFEST_DIR ->
+/// ../../native/macos/<pkg>/.build/release/<binary>`. Tests pass a tempdir.
 // SYNC: binary paths must match mcp-servers/os/src/platform-runner.ts::resolveDarwinPaths()
-fn resolve_native_cli_binary(service: &str) -> Result<std::path::PathBuf, String> {
+fn resolve_native_cli_binary_in(
+    service: &str,
+    resources_dir: Option<&std::path::Path>,
+) -> Result<std::path::PathBuf, String> {
     let (binary_name, pkg_dir) = match service {
         "reminders" => ("reminders-cli", "reminders"),
         "calendar" => ("calendar-cli", "calendar"),
@@ -531,9 +531,8 @@ fn resolve_native_cli_binary(service: &str) -> Result<std::path::PathBuf, String
         _ => return Err(format!("unknown OS service: {service}")),
     };
 
-    // Production: env var set by main.rs via resolve_resources_dir()
-    if let Ok(resources_dir) = std::env::var(speedwave_runtime::consts::BUNDLE_RESOURCES_ENV) {
-        return Ok(std::path::PathBuf::from(resources_dir).join(binary_name));
+    if let Some(dir) = resources_dir {
+        return Ok(dir.join(binary_name));
     }
 
     // Dev fallback: compile-time path from CARGO_MANIFEST_DIR (desktop/src-tauri/)
@@ -605,7 +604,26 @@ fn check_os_permission_with_timeout(
     launch_if_needed: bool,
     timeout: std::time::Duration,
 ) -> Result<(), String> {
-    let binary_path = resolve_native_cli_binary(service)?;
+    let resources_dir = std::env::var(speedwave_runtime::consts::BUNDLE_RESOURCES_ENV)
+        .ok()
+        .map(std::path::PathBuf::from);
+    check_os_permission_with_timeout_in(
+        service,
+        launch_if_needed,
+        timeout,
+        resources_dir.as_deref(),
+    )
+}
+
+/// Parameterised by `resources_dir` so unit tests pass a tempdir directly
+/// instead of mutating the global `BUNDLE_RESOURCES_ENV`.
+fn check_os_permission_with_timeout_in(
+    service: &str,
+    launch_if_needed: bool,
+    timeout: std::time::Duration,
+    resources_dir: Option<&std::path::Path>,
+) -> Result<(), String> {
+    let binary_path = resolve_native_cli_binary_in(service, resources_dir)?;
     log::info!(
         "check_os_permission: spawning {service}-cli check_permission launch={launch_if_needed} (binary={})",
         binary_path.display()
@@ -1019,10 +1037,26 @@ fn merge_oauth_state_json(
     service: &str,
     fields: &std::collections::HashMap<&str, (speedwave_runtime::consts::FieldStorage, &str)>,
 ) -> Result<(), String> {
+    merge_oauth_state_json_in(
+        speedwave_runtime::consts::data_dir(),
+        project,
+        service,
+        fields,
+    )
+}
+
+/// Parameterised by `data_dir` so unit tests avoid the `consts::data_dir()`
+/// `OnceLock` cache. Production callers go through `merge_oauth_state_json`.
+fn merge_oauth_state_json_in(
+    data_dir: &std::path::Path,
+    project: &str,
+    service: &str,
+    fields: &std::collections::HashMap<&str, (speedwave_runtime::consts::FieldStorage, &str)>,
+) -> Result<(), String> {
     use speedwave_runtime::consts::FieldStorage;
     let provider = provider_id_for_service(service)
         .ok_or_else(|| format!("service '{service}' has no provider id mapping"))?;
-    let path = speedwave_runtime::plugin::oauth_state_file(project, service);
+    let path = speedwave_runtime::plugin::oauth_state_file_in(data_dir, project, service);
     let parent = path.parent().ok_or_else(|| "no parent".to_string())?;
     std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     #[cfg(unix)]
@@ -1370,7 +1404,6 @@ pub async fn restart_integration_containers(
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
-    use serial_test::serial;
 
     /// Drift guard: the camelCase JSON keys the Desktop save-path derives from the
     /// `OAuthStateProviderData` descriptors (via `snake_to_oauth_json_key`, which
@@ -2415,7 +2448,7 @@ mod tests {
             ("mail", "mail-cli"),
             ("notes", "notes-cli"),
         ] {
-            let path = resolve_native_cli_binary(service).unwrap();
+            let path = resolve_native_cli_binary_in(service, None).unwrap();
             assert!(
                 path.to_string_lossy().contains(expected_binary),
                 "path for {service} should contain {expected_binary}, got: {}",
@@ -2426,7 +2459,7 @@ mod tests {
 
     #[test]
     fn resolve_native_cli_binary_rejects_unknown() {
-        assert!(resolve_native_cli_binary("unknown").is_err());
+        assert!(resolve_native_cli_binary_in("unknown", None).is_err());
     }
 
     #[test]
@@ -2441,8 +2474,8 @@ mod tests {
 
         for service in &os_services {
             assert!(
-                resolve_native_cli_binary(service).is_ok(),
-                "resolve_native_cli_binary must handle OS service '{service}'"
+                resolve_native_cli_binary_in(service, None).is_ok(),
+                "resolve_native_cli_binary_in must handle OS service '{service}'"
             );
         }
 
@@ -2473,14 +2506,14 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
-    #[serial]
     fn check_os_permission_handles_binary_not_found() {
-        std::env::set_var(
-            speedwave_runtime::consts::BUNDLE_RESOURCES_ENV,
-            "/nonexistent/path",
+        let dir = std::path::Path::new("/nonexistent/path");
+        let result = check_os_permission_with_timeout_in(
+            "reminders",
+            false,
+            std::time::Duration::from_secs(60),
+            Some(dir),
         );
-        let result = check_os_permission("reminders", false);
-        std::env::remove_var(speedwave_runtime::consts::BUNDLE_RESOURCES_ENV);
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(
@@ -2491,7 +2524,6 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
-    #[serial]
     fn check_os_permission_handles_non_executable_binary() {
         let tmp = tempfile::tempdir().unwrap();
         let binary_path = tmp.path().join("reminders-cli");
@@ -2500,9 +2532,12 @@ mod tests {
         use std::os::unix::fs::PermissionsExt;
         std::fs::set_permissions(&binary_path, std::fs::Permissions::from_mode(0o644)).unwrap();
 
-        std::env::set_var(speedwave_runtime::consts::BUNDLE_RESOURCES_ENV, tmp.path());
-        let result = check_os_permission("reminders", false);
-        std::env::remove_var(speedwave_runtime::consts::BUNDLE_RESOURCES_ENV);
+        let result = check_os_permission_with_timeout_in(
+            "reminders",
+            false,
+            std::time::Duration::from_secs(60),
+            Some(tmp.path()),
+        );
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(
@@ -2513,7 +2548,6 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
-    #[serial]
     fn check_os_permission_handles_nonzero_exit() {
         let tmp = tempfile::tempdir().unwrap();
         let script = tmp.path().join("reminders-cli");
@@ -2521,16 +2555,18 @@ mod tests {
         use std::os::unix::fs::PermissionsExt;
         std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
 
-        std::env::set_var(speedwave_runtime::consts::BUNDLE_RESOURCES_ENV, tmp.path());
-        let result = check_os_permission("reminders", false);
-        std::env::remove_var(speedwave_runtime::consts::BUNDLE_RESOURCES_ENV);
+        let result = check_os_permission_with_timeout_in(
+            "reminders",
+            false,
+            std::time::Duration::from_secs(60),
+            Some(tmp.path()),
+        );
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("crash info"));
     }
 
     #[cfg(target_os = "macos")]
     #[test]
-    #[serial]
     fn check_os_permission_handles_exit_0_garbage_stdout() {
         let tmp = tempfile::tempdir().unwrap();
         let script = tmp.path().join("reminders-cli");
@@ -2538,16 +2574,18 @@ mod tests {
         use std::os::unix::fs::PermissionsExt;
         std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
 
-        std::env::set_var(speedwave_runtime::consts::BUNDLE_RESOURCES_ENV, tmp.path());
-        let result = check_os_permission("reminders", false);
-        std::env::remove_var(speedwave_runtime::consts::BUNDLE_RESOURCES_ENV);
+        let result = check_os_permission_with_timeout_in(
+            "reminders",
+            false,
+            std::time::Duration::from_secs(60),
+            Some(tmp.path()),
+        );
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Failed to parse"));
     }
 
     #[cfg(target_os = "macos")]
     #[test]
-    #[serial]
     fn check_os_permission_timeout_kills_child() {
         // Intentionally slow test (~5s) — spawns a script that sleeps 60s,
         // but we set a 2s timeout so it gets killed quickly.
@@ -2557,10 +2595,12 @@ mod tests {
         use std::os::unix::fs::PermissionsExt;
         std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
 
-        std::env::set_var(speedwave_runtime::consts::BUNDLE_RESOURCES_ENV, tmp.path());
-        let result =
-            check_os_permission_with_timeout("reminders", false, std::time::Duration::from_secs(2));
-        std::env::remove_var(speedwave_runtime::consts::BUNDLE_RESOURCES_ENV);
+        let result = check_os_permission_with_timeout_in(
+            "reminders",
+            false,
+            std::time::Duration::from_secs(2),
+            Some(tmp.path()),
+        );
         assert!(result.is_err());
         assert!(
             result.unwrap_err().contains("timed out"),
@@ -2763,11 +2803,9 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn merge_oauth_state_json_initializes_with_provider_data_object() {
         let tmp = tempfile::tempdir().unwrap();
-        let prev = std::env::var("SPEEDWAVE_DATA_DIR").ok();
-        std::env::set_var("SPEEDWAVE_DATA_DIR", tmp.path());
+        let data_dir = tmp.path();
 
         let fields: std::collections::HashMap<_, _> = [
             merge_field("client_id", "cid"),
@@ -2776,9 +2814,9 @@ mod tests {
         ]
         .into_iter()
         .collect();
-        merge_oauth_state_json("p", "sharepoint", &fields).unwrap();
+        merge_oauth_state_json_in(data_dir, "p", "sharepoint", &fields).unwrap();
 
-        let path = speedwave_runtime::plugin::oauth_state_file("p", "sharepoint");
+        let path = speedwave_runtime::plugin::oauth_state_file_in(data_dir, "p", "sharepoint");
         let json: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(json["provider"], "microsoft");
@@ -2795,25 +2833,18 @@ mod tests {
             let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
             assert_eq!(mode, 0o600, "oauth.json must be created with chmod 600");
         }
-
-        match prev {
-            Some(v) => std::env::set_var("SPEEDWAVE_DATA_DIR", v),
-            None => std::env::remove_var("SPEEDWAVE_DATA_DIR"),
-        }
     }
 
     #[test]
-    #[serial]
     fn merge_oauth_state_json_merges_into_existing_provider_data() {
         // Existing file already has a populated providerData node (typical
         // read-modify-write: user updates one field via UI, the others stay).
         // The merge must add the new field, preserve the old one, and keep
         // top-level fields intact.
         let tmp = tempfile::tempdir().unwrap();
-        let prev = std::env::var("SPEEDWAVE_DATA_DIR").ok();
-        std::env::set_var("SPEEDWAVE_DATA_DIR", tmp.path());
+        let data_dir = tmp.path();
 
-        let path = speedwave_runtime::plugin::oauth_state_file("p", "sharepoint");
+        let path = speedwave_runtime::plugin::oauth_state_file_in(data_dir, "p", "sharepoint");
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
         std::fs::write(
             &path,
@@ -2832,7 +2863,7 @@ mod tests {
         ]
         .into_iter()
         .collect();
-        merge_oauth_state_json("p", "sharepoint", &fields).unwrap();
+        merge_oauth_state_json_in(data_dir, "p", "sharepoint", &fields).unwrap();
 
         let json: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
@@ -2855,21 +2886,14 @@ mod tests {
                 "oauth.json must remain chmod 600 across merges"
             );
         }
-
-        match prev {
-            Some(v) => std::env::set_var("SPEEDWAVE_DATA_DIR", v),
-            None => std::env::remove_var("SPEEDWAVE_DATA_DIR"),
-        }
     }
 
     #[test]
-    #[serial]
     fn merge_oauth_state_json_repairs_scalar_provider_data() {
         let tmp = tempfile::tempdir().unwrap();
-        let prev = std::env::var("SPEEDWAVE_DATA_DIR").ok();
-        std::env::set_var("SPEEDWAVE_DATA_DIR", tmp.path());
+        let data_dir = tmp.path();
 
-        let path = speedwave_runtime::plugin::oauth_state_file("p", "sharepoint");
+        let path = speedwave_runtime::plugin::oauth_state_file_in(data_dir, "p", "sharepoint");
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
         std::fs::write(
             &path,
@@ -2879,55 +2903,41 @@ mod tests {
 
         let fields: std::collections::HashMap<_, _> =
             [merge_field("client_id", "cid")].into_iter().collect();
-        merge_oauth_state_json("p", "sharepoint", &fields).unwrap();
+        merge_oauth_state_json_in(data_dir, "p", "sharepoint", &fields).unwrap();
 
         let json: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         assert!(json["providerData"].is_object());
         assert_eq!(json["providerData"]["clientId"], "cid");
-
-        match prev {
-            Some(v) => std::env::set_var("SPEEDWAVE_DATA_DIR", v),
-            None => std::env::remove_var("SPEEDWAVE_DATA_DIR"),
-        }
     }
 
     #[test]
-    #[serial]
     fn merge_oauth_state_json_preserves_existing_fields_on_corrupt_json() {
         let tmp = tempfile::tempdir().unwrap();
-        let prev = std::env::var("SPEEDWAVE_DATA_DIR").ok();
-        std::env::set_var("SPEEDWAVE_DATA_DIR", tmp.path());
+        let data_dir = tmp.path();
 
-        let path = speedwave_runtime::plugin::oauth_state_file("p", "sharepoint");
+        let path = speedwave_runtime::plugin::oauth_state_file_in(data_dir, "p", "sharepoint");
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
         std::fs::write(&path, "not json at all").unwrap();
 
         let fields: std::collections::HashMap<_, _> =
             [merge_field("client_id", "cid")].into_iter().collect();
-        merge_oauth_state_json("p", "sharepoint", &fields).unwrap();
+        merge_oauth_state_json_in(data_dir, "p", "sharepoint", &fields).unwrap();
 
         let json: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(json["provider"], "microsoft");
         assert_eq!(json["providerData"]["clientId"], "cid");
-
-        match prev {
-            Some(v) => std::env::set_var("SPEEDWAVE_DATA_DIR", v),
-            None => std::env::remove_var("SPEEDWAVE_DATA_DIR"),
-        }
     }
 
     #[test]
-    #[serial]
     fn merge_oauth_state_json_repairs_missing_provider_data_node() {
         // Existing file lacks `providerData` (e.g. corrupted at that node).
         // The merge must repair it rather than silently drop client_id/tenant_id.
         let tmp = tempfile::tempdir().unwrap();
-        let prev = std::env::var("SPEEDWAVE_DATA_DIR").ok();
-        std::env::set_var("SPEEDWAVE_DATA_DIR", tmp.path());
+        let data_dir = tmp.path();
 
-        let path = speedwave_runtime::plugin::oauth_state_file("p", "sharepoint");
+        let path = speedwave_runtime::plugin::oauth_state_file_in(data_dir, "p", "sharepoint");
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
         std::fs::write(
             &path,
@@ -2937,31 +2947,24 @@ mod tests {
 
         let fields: std::collections::HashMap<_, _> =
             [merge_field("client_id", "cid")].into_iter().collect();
-        merge_oauth_state_json("p", "sharepoint", &fields).unwrap();
+        merge_oauth_state_json_in(data_dir, "p", "sharepoint", &fields).unwrap();
 
         let json: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(json["providerData"]["clientId"], "cid");
         // Pre-existing top-level fields preserved.
         assert_eq!(json["refreshToken"], "old");
-
-        match prev {
-            Some(v) => std::env::set_var("SPEEDWAVE_DATA_DIR", v),
-            None => std::env::remove_var("SPEEDWAVE_DATA_DIR"),
-        }
     }
 
     #[test]
-    #[serial]
     fn merge_oauth_state_json_lifts_legacy_top_level_identity() {
         // Legacy file with clientId/tenantId at top level (pre-providerData).
         // A re-save must lift them under providerData AND remove the top-level
         // copies — not leave them orphaned next to an empty providerData.
         let tmp = tempfile::tempdir().unwrap();
-        let prev = std::env::var("SPEEDWAVE_DATA_DIR").ok();
-        std::env::set_var("SPEEDWAVE_DATA_DIR", tmp.path());
+        let data_dir = tmp.path();
 
-        let path = speedwave_runtime::plugin::oauth_state_file("p", "sharepoint");
+        let path = speedwave_runtime::plugin::oauth_state_file_in(data_dir, "p", "sharepoint");
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
         std::fs::write(
             &path,
@@ -2978,7 +2981,7 @@ mod tests {
         // Re-save only tenant_id; client_id must survive via the lift.
         let fields: std::collections::HashMap<_, _> =
             [merge_field("tenant_id", "new-tid")].into_iter().collect();
-        merge_oauth_state_json("p", "sharepoint", &fields).unwrap();
+        merge_oauth_state_json_in(data_dir, "p", "sharepoint", &fields).unwrap();
 
         let json: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
@@ -2988,10 +2991,5 @@ mod tests {
         assert!(json.get("clientId").is_none());
         assert!(json.get("tenantId").is_none());
         assert_eq!(json["refreshToken"], "rt");
-
-        match prev {
-            Some(v) => std::env::set_var("SPEEDWAVE_DATA_DIR", v),
-            None => std::env::remove_var("SPEEDWAVE_DATA_DIR"),
-        }
     }
 }

--- a/desktop/src-tauri/src/setup_wizard.rs
+++ b/desktop/src-tauri/src/setup_wizard.rs
@@ -609,9 +609,15 @@ fn merge_wslconfig_vpn_keys(input: &str) -> String {
 /// Speedwave always imports into `~/.speedwave/wsl/Speedwave/`, so a legitimate
 /// distro will have `ext4.vhdx` at that path. If the file is missing the distro
 /// was registered from somewhere else — bail with a clear security error.
-#[cfg(any(target_os = "windows", test))]
+#[cfg(target_os = "windows")]
 fn verify_wsl_distro_origin() -> anyhow::Result<()> {
-    let expected_vhdx = expected_wsl_vhdx_path()?;
+    verify_wsl_distro_origin_in(consts::data_dir())
+}
+
+/// Data-dir-explicit variant of [`verify_wsl_distro_origin`].
+#[cfg(any(target_os = "windows", test))]
+fn verify_wsl_distro_origin_in(data_dir: &std::path::Path) -> anyhow::Result<()> {
+    let expected_vhdx = expected_wsl_vhdx_path_in(data_dir);
     if !expected_vhdx.exists() {
         anyhow::bail!(
             "Security error: a WSL2 distribution named '{}' already exists but was \
@@ -626,14 +632,14 @@ fn verify_wsl_distro_origin() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Returns the expected path to the WSL2 virtual disk for the Speedwave distro:
-/// `~/.speedwave/wsl/Speedwave/ext4.vhdx`.
+/// Data-dir-explicit variant returning the expected WSL2 virtual-disk path:
+/// `<data_dir>/wsl/<distro>/ext4.vhdx`.
 #[cfg(any(target_os = "windows", test))]
-fn expected_wsl_vhdx_path() -> anyhow::Result<PathBuf> {
-    Ok(consts::data_dir()
+fn expected_wsl_vhdx_path_in(data_dir: &std::path::Path) -> PathBuf {
+    data_dir
         .join("wsl")
         .join(consts::wsl_distro_name())
-        .join("ext4.vhdx"))
+        .join("ext4.vhdx")
 }
 
 /// Attempts to install WSL2 via elevated PowerShell. Always bails: either
@@ -1999,9 +2005,11 @@ fn ensure_local_bin_on_path_for_shell(
 /// - Unix: `~/.local/bin/speedwave`
 /// - Windows: `~/.speedwave/bin/speedwave.exe`
 ///
-/// Used only in tests to verify the path computation matches `link_cli_from`.
+/// Returns the install path of the CLI binary for an explicit `data_dir`.
+/// Only the Windows branch consults `data_dir`; on Unix the path derives from
+/// the home dir. Used only in tests to verify the path matches `link_cli_from`.
 #[cfg(test)]
-fn cli_install_path() -> Option<std::path::PathBuf> {
+fn cli_install_path_in(_data_dir: &std::path::Path) -> Option<std::path::PathBuf> {
     #[cfg(unix)]
     let path = dirs::home_dir()?
         .join(".local")
@@ -2009,9 +2017,7 @@ fn cli_install_path() -> Option<std::path::PathBuf> {
         .join(consts::CLI_BINARY);
 
     #[cfg(target_os = "windows")]
-    let path = consts::data_dir()
-        .join(consts::CLI_BIN_SUBDIR)
-        .join("speedwave.exe");
+    let path = _data_dir.join(consts::CLI_BIN_SUBDIR).join("speedwave.exe");
 
     Some(path)
 }
@@ -3610,7 +3616,8 @@ mod tests {
 
     #[test]
     fn cli_install_path_returns_platform_specific_path() {
-        let path = cli_install_path().expect("should return a path");
+        let data_dir = tempfile::tempdir().expect("tempdir");
+        let path = cli_install_path_in(data_dir.path()).expect("should return a path");
 
         #[cfg(unix)]
         assert!(
@@ -4018,7 +4025,9 @@ mod tests {
     fn decode_wsl_output_imported_from_runtime_works() {
         // Smoke test: verify the re-exported decode_wsl_output handles
         // UTF-16LE correctly. Full test coverage lives in speedwave-runtime.
-        let text = "Ubuntu\r\nSpeedwave\r\n";
+        // Build the input from `wsl_distro_name()` (derived from the data_dir
+        // basename) so the test is independent of the process-global data_dir.
+        let text = format!("Ubuntu\r\n{}\r\n", consts::wsl_distro_name());
         let mut bytes: Vec<u8> = Vec::new();
         for ch in text.encode_utf16() {
             bytes.extend_from_slice(&ch.to_le_bytes());
@@ -4035,32 +4044,18 @@ mod tests {
 
     // ── verify_wsl_distro_origin tests ───────────────────────────────────
     //
-    // All three tests below mutate the same path
-    // (`<data_dir>/wsl/Speedwave/ext4.vhdx`) — they create or check for the
-    // marker file. `#[serial]` prevents them from racing each other under
-    // `cargo test` parallel execution.
+    // Each test uses its own tempdir as the data_dir via the `_in` variant, so
+    // they neither touch the production data dir nor race each other.
 
     #[test]
-    #[serial]
     fn verify_wsl_distro_origin_passes_when_vhdx_exists() {
-        // Create the expected vhdx file under the real data_dir() (OnceLock-cached).
-        let vhdx_dir = consts::data_dir()
-            .join("wsl")
-            .join(consts::wsl_distro_name());
+        let data_dir = tempfile::tempdir().expect("tempdir");
+        let vhdx_dir = data_dir.path().join("wsl").join(consts::wsl_distro_name());
         std::fs::create_dir_all(&vhdx_dir).expect("create dirs");
-        let vhdx_file = vhdx_dir.join("ext4.vhdx");
-        let existed_before = vhdx_file.exists();
-        if !existed_before {
-            std::fs::write(&vhdx_file, b"fake vhdx").expect("write marker");
-        }
+        std::fs::write(vhdx_dir.join("ext4.vhdx"), b"fake vhdx").expect("write marker");
 
-        let result = verify_wsl_distro_origin();
+        let result = verify_wsl_distro_origin_in(data_dir.path());
 
-        // Clean up only if we created the file
-        if !existed_before {
-            let _ = std::fs::remove_file(&vhdx_file);
-            let _ = std::fs::remove_dir(&vhdx_dir);
-        }
         assert!(
             result.is_ok(),
             "expected Ok when ext4.vhdx exists, got: {result:?}"
@@ -4068,20 +4063,10 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn verify_wsl_distro_origin_fails_when_vhdx_missing() {
-        // Verify that verify_wsl_distro_origin fails when the vhdx doesn't exist.
-        // Since data_dir() points to the real data dir, just ensure the vhdx
-        // file doesn't exist there (it shouldn't in dev/test environments).
-        let vhdx_path = consts::data_dir()
-            .join("wsl")
-            .join(consts::wsl_distro_name())
-            .join("ext4.vhdx");
-        if vhdx_path.exists() {
-            // Skip: can't test "missing" when file genuinely exists
-            return;
-        }
-        let result = verify_wsl_distro_origin();
+        // Empty tempdir — the vhdx file does not exist.
+        let data_dir = tempfile::tempdir().expect("tempdir");
+        let result = verify_wsl_distro_origin_in(data_dir.path());
         let err_msg = result
             .expect_err("expected Err when vhdx missing")
             .to_string();
@@ -4092,29 +4077,14 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn verify_wsl_distro_origin_rejects_empty_directory() {
         // Create the wsl distro directory without the ext4.vhdx file.
-        let vhdx_dir = consts::data_dir()
-            .join("wsl")
-            .join(consts::wsl_distro_name());
-        let dir_existed = vhdx_dir.exists();
+        let data_dir = tempfile::tempdir().expect("tempdir");
+        let vhdx_dir = data_dir.path().join("wsl").join(consts::wsl_distro_name());
         std::fs::create_dir_all(&vhdx_dir).expect("create dirs");
 
-        // Remove the vhdx file if it exists to test the "empty dir" case
-        let vhdx_file = vhdx_dir.join("ext4.vhdx");
-        let file_existed = vhdx_file.exists();
-        if file_existed {
-            // Skip: can't test "empty dir" when file genuinely exists
-            return;
-        }
+        let result = verify_wsl_distro_origin_in(data_dir.path());
 
-        let result = verify_wsl_distro_origin();
-
-        // Clean up only if we created the directory
-        if !dir_existed {
-            let _ = std::fs::remove_dir(&vhdx_dir);
-        }
         let err_msg = result
             .expect_err("expected Err when vhdx missing in empty dir")
             .to_string();
@@ -4126,9 +4096,10 @@ mod tests {
 
     #[test]
     fn expected_wsl_vhdx_path_structure() {
-        let path = expected_wsl_vhdx_path().expect("should resolve path");
+        let data_dir = tempfile::tempdir().expect("tempdir");
+        let path = expected_wsl_vhdx_path_in(data_dir.path());
         let path_str = path.to_string_lossy();
-        let data_dir_str = consts::data_dir().to_string_lossy().to_string();
+        let data_dir_str = data_dir.path().to_string_lossy().to_string();
         assert!(
             path_str.contains(&data_dir_str),
             "path should contain data dir ({data_dir_str}): {path_str}"

--- a/desktop/src/src/app/settings/auth-section/auth-section.component.spec.ts
+++ b/desktop/src/src/app/settings/auth-section/auth-section.component.spec.ts
@@ -89,13 +89,23 @@ describe('AuthSectionComponent', () => {
     expect(note?.textContent).toContain('No authentication needed for local model providers');
   });
 
+  it('shows local provider note when llmProvider is the canonical local', () => {
+    fixture.componentRef.setInput('llmProvider', 'local');
+    fixture.detectChanges();
+    const note = fixture.nativeElement.querySelector('[data-testid="auth-note"]');
+    expect(note?.textContent).toContain('No authentication needed for local model providers');
+  });
+
   it.each([
     ['ollama', true],
     ['lmstudio', true],
     ['llamacpp', true],
-    ['custom', true],
+    ['local', true],
+    ['custom', false],
     ['anthropic', false],
   ])('isLocalProvider() returns %s for provider %s', (provider, expected) => {
+    // Mirrors the SSOT LOCAL_PROVIDERS (models/llm.ts → runtime config.rs):
+    // canonical `local` is local; `custom` is not a real provider.
     fixture.componentRef.setInput('llmProvider', provider);
     expect(component.isLocalProvider()).toBe(expected);
   });

--- a/desktop/src/src/app/settings/auth-section/auth-section.component.ts
+++ b/desktop/src/src/app/settings/auth-section/auth-section.component.ts
@@ -11,6 +11,7 @@ import { CommonModule } from '@angular/common';
 import { TauriService } from '../../services/tauri.service';
 import { ProjectStateService, AuthStatusResponse } from '../../services/project-state.service';
 import { AuthTerminalComponent } from '../auth-terminal.component';
+import { isLocalProvider as isLocalProviderName } from '../../models/llm';
 
 /** Displays authentication status and controls for API key / OAuth login. */
 @Component({
@@ -166,7 +167,7 @@ export class AuthSectionComponent {
 
   /** Returns true if the selected provider is a local model (no Anthropic auth needed). */
   isLocalProvider(): boolean {
-    return ['ollama', 'lmstudio', 'llamacpp', 'custom'].includes(this.llmProvider());
+    return isLocalProviderName(this.llmProvider());
   }
 
   /** Loads the current authentication status from the backend. */

--- a/desktop/src/src/app/shell/shell.component.spec.ts
+++ b/desktop/src/src/app/shell/shell.component.spec.ts
@@ -339,6 +339,19 @@ describe('ShellComponent', () => {
       expect(overlay!.textContent).toContain('Container config changed');
     });
 
+    it('shows overlay when needsRestart is true and status is auth_required', () => {
+      // Toggling an integration is valid before Anthropic login; the restart
+      // prompt must still surface in auth_required, not only in ready.
+      projectState.status = 'auth_required';
+      projectState.needsRestart = true;
+      component['cdr'].markForCheck();
+      fixture.detectChanges();
+
+      const overlay = q('[data-testid="restart-overlay"]');
+      expect(overlay).not.toBeNull();
+      expect(overlay!.textContent).toContain('restart required');
+    });
+
     it('hides overlay when needsRestart is false', () => {
       projectState.needsRestart = false;
       component['cdr'].markForCheck();
@@ -367,15 +380,6 @@ describe('ShellComponent', () => {
           `overlay should be hidden for status=${status}`
         ).toBeNull();
       }
-    });
-
-    it('hides overlay when status is auth_required', () => {
-      projectState.needsRestart = true;
-      projectState.status = 'auth_required';
-      component['cdr'].markForCheck();
-      fixture.detectChanges();
-
-      expect(q('[data-testid="restart-overlay"]')).toBeNull();
     });
 
     it('hides overlay when status is error', () => {

--- a/desktop/src/src/app/shell/shell.component.ts
+++ b/desktop/src/src/app/shell/shell.component.ts
@@ -105,7 +105,10 @@ import { CloudStorageModalComponent } from '../shared/cloudstorage-modal/cloudst
           </div>
         }
       }
-      @if (projectState.needsRestart && projectState.status === 'ready') {
+      @if (
+        projectState.needsRestart &&
+        (projectState.status === 'ready' || projectState.status === 'auth_required')
+      ) {
         @if (projectState.restarting) {
           <div
             class="fixed inset-0 z-[900] flex items-center justify-center bg-black/75 backdrop-blur-sm"

--- a/docs/adr/ADR-005-two-interfaces-cli-and-desktop.md
+++ b/docs/adr/ADR-005-two-interfaces-cli-and-desktop.md
@@ -9,11 +9,13 @@ Speedwave ships two separate interfaces that share a single `speedwave-runtime` 
 **CLI** — for developers:
 
 ```bash
-cd ~/projects/acme-corp
-speedwave  # → Lima VM + containers + Claude Code in terminal
+speedwave  # → Lima VM + containers + Claude Code for the active project
 ```
 
-Project context = working directory. Zero configuration. Identical UX to today.
+Project context = the active project (the Desktop project switcher's
+`active_project`), or `--project <name>` to override. The working directory is
+not consulted for project selection. See [the CLI guide's Project Resolution
+section](../guides/cli.md#project-resolution) for the precedence rules.
 
 **Desktop (Speedwave.app)** — for everyone:
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -108,13 +108,13 @@ See [ADR-064: Bypass `canonicalize()` for WSL UNC project paths](../adr/ADR-064-
 After the setup wizard finishes, log in to your Claude account so Claude Code can run inside the container without prompting on every start. Two equivalent paths:
 
 - **From the Desktop app** — open Settings → Authentication and click **Open terminal and log in**. Speedwave opens a system terminal running `speedwave login --project <name>`. Type `/login` at Claude's prompt and follow the OAuth flow. Claude Code saves your credentials inside the container automatically when the flow completes.
-- **From the CLI** — `cd` into your registered project directory and run:
+- **From the CLI** — run:
 
   ```bash
   speedwave login
   ```
 
-  or pass `--project <name>` if you want to log in for a project other than the one matched by your current directory. Type `/login` at Claude's prompt.
+  This logs in for the active project (the one selected in the Desktop project switcher). Pass `--project <name>` to log in for a different registered project from any directory. Type `/login` at Claude's prompt.
 
 Credentials are stored by Claude Code at `~/.speedwave/claude-home/<project>/.claude/.credentials.json` (the per-project CLAUDE_HOME bind-mount) and are available on every subsequent `speedwave` start. To log out, run `speedwave logout` (or `speedwave logout --project <name>`). Credentials are per-project — logging in for one project does not authenticate another. See [ADR-052](../adr/ADR-052-anthropic-oauth-login-flow.md) for the full rationale.
 

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -13,10 +13,11 @@ The CLI is re-linked on every Desktop startup, so Desktop updates automatically 
 
 ## Basic Usage
 
-The CLI uses the current working directory as project context:
+Bare `speedwave` runs the **active project** — the one selected in the Desktop project switcher (`active_project` in config). The working directory does not select the project; pass `--project <name>` to target a different one:
 
 ```bash
-cd ~/projects/acme && speedwave
+speedwave                      # run the active project (Desktop selector)
+speedwave --project acme       # run a specific project from any directory
 ```
 
 This renders compose for the current bundle, starts containers for the project, then launches an interactive Claude Code session inside the Claude container with all configured MCP integrations available.
@@ -24,12 +25,12 @@ This renders compose for the current bundle, starts containers for the project, 
 ## Subcommands
 
 ```
-speedwave                      # default: compose_up + exec claude in container
+speedwave [--project <name>]   # default: compose_up + exec claude for the active project
 speedwave init [name]          # register CWD as a project
 speedwave login [--project <name>]   # OAuth login: opens claude TUI for /login
 speedwave logout [--project <name>]  # delete Claude credentials for the project
 speedwave check                # run OS prereq + security checks, exit 0/1
-speedwave update               # rebuild current bundle images + recreate containers
+speedwave update [--project <name>]  # rebuild bundle images + recreate containers
 speedwave self-update          # download latest CLI from GitHub Releases
 speedwave plugin install <path.zip>  # install plugin from signed ZIP
 speedwave plugin list                # list installed plugins with status
@@ -39,20 +40,20 @@ speedwave plugin disable <slug> --project <name>  # disable plugin for a project
 speedwave --help | -h | help   # print usage and exit (no runtime required)
 ```
 
-- **`speedwave`** (no subcommand) — starts containers via `compose_up`, then exec's into the Claude container for an interactive session
+- **`speedwave [--project <name>]`** (no subcommand) — starts containers via `compose_up`, then exec's into the Claude container for an interactive session. Targets the active project (the Desktop selector) by default; `--project <name>` overrides it from any directory.
 - **`speedwave init [name]`** — registers the current working directory as a Speedwave project. If `name` is omitted, the directory name is used. The project is set as active. Project names must be lowercase (`a-z`, `0-9`, `_`, `.`, `-`), start with a letter or digit, and be at most 63 characters. Example:
   ```bash
   cd ~/projects/acme && speedwave init        # registers as "acme"
   cd ~/projects/acme && speedwave init my-app # registers as "my-app"
   ```
   If the directory is already registered, prints the existing project name and exits.
-- **`speedwave login [--project <name>]`** — runs `compose_up`, then exec's into the Claude container and starts an interactive `claude` session. Type `/login` at Claude's prompt to walk through the Anthropic OAuth flow (browser sign-in, paste-back code if the localhost callback can't reach the host). Claude Code stores credentials inside the container at `~/.claude/.credentials.json`, persisted on the host via the per-project `CLAUDE_HOME` bind-mount. If `--project <name>` is omitted, uses the project matched by CWD. See [ADR-052](../adr/ADR-052-anthropic-oauth-login-flow.md).
-- **`speedwave logout [--project <name>]`** — deletes Claude Code's credential files (`.credentials.json`, `.claude.json`) from the project's `CLAUDE_HOME` mount. No runtime required. Idempotent — succeeds even when nothing is stored.
+- **`speedwave login [--project <name>]`** — runs `compose_up`, then exec's into the Claude container and starts an interactive `claude` session. Type `/login` at Claude's prompt to walk through the Anthropic OAuth flow (browser sign-in, paste-back code if the localhost callback can't reach the host). Claude Code stores credentials inside the container at `~/.claude/.credentials.json`, persisted on the host via the per-project `CLAUDE_HOME` bind-mount. If `--project <name>` is omitted, uses the active project. See [ADR-052](../adr/ADR-052-anthropic-oauth-login-flow.md).
+- **`speedwave logout [--project <name>]`** — deletes Claude Code's credential files (`.credentials.json`, `.claude.json`) from the project's `CLAUDE_HOME` mount. No runtime required. Idempotent — succeeds even when nothing is stored. If `--project <name>` is omitted, targets the active project.
 - **`speedwave check`** — runs OS prerequisite checks (WSL2 on Windows; no host-level prerequisites on macOS) and compose security validation (cap_drop, token isolation, port binding, etc.), exits 0 on success or 1 on failure with detailed violation messages and remediation steps. Note: `check` is diagnostic-only — it reports permission violations but does NOT auto-fix them. All container start paths (`speedwave`, update, rollback) auto-fix file permissions before running SecurityCheck. `check` (and every other runtime command except `--help`, `self-update`, `init`, and the `plugin install`/`list`/`remove` recovery commands) first runs the **plugin signature audit**: if any plugin under `~/.speedwave/plugins/` no longer matches its signed contents, the command prints the affected plugins to stderr and exits `2` before doing anything else. Recover with `speedwave plugin remove <slug>` or by deleting the plugin directory.
-- **`speedwave update`** — rebuilds the built-in images for the current `bundle_id` and recreates containers with the current bundle manifest
+- **`speedwave update [--project <name>]`** — rebuilds the built-in images for the current `bundle_id` and recreates containers with the current bundle manifest. Targets the active project by default; `--project <name>` overrides it.
 - **`speedwave self-update`** — downloads the latest CLI binary from GitHub Releases, replaces the current binary, and automatically rebuilds container images if the version changed.
 
-  > **Note:** If the rebuild fails (e.g., when run from a non-project directory or without Desktop running), run `speedwave update` from your project directory. For multiple projects, run `speedwave update` from each project directory or restart the Desktop app.
+  > **Note:** If the rebuild fails (e.g., when run without Desktop running), start Desktop and run `speedwave update` again. `update` targets the active project; select a different project in the Desktop switcher to update it, or restart the Desktop app.
 
 - **`speedwave plugin install <path.zip>`** — verifies the Ed25519 signature, extracts the plugin to `~/.speedwave/plugins/<slug>/`, and registers it.
 
@@ -70,13 +71,15 @@ speedwave --help | -h | help   # print usage and exit (no runtime required)
 
 ## Project Resolution
 
-When running `speedwave` (no subcommand), the CLI resolves which project to use:
+`speedwave`, `login`, `logout`, and `update` resolve which project to use as follows:
 
-1. **Exact path match** — CWD matches a registered project directory
-2. **Subdirectory match** — CWD is inside a registered project directory (longest prefix wins for nested projects)
-3. **Fallback** — uses `active_project` from config (with a warning and hint to run `speedwave init`)
+1. **`--project <name>`** (or `--project=<name>`) — explicit override on `speedwave`/`login`/`logout`/`update`, wins from any directory. The name must be a registered project; an unknown name is rejected with an error.
+2. **Active project** — `active_project` from config, set by the Desktop project switcher (or by the last `speedwave init`)
+3. **First project** — used when no project is active
 
-All path comparisons use canonicalized paths (symlinks resolved, trailing slashes normalized).
+The working directory is **not** consulted (except by `speedwave init`, which registers the current directory as a new project). The Desktop selector is the single source of truth.
+
+Unknown subcommands and stray arguments are rejected, not silently ignored: `speedwave updatte` exits with `unknown command: 'updatte'`, and extra arguments after a subcommand (e.g. `speedwave check junk`) exit with a usage hint.
 
 ## Bundle Compatibility
 

--- a/mcp-servers/shared/src/server.test.ts
+++ b/mcp-servers/shared/src/server.test.ts
@@ -1066,11 +1066,14 @@ describe('server', () => {
     });
 
     describe('Server Lifecycle', () => {
+      // All lifecycle tests bind port 0 (OS-assigned ephemeral) so parallel
+      // vitest workers / multiple worktrees never collide on a fixed port
+      // (EADDRINUSE). start() returns the actual port for assertions.
       it('starts server successfully', async () => {
         const server = createMCPServer({
           name: 'test-server',
           version: '1.0.0',
-          port: 3100,
+          port: 0,
         });
 
         await server.start();
@@ -1085,7 +1088,7 @@ describe('server', () => {
         const server = createMCPServer({
           name: 'test-server',
           version: '1.0.0',
-          port: 3101,
+          port: 0,
           onStart,
         });
 
@@ -1099,7 +1102,7 @@ describe('server', () => {
         const server = createMCPServer({
           name: 'test-server',
           version: '1.0.0',
-          port: 3102,
+          port: 0,
         });
 
         await server.start();
@@ -1112,22 +1115,25 @@ describe('server', () => {
         const server = createMCPServer({
           name: 'test-server',
           version: '1.0.0',
-          port: 3103,
+          port: 0,
         });
 
         await expect(server.stop()).resolves.not.toThrow();
       });
 
-      it('binds to 127.0.0.1 by default', async () => {
+      it('binds to 127.0.0.1 by default and returns the actual port', async () => {
         const server = createMCPServer({
           name: 'bind-test',
           version: '1.0.0',
-          port: 3120,
+          port: 0,
         });
 
-        await server.start();
+        const actualPort = await server.start();
 
-        expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('127.0.0.1:3120'));
+        expect(actualPort).toBeGreaterThan(0);
+        expect(consoleLogSpy).toHaveBeenCalledWith(
+          expect.stringContaining(`127.0.0.1:${actualPort}`)
+        );
 
         await server.stop();
       }, 10000);
@@ -1136,13 +1142,15 @@ describe('server', () => {
         const server = createMCPServer({
           name: 'custom-bind-test',
           version: '1.0.0',
-          port: 3121,
+          port: 0,
           host: '0.0.0.0',
         });
 
-        await server.start();
+        const actualPort = await server.start();
 
-        expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('0.0.0.0:3121'));
+        expect(consoleLogSpy).toHaveBeenCalledWith(
+          expect.stringContaining(`0.0.0.0:${actualPort}`)
+        );
 
         await server.stop();
       }, 10000);
@@ -1151,14 +1159,14 @@ describe('server', () => {
         const server = createMCPServer({
           name: 'startup-test',
           version: '2.0.0',
-          port: 3104,
+          port: 0,
         });
 
-        await server.start();
+        const actualPort = await server.start();
 
         expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('startup-test'));
         expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('2.0.0'));
-        expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('3104'));
+        expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining(String(actualPort)));
 
         await server.stop();
       }, 10000);
@@ -1167,7 +1175,7 @@ describe('server', () => {
         const server = createMCPServer({
           name: 'shutdown-test',
           version: '1.0.0',
-          port: 3105,
+          port: 0,
         });
 
         await server.start();
@@ -1181,7 +1189,7 @@ describe('server', () => {
         const server = createMCPServer({
           name: 'stop-error-test',
           version: '1.0.0',
-          port: 3122,
+          port: 0,
         });
 
         await server.start();
@@ -1920,7 +1928,7 @@ describe('server', () => {
       const server = createMCPServer({
         name: 'rate-cleanup',
         version: '1.0.0',
-        port: 3106,
+        port: 0,
         rateLimit: { maxRequests: 10 },
       });
 


### PR DESCRIPTION
## Summary

Four related fixes plus the test-infrastructure work that surfaced while verifying them.

### Bug fixes (user-facing)

- **`fix(cli)`** — bare `speedwave` in the console now runs the project selected in the Desktop **project selector** (`active_project`), not the CWD-matched project. Running it during a chat session no longer silently switches the LLM provider. The Run/Login/Logout/Update paths take an explicit optional `--project` and reject stray args.
- **`fix(runtime)`** — env values carrying YAML flow indicators (`[ ] { } ,` — notably the documented `[1m]` 1M-context suffix) are re-quoted by `harden_env_scalar_quoting` so nerdctl's strict Go YAML parser accepts them. Without this the `claude` container fails to start.
- **`fix(desktop)`** — the restart-required overlay now shows when toggling an integration while signed in via local LLM / API key (not just OAuth-`ready`): the gate widened to `ready || auth_required`. The auth-section local-provider check now delegates to the `isLocalProviderName` SSOT instead of a divergent inline list.

### Test infrastructure

- **Isolation** — every cargo test run gets a unique tempdir `SPEEDWAVE_DATA_DIR` (`RUN_CARGO_ISOLATED`), so tests never touch production `~/.speedwave` and parallel worktrees no longer collide on `compose.lock` / wsl `ext4.vhdx` / shared tokens (previously deadlocked the pre-push hook). The compose render path is threaded with `data_dir` to be env-free (`render_compose_in` + `apply_{auth,mcp_os,host_exec,oauth,worker_auth}_config_in`), fixing a TOCTOU os-error-2 flake under concurrency. ~93 wsl/lima/compose/plugin tests assert via SSOT accessors instead of hardcoded `"Speedwave"` literals. Desktop/bats/vitest tests get isolated variants; MCP tests bind port 0.
- **Guardrails** — two new test crates fail the build if a test writes to the prod data dir (runtime backstop for transitive leaks) or names `data_dir()` raw (static scan).
- **Parallelism** — drops the `--test-threads=1` cap and redesigns the aggregate `make test` as **build-once + parallel-run**: a sequential `test-build-phase` stages every shared artifact, then `$(MAKE) -j4 test-run-lanes` fans out the run-only lanes. `test-mcp`/`test-desktop-build`/`test-desktop` stay in one serial group because `bundle-build-context.bats`'s `--ci` test rebuilds the `mcp-servers/*/dist` the desktop bundle reads. **CI is unaffected** — it calls the standalone `test-X` targets, which keep their own build prereqs untouched.
- **Code-review follow-up** — removed two now-dead `static LOCK` guards (tests isolated via tempdir), added an explicit two-service `harden_env_scalar_quoting` test, documented the no-comments-in-`environment:` assumption.
