### PR TITLE
fix(runtime): skip node_modules in image build-input hash walk + bump undici to 8.5.0

### DIFF
--- a/crates/speedwave-runtime/src/bundle.rs
+++ b/crates/speedwave-runtime/src/bundle.rs
@@ -641,6 +641,12 @@ fn collect_directory_entries(
     children.sort();
 
     for child in children {
+        // node_modules is gitignored and never copied into the build context
+        // (only `--from=builder` stage copies), so its internal `.bin/*`
+        // symlinks are not image content — skip it to keep the hash honest.
+        if child.is_dir() && child.file_name().is_some_and(|n| n == "node_modules") {
+            continue;
+        }
         // Fail loud: the build-context copier dereferences symlinks, so a
         // silently-skipped link would change image content WITHOUT changing
         // the hash — users would keep the stale tag after an update.
@@ -722,6 +728,89 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("symlink not allowed"), "got: {err}");
+    }
+
+    #[test]
+    fn collect_directory_entries_skips_node_modules_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("hub");
+        std::fs::create_dir_all(dir.join("src")).unwrap();
+        std::fs::write(dir.join("src/index.ts"), "real").unwrap();
+        std::fs::create_dir_all(dir.join("node_modules/pkg")).unwrap();
+        std::fs::write(dir.join("node_modules/pkg/index.js"), "dep").unwrap();
+        let mut out = Vec::new();
+        collect_directory_entries(&dir, "p", &mut out).unwrap();
+        let rels: Vec<&str> = out.iter().map(|(r, _)| r.as_str()).collect();
+        assert!(rels.iter().any(|r| r.ends_with("src/index.ts")), "{rels:?}");
+        assert!(
+            !rels.iter().any(|r| r.contains("node_modules")),
+            "node_modules must be excluded: {rels:?}"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn collect_directory_entries_skips_node_modules_with_bin_symlink() {
+        // The exact CI failure: npm creates node_modules/.bin/<tool> symlinks.
+        // The walk must skip node_modules entirely rather than bail on them.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("hub");
+        std::fs::create_dir_all(dir.join("node_modules/.bin")).unwrap();
+        let real = dir.join("node_modules/vitest/vitest.mjs");
+        std::fs::create_dir_all(real.parent().unwrap()).unwrap();
+        std::fs::write(&real, "x").unwrap();
+        std::os::unix::fs::symlink(&real, dir.join("node_modules/.bin/vitest")).unwrap();
+        std::fs::write(dir.join("package.json"), "{}").unwrap();
+        let mut out = Vec::new();
+        let res = collect_directory_entries(&dir, "p", &mut out);
+        assert!(
+            res.is_ok(),
+            "must not bail on node_modules symlinks: {res:?}"
+        );
+        assert!(out.iter().any(|(r, _)| r.ends_with("package.json")));
+        assert!(!out.iter().any(|(r, _)| r.contains("node_modules")));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn collect_directory_entries_skips_nested_node_modules() {
+        // The skip applies at every recursion depth, not just the top level.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("hub");
+        let nested = dir.join("packages/pkg/node_modules/.bin");
+        std::fs::create_dir_all(&nested).unwrap();
+        let real = dir.join("packages/pkg/node_modules/tool/tool.js");
+        std::fs::create_dir_all(real.parent().unwrap()).unwrap();
+        std::fs::write(&real, "x").unwrap();
+        std::os::unix::fs::symlink(&real, nested.join("tool")).unwrap();
+        std::fs::write(dir.join("packages/pkg/index.ts"), "real").unwrap();
+        let mut out = Vec::new();
+        collect_directory_entries(&dir, "p", &mut out).unwrap();
+        assert!(out.iter().any(|(r, _)| r.ends_with("pkg/index.ts")));
+        assert!(!out.iter().any(|(r, _)| r.contains("node_modules")));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn node_modules_changes_do_not_alter_manifest_hash() {
+        // ADR-072: node_modules is not image content, so adding it (symlinks
+        // and all) under a hash input must leave every image hash unchanged.
+        let tmp = tempfile::tempdir().unwrap();
+        write_build_tree(tmp.path());
+        let before = generate_bundle_manifest("1.0.0", "2.0.0", tmp.path()).unwrap();
+        let nm = tmp.path().join("mcp-servers/hub/node_modules/.bin");
+        std::fs::create_dir_all(&nm).unwrap();
+        let real = tmp
+            .path()
+            .join("mcp-servers/hub/node_modules/vitest/vitest.mjs");
+        std::fs::create_dir_all(real.parent().unwrap()).unwrap();
+        std::fs::write(&real, "x").unwrap();
+        std::os::unix::fs::symlink(&real, nm.join("vitest")).unwrap();
+        let after = generate_bundle_manifest("1.0.0", "2.0.0", tmp.path()).unwrap();
+        assert_eq!(
+            before.image_hashes, after.image_hashes,
+            "node_modules must not affect image hashes"
+        );
     }
 
     fn write_resource_tree(root: &Path) {

--- a/docs/adr/ADR-072-per-image-build-input-hash-tags.md
+++ b/docs/adr/ADR-072-per-image-build-input-hash-tags.md
@@ -64,6 +64,12 @@ The mapping is kept honest by `hash_inputs_cover_copy_sources`: it parses every
 if any source is not covered by the image's declared inputs — an undeclared
 source would ship stale code without a rebuild.
 
+The hash walk rejects symlinks (the copier dereferences them, so a skipped link
+would change image content without changing the hash) but skips any
+`node_modules/` directory: it is gitignored, installed via `npm ci` inside the
+build (`--from=builder`), never copied from the build context, and its internal
+`.bin/*` symlinks are not image content.
+
 **Terminology:** this is a hash of **build inputs**, not image content. Base
 images (`node:24-*` etc.) remain external and mutable, exactly as before
 (playwright pins its base by digest; the rest float).

--- a/mcp-servers/context7/package.json
+++ b/mcp-servers/context7/package.json
@@ -25,7 +25,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@speedwave/mcp-shared": "file:../shared",
-    "undici": "^8.3.0"
+    "undici": "^8.5.0"
   },
   "devDependencies": {
     "@types/node": "^25.6.2",

--- a/mcp-servers/package-lock.json
+++ b/mcp-servers/package-lock.json
@@ -51,7 +51,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@speedwave/mcp-shared": "file:../shared",
-        "undici": "^8.3.0"
+        "undici": "^8.5.0"
       },
       "devDependencies": {
         "@types/node": "^25.6.2",
@@ -4500,9 +4500,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.3.0.tgz",
-      "integrity": "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
+      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"


### PR DESCRIPTION
Two coupled fixes that together unblock the required `test` + `audit` checks on `dev` (they form an ordering cycle, so they ship in one PR).

## 1. node_modules in the image build-input hash walk (the `test` failure)

The per-image hash walk (ADR-072, `bundle.rs::collect_directory_entries`) aborts with `symlink not allowed in image hash inputs` whenever `node_modules` exists under a `hash_input` directory — e.g. the `node_modules/.bin/*` symlinks `npm ci` creates. CI runs `cd mcp-servers && npm ci` before `make test-rust`, so the desktop `build.rs` digest and every `render_compose` test trip on it (surfaced as the `test`/`desktop` failures on the npm-mcp PR).

**Fix:** skip any `node_modules/` directory during the walk, before the symlink check. ADR-072-safe — `node_modules` is gitignored, installed via `npm ci` inside the build (`--from=builder`), never copied from the build context, so it is not image content. +4 tests (plain skip, `.bin` symlink, nested, hash-purity); existing symlink-rejection tests preserved.

## 2. undici 8.3.0 → 8.5.0 (the `audit` failure)

undici 8.0.0-8.4.1 is high-severity (GHSA-vmh5-mc38-953g TLS bypass, GHSA-pr7r-676h-xcf6 cache disclosure, GHSA-38rv-x7px-6hhq WebSocket DoS), a prod dependency via `@speedwave/mcp-context7`. The required `audit` check fails on it across every mcp-servers PR. 8.5.0 clears it (`npm audit --audit-level=high --omit=dev` → 0 vulnerabilities). This is the same bump as #805, bundled here so dev gets both fixes atomically; #805 becomes a no-op once this lands.

All 29 `bundle::` tests pass; `clippy` (both feature sets) + `fmt` clean; audit verified locally. ADR-072 updated with the node_modules exclusion rationale.