### PR TITLE
ci: build unsigned desktop bundle when signing key is absent

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -100,17 +100,13 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           MATRIX_ARGS: ${{ matrix.args }}
-          # Dependabot PR runs do not receive repo secrets, so the updater
-          # signing key is empty. Disable updater artifacts for those runs to
-          # build an unsigned bundle (proves compilation) instead of failing on
-          # the missing key.
-          IS_DEPENDABOT: ${{ github.actor == 'dependabot[bot]' }}
         run: |
           # Split MATRIX_ARGS into an array so intentional multi-token values
           # (e.g. `--target x`) still split, but no glob/metacharacter is
           # interpreted by the shell (hardening — see PR #766 review).
           read -ra ARGS <<< "$MATRIX_ARGS"
-          if [ "$IS_DEPENDABOT" = "true" ]; then
+          # No signing key (fork PR / Dependabot) → unsigned bundle.
+          if [ -z "$TAURI_SIGNING_PRIVATE_KEY" ]; then
             npx --prefix ../src tauri build "${ARGS[@]}" --config '{"bundle":{"createUpdaterArtifacts":false}}'
           else
             npx --prefix ../src tauri build "${ARGS[@]}"


### PR DESCRIPTION
## Problem

Fork PRs do not receive repo secrets (GitHub security policy for `pull_request` runs from forks). The Tauri updater signing key (`TAURI_SIGNING_PRIVATE_KEY`) is therefore empty, and `tauri build` fails decoding it:

```
failed to decode secret key: incorrect updater private key password: Missing comment in secret key
```

This broke the macOS **Desktop Build** job on PR #775 (a contributor fork PR). Internal PRs (#783 Slack) and pushes to `dev` pass because they run in the main repo and receive the secret.

## Root cause

The existing guard only covered Dependabot by actor name (`github.actor == 'dependabot[bot]'`). Fork PRs from human contributors hit the **same** empty-secret condition but were not covered, so the job failed instead of building.

## Fix

Generalise the guard to gate on the **signing key's presence** rather than the actor: when `TAURI_SIGNING_PRIVATE_KEY` is empty (fork PR / Dependabot / unconfigured), build without updater artifacts to prove compilation. Internal PRs and pushes still receive the secret and produce signed bundles. Net −1 env var, one condition covers every secret-less run.

## Verification

- `make test` green locally (1407 desktop + full Rust suite passed).
- Unblocks the Desktop Build job for PR #775 and any future fork PR.