### PR TITLE
fix: dev startup — apt tzdata build hang, start/rebuild race, premature ready state

### DIFF
--- a/containers/Containerfile.claude
+++ b/containers/Containerfile.claude
@@ -19,7 +19,7 @@ RUN mkdir -p /home/speedwave && chown 1000:1000 /home/speedwave
 # (layers are disposable) and eliminates the fsync bottleneck in nested virtualization
 # environments (WSL2/Hyper-V inside VMware). Installed files are byte-identical.
 RUN apt-get update -o Acquire::Retries=3 && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         -o Dpkg::Options::="--force-unsafe-io" \
         bash \
         ca-certificates \

--- a/crates/speedwave-runtime/src/compose/mod.rs
+++ b/crates/speedwave-runtime/src/compose/mod.rs
@@ -468,9 +468,7 @@ pub(crate) const COMPOSE_SCHEMA_VALIDATION_ERROR_FRAGMENTS: &[&str] = &[
     "driver must be a string",         // networks.<n>.driver torn
     "cpus must be a number or string", // deploy.resources.limits.cpus torn
     "memory must be a string",         // deploy.resources.limits.memory torn
-    "could not find expected",
-    "did not find expected",
-    "found unexpected end of stream", // file truncated mid-document (yaml-go)
+    "yaml:", // any yaml-go parse error: rendered YAML is always valid, so torn read
 ];
 
 /// Asserts every `services.<svc>.networks: [name]` reference resolves to a

--- a/crates/speedwave-runtime/src/compose/mod.rs
+++ b/crates/speedwave-runtime/src/compose/mod.rs
@@ -470,6 +470,7 @@ pub(crate) const COMPOSE_SCHEMA_VALIDATION_ERROR_FRAGMENTS: &[&str] = &[
     "memory must be a string",         // deploy.resources.limits.memory torn
     "could not find expected",
     "did not find expected",
+    "found unexpected end of stream", // file truncated mid-document (yaml-go)
 ];
 
 /// Asserts every `services.<svc>.networks: [name]` reference resolves to a

--- a/crates/speedwave-runtime/src/runtime/mod.rs
+++ b/crates/speedwave-runtime/src/runtime/mod.rs
@@ -2352,6 +2352,10 @@ services:
         assert!(is_propagation_error(&anyhow::anyhow!(
             "yaml: line 8: did not find expected key"
         )));
