### PR TITLE
fix(ci): regenerate npm lockfiles on release-please PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,6 +57,20 @@ updates:
           - patch
 
   - package-ecosystem: npm
+    directory: /mcp-servers/playwright
+    target-branch: dev
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    groups:
+      npm-playwright-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
     directory: /desktop/src
     target-branch: dev
     schedule:

--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -78,6 +78,7 @@ jobs:
             CHANGELOG.md
             package-lock.json
             mcp-servers/package-lock.json
+            mcp-servers/playwright/package-lock.json
             Cargo.lock
             desktop/src-tauri/Cargo.lock
           )

--- a/.github/workflows/release-please-npm-lockfile.yml
+++ b/.github/workflows/release-please-npm-lockfile.yml
@@ -7,7 +7,6 @@ on:
     paths:
       - "package.json"
       - "mcp-servers/*/package.json"
-      - "mcp-servers/playwright/package.json"
       - "desktop/src/package.json"
 
 permissions: {}

--- a/.github/workflows/release-please-npm-lockfile.yml
+++ b/.github/workflows/release-please-npm-lockfile.yml
@@ -1,0 +1,60 @@
+name: Release Please — Regenerate npm lockfiles
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "package.json"
+      - "mcp-servers/*/package.json"
+      - "mcp-servers/playwright/package.json"
+      - "desktop/src/package.json"
+
+permissions: {}
+
+jobs:
+  regenerate-lockfile:
+    if: >-
+      startsWith(github.head_ref, 'release-please--') &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: Install Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version-file: .nvmrc
+
+      # `--package-lock-only --ignore-scripts` rewrites only the workspace
+      # self-entry versions to match each package.json — no transitive bumps
+      # on a version-only release PR. See SPEED-190.
+      - name: Regenerate npm lockfiles
+        run: |
+          set -e
+          for dir in . mcp-servers mcp-servers/playwright desktop/src; do
+            echo "Regenerating $dir/package-lock.json"
+            (cd "$dir" && npm install --package-lock-only --ignore-scripts --no-audit --no-fund)
+          done
+
+      - name: Commit updated lockfiles
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          set -e
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package-lock.json mcp-servers/package-lock.json \
+            mcp-servers/playwright/package-lock.json desktop/src/package-lock.json
+          if git diff --cached --quiet; then
+            echo "Lockfiles already up to date"
+          else
+            git commit -m "regenerate npm lockfiles"
+            git push origin "HEAD:$HEAD_REF"
+          fi

--- a/Makefile
+++ b/Makefile
@@ -577,7 +577,8 @@ test-desktop-build: build-angular build-mcp
 # Fast config validation — stable, runs in `make test`.
 test-desktop-config:
 	@command -v bats >/dev/null 2>&1 || { echo "❌ bats not found. Install: brew install bats-core"; exit 1; }
