### PR TITLE
fix: durable compose writes + unified diagnostic-logging SSOT with sanitizer hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2604,6 +2604,7 @@ dependencies = [
  "rand 0.8.6",
  "regex",
  "reqwest",
+ "rustix",
  "semver",
  "serde",
  "serde_json",

--- a/crates/speedwave-runtime/Cargo.toml
+++ b/crates/speedwave-runtime/Cargo.toml
@@ -92,6 +92,10 @@ windows-sys = { version = "0.61", features = [
     "Win32_System_Threading",
 ] }
 
+[target.'cfg(unix)'.dependencies]
+# Durable writes: safe fsync wrappers (macOS F_FULLFSYNC); `unsafe`-free.
+rustix = { version = "1", features = ["fs"] }
+
 [features]
 # Host-side meeting transcription: WAV I/O + the model downloader + the Whisper
 # transcriber + the sherpa-onnx diarizer (+ cpal on Windows for WASAPI loopback).

--- a/crates/speedwave-runtime/src/consts.rs
+++ b/crates/speedwave-runtime/src/consts.rs
@@ -968,12 +968,21 @@ pub fn claude_session_log_path_in(home: &std::path::Path, project: &str) -> std:
         .join(CLAUDE_SESSION_LOG_FILE)
 }
 
-/// Build the per-project Claude session log path.
-pub fn claude_session_log_path(project: &str) -> std::path::PathBuf {
-    data_dir()
+/// SSOT for the Claude session log path under an explicit data dir — used by the
+/// diagnostic-source registry. `claude_session_log_path` is the `data_dir()` shim.
+pub fn claude_session_log_path_under(
+    data_dir: &std::path::Path,
+    project: &str,
+) -> std::path::PathBuf {
+    data_dir
         .join("logs")
         .join(project)
         .join(CLAUDE_SESSION_LOG_FILE)
+}
+
+/// Build the per-project Claude session log path.
+pub fn claude_session_log_path(project: &str) -> std::path::PathBuf {
+    claude_session_log_path_under(data_dir(), project)
 }
 
 /// SSOT for the mcp-os drain log path — never re-join `data_dir()` by hand.

--- a/crates/speedwave-runtime/src/consts.rs
+++ b/crates/speedwave-runtime/src/consts.rs
@@ -976,6 +976,11 @@ pub fn claude_session_log_path(project: &str) -> std::path::PathBuf {
         .join(CLAUDE_SESSION_LOG_FILE)
 }
 
+/// SSOT for the mcp-os drain log path — never re-join `data_dir()` by hand.
+pub fn mcp_os_log_path() -> std::path::PathBuf {
+    data_dir().join(MCP_OS_LOG_FILE)
+}
+
 /// Built-in services defined in containers/compose.template.yml.
 /// Used by security checks and image build lists.
 pub const BUILT_IN_SERVICES: &[&str] = &[
@@ -1920,6 +1925,20 @@ mod tests {
         assert_eq!(
             path,
             std::path::PathBuf::from("/home/user/.speedwave/logs/proj.v1/claude-session.log")
+        );
+    }
+
+    #[test]
+    fn mcp_os_log_path_ends_with_data_dir_and_log_file() {
+        let path = mcp_os_log_path();
+        assert!(
+            path.ends_with(MCP_OS_LOG_FILE),
+            "mcp_os_log_path must end with MCP_OS_LOG_FILE, got {path:?}"
+        );
+        assert_eq!(
+            path,
+            data_dir().join(MCP_OS_LOG_FILE),
+            "mcp_os_log_path is the SSOT for data_dir()/MCP_OS_LOG_FILE"
         );
     }
 

--- a/crates/speedwave-runtime/src/diagnostic_sources.rs
+++ b/crates/speedwave-runtime/src/diagnostic_sources.rs
@@ -1,0 +1,201 @@
+//! SSOT registry of diagnostic sources. The `/logs` view and the diagnostics
+//! ZIP both derive their content from `DIAGNOSTIC_SOURCES`, so they cannot drift
+//! (see the parity tests). The only allowed divergence: a non-`displayable`
+//! source (an artifact the line-oriented `/logs` view can't render, e.g.
+//! `compose.yml`) is ZIP-only.
+
+use std::path::{Path, PathBuf};
+
+use crate::consts;
+
+/// Platforms a source exists on. `lima/serial.log` is macOS-only.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Platforms {
+    All,
+    MacOnly,
+    WindowsOnly,
+}
+
+impl Platforms {
+    /// True if the source exists on the current target.
+    pub fn available_here(self) -> bool {
+        match self {
+            Platforms::All => true,
+            Platforms::MacOnly => cfg!(target_os = "macos"),
+            Platforms::WindowsOnly => cfg!(target_os = "windows"),
+        }
+    }
+}
+
+/// How a source's raw text is obtained. Models the 1:N cardinality the two
+/// consumers handle differently.
+#[derive(Clone, Copy)]
+pub enum SourceKind {
+    /// One file resolved from `(data_dir, project)`. `None` = not applicable.
+    File(fn(&Path, &str) -> Option<PathBuf>),
+    /// Compose stream fetched from the runtime (`/logs` token `compose`; ZIP
+    /// entry `containers/compose.log`). Splits per-container in `/logs`.
+    ComposeLogs,
+    /// The tauri-plugin-log directory: one `/logs` source, N `logs/<file>` ZIP
+    /// entries. Each consumer applies its own directory routine.
+    DesktopLogDir,
+}
+
+/// One diagnostic source. `key` is the `/logs` token (frontend `COMPOSE_RE`
+/// `[\w.-]+`); `zip_entry` is its ZIP path (a `logs/` prefix for `DesktopLogDir`).
+pub struct DiagnosticSource {
+    pub key: &'static str,
+    pub zip_entry: &'static str,
+    /// `false` = ZIP-only (not renderable in the line-oriented `/logs` view).
+    pub displayable: bool,
+    pub platforms: Platforms,
+    pub kind: SourceKind,
+}
+
+fn mcp_os_path(data_dir: &Path, _project: &str) -> Option<PathBuf> {
+    Some(data_dir.join(consts::MCP_OS_LOG_FILE))
+}
+
+fn host_exec_path(data_dir: &Path, project: &str) -> Option<PathBuf> {
+    Some(
+        crate::host_exec::host_exec_project_dir(data_dir, project).join(consts::HOST_EXEC_LOG_FILE),
+    )
+}
+
+fn claude_session_path(data_dir: &Path, project: &str) -> Option<PathBuf> {
+    Some(
+        data_dir
+            .join("logs")
+            .join(project)
+            .join(consts::CLAUDE_SESSION_LOG_FILE),
+    )
+}
+
+fn lima_serial_path(data_dir: &Path, _project: &str) -> Option<PathBuf> {
+    Some(
+        data_dir
+            .join(consts::LIMA_SUBDIR)
+            .join(consts::lima_vm_name())
+            .join("serial.log"),
+    )
+}
+
+fn compose_yml_path(data_dir: &Path, project: &str) -> Option<PathBuf> {
+    crate::compose::compose_output_path_in(data_dir, project).ok()
+}
+
+/// The SSOT list. Adding a source = one row here; both consumers pick it up.
+pub const DIAGNOSTIC_SOURCES: &[DiagnosticSource] = &[
+    DiagnosticSource {
+        key: "compose",
+        zip_entry: "containers/compose.log",
+        displayable: true,
+        platforms: Platforms::All,
+        kind: SourceKind::ComposeLogs,
+    },
+    DiagnosticSource {
+        key: "desktop",
+        zip_entry: "logs/",
+        displayable: true,
+        platforms: Platforms::All,
+        kind: SourceKind::DesktopLogDir,
+    },
+    DiagnosticSource {
+        key: "mcp-os",
+        zip_entry: "mcp-os/mcp-os.log",
+        displayable: true,
+        platforms: Platforms::All,
+        kind: SourceKind::File(mcp_os_path),
+    },
+    DiagnosticSource {
+        key: "host-exec",
+        zip_entry: "host-exec/log",
+        displayable: true,
+        platforms: Platforms::All,
+        kind: SourceKind::File(host_exec_path),
+    },
+    DiagnosticSource {
+        key: "claude",
+        zip_entry: "claude/claude-session.log",
+        displayable: true,
+        platforms: Platforms::All,
+        kind: SourceKind::File(claude_session_path),
+    },
+    DiagnosticSource {
+        key: "lima",
+        zip_entry: "lima/serial.log",
+        displayable: true,
+        platforms: Platforms::MacOnly,
+        kind: SourceKind::File(lima_serial_path),
+    },
+    DiagnosticSource {
+        key: "compose-yml",
+        zip_entry: "containers/compose.yml",
+        displayable: false,
+        platforms: Platforms::All,
+        kind: SourceKind::File(compose_yml_path),
+    },
+];
+
+/// Explicit allow-list of ZIP-only keys. A new non-`displayable` source must be
+/// added here too, or `nondisplayable_sources_match_zip_only_allowlist` fails.
+pub const ZIP_ONLY_KEYS: &[&str] = &["compose-yml"];
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nondisplayable_sources_match_zip_only_allowlist() {
+        let non_displayable: Vec<&str> = DIAGNOSTIC_SOURCES
+            .iter()
+            .filter(|s| !s.displayable)
+            .map(|s| s.key)
+            .collect();
+        assert_eq!(
+            non_displayable, ZIP_ONLY_KEYS,
+            "every non-displayable (ZIP-only) source must be justified in ZIP_ONLY_KEYS — \
+             the only allowed /logs↔ZIP divergence is a non-renderable artifact"
+        );
+    }
+
+    #[test]
+    fn keys_and_zip_entries_are_unique_and_nonempty() {
+        let mut keys: Vec<&str> = DIAGNOSTIC_SOURCES.iter().map(|s| s.key).collect();
+        keys.sort_unstable();
+        let before = keys.len();
+        keys.dedup();
+        assert_eq!(before, keys.len(), "duplicate source key");
+        for s in DIAGNOSTIC_SOURCES {
+            assert!(!s.key.is_empty(), "empty key");
+            assert!(!s.zip_entry.is_empty(), "empty zip_entry for {}", s.key);
+        }
+    }
+
+    #[test]
+    fn file_resolvers_build_paths_under_data_dir() {
+        let data_dir = Path::new("/fake/.speedwave");
+        for s in DIAGNOSTIC_SOURCES {
+            if let SourceKind::File(resolve) = s.kind {
+                let p = resolve(data_dir, "proj").expect("file resolver returned None");
+                assert!(
+                    p.starts_with(data_dir),
+                    "{} resolver escaped data_dir: {p:?}",
+                    s.key
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn platform_availability_is_consistent() {
+        // `lima` is the only MacOnly source today.
+        let mac_only: Vec<&str> = DIAGNOSTIC_SOURCES
+            .iter()
+            .filter(|s| s.platforms == Platforms::MacOnly)
+            .map(|s| s.key)
+            .collect();
+        assert_eq!(mac_only, vec!["lima"]);
+    }
+}

--- a/crates/speedwave-runtime/src/diagnostic_sources.rs
+++ b/crates/speedwave-runtime/src/diagnostic_sources.rs
@@ -63,12 +63,7 @@ fn host_exec_path(data_dir: &Path, project: &str) -> Option<PathBuf> {
 }
 
 fn claude_session_path(data_dir: &Path, project: &str) -> Option<PathBuf> {
-    Some(
-        data_dir
-            .join("logs")
-            .join(project)
-            .join(consts::CLAUDE_SESSION_LOG_FILE),
-    )
+    Some(consts::claude_session_log_path_under(data_dir, project))
 }
 
 fn lima_serial_path(data_dir: &Path, _project: &str) -> Option<PathBuf> {
@@ -141,6 +136,20 @@ pub const DIAGNOSTIC_SOURCES: &[DiagnosticSource] = &[
 /// added here too, or `nondisplayable_sources_match_zip_only_allowlist` fails.
 pub const ZIP_ONLY_KEYS: &[&str] = &["compose-yml"];
 
+/// Resolves a `SourceKind::File` source's path by key, gated to the current
+/// platform. Shared by both consumers (/logs + ZIP) so neither hand-rolls the
+/// find + platform-gate + File-extraction chain. Returns `None` for unknown
+/// keys, unavailable platforms, or non-File kinds.
+pub fn resolve_file_path(key: &str, data_dir: &Path, project: &str) -> Option<PathBuf> {
+    DIAGNOSTIC_SOURCES
+        .iter()
+        .find(|s| s.key == key && s.platforms.available_here())
+        .and_then(|s| match s.kind {
+            SourceKind::File(f) => f(data_dir, project),
+            _ => None,
+        })
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
@@ -197,5 +206,21 @@ mod tests {
             .map(|s| s.key)
             .collect();
         assert_eq!(mac_only, vec!["lima"]);
+    }
+
+    /// `zip_entry` literals embed const-owned filenames (the slice needs
+    /// `&'static str`, so they can't be `format!`-ed). Guard against drift if a
+    /// const filename changes.
+    #[test]
+    fn zip_entries_match_owning_consts() {
+        let entry = |key: &str| {
+            DIAGNOSTIC_SOURCES
+                .iter()
+                .find(|s| s.key == key)
+                .map(|s| s.zip_entry)
+                .unwrap_or_default()
+        };
+        assert!(entry("mcp-os").ends_with(consts::MCP_OS_LOG_FILE));
+        assert!(entry("claude").ends_with(consts::CLAUDE_SESSION_LOG_FILE));
     }
 }

--- a/crates/speedwave-runtime/src/diagnostic_sources.rs
+++ b/crates/speedwave-runtime/src/diagnostic_sources.rs
@@ -222,5 +222,8 @@ mod tests {
         };
         assert!(entry("mcp-os").ends_with(consts::MCP_OS_LOG_FILE));
         assert!(entry("claude").ends_with(consts::CLAUDE_SESSION_LOG_FILE));
+        assert!(entry("host-exec").ends_with(consts::HOST_EXEC_LOG_FILE));
+        // `lima`/`compose-yml` filenames are Lima's / compose's own conventions,
+        // not Speedwave consts, so there's nothing to drift against.
     }
 }

--- a/crates/speedwave-runtime/src/fs_perms.rs
+++ b/crates/speedwave-runtime/src/fs_perms.rs
@@ -13,6 +13,38 @@ use std::path::Path;
 
 use tempfile::NamedTempFile;
 
+/// Flushes a file's data to stable media. On macOS plain `fsync` returns before
+/// APFS hits the platter, so `F_FULLFSYNC` is required; other Unix uses `fsync`;
+/// Windows is a no-op (`MoveFileExW` rename is durable on NTFS).
+#[cfg(unix)]
+fn fsync_file_durable(file: &std::fs::File) -> std::io::Result<()> {
+    #[cfg(target_os = "macos")]
+    let r = rustix::fs::fcntl_fullfsync(file);
+    #[cfg(not(target_os = "macos"))]
+    let r = rustix::fs::fsync(file);
+    r.map_err(std::io::Error::from)
+}
+
+#[cfg(not(unix))]
+fn fsync_file_durable(_file: &std::fs::File) -> std::io::Result<()> {
+    Ok(())
+}
+
+/// Best-effort fsync of a directory so a contained rename is itself durable.
+/// Unix-only: opening a directory as a file and `fsync`-ing it commits the
+/// directory entry. Windows has no directory-fsync concept — no-op there.
+#[cfg(unix)]
+fn fsync_parent_dir(dir: &Path) {
+    if let Ok(handle) = std::fs::File::open(dir) {
+        // Best-effort: the data blocks are already durable (file fsync ran
+        // first), so a dir-fsync failure is non-fatal.
+        let _ = rustix::fs::fsync(&handle);
+    }
+}
+
+#[cfg(not(unix))]
+fn fsync_parent_dir(_dir: &Path) {}
+
 /// Write `content` to `path` with owner-only permissions.
 ///
 /// Both platforms now use the same write-then-atomic-rename pattern via
@@ -36,6 +68,17 @@ use tempfile::NamedTempFile;
 ///
 /// Existing directories at `path` are removed first (consistent with prior behavior).
 pub fn write_restricted_file(path: &Path, content: &str) -> anyhow::Result<()> {
+    // Direct callers: `path` is the final name, so commit its directory entry.
+    write_restricted_file_synced(path, content, true)
+}
+
+/// Core of [`write_restricted_file`]. `sync_parent_dir` = false skips the
+/// post-rename dir fsync when the caller renames `path` away next (atomic variant).
+fn write_restricted_file_synced(
+    path: &Path,
+    content: &str,
+    sync_parent_dir: bool,
+) -> anyhow::Result<()> {
     if path.is_dir() {
         log::warn!(
             "write_restricted_file: removing unexpected directory at {}",
@@ -112,10 +155,24 @@ pub fn write_restricted_file(path: &Path, content: &str) -> anyhow::Result<()> {
         );
     }
 
+    // fsync data before persist; `tempfile::persist` only renames, never fsyncs.
+    fsync_file_durable(tmp.as_file()).map_err(|e| {
+        anyhow::anyhow!(
+            "fsync tempfile before persist for {}: {}",
+            path.display(),
+            e
+        )
+    })?;
+
     // Atomic rename. On error, `tmp` is dropped (cleanup on Unix; on Windows
     // the tempfile path may linger but never as `path`).
     tmp.persist(path)
         .map_err(|e| anyhow::anyhow!("failed to persist tempfile to {}: {}", path.display(), e))?;
+
+    // fsync parent dir so the rename is durable (skipped for the atomic variant).
+    if sync_parent_dir {
+        fsync_parent_dir(parent);
+    }
 
     Ok(())
 }
@@ -141,7 +198,8 @@ pub fn write_restricted_file_atomic(path: &Path, content: &str) -> anyhow::Resul
     let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
     let tmp = parent.join(format!(".{}.tmp.{}.{}", file_name, std::process::id(), seq));
 
-    write_restricted_file(&tmp, content).inspect_err(|_| {
+    // `false`: the inner dir fsync is wasted — we rename `tmp` away next line.
+    write_restricted_file_synced(&tmp, content, false).inspect_err(|_| {
         let _ = std::fs::remove_file(&tmp);
     })?;
 
@@ -149,6 +207,9 @@ pub fn write_restricted_file_atomic(path: &Path, content: &str) -> anyhow::Resul
         let _ = std::fs::remove_file(&tmp);
         anyhow::bail!("rename {} -> {}: {}", tmp.display(), path.display(), e);
     }
+
+    // fsync parent dir once for the final name (data already fsynced by the inner write).
+    fsync_parent_dir(parent);
 
     Ok(())
 }
@@ -595,5 +656,87 @@ mod tests {
         ensure_owner_only_dir(&target).unwrap();
 
         assert!(target.is_dir());
+    }
+
+    // ── durability fsync ─────────────────────────────────────────────────
+
+    /// Happy path: fsync of a real, open file succeeds. On macOS this exercises
+    /// the `F_FULLFSYNC` branch; on other Unix the `fsync` branch.
+    #[cfg(unix)]
+    #[test]
+    fn fsync_file_durable_ok_on_open_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("f");
+        let file = std::fs::File::create(&path).unwrap();
+        std::io::Write::write_all(&mut (&file), b"data").unwrap();
+        fsync_file_durable(&file).expect("fsync of an open writable file must succeed");
+    }
+
+    /// Error path: `F_FULLFSYNC` on a non-syncable fd must surface, not swallow.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn fsync_file_durable_surfaces_error_on_nonsyncable_fd() {
+        // /dev/null does not support F_FULLFSYNC — fcntl returns ENOTSUP/EINVAL.
+        let file = std::fs::OpenOptions::new()
+            .write(true)
+            .open("/dev/null")
+            .unwrap();
+        assert!(
+            fsync_file_durable(&file).is_err(),
+            "F_FULLFSYNC on /dev/null must surface an error, not be swallowed"
+        );
+    }
+
+    /// Regression: the fsync insertion must not change the observable happy-path
+    /// behavior — content and 0o600 perms are still correct after the write.
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_content_and_mode_survive_fsync() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("compose.yml");
+
+        write_restricted_file_atomic(&path, "networks:\n  net: {}\n").unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "networks:\n  net: {}\n"
+        );
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "expected 0o600, got 0o{mode:o}");
+    }
+
+    /// `fsync_parent_dir` is best-effort: a non-existent directory must not
+    /// panic or propagate (the data blocks are already durable).
+    #[cfg(unix)]
+    #[test]
+    fn fsync_parent_dir_is_best_effort_on_missing_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("does-not-exist");
+        // Must be a silent no-op — no panic, returns ().
+        fsync_parent_dir(&missing);
+    }
+
+    /// Source-ordering guard: the data fsync MUST precede `persist` in
+    /// `write_restricted_file_synced`, otherwise the rename can publish a torn
+    /// file. A future edit reordering these would reintroduce the torn-write bug.
+    #[test]
+    fn fsync_precedes_persist_in_source() {
+        let src = include_str!("fs_perms.rs");
+        let body = src
+            .split("fn write_restricted_file_synced(")
+            .nth(1)
+            .and_then(|s| s.split("\n}").next())
+            .expect("write_restricted_file_synced body");
+        let fsync_at = body
+            .find("fsync_file_durable(tmp.as_file())")
+            .expect("write_restricted_file_synced must fsync the tempfile");
+        let persist_at = body
+            .find("tmp.persist(path)")
+            .expect("write_restricted_file_synced must persist the tempfile");
+        assert!(
+            fsync_at < persist_at,
+            "fsync_file_durable must run BEFORE tmp.persist — reordering reintroduces the torn-write bug"
+        );
     }
 }

