### PR TITLE
fix(runtime): plugin builds recover from corrupted containerd snapshots

### DIFF
--- a/crates/speedwave-runtime/src/build.rs
+++ b/crates/speedwave-runtime/src/build.rs
@@ -540,16 +540,14 @@ fn write_resources_marker_to(
 
 /// Containerd overlayfs snapshotter corruption that survived a prune attempt.
 ///
-/// Returned by [`build_images_for_bundle`] when:
-/// 1. First build fails with a snapshotter error (e.g. "failed to rename: file exists")
-/// 2. `system_prune` + retry also fails
-///
-/// The `Display` impl includes platform-specific restart commands so callers
-/// can interpolate `{e}` directly without adding their own diagnostic hints.
+/// Produced by [`with_build_recovery`] (bundle and plugin builds) when a
+/// snapshotter error persists after `system_prune` + `prune_buildkit_cache` and
+/// a retry. Bundle-build callers (setup wizard, reconcile) downcast it to
+/// restart the container engine; other callers surface its `Display` hint.
 #[derive(Debug)]
 pub struct SnapshotterRecoveryFailed {
     /// The underlying build error after prune-and-retry also failed.
-    pub inner: anyhow::Error,
+    inner: anyhow::Error,
 }
 
 impl std::fmt::Display for SnapshotterRecoveryFailed {
@@ -570,21 +568,27 @@ impl std::error::Error for SnapshotterRecoveryFailed {
     }
 }
 
-fn platform_restart_hint() -> &'static str {
+fn platform_restart_hint() -> String {
     #[cfg(target_os = "macos")]
     {
-        "limactl shell speedwave -- sudo systemctl restart containerd && \
-         limactl shell speedwave -- sudo systemctl restart buildkit; \
-         limactl shell speedwave -- sudo buildctl debug workers"
+        let vm = crate::consts::lima_vm_name();
+        format!(
+            "limactl shell {vm} -- sudo systemctl restart containerd && \
+             limactl shell {vm} -- sudo systemctl restart buildkit; \
+             limactl shell {vm} -- sudo buildctl debug workers"
+        )
     }
     #[cfg(target_os = "windows")]
     {
-        "wsl.exe -d Speedwave -- systemctl restart containerd && \
-         wsl.exe -d Speedwave -- systemctl restart buildkit"
+        let distro = crate::consts::wsl_distro_name();
+        format!(
+            "wsl.exe -d {distro} -- systemctl restart containerd && \
+             wsl.exe -d {distro} -- systemctl restart buildkit"
+        )
     }
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     {
-        "restart containerd and buildkit manually"
+        "restart containerd and buildkit manually".to_string()
     }
 }
 
@@ -781,51 +785,8 @@ pub fn build_images_for_bundle_in(
     let vm_root = runtime.prepare_build_context(root)?;
     let needs_cleanup = vm_root != root;
 
-    let result = try_build_images(runtime, images, &vm_root, manifest).or_else(|first_err| {
-        if is_disk_full_error(&first_err) {
-            log::warn!(
-                "build failed with disk-full error, pruning unused images and retrying: {first_err}"
-            );
-            if let Err(prune_err) = runtime.prune_unused_images() {
-                log::warn!("prune_unused_images failed: {prune_err}");
-            }
-            // `nerdctl system prune` does not clear BuildKit cache-mounts; under
-            // disk pressure the cache must go too (ADR-072 — sole cache-prune site).
-            if let Err(prune_err) = runtime.prune_buildkit_cache() {
-                log::warn!("prune_buildkit_cache failed: {prune_err}");
-            }
-            try_build_images(runtime, images, &vm_root, manifest)
-        } else if is_snapshotter_error(&first_err) {
-            log::warn!(
-                "build failed with containerd snapshotter error, pruning and retrying: {first_err}"
-            );
-            if let Err(prune_err) = runtime.system_prune() {
-                log::warn!("system prune failed: {prune_err}");
-            }
-            try_build_images(runtime, images, &vm_root, manifest).map_err(|second_err| {
-                anyhow::Error::new(SnapshotterRecoveryFailed { inner: second_err })
-            })
-        } else if is_transient_build_error(&first_err) {
-            // Transient — usually the boot-time DNS-fallback race (see
-            // `is_transient_build_error`). A few seconds' wait lets the resolver
-            // settle; two backed-off attempts cover a slow fallback.
-            let mut last_err = first_err;
-            for attempt in 1..=TRANSIENT_BUILD_RETRIES {
-                let delay = TRANSIENT_BUILD_RETRY_BASE_DELAY * attempt;
-                log::warn!(
-                    "build failed with transient error, retrying in {}s (attempt {attempt}/{TRANSIENT_BUILD_RETRIES}): {last_err}",
-                    delay.as_secs()
-                );
-                std::thread::sleep(delay);
-                match try_build_images(runtime, images, &vm_root, manifest) {
-                    Ok(n) => return Ok(n),
-                    Err(e) => last_err = e,
-                }
-            }
-            Err(last_err)
-        } else {
-            Err(first_err)
-        }
+    let result = with_build_recovery(runtime, || {
+        try_build_images(runtime, images, &vm_root, manifest)
     });
 
     // Enrich final error with actionable guidance
@@ -867,9 +828,70 @@ pub fn build_images_for_bundle_in(
     result
 }
 
-/// Builds `images` using a bounded worker pool. Extracted so the retry logic in
-/// [`build_images_for_bundle`] can re-call it. Worker count bounded by CPU + image
-/// count (ADR-032). Errors collected; propagate by priority: snapshotter > transient > first.
+/// Runs `attempt`; on a recoverable failure (disk-full, snapshotter corruption,
+/// transient I/O/DNS) prunes the matching cache and retries. Snapshotter
+/// corruption surviving the retry becomes [`SnapshotterRecoveryFailed`] — bundle
+/// callers downcast it to restart the engine; plugin builds surface its hint.
+pub(crate) fn with_build_recovery<T>(
+    runtime: &crate::runtime::LockedRuntime,
+    mut attempt: impl FnMut() -> anyhow::Result<T>,
+) -> anyhow::Result<T> {
+    attempt().or_else(|first_err| {
+        if is_disk_full_error(&first_err) {
+            log::warn!(
+                "build failed with disk-full error, pruning unused images and retrying: {first_err}"
+            );
+            if let Err(prune_err) = runtime.prune_unused_images() {
+                log::warn!("prune_unused_images failed: {prune_err}");
+            }
+            // `nerdctl system prune` does not clear BuildKit cache-mounts; under
+            // disk pressure the cache must go too (ADR-072).
+            if let Err(prune_err) = runtime.prune_buildkit_cache() {
+                log::warn!("prune_buildkit_cache failed: {prune_err}");
+            }
+            attempt()
+        } else if is_snapshotter_error(&first_err) {
+            log::warn!(
+                "build failed with containerd snapshotter error, pruning and retrying: {first_err}"
+            );
+            if let Err(prune_err) = runtime.system_prune() {
+                log::warn!("system prune failed: {prune_err}");
+            }
+            // A poisoned BuildKit cache key can pin a vanished snapshot
+            // ("failed to stat parent"); system prune leaves cache-mounts.
+            if let Err(prune_err) = runtime.prune_buildkit_cache() {
+                log::warn!("prune_buildkit_cache failed: {prune_err}");
+            }
+            attempt().map_err(|second_err| {
+                anyhow::Error::new(SnapshotterRecoveryFailed { inner: second_err })
+            })
+        } else if is_transient_build_error(&first_err) {
+            // Transient — usually the boot-time DNS-fallback race (see
+            // `is_transient_build_error`). A few seconds' wait lets the resolver
+            // settle; two backed-off attempts cover a slow fallback.
+            let mut last_err = first_err;
+            for attempt_no in 1..=TRANSIENT_BUILD_RETRIES {
+                let delay = TRANSIENT_BUILD_RETRY_BASE_DELAY * attempt_no;
+                log::warn!(
+                    "build failed with transient error, retrying in {}s (attempt {attempt_no}/{TRANSIENT_BUILD_RETRIES}): {last_err}",
+                    delay.as_secs()
+                );
+                std::thread::sleep(delay);
+                match attempt() {
+                    Ok(n) => return Ok(n),
+                    Err(e) => last_err = e,
+                }
+            }
+            Err(last_err)
+        } else {
+            Err(first_err)
+        }
+    })
+}
+
+/// Builds `images` using a bounded worker pool, re-invoked per attempt by
+/// [`with_build_recovery`]. Worker count bounded by CPU + image count (ADR-032).
+/// Errors collected; propagate by priority: snapshotter > transient > first.
 fn try_build_images(
     runtime: &crate::runtime::LockedRuntime,
     images: &[&ImageDef],
@@ -1059,12 +1081,14 @@ fn is_disk_full_error(err: &anyhow::Error) -> bool {
 /// - `"apply layer error"` — wrapper from containerd's differ
 /// - `"failed to prepare extraction snapshot"` — from snapshotter.Prepare()
 /// - `"failed to rename"` + `"file exists"` — OS-level rename failure on stale snapshot
+/// - `"failed to stat parent"` + `"snapshots/"` — overlayfs parent snapshot dir gone
 fn is_snapshotter_error(err: &anyhow::Error) -> bool {
     for cause in err.chain() {
         let msg = cause.to_string().to_ascii_lowercase();
         if msg.contains("apply layer error")
             || msg.contains("failed to prepare extraction snapshot")
             || (msg.contains("failed to rename") && msg.contains("file exists"))
+            || (msg.contains("failed to stat parent") && msg.contains("snapshots/"))
         {
             return true;
         }
@@ -1995,6 +2019,37 @@ mod tests {
     }
 
     #[test]
+    fn test_is_snapshotter_error_matches_failed_stat_parent() {
+        let err = anyhow::anyhow!(
+            "failed to solve: failed to compute cache key: failed to stat parent: \
+             stat /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/721/fs: \
+             no such file or directory"
+        );
+        assert!(is_snapshotter_error(&err));
+    }
+
+    #[test]
+    fn test_is_snapshotter_error_rejects_missing_copy_source() {
+        // A missing build-context file is a real user error — fail fast, never
+        // prune-and-retry on it.
+        let err = anyhow::anyhow!(
+            "failed to compute cache key: failed to calculate checksum of ref: \
+             \"/app/missing.txt\": not found"
+        );
+        assert!(!is_snapshotter_error(&err));
+    }
+
+    #[test]
+    fn test_is_snapshotter_error_rejects_stat_parent_outside_snapshotter() {
+        // "failed to stat parent" without a snapshots/ path is not our corruption
+        // signature (e.g. user RUN output) — must not prune-and-retry.
+        let err = anyhow::anyhow!(
+            "failed to stat parent: stat /home/user/app: no such file or directory"
+        );
+        assert!(!is_snapshotter_error(&err));
+    }
+
+    #[test]
     fn test_build_all_images_calls_prepare_build_context() {
         use crate::runtime::mock_runtime::MockRuntimeBuilder;
         use std::sync::atomic::Ordering;
@@ -2120,6 +2175,17 @@ mod tests {
             .unwrap()
             .iter()
             .filter(|p| **p == "unused")
+            .count()
+    }
+
+    /// Number of `prune_buildkit_cache` calls recorded on the handles.
+    fn count_buildkit_prunes(handles: &crate::runtime::mock_runtime::MockHandles) -> usize {
+        handles
+            .prune_calls
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|p| **p == "buildkit")
             .count()
     }
 
@@ -2265,6 +2331,11 @@ mod tests {
             1,
             "system_prune should be called once"
         );
+        assert_eq!(
+            count_buildkit_prunes(&handles),
+            1,
+            "snapshotter recovery must also prune the BuildKit cache"
+        );
 
         let build_count = count_builds(&handles);
         assert_eq!(
@@ -2314,7 +2385,7 @@ mod tests {
         assert_eq!(
             count_buildkit_prunes(&handles),
             1,
-            "disk-full recovery is the sole BuildKit cache-prune site (ADR-072) — \
+            "disk-full recovery prunes the BuildKit cache (ADR-072) — \
              `nerdctl system prune` does not clear cache-mounts"
         );
         assert_eq!(
@@ -2612,6 +2683,141 @@ mod tests {
             err.to_string().contains("network timeout"),
             "original error should propagate unchanged"
         );
+    }
+
+    #[test]
+    fn with_build_recovery_returns_ok_without_pruning_on_success() {
+        let (rt, handles) = crate::runtime::mock_runtime::MockRuntimeBuilder::new().build();
+        let mut calls = 0u32;
+        let result = with_build_recovery(&rt, || {
+            calls += 1;
+            Ok(42u32)
+        });
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(calls, 1, "no retry on first-try success");
+        assert_eq!(count_prunes(&handles), 0);
+        assert_eq!(count_buildkit_prunes(&handles), 0);
+    }
+
+    #[test]
+    fn with_build_recovery_snapshotter_prunes_system_and_buildkit_then_retries() {
+        let (rt, handles) = crate::runtime::mock_runtime::MockRuntimeBuilder::new().build();
+        let mut calls = 0u32;
+        let result = with_build_recovery(&rt, || {
+            calls += 1;
+            if calls == 1 {
+                anyhow::bail!(
+                    "failed to compute cache key: failed to stat parent: \
+                     stat /var/lib/containerd/...snapshots/721/fs: no such file or directory"
+                );
+            }
+            Ok(())
+        });
+        assert!(result.is_ok());
+        assert_eq!(calls, 2, "one retry after prune");
+        assert_eq!(count_prunes(&handles), 1, "system_prune once");
+        assert_eq!(
+            count_buildkit_prunes(&handles),
+            1,
+            "snapshotter recovery must also clear the BuildKit cache key"
+        );
+    }
+
+    #[test]
+    fn with_build_recovery_snapshotter_unrecovered_wraps_as_recovery_failed() {
+        let (rt, _handles) = crate::runtime::mock_runtime::MockRuntimeBuilder::new().build();
+        let result: anyhow::Result<()> = with_build_recovery(&rt, || {
+            anyhow::bail!(
+                "failed to stat parent: stat /.../snapshots/9/fs: no such file or directory"
+            )
+        });
+        let err = result.unwrap_err();
+        assert!(
+            err.downcast_ref::<SnapshotterRecoveryFailed>().is_some(),
+            "snapshotter error surviving retry must become SnapshotterRecoveryFailed, got: {err}"
+        );
+    }
+
+    #[test]
+    fn with_build_recovery_unrelated_error_is_not_retried() {
+        let (rt, handles) = crate::runtime::mock_runtime::MockRuntimeBuilder::new().build();
+        let mut calls = 0u32;
+        let result: anyhow::Result<()> = with_build_recovery(&rt, || {
+            calls += 1;
+            anyhow::bail!("permission denied");
+        });
+        assert!(result.is_err());
+        assert_eq!(calls, 1, "non-recoverable error must fail fast");
+        assert_eq!(count_prunes(&handles), 0);
+        assert_eq!(count_buildkit_prunes(&handles), 0);
+    }
+
+    #[test]
+    fn with_build_recovery_disk_full_prunes_unused_and_buildkit_then_retries() {
+        let (rt, handles) = crate::runtime::mock_runtime::MockRuntimeBuilder::new().build();
+        let mut calls = 0u32;
+        let result = with_build_recovery(&rt, || {
+            calls += 1;
+            if calls == 1 {
+                anyhow::bail!(
+                    "failed to extract layer: write /var/lib/containerd: no space left on device"
+                );
+            }
+            Ok(())
+        });
+        assert!(result.is_ok());
+        assert_eq!(calls, 2, "one retry after prune");
+        assert_eq!(count_unused_prunes(&handles), 1, "prune_unused_images once");
+        assert_eq!(
+            count_buildkit_prunes(&handles),
+            1,
+            "BuildKit cache pruned under disk pressure"
+        );
+        assert_eq!(
+            count_prunes(&handles),
+            0,
+            "system_prune is the snapshotter path, not disk-full"
+        );
+    }
+
+    #[test]
+    fn with_build_recovery_transient_retries_until_success() {
+        // cfg(test) backoff is 1ms, so the retry loop is effectively instant.
+        let (rt, handles) = crate::runtime::mock_runtime::MockRuntimeBuilder::new().build();
+        let mut calls = 0u32;
+        let result = with_build_recovery(&rt, || {
+            calls += 1;
+            if calls < 3 {
+                anyhow::bail!("dial tcp: i/o timeout");
+            }
+            Ok(())
+        });
+        assert!(result.is_ok());
+        assert_eq!(calls, 3, "initial + 2 transient retries");
+        assert_eq!(
+            count_prunes(&handles)
+                + count_unused_prunes(&handles)
+                + count_buildkit_prunes(&handles),
+            0,
+            "transient retries must not prune"
+        );
+    }
+
+    #[test]
+    fn with_build_recovery_transient_exhausted_returns_last_error() {
+        let (rt, _handles) = crate::runtime::mock_runtime::MockRuntimeBuilder::new().build();
+        let mut calls = 0u32;
+        let result: anyhow::Result<()> = with_build_recovery(&rt, || {
+            calls += 1;
+            anyhow::bail!("connection reset by peer");
+        });
+        assert!(result.is_err());
+        assert_eq!(
+            calls,
+            1 + TRANSIENT_BUILD_RETRIES,
+            "initial attempt + all transient retries"
+        );
+        assert!(result.unwrap_err().to_string().contains("connection reset"));
     }
 
     // ── images_exist tests ─────────────────────────────────────────────
@@ -2992,17 +3198,6 @@ mod tests {
             .collect()
     }
 
-    /// Number of `prune_buildkit_cache` calls recorded on the handles.
-    fn count_buildkit_prunes(handles: &crate::runtime::mock_runtime::MockHandles) -> usize {
-        handles
-            .prune_calls
-            .lock()
-            .unwrap()
-            .iter()
-            .filter(|p| **p == "buildkit")
-            .count()
-    }
-
     #[test]
     fn test_prune_old_bundle_images_generates_correct_tags() {
         let (rt, handles) = crate::runtime::mock_runtime::MockRuntimeBuilder::new().build();
@@ -3077,8 +3272,8 @@ mod tests {
     #[test]
     fn test_prune_old_bundle_images_keeps_buildkit_cache() {
         // ADR-072: routine pruning must NOT clear the BuildKit cache — apt/npm
-        // layers are reused across updates. Cache is pruned only under disk
-        // pressure (see test_retry_on_disk_full_error).
+        // layers are reused across updates. Cache is pruned only on disk
+        // pressure or snapshotter recovery (see with_build_recovery).
         let (rt, handles) = crate::runtime::mock_runtime::MockRuntimeBuilder::new().build();
         prune_old_bundle_images(&rt, "abc123").unwrap();
 

--- a/crates/speedwave-runtime/src/plugin.rs
+++ b/crates/speedwave-runtime/src/plugin.rs
@@ -2529,7 +2529,10 @@ fn build_single_plugin_image_locked(
         tag,
         plugin_dir.display()
     );
-    runtime.build_image(&tag, root_str.trim_end_matches('/'), &containerfile, &[])?;
+    let build_target = root_str.trim_end_matches('/');
+    crate::build::with_build_recovery(runtime, || {
+        runtime.build_image(&tag, build_target, &containerfile, &[])
+    })?;
 
     // Remove the pending marker on success — both the new state-dir
     // location and the legacy in-tree marker, so a plugin installed by an older release
@@ -8014,6 +8017,45 @@ mod tests {
         assert!(
             source[outer..body_end].contains("with_build_lock"),
             "plugin build+prune must be serialised by build.lock (ADR-072)"
+        );
+    }
+
+    #[test]
+    fn plugin_build_recovers_from_corrupted_snapshot() {
+        let _g = UnsignedBypassGuard::new();
+        let tmp = tempfile::tempdir().unwrap();
+        make_mcp_plugin_dir(tmp.path(), "example-plugin", "1.0.0");
+        let tag = expected_tag_for(tmp.path(), "example-plugin");
+
+        // First build hits the corrupted-snapshot signature; recovery prunes and
+        // the retry succeeds — parity with bundle builds.
+        let (rt, handle) = crate::runtime::mock_runtime::MockRuntimeBuilder::new()
+            .with_prepare_build_context_root(tmp.path().join("example-plugin"))
+            .with_build_error_for_attempt(
+                &tag,
+                1,
+                "failed to compute cache key: failed to stat parent: \
+                 stat /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/7/fs: \
+                 no such file or directory",
+            )
+            .build();
+
+        ensure_plugin_images_from_dir(&rt, &["example-plugin"], tmp.path())
+            .expect("plugin build must recover from a corrupted containerd snapshot");
+
+        let builds = handle
+            .build_calls
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|c| c.tag == tag)
+            .count();
+        assert_eq!(builds, 2, "build retried once after prune");
+        let prunes = handle.prune_calls.lock().unwrap();
+        assert!(prunes.iter().any(|p| *p == "system"), "system_prune ran");
+        assert!(
+            prunes.iter().any(|p| *p == "buildkit"),
+            "BuildKit cache pruned"
         );
     }
 

--- a/crates/speedwave-runtime/src/runtime/mod.rs
+++ b/crates/speedwave-runtime/src/runtime/mod.rs
@@ -157,8 +157,8 @@ pub(crate) trait ContainerRuntime: Send + Sync {
     }
 
     /// Removes BuildKit build cache (`nerdctl builder prune --all --force`).
-    /// Called ONLY from the disk-full recovery ladder — routine prunes keep
-    /// the cache (ADR-072).
+    /// Called only from the `with_build_recovery` ladder (disk-full or
+    /// snapshotter corruption) — routine prunes keep the cache (ADR-072).
     fn prune_buildkit_cache(&self) -> anyhow::Result<()> {
         log::debug!("prune_buildkit_cache: not implemented for this runtime, skipping");
         Ok(())

--- a/crates/speedwave-runtime/src/update.rs
+++ b/crates/speedwave-runtime/src/update.rs
@@ -1046,8 +1046,8 @@ mod tests {
     fn test_no_buildkit_prune_in_routine_prune_paths() {
         // Structural test (ADR-072): prune_buildkit_cache must NOT be called in
         // the routine prune paths — apt/npm cache layers are reused across
-        // updates. The sole cache-prune site is the disk-full recovery ladder
-        // in build_images_for_bundle_in (pinned by test_retry_on_disk_full_error in build.rs).
+        // updates. Cache is pruned only by the with_build_recovery ladder
+        // (disk-full + snapshotter recovery), never on routine updates.
         let source = include_str!("build.rs");
 
         for fn_name in [

--- a/docs/adr/ADR-032-nested-virtualization-resilience.md
+++ b/docs/adr/ADR-032-nested-virtualization-resilience.md
@@ -10,7 +10,7 @@ Apply a four-layer strategy so image builds survive nested-virt I/O degradation:
 ## Why
 
 - The `apt-get install` phase in the claude image calls `dpkg`, which uses `fsync()` heavily for crash-safe installs. Under nested virt those calls time out, failing the build with "Input/output error". `--force-unsafe-io` skips the fsync — safe here because image layers are disposable (a crashed build just rebuilds).
-- Transient I/O and boot-time DNS-fallback hiccups are usually one-off; a short backed-off retry clears them without user action. The retry path also covers disk-full (prune + retry) and containerd snapshotter corruption (`system_prune` + retry).
+- Transient I/O and boot-time DNS-fallback hiccups are usually one-off; a short backed-off retry clears them without user action. The same recovery ladder (`with_build_recovery`, shared by bundle and plugin builds) also covers disk-full and containerd snapshotter corruption — each prunes the relevant cache (`builder prune` for the BuildKit cache, plus `system prune` for snapshotter) and retries.
 - Detecting a VM host up front lets `speedwave check` warn the user before a long build fails.
 - Parallel builds cut wall-clock setup time, but the pool is **bounded** to avoid amplifying disk-I/O contention and the BuildKit overlayfs snapshotter race window on VM hosts.
 
@@ -24,7 +24,7 @@ Apply a four-layer strategy so image builds survive nested-virt I/O degradation:
 
 ## Where it lives in code
 
-- Build retry + worker pool + classifier — `crates/speedwave-runtime/src/build.rs` (`build_images_for_bundle_in`, `try_build_images`, `is_transient_build_error`, `is_snapshotter_error`, `is_disk_full_error`; constants `TRANSIENT_BUILD_RETRIES`, `TRANSIENT_BUILD_RETRY_BASE_DELAY`, `DEFAULT_BUILD_WORKER_FALLBACK`, `IMAGES`)
+- Build retry + worker pool + classifier — `crates/speedwave-runtime/src/build.rs` (`with_build_recovery` (recovery ladder, shared by bundle + plugin builds), `build_images_for_bundle_in`, `try_build_images`, `is_transient_build_error`, `is_snapshotter_error`, `is_disk_full_error`; constants `TRANSIENT_BUILD_RETRIES`, `TRANSIENT_BUILD_RETRY_BASE_DELAY`, `DEFAULT_BUILD_WORKER_FALLBACK`, `IMAGES`)
 - VM-host warning — `crates/speedwave-runtime/src/os_prereqs.rs` (`check_os_warnings`, `parse_vm_info`), surfaced by `crates/speedwave-cli/src/main.rs` on `speedwave check`
 - apt hardening — `containers/Containerfile.claude`
 

--- a/docs/adr/ADR-072-per-image-build-input-hash-tags.md
+++ b/docs/adr/ADR-072-per-image-build-input-hash-tags.md
@@ -91,11 +91,14 @@ images (`node:24-*` etc.) remain external and mutable, exactly as before
 ### BuildKit cache is no longer pruned on update
 
 The unconditional `prune_buildkit_cache` call is removed from the prune path.
-The **sole** cache-prune site is the disk-full recovery ladder in
-`build_images_for_bundle_in` (`nerdctl system prune` does not clear BuildKit
-cache mounts, so the ladder calls `builder prune` explicitly). Bounded cache
-growth is accepted: nerdctl exposes no `--keep-storage` budget for `builder
-prune` (only `--all`/`--force`)[^2], so a threshold-based prune is deferred.
+Cache is pruned only by the recovery ladder in `with_build_recovery` (shared by
+bundle and plugin builds), in two unrecoverable states — disk-full and
+containerd snapshotter corruption (`failed to stat parent`) — where cache reuse
+is impossible anyway; `nerdctl system prune` does not clear BuildKit cache
+mounts, so both branches call `builder prune` explicitly. Routine updates never
+prune the cache. Bounded cache growth is accepted: nerdctl exposes no
+`--keep-storage` budget for `builder prune` (only `--all`/`--force`)[^2], so a
+threshold-based prune is deferred.
 
 ### Cross-process build lock
 

--- a/docs/architecture/containers.md
+++ b/docs/architecture/containers.md
@@ -123,7 +123,7 @@ Disk space is reclaimed **after** the full restore succeeds (atomicity: the prev
 1. **Per-image diff prune** (`prune_replaced_images`): for every image whose applied hash differs from the manifest's, removes `name:old_hash`. Unchanged images keep their tag — nothing to reclaim.
 2. **One-time legacy prune** on migration from the pre-ADR-072 single-id format (state without a per-image map): removes every catalogue tag for the old `bundle_id`.
 
-BuildKit cache is **no longer pruned on update** — apt/npm `--mount=type=cache` layers survive and are reused by the next rebuild. The sole cache-prune site is the disk-full recovery ladder in `build_images_for_bundle_in` (`nerdctl system prune` does not clear cache mounts, so the ladder calls `builder prune` explicitly).
+BuildKit cache is **no longer pruned on update** — apt/npm `--mount=type=cache` layers survive and are reused by the next rebuild. Cache is pruned only by the recovery ladder in `with_build_recovery` (shared by bundle and plugin builds), on disk-full or containerd snapshotter corruption — `nerdctl system prune` does not clear cache mounts, so those branches call `builder prune` explicitly.
 
 Both update paths share this pruning: **Desktop** (`reconcile_bundle_update_inner`) after `ProjectsRestored`, **CLI** (`update_containers` → `maybe_prune_previous_bundle`) after containers are confirmed running. The CLI never writes `bundle-state.json` (single-writer rule, test-pinned); Desktop reconcile and the setup wizard are the only writers of `applied_image_hashes`/`applied_bundle_id`.
 


### PR DESCRIPTION
## Description

Plugin image builds called `runtime.build_image` directly with **no recovery**, so a corrupted containerd overlayfs snapshot (`failed to stat parent: stat .../snapshots/<id>/fs: no such file or directory`) made the build loop forever — an app restart didn't help, since the corruption persists on the VM disk. Bundle/integration builds already recovered (prune + retry); plugins didn't. Surfaced by a teammate toggling the Figma plugin.

### What changed

- **Shared recovery ladder.** Extracted the disk-full / snapshotter / transient `classify → prune → retry` logic out of `build_images_for_bundle_in` into a `with_build_recovery` helper, and routed plugin builds (`build_single_plugin_image_locked`) through it — DRY parity with bundle builds.
- **Classifier.** `is_snapshotter_error` now matches the `failed to stat parent` + `snapshots/` signature (scoped so a missing `COPY` source still fails fast).
- **Prune action.** The snapshotter branch now also runs `prune_buildkit_cache` (`nerdctl builder prune --all`) alongside `system_prune` — the corruption is a poisoned BuildKit cache key, which `system prune` does not clear.
- **Boy-Scout fixes.** Restart hint is built from `consts::{lima_vm_name, wsl_distro_name}` instead of hardcoded `speedwave`/`Speedwave` (was wrong on `~/.speedwave-dev` / custom installs); `SnapshotterRecoveryFailed.inner` made private.

### Tests

- Behavioral: plugin build fails attempt 1 with the corrupt-snapshot signature → asserts `system`+`buildkit` prune and a successful retry.
- `with_build_recovery` unit tests for all branches: snapshotter (prune both + retry / unrecovered → `SnapshotterRecoveryFailed`), disk-full, transient (success + exhausted), pass-through, fail-fast.
- Classifier: matches the real signature; rejects a missing `COPY` source and a `stat parent` outside the snapshotter.

### Docs

ADR-032, ADR-072, and `containers.md` updated for the shared `with_build_recovery` ladder and the second (snapshotter) BuildKit cache-prune site.

### Scope note — escalation

This delivers **prune+retry parity** (the actual fix). Automatic engine-restart-on-`SnapshotterRecoveryFailed` still fires only for bundle builds in `reconcile`/`setup_wizard`; the plugin path surfaces the (now correct) restart hint. Wiring full engine-restart parity into the reconcile plugin path is a contained follow-up — left out deliberately.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI/CD
- [ ] Other:

## Checklist

- [x] `make test` passes
- [x] `make check` passes
- [x] I have added tests for new functionality
- [x] I have updated documentation if needed
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