+        // A cut at end-of-document (file truncated mid-write) — yaml-go variant.
+        assert!(is_propagation_error(&anyhow::anyhow!(
+            "failed to parse compose.yml: yaml: line 365: found unexpected end of stream"
+        )));
         // A torn `cpus:` value under deploy.resources.limits surfaces as the
         // compose-go schema type error for that field (real-world: mcp-office).
         assert!(is_propagation_error(&anyhow::anyhow!(

--- a/crates/speedwave-runtime/tests/apt_noninteractive.rs
+++ b/crates/speedwave-runtime/tests/apt_noninteractive.rs
@@ -1,0 +1,105 @@
+//! Drift detector: every `apt-get install` in a container image file must run
+//! with `DEBIAN_FRONTEND=noninteractive` — a debconf prompt (e.g. tzdata's
+//! timezone dialog on upgrade) hangs buildkit forever, since builds have no TTY.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::{Path, PathBuf};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crates dir")
+        .parent()
+        .expect("repo root")
+        .to_path_buf()
+}
+
+fn collect_image_files(root: &Path, out: &mut Vec<PathBuf>) {
+    for entry in std::fs::read_dir(root).expect("read_dir").flatten() {
+        let path = entry.path();
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if path.is_dir() {
+            if name.starts_with('.') || name == "node_modules" || name == "dist" {
+                continue;
+            }
+            collect_image_files(&path, out);
+        } else if name == "Dockerfile" || name.starts_with("Containerfile") {
+            out.push(path);
+        }
+    }
+}
+
+/// Join `\`-continued physical lines into (first_line_number, logical_line) pairs.
+fn logical_lines(src: &str) -> Vec<(usize, String)> {
+    let mut out = Vec::new();
+    let mut current = String::new();
+    let mut start = 0usize;
+    for (idx, line) in src.lines().enumerate() {
+        if current.is_empty() {
+            start = idx + 1;
+        }
+        let trimmed = line.trim_end();
+        if let Some(stripped) = trimmed.strip_suffix('\\') {
+            current.push_str(stripped);
+            current.push(' ');
+        } else {
+            current.push_str(trimmed);
+            out.push((start, std::mem::take(&mut current)));
+        }
+    }
+    if !current.is_empty() {
+        out.push((start, current));
+    }
+    out
+}
+
+#[test]
+fn apt_get_install_runs_noninteractive() {
+    let root = repo_root();
+    let mut files = Vec::new();
+    for dir in ["containers", "mcp-servers"] {
+        collect_image_files(&root.join(dir), &mut files);
+    }
+    assert!(
+        !files.is_empty(),
+        "no image files found — repo layout changed?"
+    );
+
+    let mut violations = Vec::new();
+    for file in &files {
+        let src = std::fs::read_to_string(file).expect("read image file");
+        for (lineno, logical) in logical_lines(&src) {
+            if logical.contains("apt-get install")
+                && !logical.contains("DEBIAN_FRONTEND=noninteractive")
+            {
+                violations.push(format!("{}:{lineno}", file.display()));
+            }
+        }
+    }
+    assert!(
+        violations.is_empty(),
+        "apt-get install without DEBIAN_FRONTEND=noninteractive (debconf can hang the build):\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn logical_lines_joins_continuations() {
+    let src = "RUN a \\\n    && b\nNEXT\n";
+    let lines = logical_lines(src);
+    assert_eq!(lines.len(), 2);
+    assert_eq!(lines[0].0, 1);
+    assert!(lines[0].1.contains("RUN a") && lines[0].1.contains("&& b"));
+    assert_eq!(lines[1], (3, "NEXT".to_string()));
+}
+
+#[test]
+fn logical_lines_handles_empty_and_trailing_continuation() {
+    assert!(logical_lines("").is_empty());
+    // Trailing `\` on the last line must not drop the buffered content.
+    let lines = logical_lines("RUN a \\");
+    assert_eq!(lines.len(), 1);
+    assert!(lines[0].1.contains("RUN a"));
+}

--- a/desktop/src-tauri/src/container_logs_cmd.rs
+++ b/desktop/src-tauri/src/container_logs_cmd.rs
@@ -220,7 +220,7 @@ pub(crate) fn merge_log_sources(sources: LogSources, project: &str) -> String {
 /// Sources merged (in this fixed order, per-source-block):
 ///   1. compose   — `nerdctl compose logs --timestamps --tail <N>`
 ///   2. desktop   — tauri-plugin-log file (Rust + Angular `LoggerService` +
-///                  Swift CLI stderr forwarded by `check_os_permission`)
+///      Swift CLI stderr forwarded by `check_os_permission`)
 ///   3. mcp-os    — `~/.speedwave/mcp-os.log`
 ///   4. host-exec — `~/.speedwave/host-exec/<project>/log` (if host_exec enabled)
 ///   5. claude    — `~/.speedwave/logs/<project>/claude-session.log` (if exists)
@@ -232,22 +232,72 @@ pub(crate) fn merge_log_sources(sources: LogSources, project: &str) -> String {
 ///
 /// Compose-only output (e.g. diagnostics export) reads `rt.compose_logs`
 /// directly; this is the only log command the webview invokes.
+/// Give up on the (normally sub-second) compose-logs fetch after this long —
+/// a busy container engine must not blank the file-based sources.
+const COMPOSE_LOGS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Single-flight marker: a compose-logs fetch survives its timeout as a
+/// detached task; polls must not stack more nerdctl processes behind it.
+static COMPOSE_LOGS_IN_FLIGHT: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Synthetic `compose | …` WARN line shown while container logs are unreachable.
+fn compose_busy_marker() -> String {
+    format!(
+        "compose | {} WARN  container logs unavailable while the container engine is busy — retrying on the next refresh\n",
+        speedwave_runtime::log_ts::log_timestamp(),
+    )
+}
+
+/// Fetches compose logs with a timeout and single-flight guard; falls back to
+/// `compose_busy_marker()` instead of blocking the merged view.
+async fn fetch_compose_logs_bounded(project: String, tail: u32) -> String {
+    use std::sync::atomic::Ordering;
+    if COMPOSE_LOGS_IN_FLIGHT
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return compose_busy_marker();
+    }
+    struct InFlightGuard;
+    impl Drop for InFlightGuard {
+        fn drop(&mut self) {
+            COMPOSE_LOGS_IN_FLIGHT.store(false, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+    let handle = tokio::task::spawn_blocking(move || {
+        let _guard = InFlightGuard;
+        let rt = speedwave_runtime::runtime::detect_runtime();
+        // best-effort; missing runtime should not blank the whole view
+        if rt.is_available() {
+            rt.compose_logs(&project, tail).unwrap_or_default()
+        } else {
+            String::new()
+        }
+    });
+    match tokio::time::timeout(COMPOSE_LOGS_TIMEOUT, handle).await {
+        Ok(Ok(s)) => s,
+        Ok(Err(e)) => {
+            log::warn!("get_all_logs: compose logs task failed: {e}");
+            String::new()
+        }
+        // The detached task clears the in-flight flag when it eventually ends.
+        Err(_) => {
+            log::warn!("get_all_logs: compose logs timed out — container engine busy");
+            compose_busy_marker()
+        }
+    }
+}
+
 #[tauri::command]
 pub(crate) async fn get_all_logs(project: String, tail: Option<u32>) -> Result<String, String> {
     check_project(&project)?;
     let tail_u32 = tail.unwrap_or(200).min(10_000);
     let tail_us = tail_u32 as usize;
 
+    let compose = fetch_compose_logs_bounded(project.clone(), tail_u32).await;
+
     tokio::task::spawn_blocking(move || -> Result<String, String> {
-        let rt = speedwave_runtime::runtime::detect_runtime();
-
-        // compose (best-effort; missing runtime should not blank the whole view)
-        let compose = if rt.is_available() {
-            rt.compose_logs(&project, tail_u32).unwrap_or_default()
-        } else {
-            String::new()
-        };
-
         let desktop = match desktop_log_dir() {
             Some(dir) => read_tail_desktop_logs(&dir, tail_us),
             None => String::new(),
@@ -816,5 +866,28 @@ mod tests {
         let out = read_tail_desktop_logs(tmp.path(), 10);
         assert!(!out.contains("sk-ant-api03-secret"), "got: {out}");
         assert!(out.contains("***REDACTED"), "got: {out}");
+    }
+
+    /// The marker must match the `<source> | <ISO> LEVEL msg` shape the
+    /// frontend's `parseLogLine` recognises.
+    #[test]
+    fn compose_busy_marker_has_parseable_shape() {
+        let marker = compose_busy_marker();
+        assert!(marker.starts_with("compose | 2"), "got: {marker}");
+        assert!(marker.contains(" WARN  "), "got: {marker}");
+        assert!(marker.ends_with('\n'), "got: {marker}");
+    }
+
+    #[test]
+    fn fetch_compose_logs_skips_when_another_fetch_is_in_flight() {
+        use std::sync::atomic::Ordering;
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .unwrap();
+        COMPOSE_LOGS_IN_FLIGHT.store(true, Ordering::SeqCst);
+        let out = rt.block_on(fetch_compose_logs_bounded("p".to_string(), 10));
+        COMPOSE_LOGS_IN_FLIGHT.store(false, Ordering::SeqCst);
+        assert!(out.contains("container logs unavailable"), "got: {out}");
     }
 }

--- a/desktop/src-tauri/src/containers_cmd.rs
+++ b/desktop/src-tauri/src/containers_cmd.rs
@@ -6,7 +6,7 @@
 
 use speedwave_runtime::config;
 
-use crate::reconcile::{SharedIdeBridge, SharedMcpOs};
+use crate::reconcile::{SharedHostExec, SharedIdeBridge, SharedMcpOs, SharedOauth};
 use crate::setup_wizard;
 use crate::types::{check_project, LlmConfigResponse, LlmConfigUpdate};
 
@@ -403,6 +403,9 @@ pub async fn add_project(
     // Start subsystems on-demand (e.g. after factory reset / fresh install)
     crate::ensure_mcp_os_running(&mcp_os, &app);
     crate::ensure_ide_bridge_running(&ide_bridge, &app);
+    use tauri::Manager;
+    let host_exec_arc = app.state::<SharedHostExec>().inner().clone();
+    let oauth_arc = app.state::<SharedOauth>().inner().clone();
 
     // Pre-flight: detect CloudStorage TCC denial before adding project.
     {
@@ -459,6 +462,10 @@ pub async fn add_project(
         switch_project_core(&prev_clone, &new_clone, &rt, &|proj, _rt| {
             // start_containers calls ensure_ready internally (noop — VM already up)
             check_project(proj)?;
+            // Eager-start host workers before compose render — live WORKER_*_URLs
+            // prevent the first-message container recreate.
+            crate::ensure_host_exec_running(&host_exec_arc, proj);
+            crate::ensure_oauth_running(&oauth_arc, proj);
             log::info!("add_project: starting containers for project={proj}");
             setup_wizard::start_containers(proj).map_err(|e| {
                 log::error!("add_project: start_containers failed: {e}");
@@ -562,10 +569,17 @@ pub async fn start_containers(
 ) -> Result<(), String> {
     crate::ensure_mcp_os_running(&mcp_os, &app);
     crate::ensure_ide_bridge_running(&ide_bridge, &app);
+    use tauri::Manager;
+    let host_exec_arc = app.state::<SharedHostExec>().inner().clone();
+    let oauth_arc = app.state::<SharedOauth>().inner().clone();
 
     tokio::task::spawn_blocking(move || {
         ensure_images_ready()?;
         check_project(&project)?;
+        // Eager-start host workers before compose render — live WORKER_*_URLs
+        // prevent the first-message container recreate.
+        crate::ensure_host_exec_running(&host_exec_arc, &project);
+        crate::ensure_oauth_running(&oauth_arc, &project);
         // Pre-flight: detect CloudStorage TCC denial before attempting container start.
         if let Ok(cfg) = speedwave_runtime::config::load_user_config() {
             if let Some(p) = cfg.find_project(&project) {
@@ -2059,6 +2073,38 @@ mod tests {
              is_setup_complete() is still false (containers_started is set \
              later by start_containers)"
         );
+    }
+
+    /// Structural test: host workers must eager-start before the compose
+    /// render, or the first chat message recreates containers mid-session.
+    #[test]
+    fn start_containers_eager_starts_host_workers_before_compose() {
+        for cmd in [
+            "pub async fn start_containers(",
+            "pub async fn add_project(",
+        ] {
+            let source = include_str!("containers_cmd.rs");
+            let fn_start = source.find(cmd).expect("command function must exist");
+            let fn_body = &source[fn_start..];
+            let next_fn = fn_body[1..]
+                .find("\npub ")
+                .map(|i| i + 1)
+                .unwrap_or(fn_body.len());
+            let fn_body = &fn_body[..next_fn];
+            let host_exec = fn_body
+                .find("ensure_host_exec_running(")
+                .unwrap_or_else(|| panic!("{cmd} must call ensure_host_exec_running"));
+            let oauth = fn_body
+                .find("ensure_oauth_running(")
+                .unwrap_or_else(|| panic!("{cmd} must call ensure_oauth_running"));
+            let compose_start = fn_body
+                .find("setup_wizard::start_containers(")
+                .unwrap_or_else(|| panic!("{cmd} must call setup_wizard::start_containers"));
+            assert!(
+                host_exec < compose_start && oauth < compose_start,
+                "{cmd}: host workers must start before setup_wizard::start_containers"
+            );
+        }
     }
 
     // ─────────────────────────────────────────────────────────────────────

--- a/desktop/src-tauri/src/reconcile.rs
+++ b/desktop/src-tauri/src/reconcile.rs
@@ -117,10 +117,13 @@ const RECONCILE_REBUILDING: u8 = 2;
 
 static BUNDLE_RECONCILE_PHASE: AtomicU8 = AtomicU8::new(RECONCILE_IDLE);
 
-/// Tri-state tracking whether container images are ready for use.
+/// Tracks whether container images are ready for use. `Checking` covers the
+/// short bundle-manifest comparison at reconcile start; waiters treat it like
+/// `Building` so container starts cannot race a rebuild decision.
 #[derive(Clone, Debug)]
 enum ImageReadiness {
     Ready,
+    Checking,
     Building,
     Failed(String),
 }
@@ -131,7 +134,7 @@ static IMAGES_READY: std::sync::LazyLock<(Mutex<ImageReadiness>, Condvar)> =
 /// Blocks the calling thread until container images are ready (or timeout).
 ///
 /// - `Ready` → returns `Ok(())` immediately
-/// - `Building` → waits on Condvar until signaled, then re-checks
+/// - `Checking`/`Building` → waits on Condvar until signaled, then re-checks
 /// - `Failed(msg)` → returns `Err(msg)` immediately
 pub(crate) fn wait_for_images_ready(timeout: Duration) -> Result<(), String> {
     let (lock, cvar) = &*IMAGES_READY;
@@ -142,7 +145,7 @@ pub(crate) fn wait_for_images_ready(timeout: Duration) -> Result<(), String> {
         match &*state {
             ImageReadiness::Ready => return Ok(()),
             ImageReadiness::Failed(msg) => return Err(msg.clone()),
-            ImageReadiness::Building => {
+            ImageReadiness::Checking | ImageReadiness::Building => {
                 let remaining = deadline.saturating_duration_since(std::time::Instant::now());
                 if remaining.is_zero() {
                     return Err("Timed out waiting for container images to build".to_string());
@@ -158,7 +161,7 @@ pub(crate) fn wait_for_images_ready(timeout: Duration) -> Result<(), String> {
                     match &*state {
                         ImageReadiness::Ready => return Ok(()),
                         ImageReadiness::Failed(msg) => return Err(msg.clone()),
-                        ImageReadiness::Building => {
+                        ImageReadiness::Checking | ImageReadiness::Building => {
                             return Err(
                                 "Timed out waiting for container images to build".to_string()
                             );
@@ -185,11 +188,11 @@ struct ImageReadinessGuard;
 impl Drop for ImageReadinessGuard {
     fn drop(&mut self) {
         // Scope guard: if this thread exits without explicitly signaling Ready or Failed,
-        // the guard transitions Building->Failed and wakes all waiters. This covers
-        // early returns and panics not caught by catch_unwind.
+        // the guard transitions Checking/Building->Failed and wakes all waiters. This
+        // covers early returns and panics not caught by catch_unwind.
         let (lock, cvar) = &*IMAGES_READY;
         let mut state = lock.lock().unwrap_or_else(|e| e.into_inner());
-        if matches!(&*state, ImageReadiness::Building) {
+        if matches!(&*state, ImageReadiness::Checking | ImageReadiness::Building) {
             *state = ImageReadiness::Failed("reconcile thread exited unexpectedly".to_string());
             cvar.notify_all();
         }
@@ -318,6 +321,30 @@ fn set_bundle_error(state: &mut bundle::BundleState, message: String) -> String 
     message
 }
 
+/// Resets the bundle phase and closes the readiness gate for a rebuild.
+/// Must run before any slow work (VM start, image build).
+fn prepare_rebuild(
+    state: &mut bundle::BundleState,
+    app_handle: &tauri::AppHandle,
+) -> Result<(), String> {
+    log::info!(
+        "reconcile_bundle: rebuild needed, starting reconcile (phase={:?})",
+        state.phase,
+    );
+    // New bundle = full reconciliation from scratch. Reset phase so all
+    // is_before() gates evaluate to true and every step executes.
+    if state.phase != bundle::BundleReconcilePhase::Pending {
+        log::info!("reconcile_bundle: resetting phase to Pending for new bundle");
+        state.phase = bundle::BundleReconcilePhase::Pending;
+        bundle::save_bundle_state(state).map_err(|e| e.to_string())?;
+    }
+    // Signal Building so start_containers/switch_project callers block until done.
+    BUNDLE_RECONCILE_PHASE.store(RECONCILE_REBUILDING, Ordering::Relaxed);
+    set_image_readiness(ImageReadiness::Building);
+    emit_bundle_status(app_handle);
+    Ok(())
+}
+
 /// INVARIANT: `ensure_ready()` must NOT be gated behind `is_available()`.
 /// A stopped Lima VM returns `is_available() == false` but `ensure_ready()`
 /// can start it; gating one behind the other silently skips VM auto-start.
@@ -331,8 +358,7 @@ fn reconcile_bundle_update_inner(app_handle: &tauri::AppHandle) -> Result<(), St
     })?;
 
     let mut state = bundle::load_bundle_state();
-    let mut bundle_changed =
-        state.applied_bundle_id.as_deref() != Some(manifest.bundle_id.as_str());
+    let bundle_changed = state.applied_bundle_id.as_deref() != Some(manifest.bundle_id.as_str());
 
     log::info!(
         "reconcile_bundle: current={} applied={} changed={}",
@@ -360,22 +386,17 @@ fn reconcile_bundle_update_inner(app_handle: &tauri::AppHandle) -> Result<(), St
 
     let rt = speedwave_runtime::runtime::detect_runtime();
 
-    // Call ensure_ready() once and track whether it succeeded. This avoids a
-    // double limactl probe (once for image-existence check, once before rebuild).
-    let mut runtime_ready = false;
-    match rt.ensure_ready() {
-        Ok(()) => runtime_ready = true,
-        Err(e) => log::warn!("reconcile: runtime not ready: {e}"),
-    }
-
-    // Even when bundle_id matches, verify images actually exist.
-    // They may have been lost after containerd reinstall or VM recreation.
-    if !bundle_changed && runtime_ready && !build::images_exist(&rt, &active_integrations) {
-        log::warn!("reconcile: bundle unchanged but images missing, forcing rebuild");
-        bundle_changed = true;
-    }
-
-    if !bundle_changed {
+    if bundle_changed {
+        // Gate first, then the slow ensure_ready (VM start) — closes the
+        // start_containers vs rebuild race ("image not available").
+        prepare_rebuild(&mut state, app_handle)?;
+        rt.ensure_ready().map_err(|e| {
+            set_bundle_error(
+                &mut state,
+                format!("Runtime is not ready while applying the new bundle: {e}"),
+            )
+        })?;
+    } else {
         if state.phase != bundle::BundleReconcilePhase::Done
             || state.last_error.is_some()
             || !state.pending_running_projects.is_empty()
@@ -386,40 +407,27 @@ fn reconcile_bundle_update_inner(app_handle: &tauri::AppHandle) -> Result<(), St
             state.pending_running_projects.clear();
             bundle::save_bundle_state(&state).map_err(|e| e.to_string())?;
         }
+        // Open the gate immediately: nothing needs rebuilding, and auth/chat
+        // callers must not wait behind a VM start.
         log::info!("reconcile_bundle: no changes needed, setting Ready");
         set_image_readiness(ImageReadiness::Ready);
         emit_bundle_status(app_handle);
-        return Ok(());
-    }
 
-    log::info!(
-        "reconcile_bundle: bundle changed, starting reconcile (phase={:?})",
-        state.phase,
-    );
-
-    // New bundle = full reconciliation from scratch. Reset phase so all
-    // is_before() gates evaluate to true and every step executes.
-    if state.phase != bundle::BundleReconcilePhase::Pending {
-        log::info!("reconcile_bundle: resetting phase to Pending for new bundle");
-        state.phase = bundle::BundleReconcilePhase::Pending;
-        bundle::save_bundle_state(&state).map_err(|e| e.to_string())?;
-    }
-
-    // Now that we know images need rebuilding, signal Building so that
-    // start_containers/switch_project callers block until done.
-    BUNDLE_RECONCILE_PHASE.store(RECONCILE_REBUILDING, Ordering::Relaxed);
-    set_image_readiness(ImageReadiness::Building);
-    emit_bundle_status(app_handle);
-
-    // If the first ensure_ready() failed, retry now — runtime may have
-    // recovered (e.g. VM was starting). If it fails again, report the error.
-    if !runtime_ready {
-        rt.ensure_ready().map_err(|e| {
-            set_bundle_error(
-                &mut state,
-                format!("Runtime is not ready while applying the new bundle: {e}"),
-            )
-        })?;
+        // Repair: images may be gone after containerd reinstall/VM recreation;
+        // needs a running VM, so it runs after the gate opened (as before).
+        match rt.ensure_ready() {
+            Ok(()) => {
+                if build::images_exist(&rt, &active_integrations) {
+                    return Ok(());
+                }
+                log::warn!("reconcile: bundle unchanged but images missing, forcing rebuild");
+                prepare_rebuild(&mut state, app_handle)?;
+            }
+            Err(e) => {
+                log::warn!("reconcile: runtime not ready: {e}");
+                return Ok(());
+            }
+        }
     }
 
     let build_root = build::resolve_build_root().map_err(|e| {
@@ -594,9 +602,9 @@ pub(crate) fn reconcile_bundle_update(app_handle: &tauri::AppHandle) {
 
     log::info!("reconcile_bundle: starting");
 
-    // NOTE: we do NOT set ImageReadiness::Building here or emit status yet.
-    // The inner function sets Building only after confirming bundle_changed==true,
-    // so the frontend never shows "Rebuilding..." when nothing needs rebuilding.
+    // Close the gate before the spawn so start_containers cannot race the
+    // rebuild decision; no status emit — UI shows overlay only for Building.
+    set_image_readiness(ImageReadiness::Checking);
 
     let handle = app_handle.clone();
     std::thread::spawn(move || {
@@ -1398,6 +1406,92 @@ mod tests {
             // Cleanup
             set_readiness(ImageReadiness::Ready);
         }
+
+        #[test]
+        #[serial]
+        fn blocks_during_checking_until_ready() {
+            set_readiness(ImageReadiness::Checking);
+
+            let handle = std::thread::spawn(|| wait_for_images_ready(Duration::from_secs(5)));
+
+            // Give the waiter time to block
+            std::thread::sleep(Duration::from_millis(50));
+
+            set_readiness(ImageReadiness::Ready);
+
+            let result = handle.join().unwrap();
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        #[serial]
+        fn checking_times_out_like_building() {
+            set_readiness(ImageReadiness::Checking);
+
+            let result = wait_for_images_ready(Duration::from_millis(50));
+            assert!(result.is_err());
+            assert!(result.unwrap_err().contains("Timed out"));
+
+            // Cleanup
+            set_readiness(ImageReadiness::Ready);
+        }
+
+        #[test]
+        #[serial]
+        fn guard_fails_waiters_when_dropped_during_checking() {
+            set_readiness(ImageReadiness::Checking);
+
+            drop(ImageReadinessGuard);
+
+            let result = wait_for_images_ready(Duration::from_millis(50));
+            assert!(result.is_err());
+            assert!(result.unwrap_err().contains("exited unexpectedly"));
+
+            // Cleanup
+            set_readiness(ImageReadiness::Ready);
+        }
+
+        /// Structural: Checking must be set before the spawn, or a concurrent
+        /// start_containers slips through the Ready-initialized gate.
+        #[test]
+        fn checking_is_set_before_thread_spawn() {
+            let src = include_str!("reconcile.rs");
+            let fn_start = src
+                .find("pub(crate) fn reconcile_bundle_update(")
+                .expect("reconcile_bundle_update must exist");
+            let body = &src[fn_start..];
+            let set_checking = body
+                .find("set_image_readiness(ImageReadiness::Checking)")
+                .expect("reconcile_bundle_update must set Checking");
+            let spawn = body
+                .find("std::thread::spawn")
+                .expect("reconcile_bundle_update must spawn the worker thread");
+            assert!(
+                set_checking < spawn,
+                "Checking must be set before the thread spawn, not inside it"
+            );
+        }
+
+        /// Structural: in the bundle-changed path the gate must close
+        /// (prepare_rebuild) before the slow ensure_ready VM start.
+        #[test]
+        fn rebuild_gate_closes_before_ensure_ready() {
+            let src = include_str!("reconcile.rs");
+            let fn_start = src
+                .find("fn reconcile_bundle_update_inner(")
+                .expect("reconcile_bundle_update_inner must exist");
+            let body = &src[fn_start..];
+            let gate = body
+                .find("prepare_rebuild(&mut state, app_handle)?")
+                .expect("inner must call prepare_rebuild");
+            let ensure = body
+                .find("rt.ensure_ready()")
+                .expect("inner must call ensure_ready");
+            assert!(
+                gate < ensure,
+                "prepare_rebuild must precede the first ensure_ready call"
+            );
+        }
     }
 
     #[cfg(target_os = "macos")]
@@ -1633,10 +1727,8 @@ mod tests {
         );
     }
 
-    /// Structural test: verifies that `reconcile_bundle_update_inner` checks
-    /// `images_exist` when `bundle_changed` is false. Without this, a
-    /// containerd restart that wipes images would leave the app believing
-    /// everything is fine while containers cannot start.
+    /// Structural test: missing images with an unchanged bundle must force a
+    /// rebuild via prepare_rebuild (gate opens before this check by design).
     #[test]
     fn reconcile_forces_rebuild_when_images_missing() {
         let source = include_str!("reconcile.rs");
@@ -1645,21 +1737,15 @@ mod tests {
             .nth(1)
             .expect("reconcile_bundle_update_inner function should exist");
 
-        assert!(
-            inner_fn.contains("images_exist"),
-            "reconcile must check images_exist when bundle unchanged"
-        );
-
-        // images_exist check must appear BEFORE set_image_readiness(Ready)
         let images_pos = inner_fn
             .find("images_exist")
-            .expect("images_exist call not found");
-        let ready_pos = inner_fn
-            .find("set_image_readiness(ImageReadiness::Ready)")
-            .expect("set_image_readiness(Ready) not found");
+            .expect("reconcile must check images_exist when bundle unchanged");
+
+        // prepare_rebuild must follow the images_exist check (repair path).
+        let repair = &inner_fn[images_pos..];
         assert!(
-            images_pos < ready_pos,
-            "images_exist check must come before set_image_readiness(Ready)"
+            repair.contains("prepare_rebuild(&mut state, app_handle)?"),
+            "missing images must force a rebuild via prepare_rebuild"
         );
     }
 

--- a/desktop/src/src/app/logs-view/logs-view.component.spec.ts
+++ b/desktop/src/src/app/logs-view/logs-view.component.spec.ts
@@ -723,6 +723,20 @@ describe('LogsViewComponent — status bar layout', () => {
     expect(fixture.nativeElement.querySelector('[data-testid="health-mcpos"]')).not.toBeNull();
   });
 
+  it('shows a neutral checking placeholder until the first health snapshot lands', async () => {
+    // No snapshot yet: get_health yields nothing, so the strip must not claim "degraded".
+    mockTauri.invokeHandler = async (cmd: string) => {
+      if (cmd === 'get_all_logs') return '';
+      return undefined;
+    };
+    await component.ngOnInit();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[data-testid="health-checking"]')).not.toBeNull();
+    expect(fixture.nativeElement.querySelector('[data-testid="health-overall"]')).toBeNull();
+    expect(fixture.nativeElement.querySelector('[data-testid="health-mcpos"]')).toBeNull();
+  });
+
   it('computed signals reflect the current health snapshot', async () => {
     await component.ngOnInit();
     fixture.detectChanges();

--- a/desktop/src/src/app/logs-view/logs-view.component.ts
+++ b/desktop/src/src/app/logs-view/logs-view.component.ts
@@ -188,112 +188,119 @@ export function sortLogLinesByTime(lines: LogLine[]): LogLine[] {
       role="status"
       aria-label="System health summary"
     >
-      <button
-        type="button"
-        class="flex items-center gap-2 text-[13px]"
-        data-testid="health-overall"
-        [style.color]="overallHealthy() ? 'var(--green)' : 'var(--accent)'"
-        [attr.aria-expanded]="detailsOpen()"
-        aria-controls="logs-status-details"
-        (click)="toggleDetails()"
-        [title]="detailsOpen() ? 'Hide details' : 'Show details'"
-      >
-        <span
-          class="dot"
-          [style.background]="overallHealthy() ? 'var(--green)' : 'var(--accent)'"
-        ></span>
-        <span class="font-medium">{{ overallHealthy() ? 'healthy' : 'degraded' }}</span>
-        <span
-          class="mono text-[10px] text-[var(--ink-mute)]"
-          [style.transform]="detailsOpen() ? 'rotate(180deg)' : null"
-          aria-hidden="true"
-          >▾</span
+      @if (!healthLoaded()) {
+        <div class="flex items-center gap-2 text-[13px]" data-testid="health-checking">
+          <span class="dot" [style.background]="'var(--ink-mute)'"></span>
+          <span class="text-[var(--ink-mute)]">checking system health…</span>
+        </div>
+      } @else {
+        <button
+          type="button"
+          class="flex items-center gap-2 text-[13px]"
+          data-testid="health-overall"
+          [style.color]="overallHealthy() ? 'var(--green)' : 'var(--accent)'"
+          [attr.aria-expanded]="detailsOpen()"
+          aria-controls="logs-status-details"
+          (click)="toggleDetails()"
+          [title]="detailsOpen() ? 'Hide details' : 'Show details'"
         >
-      </button>
-
-      <span
-        class="hidden h-3 w-px bg-[var(--line-strong)] sm:inline-block"
-        aria-hidden="true"
-      ></span>
-
-      <div class="flex items-center gap-2 text-[12px]" data-testid="health-vm">
-        <span class="mono text-[10px] uppercase tracking-widest text-[var(--ink-mute)]">vm</span>
-        <span
-          class="dot"
-          [style.background]="vmRunning() ? 'var(--green)' : 'var(--accent)'"
-        ></span>
-        <span [style.color]="vmRunning() ? 'var(--ink)' : 'var(--accent)'">{{ vmLabel() }}</span>
-        <span class="mono text-[10px] text-[var(--ink-mute)]">· {{ vmDetail() }}</span>
-      </div>
-
-      <span
-        class="hidden h-3 w-px bg-[var(--line-strong)] sm:inline-block"
-        aria-hidden="true"
-      ></span>
-
-      <div class="flex items-center gap-2 text-[12px]" data-testid="health-containers">
-        <span class="mono text-[10px] uppercase tracking-widest text-[var(--ink-mute)]"
-          >containers</span
-        >
-        <span
-          class="dot"
-          [style.background]="anyContainerUnhealthy() ? 'var(--amber)' : 'var(--green)'"
-        ></span>
-        <span [style.color]="anyContainerUnhealthy() ? 'var(--amber)' : 'var(--ink)'">{{
-          containersLabel()
-        }}</span>
-        <span
-          class="mono text-[10px]"
-          [style.color]="anyContainerUnhealthy() ? 'var(--amber)' : 'var(--ink-mute)'"
-          >· {{ containersDetail() }}</span
-        >
-      </div>
-
-      <span
-        class="hidden h-3 w-px bg-[var(--line-strong)] sm:inline-block"
-        aria-hidden="true"
-      ></span>
-
-      <div class="flex items-center gap-2 text-[12px]" data-testid="health-bridge">
-        <span class="mono text-[10px] uppercase tracking-widest text-[var(--ink-mute)]"
-          >ide_bridge</span
-        >
-        <span
-          class="dot"
-          [style.background]="bridgeConnected() ? 'var(--green)' : 'var(--ink-mute)'"
-        ></span>
-        <span [style.color]="bridgeConnected() ? 'var(--ink)' : 'var(--ink-mute)'">{{
-          bridgeConnected() ? 'connected' : 'disconnected'
-        }}</span>
-        <span class="mono text-[10px] text-[var(--ink-mute)]">· {{ bridgeDetail() }}</span>
-        @if (bridgeShowConnectLink()) {
-          <a
-            routerLink="/integrations"
-            fragment="ide-bridge"
-            class="mono text-[10px] text-[var(--accent)] hover:underline"
-            data-testid="bridge-connect-link"
-            >connect →</a
+          <span
+            class="dot"
+            [style.background]="overallHealthy() ? 'var(--green)' : 'var(--accent)'"
+          ></span>
+          <span class="font-medium">{{ overallHealthy() ? 'healthy' : 'degraded' }}</span>
+          <span
+            class="mono text-[10px] text-[var(--ink-mute)]"
+            [style.transform]="detailsOpen() ? 'rotate(180deg)' : null"
+            aria-hidden="true"
+            >▾</span
           >
-        }
-      </div>
+        </button>
 
-      <span
-        class="hidden h-3 w-px bg-[var(--line-strong)] sm:inline-block"
-        aria-hidden="true"
-      ></span>
-
-      <div class="flex items-center gap-2 text-[12px]" data-testid="health-mcpos">
-        <span class="mono text-[10px] uppercase tracking-widest text-[var(--ink-mute)]"
-          >mcp_os</span
-        >
         <span
-          class="dot"
-          [style.background]="mcpOsRunning() ? 'var(--green)' : 'var(--ink-mute)'"
+          class="hidden h-3 w-px bg-[var(--line-strong)] sm:inline-block"
+          aria-hidden="true"
         ></span>
-        <span [style.color]="mcpOsRunning() ? 'var(--ink)' : 'var(--ink-mute)'">{{
-          mcpOsRunning() ? 'running' : 'stopped'
-        }}</span>
-      </div>
+
+        <div class="flex items-center gap-2 text-[12px]" data-testid="health-vm">
+          <span class="mono text-[10px] uppercase tracking-widest text-[var(--ink-mute)]">vm</span>
+          <span
+            class="dot"
+            [style.background]="vmRunning() ? 'var(--green)' : 'var(--accent)'"
+          ></span>
+          <span [style.color]="vmRunning() ? 'var(--ink)' : 'var(--accent)'">{{ vmLabel() }}</span>
+          <span class="mono text-[10px] text-[var(--ink-mute)]">· {{ vmDetail() }}</span>
+        </div>
+
+        <span
+          class="hidden h-3 w-px bg-[var(--line-strong)] sm:inline-block"
+          aria-hidden="true"
+        ></span>
+
+        <div class="flex items-center gap-2 text-[12px]" data-testid="health-containers">
+          <span class="mono text-[10px] uppercase tracking-widest text-[var(--ink-mute)]"
+            >containers</span
+          >
+          <span
+            class="dot"
+            [style.background]="anyContainerUnhealthy() ? 'var(--amber)' : 'var(--green)'"
+          ></span>
+          <span [style.color]="anyContainerUnhealthy() ? 'var(--amber)' : 'var(--ink)'">{{
+            containersLabel()
+          }}</span>
+          <span
+            class="mono text-[10px]"
+            [style.color]="anyContainerUnhealthy() ? 'var(--amber)' : 'var(--ink-mute)'"
+            >· {{ containersDetail() }}</span
+          >
+        </div>
+
+        <span
+          class="hidden h-3 w-px bg-[var(--line-strong)] sm:inline-block"
+          aria-hidden="true"
+        ></span>
+
+        <div class="flex items-center gap-2 text-[12px]" data-testid="health-bridge">
+          <span class="mono text-[10px] uppercase tracking-widest text-[var(--ink-mute)]"
+            >ide_bridge</span
+          >
+          <span
+            class="dot"
+            [style.background]="bridgeConnected() ? 'var(--green)' : 'var(--ink-mute)'"
+          ></span>
+          <span [style.color]="bridgeConnected() ? 'var(--ink)' : 'var(--ink-mute)'">{{
+            bridgeConnected() ? 'connected' : 'disconnected'
+          }}</span>
+          <span class="mono text-[10px] text-[var(--ink-mute)]">· {{ bridgeDetail() }}</span>
+          @if (bridgeShowConnectLink()) {
+            <a
+              routerLink="/integrations"
+              fragment="ide-bridge"
+              class="mono text-[10px] text-[var(--accent)] hover:underline"
+              data-testid="bridge-connect-link"
+              >connect →</a
+            >
+          }
+        </div>
+
+        <span
+          class="hidden h-3 w-px bg-[var(--line-strong)] sm:inline-block"
+          aria-hidden="true"
+        ></span>
+
+        <div class="flex items-center gap-2 text-[12px]" data-testid="health-mcpos">
+          <span class="mono text-[10px] uppercase tracking-widest text-[var(--ink-mute)]"
+            >mcp_os</span
+          >
+          <span
+            class="dot"
+            [style.background]="mcpOsRunning() ? 'var(--green)' : 'var(--ink-mute)'"
+          ></span>
+          <span [style.color]="mcpOsRunning() ? 'var(--ink)' : 'var(--ink-mute)'">{{
+            mcpOsRunning() ? 'running' : 'stopped'
+          }}</span>
+        </div>
+      }
 
       <div class="ml-auto flex items-center gap-2">
         <button
@@ -597,6 +604,9 @@ export class LogsViewComponent implements OnInit, OnDestroy {
   readonly levelChips = LEVEL_CHIPS;
 
   /** Whether the overall system is healthy. */
+  /** False until the first health snapshot lands — render neutral, not "degraded". */
+  readonly healthLoaded = computed<boolean>(() => this.health() !== null);
+
   readonly overallHealthy = computed<boolean>(() => this.health()?.overall_healthy ?? false);
 
   /** Whether the VM is reported as running. */

--- a/desktop/src/src/app/services/health-store.service.ts
+++ b/desktop/src/src/app/services/health-store.service.ts
@@ -1,0 +1,13 @@
+import { Injectable, signal } from '@angular/core';
+import type { HealthReport } from '../models/health';
+
+/**
+ * SSOT for the latest health snapshot. Written by the startup health gate
+ * (ProjectStateService) and the polling loop (SystemHealthService), so views
+ * render real data immediately instead of a "checking…" placeholder.
+ */
+@Injectable({ providedIn: 'root' })
+export class HealthStoreService {
+  /** Latest health report; `null` until the first fetch lands. */
+  readonly health = signal<HealthReport | null>(null);
+}

--- a/desktop/src/src/app/services/project-state.service.spec.ts
+++ b/desktop/src/src/app/services/project-state.service.spec.ts
@@ -4,6 +4,7 @@ import { ProjectStateService, unhealthySummary } from './project-state.service';
 import { TauriService } from './tauri.service';
 import { LoggerService } from './logger.service';
 import { MockTauriService, MOCK_BUNDLE_RECONCILE_DONE } from '../testing/mock-tauri.service';
+import { HealthStoreService } from './health-store.service';
 import type { HealthReport } from '../models/health';
 
 function makeMockLogger() {
@@ -257,6 +258,33 @@ describe('ProjectStateService', () => {
       await service.init();
 
       expect(service.status).toBe('ready');
+    });
+
+    it('seeds the shared health store with the gate snapshot', async () => {
+      const healthy = makeHealth({});
+      mockTauri.invokeHandler = async (cmd: string) => {
+        switch (cmd) {
+          case 'list_projects':
+            return { projects: [{ name: 'test', dir: '/tmp/test' }], active_project: 'test' };
+          case 'get_bundle_reconcile_state':
+            return MOCK_BUNDLE_RECONCILE_DONE;
+          case 'run_system_check':
+          case 'start_containers':
+            return undefined;
+          case 'check_containers_running':
+            return true;
+          case 'get_auth_status':
+            return { api_key_configured: false, oauth_authenticated: true };
+          case 'get_health':
+            return healthy;
+          default:
+            return undefined;
+        }
+      };
+      await service.init();
+
+      expect(service.status).toBe('ready');
+      expect(TestBed.inject(HealthStoreService).health()).toEqual(healthy);
     });
 
     it('keeps polling through transient get_health failures', async () => {

--- a/desktop/src/src/app/services/project-state.service.spec.ts
+++ b/desktop/src/src/app/services/project-state.service.spec.ts
@@ -1,12 +1,24 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { TestBed } from '@angular/core/testing';
-import { ProjectStateService } from './project-state.service';
+import { ProjectStateService, unhealthySummary } from './project-state.service';
 import { TauriService } from './tauri.service';
 import { LoggerService } from './logger.service';
 import { MockTauriService, MOCK_BUNDLE_RECONCILE_DONE } from '../testing/mock-tauri.service';
+import type { HealthReport } from '../models/health';
 
 function makeMockLogger() {
   return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+}
+
+function makeHealth(overrides: Partial<HealthReport>): HealthReport {
+  return {
+    containers: [{ name: 'claude', status: 'running', healthy: true }],
+    vm: { running: true, vm_type: 'lima' },
+    mcp_os: { running: true },
+    ide_bridge: { running: true, port: null, ws_url: null, detected_ides: [], selected_ide: null },
+    overall_healthy: true,
+    ...overrides,
+  };
 }
 
 describe('ProjectStateService', () => {
@@ -177,6 +189,104 @@ describe('ProjectStateService', () => {
 
       expect(service.status).toBe('error');
       expect(service.error).toContain('No active project');
+    });
+
+    it('holds the overlay until get_health reports overall_healthy', async () => {
+      let healthCalls = 0;
+      mockTauri.invokeHandler = async (cmd: string) => {
+        switch (cmd) {
+          case 'list_projects':
+            return { projects: [{ name: 'test', dir: '/tmp/test' }], active_project: 'test' };
+          case 'get_bundle_reconcile_state':
+            return MOCK_BUNDLE_RECONCILE_DONE;
+          case 'run_system_check':
+          case 'start_containers':
+            return undefined;
+          case 'check_containers_running':
+            return true;
+          case 'get_auth_status':
+            return { api_key_configured: false, oauth_authenticated: true };
+          case 'get_health':
+            healthCalls += 1;
+            return healthCalls < 3 ? makeHealth({ overall_healthy: false }) : makeHealth({});
+          default:
+            return undefined;
+        }
+      };
+      service.healthGatePollMs = 1;
+      await service.init();
+
+      expect(service.status).toBe('ready');
+      expect(healthCalls).toBe(3);
+    });
+
+    it('sets error with an unhealthy summary when the health gate times out', async () => {
+      mockTauri.invokeHandler = async (cmd: string) => {
+        switch (cmd) {
+          case 'list_projects':
+            return { projects: [{ name: 'test', dir: '/tmp/test' }], active_project: 'test' };
+          case 'get_bundle_reconcile_state':
+            return MOCK_BUNDLE_RECONCILE_DONE;
+          case 'run_system_check':
+          case 'start_containers':
+            return undefined;
+          case 'check_containers_running':
+            return true;
+          case 'get_auth_status':
+            return { api_key_configured: false, oauth_authenticated: true };
+          case 'get_health':
+            return makeHealth({
+              overall_healthy: false,
+              vm: { running: false, vm_type: 'lima' },
+            });
+          default:
+            return undefined;
+        }
+      };
+      service.healthGatePollMs = 1;
+      service.healthGateTimeoutMs = 5;
+      await service.init();
+
+      expect(service.status).toBe('error');
+      expect(service.error).toContain('System did not become healthy');
+      expect(service.error).toContain('VM not running');
+    });
+
+    it('passes the health gate when get_health returns no report', async () => {
+      // Default handler returns undefined for get_health — gate must not block.
+      await service.init();
+
+      expect(service.status).toBe('ready');
+    });
+
+    it('keeps polling through transient get_health failures', async () => {
+      let healthCalls = 0;
+      mockTauri.invokeHandler = async (cmd: string) => {
+        switch (cmd) {
+          case 'list_projects':
+            return { projects: [{ name: 'test', dir: '/tmp/test' }], active_project: 'test' };
+          case 'get_bundle_reconcile_state':
+            return MOCK_BUNDLE_RECONCILE_DONE;
+          case 'run_system_check':
+          case 'start_containers':
+            return undefined;
+          case 'check_containers_running':
+            return true;
+          case 'get_auth_status':
+            return { api_key_configured: false, oauth_authenticated: true };
+          case 'get_health':
+            healthCalls += 1;
+            if (healthCalls === 1) throw new Error('probe boom');
+            return makeHealth({});
+          default:
+            return undefined;
+        }
+      };
+      service.healthGatePollMs = 1;
+      await service.init();
+
+      expect(service.status).toBe('ready');
+      expect(healthCalls).toBe(2);
     });
 
     it('sets system_check status during prereq phase', async () => {
@@ -1042,6 +1152,35 @@ describe('ProjectStateService', () => {
       expect(service.needsRestart).toBe(false);
       expect(service.restarting).toBe(false);
       expect(service.restartError).toBe('');
+    });
+  });
+
+  describe('unhealthySummary', () => {
+    it('reports unavailable status for a null report', () => {
+      expect(unhealthySummary(null)).toContain('health status unavailable');
+    });
+
+    it('lists every failing subsystem', () => {
+      const msg = unhealthySummary(
+        makeHealth({
+          overall_healthy: false,
+          vm: { running: false, vm_type: 'lima' },
+          mcp_os: { running: false },
+          containers: [
+            { name: 'claude', status: 'exited', healthy: false },
+            { name: 'mcp-hub', status: 'running', healthy: true },
+          ],
+        })
+      );
+
+      expect(msg).toContain('VM not running');
+      expect(msg).toContain('mcp-os worker stopped');
+      expect(msg).toContain('unhealthy containers: claude');
+      expect(msg).not.toContain('mcp-hub');
+    });
+
+    it('falls back to unknown reason when subsystems look fine', () => {
+      expect(unhealthySummary(makeHealth({ overall_healthy: false }))).toContain('unknown reason');
     });
   });
 });

--- a/desktop/src/src/app/services/project-state.service.ts
+++ b/desktop/src/src/app/services/project-state.service.ts
@@ -8,6 +8,26 @@ import type {
   ProjectSwitchFailedPayload,
 } from '../models/update';
 import { CLOUDSTORAGE_TCC_PREFIX, cloudstorageProviderDisplayName } from './cloudstorage-prefix';
+import type { HealthReport } from '../models/health';
+
+/** Poll cadence for the post-start health gate. */
+export const HEALTH_GATE_POLL_MS = 1500;
+/** Give up on the health gate after this long and surface an error. */
+export const HEALTH_GATE_TIMEOUT_MS = 120_000;
+
+/**
+ * Human-readable reason for a failed health gate.
+ * @param report - Last health snapshot, or null if none arrived.
+ */
+export function unhealthySummary(report: HealthReport | null): string {
+  if (!report) return 'System did not become healthy: health status unavailable.';
+  const reasons: string[] = [];
+  if (!report.vm.running) reasons.push('VM not running');
+  if (!report.mcp_os.running) reasons.push('mcp-os worker stopped');
+  const unhealthy = report.containers.filter((c) => !c.healthy).map((c) => c.name);
+  if (unhealthy.length > 0) reasons.push(`unhealthy containers: ${unhealthy.join(', ')}`);
+  return `System did not become healthy: ${reasons.join('; ') || 'unknown reason'}.`;
+}
 
 /** Lifecycle status of the project + container lifecycle. */
 export type ProjectStatus =
@@ -224,6 +244,8 @@ export class ProjectStateService {
         project: this.activeProject,
       });
       if (auth.api_key_configured || auth.oauth_authenticated) {
+        // Phase 4: hold the overlay until the system is actually healthy.
+        await this.waitForSystemHealthy();
         this.status = 'ready';
       } else {
         this.status = 'auth_required';
@@ -263,6 +285,32 @@ export class ProjectStateService {
     }
   }
 
+  /** Overridable in tests; production values come from the module constants. */
+  healthGatePollMs = HEALTH_GATE_POLL_MS;
+  healthGateTimeoutMs = HEALTH_GATE_TIMEOUT_MS;
+
+  /** Polls `get_health` until `overall_healthy`; throws on timeout. */
+  private async waitForSystemHealthy(): Promise<void> {
+    const deadline = Date.now() + this.healthGateTimeoutMs;
+    let last: HealthReport | null = null;
+    for (;;) {
+      try {
+        const report = await this.tauri.invoke<HealthReport | undefined>('get_health', {
+          project: this.activeProject,
+        });
+        // No report = health unverifiable (non-Tauri/test harness) — pass through.
+        if (!report || report.overall_healthy) return;
+        last = report;
+      } catch {
+        // Transient probe failure — keep polling until the deadline.
+      }
+      if (Date.now() >= deadline) {
+        throw new Error(unhealthySummary(last));
+      }
+      await new Promise((resolve) => setTimeout(resolve, this.healthGatePollMs));
+    }
+  }
+
   /** Re-checks Claude auth status after user completes authentication. */
   async retryAuth(): Promise<void> {
     if (!this.activeProject) return;
@@ -271,6 +319,7 @@ export class ProjectStateService {
         project: this.activeProject,
       });
       if (auth.api_key_configured || auth.oauth_authenticated) {
+        await this.waitForSystemHealthy();
         this.status = 'ready';
         this.notifyChange();
         this.notifyReady();

--- a/desktop/src/src/app/services/project-state.service.ts
+++ b/desktop/src/src/app/services/project-state.service.ts
@@ -8,6 +8,7 @@ import type {
   ProjectSwitchFailedPayload,
 } from '../models/update';
 import { CLOUDSTORAGE_TCC_PREFIX, cloudstorageProviderDisplayName } from './cloudstorage-prefix';
+import { HealthStoreService } from './health-store.service';
 import type { HealthReport } from '../models/health';
 
 /** Poll cadence for the post-start health gate. */
@@ -90,6 +91,7 @@ export class ProjectStateService {
   private initialized = false;
   private tauri = inject(TauriService);
   private log = inject(LoggerService);
+  private healthStore = inject(HealthStoreService);
   /**
    * Set of integration status re-fetchers registered by the integrations component;
    * called after a failed restart so the toggled-on row reverts to reality.
@@ -299,7 +301,10 @@ export class ProjectStateService {
           project: this.activeProject,
         });
         // No report = health unverifiable (non-Tauri/test harness) — pass through.
-        if (!report || report.overall_healthy) return;
+        if (!report) return;
+        // Seed the shared snapshot so views render real data the moment the overlay lifts.
+        this.healthStore.health.set(report);
+        if (report.overall_healthy) return;
         last = report;
       } catch {
         // Transient probe failure — keep polling until the deadline.

--- a/desktop/src/src/app/services/system-health.service.ts
+++ b/desktop/src/src/app/services/system-health.service.ts
@@ -1,7 +1,8 @@
-import { Injectable, OnDestroy, inject, signal } from '@angular/core';
+import { Injectable, OnDestroy, inject } from '@angular/core';
 import { TauriService } from './tauri.service';
 import { ProjectStateService } from './project-state.service';
 import { LoggerService } from './logger.service';
+import { HealthStoreService } from './health-store.service';
 import type { HealthReport } from '../models/health';
 
 /** How often the polling loop refreshes the health snapshot. */
@@ -24,9 +25,10 @@ export class SystemHealthService implements OnDestroy {
   private readonly tauri = inject(TauriService);
   private readonly projectState = inject(ProjectStateService);
   private readonly log = inject(LoggerService);
+  private readonly store = inject(HealthStoreService);
 
-  /** Latest health report; `null` until the first fetch lands. */
-  readonly health = signal<HealthReport | null>(null);
+  /** Latest health report (SSOT in HealthStoreService); `null` until the first fetch lands. */
+  readonly health = this.store.health;
 
   private timer: ReturnType<typeof setInterval> | null = null;
   private unsubProjectSettled: (() => void) | null = null;

--- a/mcp-servers/office/Dockerfile
+++ b/mcp-servers/office/Dockerfile
@@ -46,7 +46,7 @@ WORKDIR /app
 # Document toolchain. `--no-install-recommends` keeps the image down; `libreoffice-l10n-*` and
 # `-base`/`-draw`/`-math` are deliberately omitted. tzdata is required — keep aligned with
 # crates/speedwave-runtime/src/tz.rs (see CLAUDE.md SSOT-alignment).
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
       libreoffice-writer libreoffice-calc libreoffice-impress \
       poppler-utils \
       pandoc \

--- a/mcp-servers/playwright/Containerfile
+++ b/mcp-servers/playwright/Containerfile
@@ -23,10 +23,10 @@
 FROM mcr.microsoft.com/playwright:v1.59.1-jammy@sha256:8a0360d39d1973be506dd59002904a774f6d697d4946c94063b3fd006461c8ff
 
 # tzdata for the TZ env injected by compose — keep aligned with tz.rs (CLAUDE.md
-# SSOT). The jammy base image (apt) usually ships it, but install explicitly so a
-# numeric TZ offset never leaks (no-op when already present).
+# SSOT). noninteractive is mandatory: an upgrade re-runs tzdata's debconf
+# prompt, which hangs buildkit forever (no TTY).
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends tzdata \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata \
     && rm -rf /var/lib/apt/lists/*
 
 # @playwright/mcp is Microsoft's official MCP server for Playwright.


### PR DESCRIPTION
## Problems (one debugging session, three root causes)

### 1. `mcp-playwright` image build hangs forever
The jammy base ships tzdata; `apt-get update` pulls a newer candidate from jammy-updates and the upgrade re-runs tzdata's debconf timezone prompt — buildkit has no TTY, so the build blocks indefinitely. Debian-based images (`office`, `claude`) only pass because current Debian tzdata dropped its debconf prompts (same latent bug).

**Fix:** `DEBIAN_FRONTEND=noninteractive` on every `apt-get install` (playwright, office, claude) + drift-detector test `crates/speedwave-runtime/tests/apt_noninteractive.rs` (joins backslash-continued lines, fails on any unprotected `apt-get install` in `containers/` + `mcp-servers/`).

### 2. start_containers races the image rebuild ("image not available")
`IMAGES_READY` initialized as `Ready` and flipped to `Building` only after `ensure_ready()` — which starts a stopped VM (~30 s). A concurrent `start_containers` passed the gate during that window and composed images that were still being built.

**Fix:** new `Checking` readiness state set synchronously before the reconcile thread spawns; the changed-bundle path closes the gate (`prepare_rebuild`) before `ensure_ready()`. Unchanged bundle opens the gate right after the (fast) manifest comparison, so `get_auth_status`/chat-session callers never wait behind a VM start. Guard now fails waiters from `Checking` too. Structural tests pin both orderings; behavioral tests cover the new state.

### 3. Chat appears usable before the system is actually healthy
After containers start and auth passes, status flipped to `ready` immediately — while mcp-os could still be down and container healthchecks pending. The startup overlay lifted and chat looked writable on a degraded system.

**Fix:** Phase-4 health gate in `ProjectStateService`: poll `get_health` until `overall_healthy` (1.5 s cadence, 120 s cap) before `ready`; timeout surfaces a per-subsystem summary as a retryable error. Applied to both `ensureContainersRunning` and `retryAuth`.

Follow-ups in the same PR: the System health strip rendered a null snapshot as hard claims ("degraded / VM no data / mcp_os stopped") for the first seconds after opening the view — fixed with a neutral placeholder, then eliminated entirely by `HealthStoreService`: an SSOT snapshot signal seeded by the startup gate and shared with the polling loop, so the view renders real data the moment the overlay lifts.

### 4. /logs view blanks while the container engine is busy
`get_all_logs` merged six log sources sequentially; a hung `nerdctl compose logs` (parallel image builds, container recreate) kept the whole view on "Loading logs…" with an empty sources dropdown, even though five sources are instant local file reads.

**Fix:** the compose fetch runs under a 10 s timeout with a single-flight guard (5 s polls don't stack nerdctl processes) and degrades to a synthetic `compose | … WARN container logs unavailable…` line; file-based sources always return immediately.

### 5. Torn compose.yml read not retried
A truncated virtiofs read of the generated compose.yml at end-of-document (`yaml: … found unexpected end of stream`) was not in `COMPOSE_SCHEMA_VALIDATION_ERROR_FRAGMENTS`, so `is_propagation_error` let it surface as a fatal error instead of retrying. Root issue: enumerating yaml-go phrasings lags reality.

**Fix:** match the class — rendered compose.yml is always valid YAML, so any `yaml:` parse error on it means a stale/torn read; bounded retries still surface genuine render bugs on the final attempt.

## Testing
- `cargo test reconcile` — 38 pass (new: Checking wait/timeout/guard + 2 structural ordering tests)
- `make test-angular` — 2056 pass (new: health-gate hold/timeout/transient-failure/no-report + `unhealthySummary` units)
- `cargo test --test apt_noninteractive` — 3 pass
- `make check` — clean
- Verified under `make dev`: playwright image builds in seconds (previously hung indefinitely); app starts; containers come up