-	bats _tests/desktop/updater-config.bats _tests/desktop/version-consistency.bats
+	bats _tests/desktop/updater-config.bats _tests/desktop/version-consistency.bats \
+	  _tests/desktop/backmerge-alignment.bats
 	@echo "✅ Desktop config tests passed"
 
 # Release gate — uses gh shim, CI-only. NOT in `make test` to prevent shim

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -395,18 +395,19 @@ Or use `desktop-build.yml` which runs automatically on PRs to `main` or `dev` (m
 
 ## Files Involved
 
-| File                                            | Role                                                           |
-| ----------------------------------------------- | -------------------------------------------------------------- |
-| `release-please-config.json`                    | release-please configuration — extra-files, changelog sections |
-| `.release-please-manifest.json`                 | Current version tracker for release-please                     |
-| `.github/workflows/release-please.yml`          | Runs release-please on push to main, triggers builds           |
-| `.github/workflows/release-please-lockfile.yml` | Regenerates Cargo.lock on release-please PRs                   |
-| `.github/workflows/desktop-release.yml`         | Matrix build, code signing, CLI cross-compile, publish         |
-| `.github/workflows/desktop-build.yml`           | PR/push CI build (unsigned)                                    |
-| `.github/workflows/backmerge.yml`               | Automated main → dev backmerge after release publish           |
-| `.github/workflows/merge-strategy-check.yml`    | Enforces conventional commit PR titles on PRs to main          |
-| `desktop/src-tauri/src/updater.rs`              | Stable endpoint, version comparator, auto-check loop           |
-| `desktop/src-tauri/tauri.conf.json`             | Tauri config — updater pubkey, default stable endpoint         |
+| File                                                | Role                                                           |
+| --------------------------------------------------- | -------------------------------------------------------------- |
+| `release-please-config.json`                        | release-please configuration — extra-files, changelog sections |
+| `.release-please-manifest.json`                     | Current version tracker for release-please                     |
+| `.github/workflows/release-please.yml`              | Runs release-please on push to main, triggers builds           |
+| `.github/workflows/release-please-lockfile.yml`     | Regenerates Cargo.lock on release-please PRs                   |
+| `.github/workflows/release-please-npm-lockfile.yml` | Regenerates npm package-lock.json files on release-please PRs  |
+| `.github/workflows/desktop-release.yml`             | Matrix build, code signing, CLI cross-compile, publish         |
+| `.github/workflows/desktop-build.yml`               | PR/push CI build (unsigned)                                    |
+| `.github/workflows/backmerge.yml`                   | Automated main → dev backmerge after release publish           |
+| `.github/workflows/merge-strategy-check.yml`        | Enforces conventional commit PR titles on PRs to main          |
+| `desktop/src-tauri/src/updater.rs`                  | Stable endpoint, version comparator, auto-check loop           |
+| `desktop/src-tauri/tauri.conf.json`                 | Tauri config — updater pubkey, default stable endpoint         |
 
 ## Verifying a Release
 

--- a/_tests/desktop/backmerge-alignment.bats
+++ b/_tests/desktop/backmerge-alignment.bats
@@ -73,6 +73,7 @@ _static_version_files() {
         CHANGELOG.md
         package-lock.json
         mcp-servers/package-lock.json
+        mcp-servers/playwright/package-lock.json
         Cargo.lock
         desktop/src-tauri/Cargo.lock
     )

--- a/mcp-servers/playwright/package-lock.json
+++ b/mcp-servers/playwright/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@speedwave/mcp-playwright",
-  "version": "0.1.0",
+  "version": "0.13.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@speedwave/mcp-playwright",
-      "version": "0.1.0",
+      "version": "0.13.3",
       "dependencies": {
         "@playwright/mcp": "0.0.70"
       }


### PR DESCRIPTION
## Problem

npm `package-lock.json` files drift behind their `package.json` versions between releases. release-please only does a top-level string replace on string-type extra-files, so it never updates nested `packages[""]` entries, and it does not touch lockfiles outside extra-files at all. The only thing keeping any lockfile fresh was a coincidental dependabot run after a release.

`mcp-servers/playwright/package-lock.json` had **no** dependabot coverage and **no** extra-files entry, so it was frozen at `0.1.0` while its `package.json` climbed to `0.13.3`.

## Root cause (three layers, verified empirically)

- **Layer A** — lockfile not in extra-files and not regenerated by any workflow (`mcp-servers/package-lock.json`, `mcp-servers/playwright/package-lock.json`). Cargo has `release-please-lockfile.yml`; npm had no equivalent.
- **Layer B** — lockfile in extra-files but release-please updates only the top-level `.version`, leaving `packages[""]` stale (`desktop/src/package-lock.json`).
- The root `package-lock.json` is self-healthy (node release-type fixes both fields).

## Fix — mirror the Cargo lockfile workflow for npm

New `release-please-npm-lockfile.yml` regenerates all four versioned npm lockfiles (`.`, `mcp-servers`, `mcp-servers/playwright`, `desktop/src`) via `npm install --package-lock-only --ignore-scripts` on every release-please PR and pushes the result back. This resolves all three layers at once, independent of where each version lives.

**Transitive freeze (decision + evidence):** on a version-only release PR this rewrites *only* the workspace self-entry versions — verified empirically (bumping all 12 mcp-servers members to a fake version changed 12 self-entries and **0** transitive `version`/`resolved` fields). No `--offline` (would fail in cold CI). The release PR stays reproducible.

## Also in this PR

- One-time fix of the stale playwright lockfile (`0.1.0` → `0.13.3`, two version lines only).
- Dependabot npm coverage for `/mcp-servers/playwright` (defense-in-depth).
- `mcp-servers/playwright/package-lock.json` added to backmerge `STATIC_VERSION_FILES` — the workflow now commits it on the release branch, so it lands on `main`, and the post-release backmerge must be able to auto-resolve it. Mirrored in `backmerge-alignment.bats`.
- Wired `backmerge-alignment.bats` into `make test` (`test-desktop-config`) — it existed but was run by no make target.

## Testing

- `make check-fmt` ✅
- `make test-desktop-config` ✅ (19/19, incl. the 4 backmerge-alignment + version-consistency checks)
- Transitive-freeze and playwright fix verified empirically with `npm install --package-lock-only` on temp copies.

Closes #487