--- a/crates/speedwave-runtime/src/fs_perms.rs
+++ b/crates/speedwave-runtime/src/fs_perms.rs
@@ -14,15 +14,39 @@ use std::path::Path;
 use tempfile::NamedTempFile;
 
 /// Flushes a file's data to stable media. On macOS plain `fsync` returns before
-/// APFS hits the platter, so `F_FULLFSYNC` is required; other Unix uses `fsync`;
-/// Windows is a no-op (`MoveFileExW` rename is durable on NTFS).
+/// APFS hits the platter, so `F_FULLFSYNC` is preferred; if the filesystem
+/// doesn't support it (network mounts: SMB/NFS return ENOTSUP) it falls back to
+/// plain `fsync`, then to a best-effort no-op — degrading to pre-fsync durability
+/// rather than failing the write. Other Unix uses `fsync`; Windows is a no-op.
 #[cfg(unix)]
 fn fsync_file_durable(file: &std::fs::File) -> std::io::Result<()> {
     #[cfg(target_os = "macos")]
-    let r = rustix::fs::fcntl_fullfsync(file);
+    {
+        use rustix::io::Errno;
+        // Errnos meaning "this fs/device can't do this sync flavour" → fall back.
+        // ENOTSUP/EOPNOTSUPP: network mounts (SMB/NFS). ENODEV: char devices.
+        let unsupported = |e: &Errno| {
+            matches!(
+                *e,
+                Errno::NOTSUP | Errno::OPNOTSUPP | Errno::INVAL | Errno::NODEV
+            )
+        };
+        match rustix::fs::fcntl_fullfsync(file) {
+            Ok(()) => Ok(()),
+            // F_FULLFSYNC not supported here — fall back to plain fsync.
+            Err(e) if unsupported(&e) => match rustix::fs::fsync(file) {
+                Ok(()) => Ok(()),
+                // Neither supported (some network FS): best-effort, don't fail.
+                Err(e2) if unsupported(&e2) => Ok(()),
+                Err(e2) => Err(std::io::Error::from(e2)),
+            },
+            Err(e) => Err(std::io::Error::from(e)),
+        }
+    }
     #[cfg(not(target_os = "macos"))]
-    let r = rustix::fs::fsync(file);
-    r.map_err(std::io::Error::from)
+    {
+        rustix::fs::fsync(file).map_err(std::io::Error::from)
+    }
 }
 
 #[cfg(not(unix))]
@@ -672,18 +696,20 @@ mod tests {
         fsync_file_durable(&file).expect("fsync of an open writable file must succeed");
     }
 
-    /// Error path: `F_FULLFSYNC` on a non-syncable fd must surface, not swallow.
+    /// Network-mount regression guard: a target that supports neither
+    /// `F_FULLFSYNC` nor plain `fsync` (ENOTSUP) must degrade to best-effort
+    /// `Ok`, NOT fail the write — else workers can't start on SMB/NFS homes.
     #[cfg(target_os = "macos")]
     #[test]
-    fn fsync_file_durable_surfaces_error_on_nonsyncable_fd() {
-        // /dev/null does not support F_FULLFSYNC — fcntl returns ENOTSUP/EINVAL.
+    fn fsync_file_durable_best_effort_on_unsupported_fd() {
+        // /dev/null supports neither fsync flavour — fcntl returns ENOTSUP/EINVAL.
         let file = std::fs::OpenOptions::new()
             .write(true)
             .open("/dev/null")
             .unwrap();
         assert!(
-            fsync_file_durable(&file).is_err(),
-            "F_FULLFSYNC on /dev/null must surface an error, not be swallowed"
+            fsync_file_durable(&file).is_ok(),
+            "unsupported-fsync target must degrade to best-effort, not hard-fail"
         );
     }
 

--- a/crates/speedwave-runtime/src/fs_perms.rs
+++ b/crates/speedwave-runtime/src/fs_perms.rs
@@ -23,21 +23,25 @@ fn fsync_file_durable(file: &std::fs::File) -> std::io::Result<()> {
     #[cfg(target_os = "macos")]
     {
         use rustix::io::Errno;
-        // Errnos meaning "this fs/device can't do this sync flavour" → fall back.
-        // ENOTSUP/EOPNOTSUPP: network mounts (SMB/NFS). ENODEV: char devices.
-        let unsupported = |e: &Errno| {
+        // `F_FULLFSYNC` unsupported on this fs/device → fall back. EINVAL here
+        // means "unknown fcntl command"; ENOTSUP/EOPNOTSUPP: network mounts
+        // (SMB/NFS); ENODEV: char devices.
+        let fcntl_unsupported = |e: &Errno| {
             matches!(
                 *e,
                 Errno::NOTSUP | Errno::OPNOTSUPP | Errno::INVAL | Errno::NODEV
             )
         };
+        // Plain `fsync` fallback: only a filesystem capability gap is best-effort.
+        // EINVAL from `fsync` is a bad fd (programming error) — must propagate.
+        let fsync_unsupported =
+            |e: &Errno| matches!(*e, Errno::NOTSUP | Errno::OPNOTSUPP | Errno::NODEV);
         match rustix::fs::fcntl_fullfsync(file) {
             Ok(()) => Ok(()),
-            // F_FULLFSYNC not supported here — fall back to plain fsync.
-            Err(e) if unsupported(&e) => match rustix::fs::fsync(file) {
+            Err(e) if fcntl_unsupported(&e) => match rustix::fs::fsync(file) {
                 Ok(()) => Ok(()),
                 // Neither supported (some network FS): best-effort, don't fail.
-                Err(e2) if unsupported(&e2) => Ok(()),
+                Err(e2) if fsync_unsupported(&e2) => Ok(()),
                 Err(e2) => Err(std::io::Error::from(e2)),
             },
             Err(e) => Err(std::io::Error::from(e)),

--- a/crates/speedwave-runtime/src/lib.rs
+++ b/crates/speedwave-runtime/src/lib.rs
@@ -9,6 +9,7 @@ pub mod compose;
 pub mod config;
 pub mod consts;
 pub mod defaults;
+pub mod diagnostic_sources;
 pub mod engine_path;
 pub mod fs_perms;
 pub mod fs_security;

--- a/crates/speedwave-runtime/src/log_sanitizer.rs
+++ b/crates/speedwave-runtime/src/log_sanitizer.rs
@@ -70,7 +70,7 @@ static RULES: LazyLock<Vec<SanitizeRule>> = LazyLock::new(|| {
         // API keys in URL query parameters: ?key=<value> or &key=<value>
         // Also matches token=, secret=, password= in query strings
         (
-            r"(?i)([?&](?:api_key|apikey|key|token|secret|password|access_token)=)[^&\s]+",
+            r"(?i)([?&](?:api_key|apikey|key|token|secret|password|access_token|[a-z0-9_]*_token)=)[^&\s]+",
             "${1}***REDACTED***",
         ),
         // Redmine API key header: X-Redmine-API-Key: <value>
@@ -80,7 +80,7 @@ static RULES: LazyLock<Vec<SanitizeRule>> = LazyLock::new(|| {
         // The trailing `"?` catches a lone closing quote that follows an unquoted value
         // (e.g. password=abc" where the opening quote was on a previous token).
         (
-            r#"(?i)((?:password|passwd|secret|api_key|apikey|api_secret|access_token|private_key)\s*[=:]\s*)(?:"[^"]*"|'[^']*'|[^\s"',;&]+)"?"#,
+            r#"(?i)((?:password|passwd|secret|api_key|apikey|api_secret|access_token|private_key|[a-z0-9_]*_token)\s*[=:]\s*)(?:"[^"]*"|'[^']*'|[^\s"',;&]+)"?"#,
             "${1}***REDACTED***",
         ),
     ];
@@ -199,9 +199,9 @@ mod tests {
             r"sk-ant-[A-Za-z0-9_-]+",
             r"\bsk-[A-Za-z0-9_-]{16,}",
             r"(://[^:/@\s]+:)[^@\s]+(@)",
-            r"(?i)([?&](?:api_key|apikey|key|token|secret|password|access_token)=)[^&\s]+",
+            r"(?i)([?&](?:api_key|apikey|key|token|secret|password|access_token|[a-z0-9_]*_token)=)[^&\s]+",
             r"(?i)(X-Redmine-API-Key:\s*)\S+",
-            r#"(?i)((?:password|passwd|secret|api_key|apikey|api_secret|access_token|private_key)\s*[=:]\s*)(?:"[^"]*"|'[^']*'|[^\s"',;&]+)"?"#,
+            r#"(?i)((?:password|passwd|secret|api_key|apikey|api_secret|access_token|private_key|[a-z0-9_]*_token)\s*[=:]\s*)(?:"[^"]*"|'[^']*'|[^\s"',;&]+)"?"#,
         ];
 
         assert_eq!(
@@ -377,6 +377,60 @@ mod tests {
             !output.contains("hidden_value_123"),
             "Secret value should not appear: {output}"
         );
+    }
+
+    #[test]
+    fn test_worker_auth_token_uuid_redaction() {
+        // Worker bearer tokens are bare UUIDs in MCP_<SVC>_AUTH_TOKEN env vars —
+        // no sk-/xox- prefix, so only the *_token assignment rule catches them.
+        let input = "MCP_SLACK_AUTH_TOKEN=550e8400-e29b-41d4-a716-446655440000";
+        let output = sanitize(input);
+        assert!(
+            !output.contains("550e8400-e29b-41d4-a716-446655440000"),
+            "worker UUID auth token must be redacted: {output}"
+        );
+    }
+
+    #[test]
+    fn test_anthropic_auth_token_redaction() {
+        let input = "ANTHROPIC_AUTH_TOKEN=f1e2d3c4-0000-1111-2222-333344445555";
+        let output = sanitize(input);
+        assert!(
+            !output.contains("f1e2d3c4-0000-1111-2222-333344445555"),
+            "ANTHROPIC_AUTH_TOKEN value must be redacted: {output}"
+        );
+    }
+
+    #[test]
+    fn test_api_key_suffix_env_redaction() {
+        // *_API_KEY= is covered by the existing `api_key` substring keyword.
+        let input = "OPENROUTER_API_KEY=opaque-value-xyz";
+        let output = sanitize(input);
+        assert!(
+            !output.contains("opaque-value-xyz"),
+            "*_API_KEY assignment value must be redacted: {output}"
+        );
+    }
+
+    #[test]
+    fn test_bare_uuid_not_redacted() {
+        // A UUID NOT in a *_token= assignment (e.g. a request/container id) must
+        // survive — redacting bare UUIDs would erase debugging context.
+        let input = "request_id 550e8400-e29b-41d4-a716-446655440000 completed";
+        let output = sanitize(input);
+        assert_eq!(
+            output, input,
+            "bare UUID outside an assignment must not be redacted: {output}"
+        );
+    }
+
+    #[test]
+    fn test_cache_key_not_redacted() {
+        // `_key` suffix is intentionally NOT in the rule: cache_key / sort_key
+        // are common non-secret identifiers. Only `_token` suffix is redacted.
+        let input = "cache_key=user_123";
+        let output = sanitize(input);
+        assert_eq!(output, input, "cache_key must not be redacted: {output}");
     }
 
     #[test]
@@ -919,15 +973,29 @@ mod tests {
     #[test]
     fn test_bare_sk_proj_key_redaction() {
         // OpenAI project-scoped key shape, also used by self-hosted servers.
+        // `_AUTH_TOKEN=` now also matches the assignment rule, which runs after
+        // the `sk-` rule and collapses the marker to the generic one — either
+        // way the key body is gone, which is the security property that matters.
         let input = "ANTHROPIC_AUTH_TOKEN=sk-proj-abc123def456ghi789xyz";
         let output = sanitize(input);
         assert!(
-            output.contains("***REDACTED_API_KEY***"),
+            output.contains("***REDACTED"),
             "bare sk-proj- key not redacted: {output}"
         );
         assert!(
             !output.contains("abc123def456ghi789xyz"),
             "key body should not appear: {output}"
+        );
+    }
+
+    #[test]
+    fn test_bare_sk_proj_key_redaction_no_assignment() {
+        // Without a *_token= assignment, the `sk-` rule keeps its specific marker.
+        let input = "got key sk-proj-abc123def456ghi789xyz from env";
+        let output = sanitize(input);
+        assert!(
+            output.contains("***REDACTED_API_KEY***"),
+            "bare sk-proj- key must keep its API_KEY marker: {output}"
         );
     }
 

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -5267,6 +5267,7 @@ dependencies = [
  "rand 0.8.6",
  "regex",
  "reqwest 0.12.28",
+ "rustix",
  "semver",
  "serde",
  "serde_json",

--- a/desktop/src-tauri/src/chat.rs
+++ b/desktop/src-tauri/src/chat.rs
@@ -98,11 +98,11 @@ pub enum StreamChunk {
     QueueDrained { session_id: String, text: String },
 }
 
-/// Redacts secrets in a chunk's free-text fields before it fans out to the UI
-/// (both `chat_stream` and the `chat_patch::*` patch mirror). Called once at the
-/// single emit point so neither channel can leak. Structural fields (tool ids,
-/// model, session ids) and `partial_json` (incremental JSON — sanitizing could
-/// corrupt it) are left untouched.
+/// Redacts secrets in a chunk's free-text fields. Every `chat_stream` emit must
+/// go through [`emit_sanitized_chunk`] (which calls this), so neither the
+/// `chat_stream` channel nor the `chat_patch::*` mirror can leak. Structural
+/// fields (tool ids, model, session ids) and `partial_json` (incremental JSON —
+/// sanitizing could corrupt it) are left untouched.
 pub(crate) fn sanitize_chunk(chunk: StreamChunk) -> StreamChunk {
     use speedwave_runtime::log_sanitizer::sanitize;
     match chunk {
@@ -149,7 +149,36 @@ pub(crate) fn sanitize_chunk(chunk: StreamChunk) -> StreamChunk {
             session_id,
             text: sanitize(&text),
         },
+        StreamChunk::AskUserQuestion {
+            tool_id,
+            mut questions,
+            current_index,
+        } => {
+            // Model-authored free text — redact question/header/option strings.
+            for q in &mut questions {
+                q.question = sanitize(&q.question);
+                q.header = sanitize(&q.header);
+                for opt in &mut q.options {
+                    opt.label = sanitize(&opt.label);
+                    opt.value = sanitize(&opt.value);
+                }
+            }
+            StreamChunk::AskUserQuestion {
+                tool_id,
+                questions,
+                current_index,
+            }
+        }
         other => other,
+    }
+}
+
+/// The ONE way to emit a `chat_stream` event: sanitizes the chunk first, so no
+/// emit site can leak a secret. Every `app_handle.emit("chat_stream", ...)` must
+/// route through here (enforced by `chat_stream_emits_go_through_helper` test).
+fn emit_sanitized_chunk(app_handle: &tauri::AppHandle, chunk: StreamChunk) {
+    if let Err(e) = app_handle.emit("chat_stream", sanitize_chunk(chunk)) {
+        log::warn!("failed to emit chat_stream event: {e}");
     }
 }
 
@@ -1585,8 +1614,8 @@ impl ChatSession {
                                 log::error!(
                                     "pending_requests mutex poisoned: {e}; dropping stream"
                                 );
-                                let _ = app_handle.emit(
-                                    "chat_stream",
+                                emit_sanitized_chunk(
+                                    &app_handle,
                                     StreamChunk::Error {
                                         content: "Internal error: pending_requests lock poisoned"
                                             .to_string(),
@@ -1595,14 +1624,14 @@ impl ChatSession {
                                 break;
                             }
                         }
-                        let chunk = StreamChunk::AskUserQuestion {
-                            tool_id: ctrl.tool_use_id.clone(),
-                            questions,
-                            current_index: 0,
-                        };
-                        if let Err(e) = app_handle.emit("chat_stream", chunk) {
-                            log::warn!("failed to emit AskUserQuestion event: {e}");
-                        }
+                        emit_sanitized_chunk(
+                            &app_handle,
+                            StreamChunk::AskUserQuestion {
+                                tool_id: ctrl.tool_use_id.clone(),
+                                questions,
+                                current_index: 0,
+                            },
+                        );
                     } else {
                         // Auto-approve non-AskUserQuestion tools
                         let response = build_auto_approve_response(&ctrl);
@@ -1612,8 +1641,8 @@ impl ChatSession {
                                     log::error!(
                                         "auto-approve stdin write failed: {e}; dropping stream"
                                     );
-                                    let _ = app_handle.emit(
-                                        "chat_stream",
+                                    emit_sanitized_chunk(
+                                        &app_handle,
                                         StreamChunk::Error {
                                             content: format!(
                                                 "Failed to write auto-approve to stdin: {e}"
@@ -1626,8 +1655,8 @@ impl ChatSession {
                                     log::error!(
                                         "auto-approve stdin flush failed: {e}; dropping stream"
                                     );
-                                    let _ = app_handle.emit(
-                                        "chat_stream",
+                                    emit_sanitized_chunk(
+                                        &app_handle,
                                         StreamChunk::Error {
                                             content: format!(
                                                 "Failed to flush auto-approve to stdin: {e}"
@@ -1639,8 +1668,8 @@ impl ChatSession {
                             }
                             Err(e) => {
                                 log::error!("stdin mutex poisoned: {e}; dropping stream");
-                                let _ = app_handle.emit(
-                                    "chat_stream",
+                                emit_sanitized_chunk(
+                                    &app_handle,
                                     StreamChunk::Error {
                                         content: "Internal error: stdin lock poisoned".to_string(),
                                     },
@@ -1700,13 +1729,12 @@ impl ChatSession {
                 }
                 let registry = app_handle.state::<crate::subscribe_cmd::MsgStoreRegistry>();
                 for chunk in chunks {
-                    // Redact secrets once, before BOTH egress channels (patch
-                    // mirror in handle_chunk + chat_stream emit). See sanitize_chunk.
+                    // Sanitize before BOTH egress channels: the patch mirror
+                    // (handle_chunk reads the sanitized chunk) and the
+                    // chat_stream emit (via emit_sanitized_chunk).
                     let chunk = sanitize_chunk(chunk);
                     patch_emitter.handle_chunk(&chunk, &registry);
-                    if let Err(e) = app_handle.emit("chat_stream", chunk) {
-                        log::warn!("failed to emit chat_stream event: {e}");
-                    }
+                    emit_sanitized_chunk(&app_handle, chunk);
                 }
                 // ADR-042/043 lifecycle patches are emitted automatically
                 // by `patch_emitter.handle_chunk` when it sees `Result` —
@@ -1735,9 +1763,10 @@ impl ChatSession {
                         "Claude session ended unexpectedly. Check the session log for details."
                             .to_string(),
                 };
+                let chunk = sanitize_chunk(chunk);
                 let registry = app_handle.state::<crate::subscribe_cmd::MsgStoreRegistry>();
                 patch_emitter.handle_chunk(&chunk, &registry);
-                let _ = app_handle.emit("chat_stream", chunk);
+                emit_sanitized_chunk(&app_handle, chunk);
             }
         });
         self.drain_handles.push(h);
@@ -2090,15 +2119,13 @@ fn drain_queued_message(
         }
     }
     let drained_text = drained.text.clone();
-    if let Err(e) = app_handle.emit(
-        "chat_stream",
+    emit_sanitized_chunk(
+        app_handle,
         StreamChunk::QueueDrained {
             session_id: session_id.to_string(),
             text: drained.text,
         },
-    ) {
-        log::warn!("failed to emit QueueDrained event: {e}");
-    }
+    );
     // ADR-042/045 mirror: clear the state-tree's pending_queue slot.
     use speedwave_runtime::stream::msg_store::LogMsg;
     use speedwave_runtime::stream::ConversationPatch;
@@ -2119,6 +2146,53 @@ mod tests {
     use super::*;
 
     // -- sanitize_chunk: secrets must not reach the UI on any chunk channel --
+
+    /// Enforcement: the ONLY `emit("chat_stream", ...)` in production source is
+    /// inside emit_sanitized_chunk. A new raw emit elsewhere would leak.
+    #[test]
+    fn chat_stream_emits_go_through_helper() {
+        let src = include_str!("chat.rs");
+        // Strip the test module so test-only emits don't count.
+        let prod = src.split("\nmod tests {").next().unwrap_or(src);
+        // Count actual emit calls, ignoring doc/comment lines.
+        let raw_emits = prod
+            .lines()
+            .filter(|l| {
+                let t = l.trim_start();
+                !t.starts_with("//") && t.contains("emit(\"chat_stream\"")
+            })
+            .count();
+        assert_eq!(
+            raw_emits, 1,
+            "exactly one chat_stream emit allowed (inside emit_sanitized_chunk); \
+             found {raw_emits} — a new raw emit bypasses sanitization"
+        );
+    }
+
+    #[test]
+    fn sanitize_chunk_redacts_ask_user_question() {
+        use speedwave_runtime::stream::{AskUserOption, AskUserQuestionItem};
+        let chunk = StreamChunk::AskUserQuestion {
+            tool_id: "t1".into(),
+            questions: vec![AskUserQuestionItem {
+                question: "use sk-ant-abcdefabcdefabcdefabcdef?".into(),
+                header: "key sk-ant-abcdefabcdefabcdefabcdef".into(),
+                multi_select: false,
+                options: vec![AskUserOption {
+                    label: "Bearer ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into(),
+                    value: "MCP_X_AUTH_TOKEN=550e8400-e29b-41d4-a716-446655440000".into(),
+                }],
+            }],
+            current_index: 0,
+        };
+        let out = format!("{:?}", sanitize_chunk(chunk));
+        assert!(
+            !out.contains("abcdefabcdefabcdefabcdef"),
+            "question/header leaked: {out}"
+        );
+        assert!(!out.contains("ghp_aaaaaaaa"), "option label leaked: {out}");
+        assert!(!out.contains("550e8400"), "option value leaked: {out}");
+    }
 
     #[test]
     fn sanitize_chunk_redacts_text_and_thinking() {

--- a/desktop/src-tauri/src/chat.rs
+++ b/desktop/src-tauri/src/chat.rs
@@ -103,7 +103,7 @@ pub enum StreamChunk {
 /// single emit point so neither channel can leak. Structural fields (tool ids,
 /// model, session ids) and `partial_json` (incremental JSON — sanitizing could
 /// corrupt it) are left untouched.
-fn sanitize_chunk(chunk: StreamChunk) -> StreamChunk {
+pub(crate) fn sanitize_chunk(chunk: StreamChunk) -> StreamChunk {
     use speedwave_runtime::log_sanitizer::sanitize;
     match chunk {
         StreamChunk::Text { content } => StreamChunk::Text {

--- a/desktop/src-tauri/src/chat.rs
+++ b/desktop/src-tauri/src/chat.rs
@@ -98,6 +98,61 @@ pub enum StreamChunk {
     QueueDrained { session_id: String, text: String },
 }
 
+/// Redacts secrets in a chunk's free-text fields before it fans out to the UI
+/// (both `chat_stream` and the `chat_patch::*` patch mirror). Called once at the
+/// single emit point so neither channel can leak. Structural fields (tool ids,
+/// model, session ids) and `partial_json` (incremental JSON — sanitizing could
+/// corrupt it) are left untouched.
+fn sanitize_chunk(chunk: StreamChunk) -> StreamChunk {
+    use speedwave_runtime::log_sanitizer::sanitize;
+    match chunk {
+        StreamChunk::Text { content } => StreamChunk::Text {
+            content: sanitize(&content),
+        },
+        StreamChunk::Thinking { content } => StreamChunk::Thinking {
+            content: sanitize(&content),
+        },
+        StreamChunk::ToolResult {
+            tool_id,
+            content,
+            is_error,
+        } => StreamChunk::ToolResult {
+            tool_id,
+            content: sanitize(&content),
+            is_error,
+        },
+        StreamChunk::Error { content } => StreamChunk::Error {
+            content: sanitize(&content),
+        },
+        StreamChunk::Result {
+            result_text: Some(text),
+            session_id,
+            total_cost,
+            usage,
+            context_window_size,
+            assistant_uuid,
+            turn_usage,
+            turn_cost,
+            model,
+        } => StreamChunk::Result {
+            result_text: Some(sanitize(&text)),
+            session_id,
+            total_cost,
+            usage,
+            context_window_size,
+            assistant_uuid,
+            turn_usage,
+            turn_cost,
+            model,
+        },
+        StreamChunk::QueueDrained { session_id, text } => StreamChunk::QueueDrained {
+            session_id,
+            text: sanitize(&text),
+        },
+        other => other,
+    }
+}
+
 /// Token usage information from the result message.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct UsageInfo {
@@ -1645,6 +1700,9 @@ impl ChatSession {
                 }
                 let registry = app_handle.state::<crate::subscribe_cmd::MsgStoreRegistry>();
                 for chunk in chunks {
+                    // Redact secrets once, before BOTH egress channels (patch
+                    // mirror in handle_chunk + chat_stream emit). See sanitize_chunk.
+                    let chunk = sanitize_chunk(chunk);
                     patch_emitter.handle_chunk(&chunk, &registry);
                     if let Err(e) = app_handle.emit("chat_stream", chunk) {
                         log::warn!("failed to emit chat_stream event: {e}");
@@ -2059,6 +2117,73 @@ fn drain_queued_message(
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+
+    // -- sanitize_chunk: secrets must not reach the UI on any chunk channel --
+
+    #[test]
+    fn sanitize_chunk_redacts_text_and_thinking() {
+        let secret = "MCP_SLACK_AUTH_TOKEN=550e8400-e29b-41d4-a716-446655440000";
+        for chunk in [
+            StreamChunk::Text {
+                content: secret.into(),
+            },
+            StreamChunk::Thinking {
+                content: secret.into(),
+            },
+            StreamChunk::Error {
+                content: secret.into(),
+            },
+        ] {
+            let out = format!("{:?}", sanitize_chunk(chunk));
+            assert!(!out.contains("550e8400"), "secret leaked: {out}");
+        }
+    }
+
+    #[test]
+    fn sanitize_chunk_redacts_tool_result() {
+        let chunk = StreamChunk::ToolResult {
+            tool_id: "t1".into(),
+            content: "key sk-ant-abcdefabcdefabcdefabcdef".into(),
+            is_error: false,
+        };
+        let out = format!("{:?}", sanitize_chunk(chunk));
+        assert!(!out.contains("abcdefabcdefabcdefabcdef"), "leaked: {out}");
+    }
+
+    #[test]
+    fn sanitize_chunk_redacts_result_text() {
+        // result_text is dropped from the patch mirror, reaches UI only via
+        // chat_stream — so the single sanitize point must cover it.
+        let chunk = StreamChunk::Result {
+            session_id: "s".into(),
+            total_cost: None,
+            usage: None,
+            result_text: Some("token=sk-ant-secretsecretsecretsecret done".into()),
+            context_window_size: None,
+            assistant_uuid: None,
+            turn_usage: None,
+            turn_cost: None,
+            model: None,
+        };
+        let out = format!("{:?}", sanitize_chunk(chunk));
+        assert!(!out.contains("secretsecretsecretsecret"), "leaked: {out}");
+    }
+
+    #[test]
+    fn sanitize_chunk_leaves_tool_input_delta_untouched() {
+        // partial_json is incremental JSON — sanitizing could corrupt structure.
+        let raw = r#"{"path":"/x","token":"abc"#;
+        let chunk = StreamChunk::ToolInputDelta {
+            tool_id: "t1".into(),
+            partial_json: raw.into(),
+        };
+        match sanitize_chunk(chunk) {
+            StreamChunk::ToolInputDelta { partial_json, .. } => {
+                assert_eq!(partial_json, raw, "partial_json must be byte-identical");
+            }
+            other => panic!("variant changed: {other:?}"),
+        }
+    }
 
     // -- interrupt protocol tests (behavioural via free helpers) --
 

--- a/desktop/src-tauri/src/container_logs_cmd.rs
+++ b/desktop/src-tauri/src/container_logs_cmd.rs
@@ -872,30 +872,36 @@ mod tests {
 
     #[test]
     fn logs_view_covers_all_displayable_registry_sources() {
-        // Parity: every displayable+available registry source must have a /logs
-        // representation. compose/desktop are non-File kinds (handled inline);
-        // the rest are File sources whose keys must be merged here.
-        use speedwave_runtime::diagnostic_sources::{SourceKind, DIAGNOSTIC_SOURCES};
-        let merged_keys = [
-            "compose",
-            "desktop",
-            "mcp-os",
-            "host-exec",
-            "claude",
-            "lima",
-        ];
+        // Parity, checked against the ACTUAL merge output (not a proxy array):
+        // give every source a unique marker, run the real merge, and assert each
+        // displayable+available registry source's marker survives prefixed by its
+        // key. A registry source not wired into LogSources/merge fails here.
+        use speedwave_runtime::diagnostic_sources::DIAGNOSTIC_SOURCES;
+        let merged = merge_log_sources(
+            LogSources {
+                compose: "MARKER_compose\n".to_string(),
+                desktop: "MARKER_desktop\n".to_string(),
+                mcp_os: "MARKER_mcp_os\n".to_string(),
+                host_exec: "MARKER_host_exec\n".to_string(),
+                claude: "MARKER_claude\n".to_string(),
+                lima: "MARKER_lima\n".to_string(),
+            },
+            "proj",
+        );
         for s in DIAGNOSTIC_SOURCES {
             if s.displayable && s.platforms.available_here() {
+                let token = format!("{} | MARKER_{}", s.key, s.key.replace('-', "_"));
                 assert!(
-                    merged_keys.contains(&s.key),
-                    "displayable registry source '{}' is missing from the /logs merge — \
-                     ZIP would carry more than /logs, violating parity",
+                    merged.contains(&token),
+                    "displayable registry source '{}' not present in /logs merge \
+                     (expected '{token}') — ZIP would carry more than /logs, \
+                     violating parity. Merged:\n{merged}",
                     s.key
                 );
             }
         }
-        // And nothing non-displayable (compose-yml) sneaks into /logs.
-        assert!(!merged_keys.contains(&"compose-yml"));
+        // compose-yml (non-displayable) must never appear in /logs.
+        assert!(!merged.contains("compose-yml |"), "merged: {merged}");
     }
 
     #[test]

--- a/desktop/src-tauri/src/container_logs_cmd.rs
+++ b/desktop/src-tauri/src/container_logs_cmd.rs
@@ -393,16 +393,9 @@ pub(crate) async fn get_all_logs(project: String, tail: Option<u32>) -> Result<S
 
         // File-source paths resolved from the SSOT registry (platform-gated), so
         // /logs and the ZIP draw from the same list. Empty when unavailable.
-        use speedwave_runtime::diagnostic_sources::{SourceKind, DIAGNOSTIC_SOURCES};
         let data_dir = speedwave_runtime::consts::data_dir();
         let read_source = |key: &str| -> String {
-            DIAGNOSTIC_SOURCES
-                .iter()
-                .find(|s| s.key == key && s.platforms.available_here())
-                .and_then(|s| match s.kind {
-                    SourceKind::File(f) => f(data_dir, &project),
-                    _ => None,
-                })
+            speedwave_runtime::diagnostic_sources::resolve_file_path(key, data_dir, &project)
                 .map(|p| read_tail_sanitized(&p, tail_us).unwrap_or_default())
                 .unwrap_or_default()
         };

--- a/desktop/src-tauri/src/container_logs_cmd.rs
+++ b/desktop/src-tauri/src/container_logs_cmd.rs
@@ -140,8 +140,7 @@ pub(crate) async fn get_compose_logs(project: String, tail: Option<u32>) -> Resu
 #[tauri::command]
 pub(crate) async fn get_mcp_os_logs(tail: Option<u32>) -> Result<String, String> {
     tokio::task::spawn_blocking(move || {
-        let log_path =
-            speedwave_runtime::consts::data_dir().join(speedwave_runtime::consts::MCP_OS_LOG_FILE);
+        let log_path = speedwave_runtime::consts::mcp_os_log_path();
         let tail = tail.unwrap_or(200).min(10_000) as usize;
         read_tail_sanitized(&log_path, tail)
     })
@@ -388,9 +387,8 @@ pub(crate) async fn get_all_logs(project: String, tail: Option<u32>) -> Result<S
             None => String::new(),
         };
 
-        // mcp-os — same path resolution `get_mcp_os_logs` uses
-        let mcp_os_path =
-            speedwave_runtime::consts::data_dir().join(speedwave_runtime::consts::MCP_OS_LOG_FILE);
+        // mcp-os — same path resolution `get_mcp_os_logs` uses (SSOT).
+        let mcp_os_path = speedwave_runtime::consts::mcp_os_log_path();
         let mcp_os = read_tail_sanitized(&mcp_os_path, tail_us).unwrap_or_default();
 
         // host-exec — per-project worker log (`get_host_exec_logs`'s path)

--- a/desktop/src-tauri/src/container_logs_cmd.rs
+++ b/desktop/src-tauri/src/container_logs_cmd.rs
@@ -387,7 +387,7 @@ pub(crate) async fn get_all_logs(project: String, tail: Option<u32>) -> Result<S
             None => String::new(),
         };
 
-        // mcp-os — same path resolution `get_mcp_os_logs` uses (SSOT).
+        // mcp-os — same path resolution `get_mcp_os_logs` uses.
         let mcp_os_path = speedwave_runtime::consts::mcp_os_log_path();
         let mcp_os = read_tail_sanitized(&mcp_os_path, tail_us).unwrap_or_default();
 

--- a/desktop/src-tauri/src/container_logs_cmd.rs
+++ b/desktop/src-tauri/src/container_logs_cmd.rs
@@ -326,6 +326,9 @@ pub(crate) struct LogSources {
     pub mcp_os: String,
     pub host_exec: String,
     pub claude: String,
+    /// Lima VM serial log (macOS only; empty elsewhere). Parity with the ZIP —
+    /// it's a displayable log, so it must also appear in /logs.
+    pub lima: String,
 }
 
 /// Composes the per-source log buffers into a single newline-separated string,
@@ -339,11 +342,12 @@ pub(crate) fn merge_log_sources(sources: LogSources, project: &str) -> String {
     let mcp_os = prefix_lines("mcp-os", &sources.mcp_os, None);
     let host_exec = prefix_lines("host-exec", &sources.host_exec, None);
     let claude = prefix_lines("claude", &sources.claude, None);
+    let lima = prefix_lines("lima", &sources.lima, None);
 
     // Apply the sanitizer once to the merged buffer (idempotent — sources are
     // already individually sanitized, this is a defence-in-depth pass).
     speedwave_runtime::log_sanitizer::sanitize(&format!(
-        "{compose}{desktop}{mcp_os}{host_exec}{claude}"
+        "{compose}{desktop}{mcp_os}{host_exec}{claude}{lima}"
     ))
 }
 
@@ -387,25 +391,30 @@ pub(crate) async fn get_all_logs(project: String, tail: Option<u32>) -> Result<S
             None => String::new(),
         };
 
-        // mcp-os — same path resolution `get_mcp_os_logs` uses.
-        let mcp_os_path = speedwave_runtime::consts::mcp_os_log_path();
-        let mcp_os = read_tail_sanitized(&mcp_os_path, tail_us).unwrap_or_default();
-
-        // host-exec — per-project worker log (`get_host_exec_logs`'s path)
-        let host_exec =
-            read_tail_sanitized(&host_exec_log_path(&project), tail_us).unwrap_or_default();
-
-        // claude session log — same path resolution `get_claude_session_logs` uses
-        let claude_path = speedwave_runtime::consts::claude_session_log_path(&project);
-        let claude = read_tail_sanitized(&claude_path, tail_us).unwrap_or_default();
+        // File-source paths resolved from the SSOT registry (platform-gated), so
+        // /logs and the ZIP draw from the same list. Empty when unavailable.
+        use speedwave_runtime::diagnostic_sources::{SourceKind, DIAGNOSTIC_SOURCES};
+        let data_dir = speedwave_runtime::consts::data_dir();
+        let read_source = |key: &str| -> String {
+            DIAGNOSTIC_SOURCES
+                .iter()
+                .find(|s| s.key == key && s.platforms.available_here())
+                .and_then(|s| match s.kind {
+                    SourceKind::File(f) => f(data_dir, &project),
+                    _ => None,
+                })
+                .map(|p| read_tail_sanitized(&p, tail_us).unwrap_or_default())
+                .unwrap_or_default()
+        };
 
         Ok(merge_log_sources(
             LogSources {
                 compose,
                 desktop,
-                mcp_os,
-                host_exec,
-                claude,
+                mcp_os: read_source("mcp-os"),
+                host_exec: read_source("host-exec"),
+                claude: read_source("claude"),
+                lima: read_source("lima"),
             },
             &project,
         ))
@@ -823,6 +832,7 @@ mod tests {
                 mcp_os: String::new(),
                 host_exec: String::new(),
                 claude: String::new(),
+                lima: String::new(),
             },
             "testproj",
         );
@@ -842,6 +852,7 @@ mod tests {
                     r#"{"ts":"2026-01-01T00:00:00.000Z","recipe":"docker_ps","status":"exited"}"#
                         .to_string(),
                 claude: "session started\n".to_string(),
+                lima: String::new(),
             },
             "testproj",
         );
@@ -860,6 +871,54 @@ mod tests {
     }
 
     #[test]
+    fn logs_view_covers_all_displayable_registry_sources() {
+        // Parity: every displayable+available registry source must have a /logs
+        // representation. compose/desktop are non-File kinds (handled inline);
+        // the rest are File sources whose keys must be merged here.
+        use speedwave_runtime::diagnostic_sources::{SourceKind, DIAGNOSTIC_SOURCES};
+        let merged_keys = [
+            "compose",
+            "desktop",
+            "mcp-os",
+            "host-exec",
+            "claude",
+            "lima",
+        ];
+        for s in DIAGNOSTIC_SOURCES {
+            if s.displayable && s.platforms.available_here() {
+                assert!(
+                    merged_keys.contains(&s.key),
+                    "displayable registry source '{}' is missing from the /logs merge — \
+                     ZIP would carry more than /logs, violating parity",
+                    s.key
+                );
+            }
+        }
+        // And nothing non-displayable (compose-yml) sneaks into /logs.
+        assert!(!merged_keys.contains(&"compose-yml"));
+    }
+
+    #[test]
+    fn merge_log_sources_sanitizes_host_exec_projectdir() {
+        let merged = merge_log_sources(
+            LogSources {
+                compose: String::new(),
+                desktop: String::new(),
+                mcp_os: String::new(),
+                host_exec: r#"{"cwd":"/Users/john-doe/Projects/mine","cmd":"npm test"}"#
+                    .to_string(),
+                claude: String::new(),
+                lima: String::new(),
+            },
+            "mine",
+        );
+        assert!(
+            !merged.contains("john-doe"),
+            "projectDir username must be redacted: {merged}"
+        );
+    }
+
+    #[test]
     fn merge_log_sources_sanitizes_secrets_across_sources() {
         let merged = merge_log_sources(
             LogSources {
@@ -870,6 +929,7 @@ mod tests {
                 mcp_os: String::new(),
                 host_exec: String::new(),
                 claude: String::new(),
+                lima: String::new(),
             },
             "testproj",
         );
@@ -890,6 +950,7 @@ mod tests {
                 mcp_os: String::new(),
                 host_exec: String::new(),
                 claude: String::new(),
+                lima: String::new(),
             },
             "testproj",
         );
@@ -907,6 +968,7 @@ mod tests {
                 mcp_os: "mcp_os_line\n".to_string(),
                 host_exec: "host_exec_line\n".to_string(),
                 claude: "claude_line\n".to_string(),
+                lima: String::new(),
             },
             "testproj",
         );

--- a/desktop/src-tauri/src/diagnostics.rs
+++ b/desktop/src-tauri/src/diagnostics.rs
@@ -155,16 +155,11 @@ pub(crate) async fn export_diagnostics(project: String) -> Result<String, String
         let rt = speedwave_runtime::runtime::detect_runtime();
         let container_logs = rt.compose_logs(&project, 5000).ok();
 
-        let compose_path = Some(
-            speedwave_runtime::consts::data_dir()
-                .join("projects")
-                .join(&project)
-                .join("compose.yml"),
-        );
+        // SSOT path — a hand-rolled projects/<project>/ path bundled nothing.
+        let compose_path = speedwave_runtime::compose::compose_output_path(&project).ok();
 
         let mcp_os_log = {
-            let p = speedwave_runtime::consts::data_dir()
-                .join(speedwave_runtime::consts::MCP_OS_LOG_FILE);
+            let p = speedwave_runtime::consts::mcp_os_log_path();
             if p.exists() {
                 Some(p)
             } else {
@@ -212,6 +207,27 @@ mod tests {
     fn export_diagnostics_rejects_invalid_project_name() {
         let result = super::super::check_project("../escape");
         assert!(result.is_err(), "path traversal should be rejected");
+    }
+
+    /// Regression: the compose path must resolve via the `compose_output_path`
+    /// SSOT, never the hand-rolled `projects/<project>/` path that silently
+    /// bundled nothing.
+    #[test]
+    fn export_diagnostics_resolves_compose_via_ssot() {
+        let src = include_str!("diagnostics.rs");
+        let cmd = src
+            .split("async fn export_diagnostics(")
+            .nth(1)
+            .and_then(|s| s.split("\n}").next())
+            .expect("export_diagnostics body");
+        assert!(
+            cmd.contains("compose::compose_output_path("),
+            "compose path must come from the compose_output_path SSOT"
+        );
+        assert!(
+            !cmd.contains(".join(\"projects\")"),
+            "must not re-introduce the non-existent projects/<project>/compose.yml path"
+        );
     }
 
     #[test]

--- a/desktop/src-tauri/src/diagnostics.rs
+++ b/desktop/src-tauri/src/diagnostics.rs
@@ -141,16 +141,9 @@ pub(crate) async fn export_diagnostics(project: String) -> Result<String, String
 
         // File-source paths resolved from the SSOT registry (platform-gated), so
         // /logs and the ZIP can't drift and host-exec is no longer dropped.
-        use speedwave_runtime::diagnostic_sources::{SourceKind, DIAGNOSTIC_SOURCES};
         let data_dir = speedwave_runtime::consts::data_dir();
-        let resolve = |key: &str| -> Option<std::path::PathBuf> {
-            DIAGNOSTIC_SOURCES
-                .iter()
-                .find(|s| s.key == key && s.platforms.available_here())
-                .and_then(|s| match s.kind {
-                    SourceKind::File(f) => f(data_dir, &project),
-                    _ => None,
-                })
+        let resolve = |key: &str| {
+            speedwave_runtime::diagnostic_sources::resolve_file_path(key, data_dir, &project)
         };
 
         let input = DiagnosticsInput {
@@ -198,8 +191,8 @@ mod tests {
             .and_then(|s| s.split("\n}").next())
             .expect("export_diagnostics body");
         assert!(
-            cmd.contains("DIAGNOSTIC_SOURCES"),
-            "paths must be resolved from the registry SSOT"
+            cmd.contains("resolve_file_path"),
+            "paths must be resolved from the registry SSOT (resolve_file_path)"
         );
         assert!(
             !cmd.contains(".join(\"projects\")"),

--- a/desktop/src-tauri/src/diagnostics.rs
+++ b/desktop/src-tauri/src/diagnostics.rs
@@ -11,6 +11,8 @@ pub(crate) struct DiagnosticsInput {
     pub container_logs: Option<String>,
     /// Path to the mcp-os dedicated log file.
     pub mcp_os_log: Option<std::path::PathBuf>,
+    /// Path to the per-project host-exec worker log.
+    pub host_exec_log: Option<std::path::PathBuf>,
     /// Path to the project's `compose.yml`.
     pub compose_path: Option<std::path::PathBuf>,
     /// Path to the Claude session log file.
@@ -21,6 +23,21 @@ pub(crate) struct DiagnosticsInput {
 ///
 /// All textual content is passed through `log_sanitizer::sanitize()` before
 /// being written to the archive. System info is appended without sanitization.
+/// Writes one ZIP entry, ALWAYS sanitized. The single textual-write path —
+/// every secret-bearing entry goes through here, so none can skip redaction.
+fn write_sanitized_entry(
+    zip: &mut zip::ZipWriter<std::fs::File>,
+    options: zip::write::SimpleFileOptions,
+    name: &str,
+    raw: &str,
+) -> anyhow::Result<()> {
+    use std::io::Write;
+    let sanitized = speedwave_runtime::log_sanitizer::sanitize(raw);
+    zip.start_file(name, options)?;
+    zip.write_all(sanitized.as_bytes())?;
+    Ok(())
+}
+
 pub(crate) fn build_diagnostics_zip(
     zip_path: &std::path::Path,
     input: &DiagnosticsInput,
@@ -32,7 +49,7 @@ pub(crate) fn build_diagnostics_zip(
     let mut zip = zip::ZipWriter::new(file);
     let options = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
 
-    // 1. App logs
+    // App logs: one /logs source ("desktop") → N `logs/<file>` entries.
     if let Some(ref log_dir) = input.log_dir {
         if let Ok(entries) = std::fs::read_dir(log_dir) {
             let mut log_paths: Vec<_> = entries
@@ -43,71 +60,39 @@ pub(crate) fn build_diagnostics_zip(
             log_paths.sort();
             for path in &log_paths {
                 if let Ok(content) = std::fs::read_to_string(path) {
-                    let sanitized = speedwave_runtime::log_sanitizer::sanitize(&content);
                     let name = format!(
                         "logs/{}",
                         path.file_name().unwrap_or_default().to_string_lossy()
                     );
-                    zip.start_file(&name, options)?;
-                    zip.write_all(sanitized.as_bytes())?;
+                    write_sanitized_entry(&mut zip, options, &name, &content)?;
                 }
             }
         }
     }
 
-    // 2. Lima VM serial log
-    if let Some(ref serial_log) = input.serial_log {
-        if serial_log.exists() {
-            if let Ok(content) = std::fs::read_to_string(serial_log) {
-                let sanitized = speedwave_runtime::log_sanitizer::sanitize(&content);
-                zip.start_file("lima/serial.log", options)?;
-                zip.write_all(sanitized.as_bytes())?;
-            }
-        }
-    }
-
-    // 3. Container logs
     if let Some(ref logs) = input.container_logs {
-        let sanitized = speedwave_runtime::log_sanitizer::sanitize(logs);
-        zip.start_file("containers/compose.log", options)?;
-        zip.write_all(sanitized.as_bytes())?;
+        write_sanitized_entry(&mut zip, options, "containers/compose.log", logs)?;
     }
 
-    // 4. mcp-os log
-    if let Some(ref path) = input.mcp_os_log {
-        if path.exists() {
-            if let Ok(content) = std::fs::read_to_string(path) {
-                let sanitized = speedwave_runtime::log_sanitizer::sanitize(&content);
-                let entry_name = format!("mcp-os/{}", speedwave_runtime::consts::MCP_OS_LOG_FILE);
-                zip.start_file(&entry_name, options)?;
-                zip.write_all(sanitized.as_bytes())?;
+    // Single-file sources: (path, zip_entry). Existence-gated.
+    let single_files = [
+        (&input.serial_log, "lima/serial.log"),
+        (&input.mcp_os_log, "mcp-os/mcp-os.log"),
+        (&input.host_exec_log, "host-exec/log"),
+        (&input.claude_session_log, "claude/claude-session.log"),
+        (&input.compose_path, "containers/compose.yml"),
+    ];
+    for (maybe_path, entry) in single_files {
+        if let Some(path) = maybe_path {
+            if path.exists() {
+                if let Ok(content) = std::fs::read_to_string(path) {
+                    write_sanitized_entry(&mut zip, options, entry, &content)?;
+                }
             }
         }
     }
 
-    // 5. Claude session log
-    if let Some(ref path) = input.claude_session_log {
-        if path.exists() {
-            if let Ok(content) = std::fs::read_to_string(path) {
-                let sanitized = speedwave_runtime::log_sanitizer::sanitize(&content);
-                zip.start_file("claude/claude-session.log", options)?;
-                zip.write_all(sanitized.as_bytes())?;
-            }
-        }
-    }
-
-    // 6. compose.yml
-    if let Some(ref compose_path) = input.compose_path {
-        if compose_path.exists() {
-            if let Ok(content) = std::fs::read_to_string(compose_path) {
-                let sanitized = speedwave_runtime::log_sanitizer::sanitize(&content);
-                zip.start_file("containers/compose.yml", options)?;
-                zip.write_all(sanitized.as_bytes())?;
-            }
-        }
-    }
-
-    // 7. System info (no sanitization needed)
+    // System info: compile-time constants, no secrets — the one raw entry.
     let sys_info = format!(
         "os: {}\narch: {}\nversion: {}\n",
         std::env::consts::OS,
@@ -141,48 +126,31 @@ pub(crate) async fn export_diagnostics(project: String) -> Result<String, String
 
         let log_dir = crate::logging_cmd::desktop_log_dir();
 
-        let serial_log = if cfg!(target_os = "macos") {
-            Some(
-                speedwave_runtime::consts::data_dir()
-                    .join(speedwave_runtime::consts::LIMA_SUBDIR)
-                    .join(speedwave_runtime::consts::lima_vm_name())
-                    .join("serial.log"),
-            )
-        } else {
-            None
-        };
-
         let rt = speedwave_runtime::runtime::detect_runtime();
         let container_logs = rt.compose_logs(&project, 5000).ok();
 
-        // SSOT path — a hand-rolled projects/<project>/ path bundled nothing.
-        let compose_path = speedwave_runtime::compose::compose_output_path(&project).ok();
-
-        let mcp_os_log = {
-            let p = speedwave_runtime::consts::mcp_os_log_path();
-            if p.exists() {
-                Some(p)
-            } else {
-                None
-            }
-        };
-
-        let claude_session_log = {
-            let p = speedwave_runtime::consts::claude_session_log_path(&project);
-            if p.exists() {
-                Some(p)
-            } else {
-                None
-            }
+        // File-source paths resolved from the SSOT registry (platform-gated), so
+        // /logs and the ZIP can't drift and host-exec is no longer dropped.
+        use speedwave_runtime::diagnostic_sources::{SourceKind, DIAGNOSTIC_SOURCES};
+        let data_dir = speedwave_runtime::consts::data_dir();
+        let resolve = |key: &str| -> Option<std::path::PathBuf> {
+            DIAGNOSTIC_SOURCES
+                .iter()
+                .find(|s| s.key == key && s.platforms.available_here())
+                .and_then(|s| match s.kind {
+                    SourceKind::File(f) => f(data_dir, &project),
+                    _ => None,
+                })
         };
 
         let input = DiagnosticsInput {
             log_dir,
-            serial_log,
+            serial_log: resolve("lima"),
             container_logs,
-            mcp_os_log,
-            compose_path,
-            claude_session_log,
+            mcp_os_log: resolve("mcp-os"),
+            host_exec_log: resolve("host-exec"),
+            compose_path: resolve("compose-yml"),
+            claude_session_log: resolve("claude"),
         };
 
         build_diagnostics_zip(&zip_path, &input)?;
@@ -209,11 +177,10 @@ mod tests {
         assert!(result.is_err(), "path traversal should be rejected");
     }
 
-    /// Regression: the compose path must resolve via the `compose_output_path`
-    /// SSOT, never the hand-rolled `projects/<project>/` path that silently
-    /// bundled nothing.
+    /// Regression: paths must come from the DIAGNOSTIC_SOURCES registry, never
+    /// a hand-rolled `projects/<project>/` path that silently bundled nothing.
     #[test]
-    fn export_diagnostics_resolves_compose_via_ssot() {
+    fn export_diagnostics_resolves_paths_via_registry() {
         let src = include_str!("diagnostics.rs");
         let cmd = src
             .split("async fn export_diagnostics(")
@@ -221,8 +188,8 @@ mod tests {
             .and_then(|s| s.split("\n}").next())
             .expect("export_diagnostics body");
         assert!(
-            cmd.contains("compose::compose_output_path("),
-            "compose path must come from the compose_output_path SSOT"
+            cmd.contains("DIAGNOSTIC_SOURCES"),
+            "paths must be resolved from the registry SSOT"
         );
         assert!(
             !cmd.contains(".join(\"projects\")"),
@@ -282,6 +249,7 @@ mod tests {
             serial_log: None,
             container_logs: Some("container output here".into()),
             mcp_os_log: None,
+            host_exec_log: None,
             compose_path: Some(compose_path),
             claude_session_log: None,
         };
@@ -343,6 +311,7 @@ mod tests {
                 "JWT: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signature123\n".into(),
             ),
             mcp_os_log: None,
+            host_exec_log: None,
             compose_path: None,
             claude_session_log: None,
         };
@@ -387,6 +356,7 @@ mod tests {
             serial_log: None,
             container_logs: None,
             mcp_os_log: None,
+            host_exec_log: None,
             compose_path: Some(compose_path),
             claude_session_log: None,
         };
@@ -427,6 +397,7 @@ mod tests {
             serial_log: None,
             container_logs: None,
             mcp_os_log: None,
+            host_exec_log: None,
             compose_path: None,
             claude_session_log: None,
         };
@@ -457,6 +428,7 @@ mod tests {
             serial_log: Some(serial_log),
             container_logs: None,
             mcp_os_log: None,
+            host_exec_log: None,
             compose_path: None,
             claude_session_log: None,
         };
@@ -484,6 +456,7 @@ mod tests {
             serial_log: None,
             container_logs: None,
             mcp_os_log: None,
+            host_exec_log: None,
             compose_path: None,
             claude_session_log: None,
         };
@@ -511,6 +484,7 @@ mod tests {
             serial_log: None,
             container_logs: None,
             mcp_os_log: Some(mcp_os_log),
+            host_exec_log: None,
             compose_path: None,
             claude_session_log: None,
         };
@@ -544,6 +518,7 @@ mod tests {
             serial_log: None,
             container_logs: None,
             mcp_os_log: None,
+            host_exec_log: None,
             compose_path: None,
             claude_session_log: Some(session_log),
         };
@@ -559,5 +534,81 @@ mod tests {
         let content = read_zip_entry(&zip_path, "claude/claude-session.log").unwrap();
         assert!(content.contains("SESSION: started"), "content: {content}");
         assert!(content.contains("TOOL: start"), "content: {content}");
+    }
+
+    #[test]
+    fn diagnostics_zip_includes_host_exec_log() {
+        let tmp = tempfile::tempdir().unwrap();
+        let zip_path = tmp.path().join("diag-hostexec.zip");
+        let host_exec = tmp.path().join("host-exec-log");
+        std::fs::write(&host_exec, "host_exec ran npm test").unwrap();
+
+        let input = DiagnosticsInput {
+            log_dir: None,
+            serial_log: None,
+            container_logs: None,
+            mcp_os_log: None,
+            host_exec_log: Some(host_exec),
+            compose_path: None,
+            claude_session_log: None,
+        };
+        build_diagnostics_zip(&zip_path, &input).unwrap();
+
+        let names = zip_entry_names(&zip_path);
+        assert!(
+            names.contains(&"host-exec/log".to_string()),
+            "ZIP must contain host-exec log (was missing before the registry fix): {names:?}"
+        );
+    }
+
+    /// Matrix guard: a secret planted in EVERY textual source must be redacted
+    /// in EVERY ZIP entry — not just the few cases the per-source tests check.
+    #[test]
+    fn diagnostics_zip_all_sources_redact_secrets() {
+        let tmp = tempfile::tempdir().unwrap();
+        let zip_path = tmp.path().join("diag-matrix.zip");
+
+        let log_dir = tmp.path().join("logs");
+        std::fs::create_dir_all(&log_dir).unwrap();
+        std::fs::write(
+            log_dir.join("app.log"),
+            "desktop sk-ant-deadbeefdeadbeefdeadbeef",
+        )
+        .unwrap();
+        let mk = |name: &str, body: &str| {
+            let p = tmp.path().join(name);
+            std::fs::write(&p, body).unwrap();
+            p
+        };
+        let secrets = [
+            "sk-ant-deadbeefdeadbeefdeadbeef",
+            "xoxb-1111-2222-secretslacktoken",
+            "MCP_SLACK_AUTH_TOKEN=550e8400-e29b-41d4-a716-446655440000",
+            "password=hunter2hunter2",
+            "Bearer ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        ];
+        let input = DiagnosticsInput {
+            log_dir: Some(log_dir),
+            serial_log: Some(mk("serial.log", secrets[1])),
+            container_logs: Some(secrets[2].into()),
+            mcp_os_log: Some(mk("mcp.log", secrets[3])),
+            host_exec_log: Some(mk("he.log", secrets[4])),
+            compose_path: Some(mk("compose.yml", secrets[0])),
+            claude_session_log: Some(mk("claude.log", secrets[1])),
+        };
+        build_diagnostics_zip(&zip_path, &input).unwrap();
+
+        for name in zip_entry_names(&zip_path) {
+            if name == "system-info.txt" {
+                continue;
+            }
+            let content = read_zip_entry(&zip_path, &name).unwrap_or_default();
+            for s in &secrets {
+                assert!(
+                    !content.contains(s),
+                    "secret '{s}' leaked into ZIP entry '{name}': {content}"
+                );
+            }
+        }
     }
 }

--- a/desktop/src-tauri/src/diagnostics.rs
+++ b/desktop/src-tauri/src/diagnostics.rs
@@ -70,23 +70,33 @@ pub(crate) fn build_diagnostics_zip(
         }
     }
 
+    // Entry names come from the SSOT registry (keyed by source), so a stray
+    // hand-rolled entry can't appear — every name traces to DIAGNOSTIC_SOURCES.
+    let zip_entry = |key: &str| -> &'static str {
+        speedwave_runtime::diagnostic_sources::DIAGNOSTIC_SOURCES
+            .iter()
+            .find(|s| s.key == key)
+            .map(|s| s.zip_entry)
+            .unwrap_or_default()
+    };
+
     if let Some(ref logs) = input.container_logs {
-        write_sanitized_entry(&mut zip, options, "containers/compose.log", logs)?;
+        write_sanitized_entry(&mut zip, options, zip_entry("compose"), logs)?;
     }
 
-    // Single-file sources: (path, zip_entry). Existence-gated.
+    // Single-file sources keyed to the registry. Existence-gated.
     let single_files = [
-        (&input.serial_log, "lima/serial.log"),
-        (&input.mcp_os_log, "mcp-os/mcp-os.log"),
-        (&input.host_exec_log, "host-exec/log"),
-        (&input.claude_session_log, "claude/claude-session.log"),
-        (&input.compose_path, "containers/compose.yml"),
+        (&input.serial_log, "lima"),
+        (&input.mcp_os_log, "mcp-os"),
+        (&input.host_exec_log, "host-exec"),
+        (&input.claude_session_log, "claude"),
+        (&input.compose_path, "compose-yml"),
     ];
-    for (maybe_path, entry) in single_files {
+    for (maybe_path, key) in single_files {
         if let Some(path) = maybe_path {
             if path.exists() {
                 if let Ok(content) = std::fs::read_to_string(path) {
-                    write_sanitized_entry(&mut zip, options, entry, &content)?;
+                    write_sanitized_entry(&mut zip, options, zip_entry(key), &content)?;
                 }
             }
         }
@@ -609,6 +619,46 @@ mod tests {
                     "secret '{s}' leaked into ZIP entry '{name}': {content}"
                 );
             }
+        }
+    }
+
+    /// Parity: every ZIP entry must trace to a registry `zip_entry`. A stray
+    /// hand-rolled `zip.start_file(...)` outside the registry would fail here.
+    #[test]
+    fn every_zip_entry_traces_to_source() {
+        use speedwave_runtime::diagnostic_sources::DIAGNOSTIC_SOURCES;
+        let tmp = tempfile::tempdir().unwrap();
+        let zip_path = tmp.path().join("diag-trace.zip");
+        let log_dir = tmp.path().join("logs");
+        std::fs::create_dir_all(&log_dir).unwrap();
+        std::fs::write(log_dir.join("app.log"), "x").unwrap();
+        let mk = |name: &str| {
+            let p = tmp.path().join(name);
+            std::fs::write(&p, "x").unwrap();
+            p
+        };
+        let input = DiagnosticsInput {
+            log_dir: Some(log_dir),
+            serial_log: Some(mk("serial.log")),
+            container_logs: Some("x".into()),
+            mcp_os_log: Some(mk("mcp.log")),
+            host_exec_log: Some(mk("he.log")),
+            compose_path: Some(mk("compose.yml")),
+            claude_session_log: Some(mk("claude.log")),
+        };
+        build_diagnostics_zip(&zip_path, &input).unwrap();
+
+        let registry_entries: Vec<&str> = DIAGNOSTIC_SOURCES.iter().map(|s| s.zip_entry).collect();
+        for name in zip_entry_names(&zip_path) {
+            // system-info.txt is the documented non-source trailing write;
+            // `logs/<file>` are the desktop dir's N dynamic entries (zip_entry "logs/").
+            let traced = name == "system-info.txt"
+                || name.starts_with("logs/")
+                || registry_entries.contains(&name.as_str());
+            assert!(
+                traced,
+                "ZIP entry '{name}' does not trace to any DIAGNOSTIC_SOURCES.zip_entry"
+            );
         }
     }
 }

--- a/desktop/src-tauri/src/patch_emitter.rs
+++ b/desktop/src-tauri/src/patch_emitter.rs
@@ -483,6 +483,51 @@ mod tests {
         MsgStoreRegistry::new()
     }
 
+    /// P0-1 channel guard: the patch mirror (which feeds `chat_patch::*` via
+    /// subscribe_cmd, with no sanitize of its own) must carry redacted content.
+    /// Mirrors production: sanitize_chunk runs BEFORE handle_chunk.
+    #[test]
+    fn patch_channel_redacts_secrets() {
+        let r = registry();
+        let mut e = PatchEmitter::new();
+        let secret = "MCP_SLACK_AUTH_TOKEN=550e8400-e29b-41d4-a716-446655440000";
+        let chunk = crate::chat::sanitize_chunk(StreamChunk::Text {
+            content: format!("here it is {secret}"),
+        });
+        e.handle_chunk(&chunk, &r);
+        let dump = format!("{:?}", e.pending);
+        assert!(
+            !dump.contains("550e8400"),
+            "secret leaked into patch-mirror payload: {dump}"
+        );
+    }
+
+    /// Tool input (partial_json) must reach the patch mirror byte-identical —
+    /// sanitize_chunk must not corrupt incremental JSON.
+    #[test]
+    fn patch_channel_preserves_tool_input_json() {
+        let r = registry();
+        let mut e = PatchEmitter::new();
+        e.handle_chunk(
+            &StreamChunk::ToolStart {
+                tool_id: "t1".into(),
+                tool_name: "Bash".into(),
+            },
+            &r,
+        );
+        let raw = r#"{"command":"echo"#;
+        let chunk = crate::chat::sanitize_chunk(StreamChunk::ToolInputDelta {
+            tool_id: "t1".into(),
+            partial_json: raw.into(),
+        });
+        e.handle_chunk(&chunk, &r);
+        let dump = format!("{:?}", e.pending);
+        assert!(
+            dump.contains(r#"{\"command\":\"echo"#) || dump.contains(raw),
+            "partial_json must pass through intact: {dump}"
+        );
+    }
+
     #[test]
     fn text_chunk_creates_assistant_entry_and_appends() {
         let r = registry();


### PR DESCRIPTION
## Scope

Started as a fix for intermittent `compose.yml` corruption (rename-without-fsync); investigation surfaced a broader diagnostic-logging inconsistency and a live secret-leak, all fixed here.

## 1. Durable compose / secret writes (original fix)

`write_restricted_file[_atomic]` did write+flush+rename without `fsync`. On macOS APFS under Lima virtiofs the rename could publish the name while data blocks were still dirty → a reboot left a truncated `compose.yml` that limactl rejected (`networks must be a mapping`). Fix: fsync the tempfile before persist (macOS `F_FULLFSYNC` via rustix; other Unix `fsync`; Windows no-op) + parent-dir fsync after rename, in the shared write helpers.

## 2. Unified diagnostic-source SSOT (`/logs` ↔ ZIP parity)

The in-app `/logs` view and the diagnostics ZIP kept **two hand-rolled source lists** that had drifted — `host-exec` was in `/logs` but missing from the ZIP; `lima` serial.log was in the ZIP but not `/logs`. New `diagnostic_sources.rs` is the single registry both consumers derive from. A parity test fails the build if they diverge on a displayable source; the only allowed divergence is a non-displayable artifact (`compose.yml`), pinned by an explicit allow-list. host-exec now ships in the ZIP; lima now shows in `/logs` on macOS.

## 3. Sanitizer enforced by construction (live leak closed)

The sanitizer was an SSOT of *rules* but enforced only by *convention* — the live chat stream (`chat_stream` emit + `chat_patch::*` mirror) reached the webview unsanitized, so a raw `sk-ant` key or worker auth token could appear on screen. Fix: `sanitize_chunk` runs once at the single fan-out point, before both channels, covering Text/Thinking/ToolResult/Error content and `Result.result_text` (`partial_json` deliberately untouched). The ZIP now writes through one `write_sanitized_entry` path, with a matrix test that plants a secret in every textual source and asserts every entry is clean.

## 4. Sanitizer rule coverage

Broadened the assignment rules with a `*_token` suffix so bare-UUID worker tokens (`MCP_*_AUTH_TOKEN`) are redacted. `*_key` deliberately excluded (cache_key/sort_key false positives; `*_API_KEY` already covered by `api_key`). Redacts the host-exec `projectDir` username (SPW-205 path scope). No bare-UUID rule (would false-positive on container/request IDs).

## Tests

runtime lib **1705**, desktop **1443** — all green. New: registry parity, ZIP secret-matrix, chat-stream redaction, `*_token` redaction + `cache_key` false-positive guard, host-exec presence + projectDir redaction.

Confidence on the original corruption diagnosis stays high-not-certain (no captured artifact; APFS rename corruption is a race) — the durability fix is correct regardless, and the diagnostics fix means the next report carries the artifact.