### PR TITLE
refactor: enforce comment-length rule across codebase

### DIFF
--- a/.claude/scripts/plan-loop-context.sh
+++ b/.claude/scripts/plan-loop-context.sh
@@ -2,27 +2,17 @@
 # plan-loop-context.sh — pure helpers for building the project-context block
 # that plan-loop.sh inlines into every agent's system prompt.
 #
-# Sourced by:
-#   - .claude/scripts/plan-loop.sh (production)
-#   - _tests/ci/plan-loop-context.bats (unit tests)
-#
-# Functions defined here are pure (no globals mutated, no side effects beyond
-# stdout) and depend only on the caller setting RULE_FILE_MARKER_PREFIX and
-# RULE_FILE_MARKER_SUFFIX before invocation.
+# Sourced by plan-loop.sh (production) and _tests/ci/plan-loop-context.bats.
 
 # emit_file_block: cat $1 with trailing newlines preserved.
-# Plain $(cat …) command substitution strips trailing newlines, which would
-# glue the last line of one rule file to the next file's marker. Append a
-# sentinel byte and strip it afterwards.
 emit_file_block() {
     local content
     content="$(cat "$1"; printf 'X')"
     printf '%s' "${content%X}"
 }
 
-# list_rule_files: emit basenames-stripped paths of every rule file under
-# $1/.claude/rules, deterministically sorted, following symlinks, excluding
-# dotfiles. Returns no output (and success) when the directory is missing.
+# list_rule_files: emit *.md paths under $1/.claude/rules, sorted, symlinks
+# followed, dotfiles excluded; no output and success when dir is missing.
 list_rule_files() {
     local root="$1"
     [[ -d "$root/.claude/rules" ]] || return 0
@@ -30,9 +20,8 @@ list_rule_files() {
         ! -name '.*' | LC_ALL=C sort
 }
 
-# build_project_context: print CLAUDE.md + every rule file from
-# $1/.claude/rules, separated by per-run markers. Caller MUST set
-# RULE_FILE_MARKER_PREFIX and RULE_FILE_MARKER_SUFFIX before calling.
+# build_project_context: print CLAUDE.md + every $1/.claude/rules file, marker-
+# separated. Caller MUST set RULE_FILE_MARKER_PREFIX/RULE_FILE_MARKER_SUFFIX.
 build_project_context() {
     local root="$1"
     local out=""
@@ -48,28 +37,15 @@ build_project_context() {
     printf '%s' "$out"
 }
 
-# validate_rules_compliance: compare a JSON array of rule_file basenames
-# (read from stdin) against an expected list (passed as args). Prints a
-# multi-line report to stdout when there is a problem; exits 0 with no
-# output when the actual set matches expected and no notes are too short.
-#
-# Usage:
-#   echo "$RESULT_JSON" | validate_rules_compliance "${EXPECTED_RULE_FILES[@]}"
-#
-# Reads from $RESULT_FILE_VAR (env var holding a path), not stdin, because
-# we need both rule_file extraction and short-note detection from the same
-# source. The caller sets RESULT_FILE_VAR before invoking.
+# validate_rules_compliance: compare rule_file basenames in JSON at $1 against
+# expected args; print report on mismatch/short-note, else exit 0 no output.
 validate_rules_compliance() {
     local result_file="$1"
     shift
     local expected_files=("$@")
     local issues=""
 
-    # `|| true` shields the assignment under `set -euo pipefail`: jq exits
-    # non-zero on malformed JSON, which under pipefail kills the pipeline,
-    # which under set -e aborts plan-loop.sh in its error-recovery path.
-    # On failure we want the empty-set behavior (treated as missing all
-    # expected files), not a crash.
+    # `|| true` keeps malformed JSON (jq non-zero) from aborting under set -euo pipefail.
     local actual_files
     actual_files=$(jq -r '.structured_output.rules_compliance // [] | .[].rule_file' "$result_file" 2>/dev/null | LC_ALL=C sort -u || true)
     local expected_sorted

--- a/.claude/scripts/plan-loop.sh
+++ b/.claude/scripts/plan-loop.sh
@@ -100,20 +100,11 @@ BOLD='\033[1m'
 NC='\033[0m'
 
 # --- Dependency freshness ---
-#
-# Delegates to `make install-deps` (= setup-dev) — the Makefile is the SSOT for
-# provisioning the workspace: cargo fetch + npm install in every npm subproject
-# including mcp-servers/* sub-packages where tsc lives. A hand-rolled npm-ci
-# loop would miss those and fail at build-mcp. The state file caches the
-# aggregate hash of all package-lock.json files; reruns skip when nothing
-# changed.
+# Delegates to `make install-deps`; state file caches aggregate package-lock.json hash.
 
 LOCK_STATE_FILE=""
 
-# Portable SHA-256: prefer sha256sum (coreutils, default on Linux), fall back
-# to shasum -a 256 (macOS / systems shipping Perl's shasum). Resolved once at
-# start; the absence of both yields an empty SHA_CMD, which aggregate_lock_hash
-# treats as "state unknown → reinstall".
+# Portable SHA-256: prefer sha256sum (Linux), fall back to shasum -a 256 (macOS).
 if command -v sha256sum >/dev/null 2>&1; then
     SHA_CMD="sha256sum"
 elif command -v shasum >/dev/null 2>&1; then
@@ -325,11 +316,8 @@ CODE_REVIEW_SCHEMA="$(cat "$CODE_REVIEW_SCHEMA_FILE")"
 TMPDIR_LOOP=$(mktemp -d)
 RESULT_FILE="$TMPDIR_LOOP/result.json"
 
-# Per-run npm cache — avoids EINTEGRITY/ENOTEMPTY races from concurrent npm ci
-# across parallel plan-loops, regardless of --no-worktree/--impl-only mode.
-# Stored in TMPDIR_LOOP (unique per run via mktemp -d, auto-cleaned on exit).
-# CARGO_TARGET_DIR intentionally not overridden: Makefile hard-codes
-# ./target/debug/ paths in cp rules.
+# Per-run npm cache in TMPDIR_LOOP (unique per run) avoids concurrent npm ci races.
+# CARGO_TARGET_DIR not overridden: Makefile hard-codes ./target/debug/ paths.
 export NPM_CONFIG_CACHE="$TMPDIR_LOOP/.npm-cache"
 
 WRITER_SESSION_ID=""
@@ -424,22 +412,9 @@ else
 fi
 
 # --- Project context injection ---
-#
-# Every headless agent must see the same authoritative project context: CLAUDE.md
-# and every file in .claude/rules/. We cannot rely on the agent reading these on
-# its own — `claude -p` does not auto-load CLAUDE.md the same way as interactive
-# sessions, and rules with `paths:` frontmatter are not pulled in headless either.
-# Inlining the content into the system prompt makes the contract identical for
-# writer, reviewer, implementer, verifier, and every code-review subagent.
-#
-# Discovery is glob-based (no hardcoded list) so newly added rule files reach
-# every agent automatically — no skill edits required.
+# Inlines CLAUDE.md + .claude/rules/ (glob-based) into the system prompt for every agent.
 
-# Random delimiter prevents prompt injection: a malicious CLAUDE.md cannot
-# forge an "END" marker because it doesn't know this run's nonce.
-# Try openssl first, fall back to xxd, fall back to od (POSIX-mandated).
-# An empty nonce would make markers identical across runs and forgeable, so
-# we hard-fail rather than running with a degraded security argument.
+# Random delimiter nonce: try openssl, fall back to xxd, fall back to od.
 CONTEXT_NONCE="$(
     openssl rand -hex 16 2>/dev/null \
     || head -c 16 /dev/urandom 2>/dev/null | xxd -p -c 32 2>/dev/null \
@@ -454,9 +429,7 @@ CONTEXT_END_MARKER="===END_PROJECT_CONTEXT_${CONTEXT_NONCE}==="
 RULE_FILE_MARKER_PREFIX="--- BEGIN_RULE_FILE_${CONTEXT_NONCE}: "
 RULE_FILE_MARKER_SUFFIX=" ---"
 
-# Pure context-building helpers (emit_file_block, list_rule_files,
-# build_project_context, validate_rules_compliance) are sourced from a
-# sibling file so they can be unit-tested in isolation.
+# Pure context-building helpers sourced from a sibling file for unit-test isolation.
 # shellcheck source=plan-loop-context.sh
 source "$SCRIPT_DIR/plan-loop-context.sh"
 
@@ -737,10 +710,8 @@ Only report NEW issues if they are BLOCKER or HIGH severity."
     PREV_FINDINGS="$findings"
     PREV_HIGH_COUNT="$high_count"
 
-    # Sanity check: reviewer may return READY_TO_IMPLEMENT while also reporting
-    # blockers (schema does not enforce the correlation). Reject that combo — a
-    # plan with BLOCKERS is never ready to implement regardless of what the
-    # model claims in the verdict field.
+    # Sanity check: schema cannot express verdict↔blocker correlation; reject
+    # READY_TO_IMPLEMENT with blockers.
     if [[ "$verdict" == "READY_TO_IMPLEMENT" && "$blocker_count" -gt 0 ]]; then
         printf "\n  ${RED}[sanity] Reviewer returned READY_TO_IMPLEMENT with $blocker_count blocker(s) — demoting to NEEDS_REVISION${NC}\n"
         verdict="NEEDS_REVISION"
@@ -759,10 +730,7 @@ Only report NEW issues if they are BLOCKER or HIGH severity."
             printf "  ${RED}Demoting verdict from READY_TO_IMPLEMENT to NEEDS_REVISION${NC}\n"
             verdict="NEEDS_REVISION"
         fi
-        # Surface to the writer so the next iteration fixes it explicitly.
-        # Append to `findings` only — REVIEW_FEEDBACK is rebuilt from `findings`
-        # at the end of the loop body (see end of `while` body), so writing to
-        # it directly here would be overwritten before the next iteration.
+        # Append to `findings` only; REVIEW_FEEDBACK is rebuilt from it at loop end.
         findings="${findings}
 
 ORCHESTRATOR POST-VALIDATION (rules_compliance):
@@ -933,10 +901,7 @@ $IMPL_FEEDBACK" \
     v_verdict=$(jq -r '.structured_output.overall_verdict // "UNKNOWN"' "$RESULT_FILE" 2>/dev/null)
     v_steps=$(jq -r '.structured_output.steps_verified // 0' "$RESULT_FILE" 2>/dev/null)
     v_total=$(jq -r '.structured_output.steps_total // 0' "$RESULT_FILE" 2>/dev/null)
-    # New 3-state enum: PASSED / FAILED / UNKNOWN. Legacy boolean fields
-    # (make_check_passed / make_test_passed) are honored as a fallback so an
-    # older verifier that still emits the boolean form does not blow up the
-    # orchestrator — true→PASSED, false→FAILED, missing→UNKNOWN.
+    # 3-state enum PASSED/FAILED/UNKNOWN; legacy booleans map true→PASSED, false→FAILED, missing→UNKNOWN.
     v_check=$(jq -r '.structured_output.make_check_status // (if .structured_output.make_check_passed == true then "PASSED" elif .structured_output.make_check_passed == false then "FAILED" else "UNKNOWN" end)' "$RESULT_FILE" 2>/dev/null)
     v_test=$(jq -r '.structured_output.make_test_status // (if .structured_output.make_test_passed == true then "PASSED" elif .structured_output.make_test_passed == false then "FAILED" else "UNKNOWN" end)' "$RESULT_FILE" 2>/dev/null)
     v_gaps=$(jq -r '.structured_output.gaps_summary // ""' "$RESULT_FILE" 2>/dev/null)
@@ -948,16 +913,11 @@ $IMPL_FEEDBACK" \
     echo "  make check: $v_check"
     echo "  make test:  $v_test"
 
-    # Sanity check: demote VERIFIED if model contradicts itself (e.g. reports
-    # VERIFIED with missing steps or failing checks). The JSON schema cannot
-    # express these correlations, so the orchestrator enforces them.
-    #
+    # Orchestrator enforces verdict↔step/check correlations.
     # Verdict routing:
-    #   VERIFIED  — both check and test PASSED AND all steps done → accept
-    #   UNKNOWN   — verifier could not confirm one or both of check/test
-    #               (e.g., make test timed out). Retry the verifier on the
-    #               next loop iteration instead of treating as failure.
-    #   GAPS_FOUND — verifier confirmed a real failure or missing step
+    #   VERIFIED   — check+test PASSED AND all steps done → accept
+    #   UNKNOWN    — check/test unconfirmed (e.g. timeout) → retry verifier
+    #   GAPS_FOUND — confirmed failure or missing step
     if [[ "$v_verdict" == "VERIFIED" ]]; then
         if [[ "$v_check" != "PASSED" || "$v_test" != "PASSED" ]]; then
             printf "\n  ${RED}[sanity] Verifier returned VERIFIED with check=$v_check test=$v_test — demoting${NC}\n"
@@ -982,10 +942,7 @@ $IMPL_FEEDBACK" \
         break
     fi
 
-    # UNKNOWN → don't ask the implementer to change code. Retry verification
-    # on the next iteration of this loop (same working tree, fresh verifier
-    # context). An implementer fix driven by an inconclusive verdict can
-    # corrupt a perfectly good working tree.
+    # UNKNOWN: retry verification next iteration, do not change code.
     if [[ "$v_verdict" == "UNKNOWN" ]]; then
         printf "\n  ${YELLOW}[verifier] Result inconclusive — will retry without touching the implementation${NC}\n"
         IMPL_FEEDBACK=""
@@ -1160,11 +1117,7 @@ $cr_findings" \
 
     printf "  ${CYAN}[verifier]${NC} Re-verifying after code review fixes...\n"
 
-    # Re-verify with an inner retry for UNKNOWN verdicts. An inconclusive
-    # verifier (e.g., make test hit the 15-min cap mid-run) is NOT a signal
-    # to ask the implementer to touch the code — the implementer just did.
-    # Retry the verifier up to RV_MAX_RETRIES times with a fresh context on
-    # each attempt before escalating to "stop Phase 3".
+    # Retry verifier on UNKNOWN up to RV_MAX_RETRIES; do not touch code.
     RV_MAX_RETRIES=2
     rv_attempt=0
     rv_verdict="UNKNOWN"
@@ -1214,8 +1167,7 @@ $cr_findings" \
         printf "  ${GREEN}[verifier] Done${NC} ($((rv_end - rv_start))s)\n"
         echo "  Verdict: $rv_verdict  check: $rv_check  test: $rv_test"
 
-        # Conclusive result (VERIFIED or GAPS_FOUND): exit the retry loop and
-        # let the surrounding code-review-loop logic decide what to do next.
+        # Conclusive result (VERIFIED or GAPS_FOUND): exit the retry loop.
         if [[ "$rv_verdict" != "UNKNOWN" ]]; then
             break
         fi
@@ -1230,9 +1182,8 @@ $cr_findings" \
     fi
 
     if [[ "$rv_verdict" == "UNKNOWN" ]]; then
-        # All RV retries returned UNKNOWN. Treat as a warning, not a hard
-        # failure — the user can run make check/test themselves. Don't block
-        # them from seeing the diff.
+        # All retries returned UNKNOWN: treat as warning (user verifies manually),
+        # not a hard failure.
         printf "\n  ${YELLOW}Re-verification remained inconclusive after $RV_MAX_RETRIES retries. Treating as warning — user must run 'make check' and 'make test' manually to confirm.${NC}\n"
         break
     fi
@@ -1252,9 +1203,7 @@ if [[ "$phase3_error" == "true" ]]; then
     exit 1
 fi
 
-# Warning banner if we broke out of the review loop with an UNKNOWN verdict.
-# Implementation is NOT broken — the verifier just could not confirm (e.g.
-# make test timed out). The user needs to run check/test themselves.
+# Warning banner if the review loop broke out with an UNKNOWN verdict.
 if [[ "${rv_verdict:-VERIFIED}" == "UNKNOWN" ]]; then
     printf "\n${YELLOW}╔══════════════════════════════════════════════════════════════╗${NC}\n"
     printf "${YELLOW}║  Phase 3: INCONCLUSIVE — verifier could not confirm${NC}\n"
@@ -1277,10 +1226,7 @@ fi # end of Phase 3 (skipped if --skip-review)
 # DONE — print next steps
 # ═══════════════════════════════════════════════════════════════
 
-# Green banner only when code review came back CLEAN or was skipped.
-# If Phase 3 ran and ended with HAS_ISSUES (max iter exhausted), use a neutral
-# yellow "done with warnings" banner so the prior warning is not visually
-# cancelled by a green "ALL PHASES COMPLETE".
+# Green banner only when code review came back CLEAN or was skipped; else yellow.
 if [[ "$SKIP_REVIEW" == "true" || "${cr_verdict:-UNKNOWN}" == "CLEAN" ]]; then
     banner_color="$GREEN"
     banner_title="ALL PHASES COMPLETE"

--- a/.github/actions/download-sherpa-onnx/action.yml
+++ b/.github/actions/download-sherpa-onnx/action.yml
@@ -7,10 +7,8 @@ runs:
       shell: bash
       run: |
         LIB_DIR="$(scripts/lib/fetch-sherpa-onnx-md.sh)"
-        # Git Bash on windows-latest is MSYS2 — convert the POSIX path
-        # (/d/a/_temp/...) to native Windows form (D:\a\_temp\...) so cargo's
-        # native sherpa-onnx-sys build process resolves it. Same class of fix
-        # as wslpath -w in scripts/e2e-vm.sh.
+        # Git Bash (MSYS2) — convert POSIX path (/d/a/_temp/...) to Windows
+        # form (D:\a\_temp\...) for the native sherpa-onnx-sys build.
         WIN_LIB_DIR="$(cygpath -w "$LIB_DIR")"
         echo "SHERPA_ONNX_LIB_DIR=${WIN_LIB_DIR}" >> "$GITHUB_ENV"
         echo "::notice::SHERPA_ONNX_LIB_DIR set to ${WIN_LIB_DIR}"

--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -1,13 +1,4 @@
-# Backmerge main → dev after a release is published
-#
-# Resets dev to match main exactly (force-push). This prevents ghost commits
-# from accumulating on dev due to SHA divergence from squash merges.
-#
-# If dev has commits not yet on main (someone merged between release and
-# backmerge), falls back to a regular merge via PR for manual resolution.
-#
-# Force-push is allowed by the dev branch ruleset which grants bypass to
-# admin role (used by RELEASE_TOKEN).
+# Backmerge main → dev after release: force-push dev=main, or fall back to a merge PR if dev has new commits
 
 name: Backmerge
 
@@ -50,23 +41,7 @@ jobs:
             exit 0
           fi
 
-          # Check if dev has genuinely new work not on main.
-          #
-          # We cannot use `git log dev --not main` because ghost commits
-          # (squash-merged to main with different SHAs) also appear there.
-          # We cannot use commit timestamps because commits merged to dev
-          # between the squash merge and the release tag would be lost.
-          #
-          # Instead, compare file trees: after squash merge dev→main, both
-          # have identical content. Main then gets a version bump (release-
-          # please), so we exclude version/release files from the diff.
-          # Any remaining difference = genuinely new work on dev.
-          #
-          # The per-package version files are derived at runtime from
-          # release-please-config.json `extra-files` (the SSOT — see CLAUDE.md),
-          # so adding a worker there needs no edit here. Only files release-
-          # please bumps but does NOT list in extra-files stay inline below
-          # (its own manifest/config/workflow, lockfiles, CHANGELOG).
+          # Compare file trees excluding version files (extra-files from release-please-config.json SSOT + static files below)
           mapfile -t RP_EXTRA_FILES < <(
             jq -r '.packages["."]["extra-files"][] | if type=="string" then . else .path end' \
               release-please-config.json
@@ -115,11 +90,7 @@ jobs:
           else
             echo "Merge conflicts detected — attempting auto-resolution of version files"
 
-            # Auto-resolve version files (main wins — it has the latest release
-            # version). Same SSOT as VERSION_EXCLUDES above: extra-files from
-            # release-please-config.json plus the static files release-please
-            # bumps but does not list (manifest/config/workflow, lockfiles,
-            # CHANGELOG). Adding a worker to extra-files needs no edit here.
+            # Auto-resolve version files (main wins); same SSOT as VERSION_EXCLUDES above
             AUTO_RESOLVE_FILES=("${RP_EXTRA_FILES[@]}" "${STATIC_VERSION_FILES[@]}")
 
             for f in "${AUTO_RESOLVE_FILES[@]}"; do

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -101,9 +101,7 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           MATRIX_ARGS: ${{ matrix.args }}
         run: |
-          # Split MATRIX_ARGS into an array so intentional multi-token values
-          # (e.g. `--target x`) still split, but no glob/metacharacter is
-          # interpreted by the shell (hardening — see PR #766 review).
+          # Split MATRIX_ARGS into an array (word-split, no glob expansion).
           read -ra ARGS <<< "$MATRIX_ARGS"
           # No signing key (fork PR / Dependabot) → unsigned bundle.
           if [ -z "$TAURI_SIGNING_PRIVATE_KEY" ]; then

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -82,9 +82,7 @@ jobs:
             TAG="v${VERSION}"
           fi
 
-          # Validate version format (stable only — no pre-release suffixes).
-          # Defense-in-depth: same regex also enforced by verify-release-assets.sh
-          # (line 21). Both must stay in sync if the format contract ever changes.
+          # Stable-only regex; kept in sync with verify-release-assets.sh.
           if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "ERROR: Version '$VERSION' has invalid format. Expected: X.Y.Z"
             exit 1
@@ -156,9 +154,8 @@ jobs:
         run: npm ci
         working-directory: desktop/src
 
-      # Export code-signing secrets to GITHUB_ENV only when they are configured.
-      # tauri-action attempts certificate import when APPLE_CERTIFICATE env var
-      # exists (even if empty), so we must not set it unless the secret is real.
+      # Set APPLE_* in GITHUB_ENV only when the secret is real (tauri-action
+      # imports on any non-null APPLE_CERTIFICATE).
       - name: Configure macOS code signing
         if: matrix.platform == 'macos-latest'
         env:
@@ -188,14 +185,8 @@ jobs:
             echo "::notice::macOS code signing skipped (no APPLE_CERTIFICATE secret)"
           fi
 
-      # tauri-action does not import the certificate into the macOS keychain —
-      # it only passes APPLE_CERTIFICATE to tauri-bundler for signing the outer
-      # .app. Our beforeBundleCommand (scripts/sign-bundled-binaries.sh) runs
-      # `codesign --sign "$APPLE_SIGNING_IDENTITY"` on bundled Mach-O resources
-      # and requires the identity to already be resolvable in a keychain.
-      # This step performs the prescribed Tauri/Apple pattern of creating a
-      # throwaway build keychain and importing the .p12 before tauri-action
-      # starts. See: https://v2.tauri.app/distribute/sign/macos/
+      # Import the .p12 into a throwaway build keychain so codesign can resolve
+      # APPLE_SIGNING_IDENTITY. See: https://v2.tauri.app/distribute/sign/macos/
       - name: Import Apple signing certificate to keychain
         if: matrix.platform == 'macos-latest' && env.APPLE_CERTIFICATE != ''
         shell: bash
@@ -216,9 +207,7 @@ jobs:
           security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
-          # Prepend the build keychain to the search list so codesign can find
-          # the identity without overriding the login keychain globally.
-          # macOS ships bash 3.2 which lacks mapfile — use a while-read loop.
+          # Prepend the build keychain to the search list (bash 3.2: no mapfile).
           _existing_keychains=()
           while IFS= read -r _kc; do
             [ -n "$_kc" ] && _existing_keychains+=("$_kc")
@@ -236,16 +225,12 @@ jobs:
 
           rm -f "$CERT_FILE"
 
-          # Guard against an empty APPLE_SIGNING_IDENTITY — `grep -q ""` would
-          # match every line and the verification below would silently pass
-          # even without a usable identity in the keychain.
+          # Empty identity would make the grep below match any line.
           if [ -z "${APPLE_SIGNING_IDENTITY:-}" ]; then
             echo "::error::APPLE_SIGNING_IDENTITY is empty — check the repository secret"
             exit 1
           fi
-          # Verify the identity is now resolvable — fail fast if not.
-          # -qF: fixed-string match, since the identity contains `()` which
-          # grep would otherwise treat as regex metacharacters in ERE.
+          # Verify the identity is resolvable (-qF: identity contains `()`).
           if ! security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
                | grep -qF "$APPLE_SIGNING_IDENTITY"; then
             echo "::error::APPLE_SIGNING_IDENTITY not found in imported keychain"
@@ -277,9 +262,8 @@ jobs:
           platform: ${{ matrix.platform }}
           args: ${{ matrix.args }}
 
-      # When releaseId is set, tauri-action uploads artifacts to the existing
-      # release and ignores tagName/releaseName/releaseDraft. When releaseId is
-      # empty (manual dispatch), tauri-action creates/finds the release by tag.
+      # releaseId set: upload to existing release (tag* ignored); empty: create
+      # by tag.
       - uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5  # v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -414,9 +398,7 @@ jobs:
           if [ -z "$RID" ]; then
             RID=$(gh release view "$TAG_NAME" --repo "$REPO" --json databaseId --jq '.databaseId')
           fi
-          # All asset / latest.json shape checks happened in the pre-publish gate
-          # (scripts/verify-release-assets.sh). The post-publish step re-runs that
-          # gate as a safety net.
+          # Asset/latest.json checks ran in the pre-publish gate; post-publish re-runs it.
           gh api --method PATCH "repos/$REPO/releases/$RID" -f draft=false
           echo "Release published successfully"
 

--- a/.github/workflows/merge-strategy-check.yml
+++ b/.github/workflows/merge-strategy-check.yml
@@ -2,8 +2,7 @@
 #
 # - Release-please and backmerge PRs are exempt
 # - All other PRs must have conventional commit titles (for squash merge)
-# - `chore` is intentionally rejected here (see scripts/validate-pr-title-main.sh
-#   header and issue #371) because release-please ignores `chore` commits.
+# - `chore` is rejected (release-please ignores it); see scripts/validate-pr-title-main.sh
 
 name: Merge Strategy Check
 

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -15,8 +15,7 @@ jobs:
     steps:
       - name: Validate conventional commit title
         env:
-          # Pass the title via env (never interpolated into the run: body) so a
-          # malicious PR title cannot inject shell commands. Mirrors
+          # Pass title via env (never interpolated into run: body); mirrors
           # merge-strategy-check.yml.
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,9 +24,7 @@ jobs:
           token: ${{ secrets.RELEASE_TOKEN }}
           target-branch: main
 
-      # Defense-in-depth: ensure the release PR has the label that release-please
-      # needs to identify it as a merged release PR. The labeling API call inside
-      # release-please can fail transiently (PR node ID not propagated yet).
+      # release-please's own label call can fail transiently
       - name: Ensure release PR has autorelease label
         if: steps.release.outputs.pr
         continue-on-error: true
@@ -51,9 +49,7 @@ jobs:
           done
           echo "::warning::Failed to apply label after 3 retries"
 
-      # Defense-in-depth: ensure the git tag exists as a ref. GitHub draft
-      # releases may not create a git ref, even with force-tag-creation: true.
-      # Without the tag, checkout in desktop-release.yml fails.
+      # GitHub draft releases may not create the git ref desktop-release.yml needs
       - name: Ensure release tag exists
         if: steps.release.outputs.release_created == 'true'
         continue-on-error: true

--- a/Makefile
+++ b/Makefile
@@ -691,10 +691,10 @@ setup-e2e-vms:
 # ── Linting ──────────────────────────────────────────────────────────────────
 
 check-clippy:
-	cargo clippy -p speedwave-runtime -p speedwave-cli -- -D warnings
-	@# The `audio-transcription` feature is off by default, so the line above
-	@# doesn't lint the `transcription` module — clippy it explicitly too.
-	cargo clippy -p speedwave-runtime --features audio-transcription -- -D warnings
+	cargo clippy -p speedwave-runtime -p speedwave-cli --all-targets -- -D warnings
+	@# `--all-targets` lints test code too. `test-support` + `audio-transcription`
+	@# are off by default, so lint those modules/feature-gated tests explicitly.
+	cargo clippy -p speedwave-runtime --all-targets --features test-support,audio-transcription -- -D warnings
 	@echo "✅ Clippy: 0 warnings"
 
 check-desktop-clippy: build-angular build-mcp

--- a/_tests/ci/plan-loop-context.bats
+++ b/_tests/ci/plan-loop-context.bats
@@ -1,12 +1,6 @@
 #!/usr/bin/env bats
-# Tests for .claude/scripts/plan-loop-context.sh — the pure helpers that
-# build the AUTHORITATIVE PROJECT CONTEXT block injected into every
-# plan-loop agent's system prompt.
-#
-# These helpers are load-bearing: a bug here means agents either miss
-# rules (security regression) or read corrupted concatenated text
-# (correctness regression). The plan-loop orchestrator mode is hard to
-# test end-to-end, so we cover the helpers in isolation.
+# Tests for .claude/scripts/plan-loop-context.sh — helpers that build the
+# PROJECT CONTEXT block injected into plan-loop agent system prompts.
 
 LIB="$BATS_TEST_DIRNAME/../../.claude/scripts/plan-loop-context.sh"
 
@@ -151,8 +145,6 @@ teardown() {
     printf 'b body\n' > "$TMP/.claude/rules/b.md"
     out="$(build_project_context "$TMP")"
     # The marker for b.md must appear on its own line, not glued to "newline".
-    # Two newlines between file body and next marker means the marker line
-    # starts at column 1.
     [[ "$out" == *"no trailing newline"*$'\n\n'*"b.md"*"$RULE_FILE_MARKER_SUFFIX"* ]]
 }
 
@@ -182,8 +174,7 @@ teardown() {
 # ---------------------------------------------------------------------------
 
 write_result() {
-    # Helper: write a fake reviewer result file with a rules_compliance array.
-    # Args: path, then JSON array string (or "[]" for empty).
+    # Args: result path, JSON array string (or "[]").
     cat > "$1" <<EOF
 { "structured_output": { "rules_compliance": $2 } }
 EOF
@@ -258,13 +249,7 @@ EOF
 }
 
 @test "validate_rules_compliance: malformed JSON does not crash UNDER set -euo pipefail" {
-    # Defensive coverage. plan-loop.sh runs with `set -euo pipefail` and
-    # consumes this function via command substitution: `rc_issues=$(…)`.
-    # In stock bash (no `inherit_errexit`) command substitutions do NOT
-    # propagate `set -e`, so a non-zero exit inside `$(…)` is currently
-    # absorbed. If anyone later adds `shopt -s inherit_errexit` (recommended
-    # by ShellCheck SC2310), the function MUST still be safe — that is
-    # exactly the scenario this test pins.
+    # Pins safety under `set -euo pipefail` + `shopt -s inherit_errexit`.
     printf 'not json at all' > "$TMP/r.json"
     run bash -c "
         set -euo pipefail

--- a/_tests/ci/validate-pr-title-main.bats
+++ b/_tests/ci/validate-pr-title-main.bats
@@ -1,8 +1,5 @@
 #!/usr/bin/env bats
-# Tests for scripts/validate-pr-title-main.sh
-#
-# Regression: issue #371 — `chore` as PR title to main makes release-please
-# ignore the merge, collapsing feat/fix commits into an invisible release.
+# Tests for scripts/validate-pr-title-main.sh — regression guard for issue #371
 
 SCRIPT="$BATS_TEST_DIRNAME/../../scripts/validate-pr-title-main.sh"
 

--- a/_tests/desktop/backmerge-alignment.bats
+++ b/_tests/desktop/backmerge-alignment.bats
@@ -1,12 +1,6 @@
 #!/usr/bin/env bats
-# Verifies that .github/workflows/backmerge.yml derives its version-file lists
-# (VERSION_EXCLUDES / AUTO_RESOLVE_FILES) from release-please-config.json
-# `extra-files` at runtime, so they can never drift out of sync. Only files
-# release-please bumps but does NOT list in extra-files (its own
-# manifest/config/workflow, lockfiles, CHANGELOG) may be hardcoded inline.
-#
-# Before this derivation, both lists were ~30-entry hand-synced arrays that
-# silently broke the backmerge on every new worker. See CLAUDE.md SSOT note.
+# Verifies backmerge.yml derives VERSION_EXCLUDES/AUTO_RESOLVE_FILES from
+# release-please-config.json extra-files. See CLAUDE.md SSOT note.
 
 REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
 CONFIG="$REPO_ROOT/release-please-config.json"
@@ -27,7 +21,7 @@ for item in cfg['packages']['.']['extra-files']:
 }
 
 # Paths hardcoded in the STATIC_VERSION_FILES bash array in the YAML.
-# Use [[:space:]] (not \s) so BSD awk on macOS matches the closing paren line.
+# Use [[:space:]] (not \s) for BSD awk macOS compatibility.
 _static_version_files() {
     awk '
         /STATIC_VERSION_FILES=\(/ { capture=1; next }

--- a/_tests/desktop/bundle-build-context.bats
+++ b/_tests/desktop/bundle-build-context.bats
@@ -10,11 +10,7 @@
 
 SCRIPT="$BATS_TEST_DIRNAME/../../scripts/bundle-build-context.sh"
 
-# Per-test temp DEST so the suite can run in parallel with `make dev` (which
-# writes to the real desktop/src-tauri/). The script honours $BUNDLE_DEST.
-# macOS EDR products (Bitdefender, Microsoft Defender) open freshly-written
-# files for real-time scanning, so a follow-up `rm -rf` can race the scanner's
-# open fd — retry with a short backoff.
+# Per-test temp DEST (script honours $BUNDLE_DEST). Retry rm to survive EDR open fds.
 rm_with_retry() {
     local target="$1"
     local attempt
@@ -96,9 +92,7 @@ teardown() {
 @test "mcp-os bundle: full import chain resolves (spawn and check)" {
     run "$SCRIPT"
     [ "$status" -eq 0 ]
-    # Spawn mcp-os with PORT=0 and a token. If imports fail,
-    # node exits immediately with ERR_MODULE_NOT_FOUND (exit 1).
-    # On success, it prints {"port":N} and keeps running — we kill it.
+    # Failed imports exit 1; success prints {"port":N} and keeps running.
     local script="$DEST/mcp-os/os/dist/index.js"
     local tmpout
     tmpout="$(mktemp)"
@@ -156,9 +150,7 @@ teardown() {
 }
 
 @test "bundle script references only existing source files" {
-    # Extract all cp/cp -r source paths from the script and verify they exist.
-    # This catches bugs like referencing shared/package-lock.json when the
-    # lockfile is at the workspace root.
+    # Extract all cp source paths from the script and verify they exist.
     REPO_ROOT="$BATS_TEST_DIRNAME/../.."
 
     # Collect non-variable literal paths used as cp sources (skip $DEST targets)
@@ -233,9 +225,7 @@ teardown() {
     local src="$BATS_TEST_DIRNAME/../../containers/install-claude.sh"
     local dst="$DEST/build-context/containers/install-claude.sh"
 
-    # GNU stat (Linux/Git Bash) first; BSD stat (macOS) is the fallback. Order
-    # matters: GNU `stat -f` means `--file-system` (exit 0 with garbage output),
-    # so probing BSD first on Linux yields wrong results without errors.
+    # GNU stat (-c) first, BSD stat (-f) fallback: GNU `stat -f` means --file-system.
     local src_perms
     local dst_perms
     src_perms=$(stat -c '%a' "$src" 2>/dev/null || stat -f '%A' "$src")
@@ -262,19 +252,13 @@ teardown() {
 }
 
 @test "lock held by a live holder blocks a second run until released" {
-    # Directly proves mutual exclusion (not just final-state). Hold the lock with
-    # OUR (live) PID, launch the script, assert it does NOT proceed while held,
-    # then release and assert it completes. Without the mutex it would race in
-    # immediately.
+    # Hold the lock with our live PID; the script must block until release.
     mkdir -p "$DEST/.bundle.lock"
     echo "$$" > "$DEST/.bundle.lock/pid"   # $$ is bats — a live process
 
     "$SCRIPT" &
     local pid=$!
-    # While WE hold the lock, the script must never start its body no matter how
-    # long we wait — so observe across several polls. A longer wall-clock only
-    # strengthens the "stayed blocked" assertion; it cannot make this flaky on a
-    # slow host (unlike a single fixed sleep that could fire before the body).
+    # While we hold the lock the script must never start its body — poll repeatedly.
     local i
     for i in 1 2 3 4 5 6 7 8 9 10; do
         [ ! -d "$DEST/build-context" ] || {
@@ -298,10 +282,7 @@ teardown() {
 }
 
 @test "concurrent runs on the same DEST both finish with a valid package.json" {
-    # The incident: `make dev` building an image while `make test` re-bundles the
-    # SAME DEST captured a 0-byte mcp-shared/package.json. Serialization itself is
-    # proven by the mutual-exclusion test above; this asserts the end state is
-    # never corrupt under real concurrency.
+    # Two runs on the same DEST must both finish with a non-corrupt package.json.
     "$SCRIPT" &
     local p1=$!
     "$SCRIPT" &

--- a/_tests/desktop/entitlements-audio-capture.bats
+++ b/_tests/desktop/entitlements-audio-capture.bats
@@ -1,9 +1,5 @@
 #!/usr/bin/env bats
-# Static checks on desktop/src-tauri/entitlements/audio-capture.plist (ADR-056).
-# The audio-capture-cli uses CoreAudio process taps + AVAudioEngine for the
-# microphone; under Hardened Runtime, microphone access needs the
-# com.apple.security.device.audio-input entitlement. This file guards against
-# the plist going missing or accidentally accumulating broader entitlements.
+# Guard audio-capture.plist: must have com.apple.security.device.audio-input entitlement, no broader (ADR-056).
 
 PLIST="$BATS_TEST_DIRNAME/../../desktop/src-tauri/entitlements/audio-capture.plist"
 
@@ -33,8 +29,7 @@ PY
 }
 
 @test "audio-capture.plist declares exactly one <key>" {
-    # Stay minimal: capturing system audio via taps does not need a separate
-    # entitlement on macOS; only the mic does. A second key here is a red flag.
+    # Only the mic entitlement is needed; a second key is a regression.
     local keys
     keys="$(grep -c '<key>' "$PLIST")"
     [ "$keys" = "1" ]

--- a/_tests/desktop/entitlements-reminders.bats
+++ b/_tests/desktop/entitlements-reminders.bats
@@ -1,9 +1,5 @@
 #!/usr/bin/env bats
-# Static checks on desktop/src-tauri/entitlements/reminders.plist — prevents
-# regressions where the Reminders entitlement file is missing or malformed.
-# The separate reminders.plist (distinct from calendars.plist) is required because
-# com.apple.security.personal-information.reminders and .calendars are separate
-# Hardened Runtime Resource Access entitlements per ADR-037.
+# Static checks on desktop/src-tauri/entitlements/reminders.plist per ADR-037.
 
 PLIST="$BATS_TEST_DIRNAME/../../desktop/src-tauri/entitlements/reminders.plist"
 

--- a/_tests/desktop/guard-prod-data-dir.bats
+++ b/_tests/desktop/guard-prod-data-dir.bats
@@ -1,8 +1,6 @@
 #!/usr/bin/env bats
 # Tests for the `guard-not-prod-data-dir` Makefile target (ADR-031 §4).
-# It must hard-refuse a production data dir (basename `.speedwave`) so a
-# dev/test action can never touch ~/.speedwave, even if the user exported
-# SPEEDWAVE_DATA_DIR to point there.
+# Must hard-refuse a production data dir (basename `.speedwave`).
 
 REPO_ROOT="$BATS_TEST_DIRNAME/../.."
 
@@ -39,10 +37,7 @@ run_guard() {
 }
 
 @test "guard allows an empty SPEEDWAVE_DATA_DIR" {
-    # An empty value does not match the `*/.speedwave` production pattern, so the
-    # guard passes it. (Make's `?=` does NOT substitute the default for an
-    # explicitly-empty value; the empty-as-unset → ~/.speedwave fallback is
-    # enforced in Rust by `data_dir_from`, not here.)
+    # Empty value does not match the `*/.speedwave` production pattern.
     run run_guard ""
     [ "$status" -eq 0 ]
 }

--- a/_tests/desktop/info-plist.bats
+++ b/_tests/desktop/info-plist.bats
@@ -1,16 +1,9 @@
 #!/usr/bin/env bats
-# Static checks on desktop/src-tauri/Info.plist — prevents regressions where
-# a TCC usage-description key is removed or misspelled. Without the right
-# description key, macOS cannot display the consent dialog and silently
-# blocks access to the protected resource (Reminders, Calendar, Contacts,
-# Apple Events, FileProvider domains like OneDrive/iCloud Drive).
+# Static checks on desktop/src-tauri/Info.plist TCC usage-description keys.
 
 INFO_PLIST="$BATS_TEST_DIRNAME/../../desktop/src-tauri/Info.plist"
 
-# Single source of truth for which TCC usage-description keys Speedwave must
-# declare. Add a key here when a bundled binary starts using a new TCC-gated
-# API — every @test below iterates this list. See ADR-037 §1b for the mapping
-# between keys and the APIs/binaries that require them.
+# SSOT for required TCC usage-description keys (see ADR-037 §1b for mapping).
 REQUIRED_TCC_KEYS=(
     NSRemindersUsageDescription
     NSRemindersFullAccessUsageDescription
@@ -24,9 +17,7 @@ REQUIRED_TCC_KEYS=(
 )
 
 plist_get() {
-    # Parse the plist XML directly with python so this works on Linux CI
-    # where plutil does not exist. Handles the standard <key>/<string>
-    # layout used in Info.plist files.
+    # Parse the plist XML with python (cross-platform; plutil is macOS-only).
     local key="$1"
     python3 - "$INFO_PLIST" "$key" <<'PY'
 import plistlib, sys
@@ -49,9 +40,7 @@ PY
 }
 
 @test "all required TCC usage descriptions are present and non-empty" {
-    # Each key must resolve to a non-empty string, otherwise macOS cannot
-    # display the consent dialog. Failures are reported per-key so a
-    # missing key names itself in the output.
+    # Each key must resolve to a non-empty string; failures reported per-key.
     local key val missing=()
     for key in "${REQUIRED_TCC_KEYS[@]}"; do
         val="$(plist_get "$key")"
@@ -66,19 +55,16 @@ PY
 }
 
 @test "NSFileProviderDomainUsageDescription specifically is declared" {
-    # Explicit test for the key that caused the v0.7.2 CloudStorage
-    # regression — macOS silently blocks virtiofs reads from
-    # ~/Library/CloudStorage/ (OneDrive, iCloud Drive, Dropbox, Google
-    # Drive) without this key. See anthropics/claude-code#26981.
+    # v0.7.2 regression: without this key macOS silently blocks virtiofs
+    # reads from ~/Library/CloudStorage/. See anthropics/claude-code#26981.
     local val
     val="$(plist_get NSFileProviderDomainUsageDescription)"
     [ -n "$val" ]
 }
 
 @test "NSAppleEventsUsageDescription specifically is declared" {
-    # Explicit test for the key used by mail-cli and notes-cli. Missing
-    # this key makes osascript → Apple Events calls fail silently with
-    # error -1743.
+    # Key used by mail-cli and notes-cli; missing it makes Apple Events
+    # calls fail silently with error -1743.
     local val
     val="$(plist_get NSAppleEventsUsageDescription)"
     [ -n "$val" ]

--- a/_tests/desktop/native-cli-info-plist.bats
+++ b/_tests/desktop/native-cli-info-plist.bats
@@ -1,25 +1,6 @@
 #!/usr/bin/env bats
-# SSOT-alignment test: verifies that each native macOS CLI binary
-# (calendar-cli, reminders-cli, mail-cli, notes-cli) carries an embedded
-# `__TEXT,__info_plist` Mach-O section with the right CFBundleIdentifier,
-# usage description, and version.
-#
-# Without this section, EventKit's `requestFullAccessToEvents` silently
-# rejects on macOS 14+ (the Calendar TCC bug fixed by this PR), and TCC
-# binds the permission row to the codesign-default identifier (e.g.
-# `calendar-cli`) instead of the sub-identifier the troubleshooting docs
-# reference (`pl.speedwave.desktop.calendar`).
-#
-# This test is macOS-only because:
-# - `segedit` (extracts Mach-O sections) ships only with macOS Xcode tools
-# - `lipo` (thins universal binaries) is macOS-only
-# - The binaries themselves are only built on macOS via build-native-macos.sh
-#
-# The test reads the source-of-truth Info.plist files directly (not the
-# embedded section) for everything except the existence-of-section check —
-# the build script (build-native-macos.sh) is responsible for stamping
-# tauri.conf.json's version into them, so this test follows the same
-# files SwiftPM linker reads at build time.
+# SSOT-alignment test: each native macOS CLI binary carries an embedded
+# `__TEXT,__info_plist` section with the right id, usage description, version. macOS-only.
 
 setup() {
     if [ "$(uname)" != "Darwin" ]; then
@@ -154,9 +135,8 @@ extract_embedded_plist() {
 }
 
 @test "embedded CFBundleShortVersionString matches tauri.conf.json version" {
-    # SSOT drift guard: build-native-macos.sh stamps tauri.conf.json's version into each
-    # CLI's Resources/Info.plist before swift build. If the stamp step is skipped or the
-    # tauri.conf.json version changes without a rebuild, this fails.
+    # build-native-macos.sh stamps tauri.conf.json's version into each
+    # CLI's Resources/Info.plist before swift build.
     local tauri_version svc bin tmp actual
     if command -v jq >/dev/null 2>&1; then
         tauri_version="$(jq -r '.version' "$REPO_ROOT/desktop/src-tauri/tauri.conf.json")"
@@ -181,9 +161,8 @@ extract_embedded_plist() {
 }
 
 @test "each CLI Info.plist has correct UsageDescription key" {
-    # Source-of-truth Info.plist files (read directly, not from binary) must
-    # carry the right TCC usage description for each service. The linker
-    # embeds these into the binary, so the source file is authoritative.
+    # Source Info.plist files (read directly, not from binary) must
+    # carry the right TCC usage description for each service.
     local svc plist key val
     for svc in "${SERVICES[@]}"; do
         plist="$REPO_ROOT/native/macos/$svc/Resources/Info.plist"
@@ -205,8 +184,6 @@ extract_embedded_plist() {
 }
 
 @test "Resources/Info.plist files exist for every native CLI" {
-    # Without the source plist, the linker -sectcreate flag would point at a
-    # nonexistent path and the build would fail with a cryptic ld error.
     local svc plist
     for svc in "${SERVICES[@]}"; do
         plist="$REPO_ROOT/native/macos/$svc/Resources/Info.plist"
@@ -218,10 +195,8 @@ extract_embedded_plist() {
 }
 
 @test "Package.swift files declare Info.plist linker flags for every CLI" {
-    # Drift guard: every CLI's Package.swift must carry the -sectcreate __TEXT
-    # __info_plist flags pointing at Resources/Info.plist. If a future PR adds a
-    # new native CLI without these flags, EventKit/AppleEvents calls will silently
-    # reject on macOS 14+. This test catches that at PR review time.
+    # Every CLI's Package.swift must carry the -sectcreate __TEXT
+    # __info_plist flags pointing at Resources/Info.plist.
     local svc pkg pattern
     for svc in "${SERVICES[@]}"; do
         pkg="$REPO_ROOT/native/macos/$svc/Package.swift"

--- a/_tests/desktop/sign-bundled-binaries.bats
+++ b/_tests/desktop/sign-bundled-binaries.bats
@@ -7,9 +7,8 @@ setup() {
     SRC_TAURI="$(mktemp -d "${BATS_TEST_TMPDIR}/sign-bundled.XXXXXX")"
     export SRC_TAURI
 
-    # Force the script's `uname` check to return "Darwin" on any host so tests
-    # exercise the Darwin-only branches on Linux CI too. PATH shim is undone
-    # automatically when the subshell exits after each test.
+    # Force the script's `uname` to return "Darwin" so Darwin-only branches run
+    # on Linux CI too.
     UNAME_SHIM_DIR="${BATS_TEST_TMPDIR}/uname-shim"
     mkdir -p "$UNAME_SHIM_DIR"
     cat > "$UNAME_SHIM_DIR/uname" <<'EOF'
@@ -28,23 +27,14 @@ with_darwin_uname() {
     PATH="$UNAME_SHIM_DIR:$PATH" "$@"
 }
 
-# Tauri copies a small synthetic Mach-O into each expected path, so the script's
-# existence + file-type checks pass. We cannot invoke codesign in tests (no real
-# cert), so these helpers mirror the production layout but stop short of signing.
+# Helpers mirror the production layout but stop short of signing (no real cert).
 
 write_mach_o() {
-    # Minimal Mach-O 64-bit magic number (cafebabe / feedfacf) — enough for
-    # `file(1)` to classify as Mach-O. Not executable in practice, which is
-    # fine since we mock codesign below.
     mkdir -p "$(dirname "$1")"
-    # Use the system /bin/ls as a known-valid Mach-O binary on macOS; on Linux
-    # it's ELF and the Mach-O check will fail — tests only exercise the
-    # Mach-O-assertion path via the negative test, not positive execution.
+    # /bin/ls is Mach-O on macOS, ELF on Linux.
     if [[ "$(uname)" == "Darwin" ]]; then
         cp /bin/ls "$1"
     else
-        # On Linux, copy an ELF file as a stand-in; tests that need a true
-        # Mach-O are skipped on Linux.
         cp /bin/ls "$1" 2>/dev/null || printf '\x7fELF' > "$1"
     fi
     chmod +x "$1"
@@ -74,9 +64,7 @@ populate_targets() {
 }
 
 @test "exits 0 on non-Darwin host (no uname shim)" {
-    # Without the shim, real `uname` decides: macOS returns Darwin and the
-    # script continues past the guard; Linux returns Linux and it exits early.
-    # Either way, with no signing identity set, the final exit code is 0.
+    # With no signing identity set, the final exit code is 0 on any host.
     unset APPLE_SIGNING_IDENTITY
 
     run "$SCRIPT"
@@ -121,9 +109,7 @@ populate_targets() {
 }
 
 @test "SIGN_TARGETS covers every executable resource in tauri.macos.conf.json" {
-    # Prevents the "added binary to tauri.macos.conf.json but forgot
-    # SIGN_TARGETS" regression. Extracts executable resource keys (those
-    # that don't end with /) and verifies each has a SIGN_TARGETS entry.
+    # Every executable resource key (not ending in /) must have a SIGN_TARGETS entry.
     local macos_conf="$BATS_TEST_DIRNAME/../../desktop/src-tauri/tauri.macos.conf.json"
     [ -f "$macos_conf" ]
 
@@ -195,10 +181,7 @@ for key in conf.get('bundle', {}).get('resources', {}):
 }
 
 @test "speedwave CLI has no entitlements in SIGN_TARGETS" {
-    # speedwave is pure Rust — no restricted APIs, no entitlements needed.
-    # The entry must end with ":" followed by end-of-value. Match the full
-    # array-element form explicitly so the test doesn't accidentally rely on
-    # shell quoting around the colon.
+    # speedwave is pure Rust — no entitlements; its entry ends with ":".
     grep -E '"\$SRC_TAURI/cli/speedwave:"[[:space:]]*$' "$SCRIPT"
 }
 
@@ -211,16 +194,12 @@ for key in conf.get('bundle', {}).get('resources', {}):
 }
 
 @test "post-sign verification rejects plists with zero entitlement keys" {
-    # Guard against silent verification pass when grep '<key>' yields nothing
-    # (malformed plist, truncated file, future format change). Without this
-    # guard the while-loop never executes and signing reports success.
+    # Guard against silent pass when grep '<key>' yields nothing (malformed plist).
     grep -qF 'contains no <key> entries' "$SCRIPT"
 }
 
 @test "sign_macho fails fast when entitlements plist is missing" {
-    # Binary path is validated; plist path must be validated too. Without
-    # this check codesign produces a cryptic error instead of a friendly
-    # "create the plist" hint.
+    # Plist path must be validated too, not just the binary path.
     grep -qF 'entitlements plist does not exist' "$SCRIPT"
 }
 
@@ -258,9 +237,7 @@ for path in glob.glob('$ent_dir/*.plist'):
 }
 
 @test "each single-capability plist declares exactly one <key>" {
-    # Prevents least-privilege drift. node.plist is exempt — V8 needs both
-    # allow-jit and allow-unsigned-executable-memory and the two are
-    # structurally inseparable.
+    # One <key> per plist; node.plist is exempt (V8 needs two).
     local ent_dir="$BATS_TEST_DIRNAME/../../desktop/src-tauri/entitlements"
     local plist keys
     for plist in virtualization.plist calendars.plist reminders.plist apple-events.plist; do
@@ -293,10 +270,7 @@ for path in glob.glob('$ent_dir/*.plist'):
 }
 
 @test "verify_identifier function is defined for native CLI sub-identifier check" {
-    # Sub-identifier verification is what guarantees TCC.db rows are bound to
-    # `pl.speedwave.desktop.<svc>` and the recovery commands in
-    # docs/troubleshooting.md actually work. Without this, the codesign default
-    # identifier (`<svc>-cli`) would silently apply.
+    # Sub-identifier binding ensures TCC.db rows match pl.speedwave.desktop.<svc>.
     grep -qF 'verify_identifier()' "$SCRIPT"
 }
 
@@ -309,10 +283,7 @@ for path in glob.glob('$ent_dir/*.plist'):
 
 @test "expected sub-identifier mapping covers all native CLIs" {
     # SSOT-alignment with native/macos/shared/Sources/SharedCLI/Utilities.swift
-    # ::subBundleIdentifier(for:) (and, for audio-capture, that CLI's
-    # Resources/Info.plist) — these exact values must match, otherwise the Swift
-    # gate / embedded plist produces different tccutil hints than the codesign
-    # binding.
+    # ::subBundleIdentifier(for:); these exact values must match.
     grep -qF 'pl.speedwave.desktop.calendar' "$SCRIPT"
     grep -qF 'pl.speedwave.desktop.reminders' "$SCRIPT"
     grep -qF 'pl.speedwave.desktop.mail' "$SCRIPT"
@@ -321,9 +292,7 @@ for path in glob.glob('$ent_dir/*.plist'):
 }
 
 @test "verify_identifier is invoked for each native CLI in sign loop" {
-    # The post-sign loop must call verify_identifier (not just sign_macho +
-    # verify_macho). If a future refactor drops the call, sub-identifier
-    # binding regressions slip through.
+    # The post-sign loop must call verify_identifier, not just sign_macho + verify_macho.
     grep -qE 'verify_identifier "\$path"' "$SCRIPT"
 }
 

--- a/_tests/desktop/transcription-bundle.bats
+++ b/_tests/desktop/transcription-bundle.bats
@@ -1,9 +1,5 @@
 #!/usr/bin/env bats
-# Drift guards for the meeting-transcription bundle wiring (ADR-056). These are
-# the SSOT-alignment pairs from CLAUDE.md that must move together:
-#   tauri.macos.conf.json bundle.resources ↔ scripts/sign-bundled-binaries.sh
-#   SIGN_TARGETS ↔ desktop/src-tauri/entitlements/audio-capture.plist, plus the
-#   static third-party licenses kept in desktop/src-tauri/licenses-static/.
+# Drift guards for the meeting-transcription bundle wiring (ADR-056).
 
 REPO_ROOT="$BATS_TEST_DIRNAME/../.."
 MACOS_CONF="$REPO_ROOT/desktop/src-tauri/tauri.macos.conf.json"
@@ -53,8 +49,7 @@ PY
 
 @test "Makefile has a bundle-static-licenses target wired into build-tauri" {
     grep -qE '^bundle-static-licenses:' "$MAKEFILE"
-    # build-tauri must invoke it (so the bundled THIRD-PARTY-LICENSES dir gets
-    # the transcription licenses alongside the lima/nodejs ones).
+    # build-tauri must invoke bundle-static-licenses.
     grep -qF 'bundle-static-licenses' "$MAKEFILE"
 }
 

--- a/_tests/desktop/updater-config.bats
+++ b/_tests/desktop/updater-config.bats
@@ -1,8 +1,5 @@
 #!/usr/bin/env bats
 # Static validation of critical updater config fields in tauri.conf.json.
-# Each test runs against the real file (expect PASS) and against a matching
-# fixture (expect FAIL with asserted stderr substring).
-#
 # Set TAURI_CONF_OVERRIDE to use a different config file.
 
 REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"

--- a/_tests/desktop/version-consistency.bats
+++ b/_tests/desktop/version-consistency.bats
@@ -1,9 +1,6 @@
 #!/usr/bin/env bats
 # Verifies that every version-bearing file listed in release-please-config.json
 # agrees with .release-please-manifest.json["."].
-#
-# All validation logic lives in scripts/check-version-consistency.py so the
-# script is independently runnable by developers.
 
 REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
 FIXTURES="$REPO_ROOT/_tests/desktop/fixtures/version-consistency"

--- a/_tests/e2e/plugin-tamper.bats
+++ b/_tests/e2e/plugin-tamper.bats
@@ -1,24 +1,11 @@
 #!/usr/bin/env bats
 
 # Behavioral verification for the plugin signature runtime invariant.
-#
-# These tests exercise `speedwave check` against synthetic plugin
-# directories that should be rejected, then assert exit code 2 and a
-# diagnostic message. They run against whatever binary `SPEEDWAVE_BIN`
-# points at — pass a release build to verify that the
-# `SPEEDWAVE_ALLOW_UNSIGNED` debug bypass is compiled out.
 
 load setup
 
-# Override `setup` to also point SPEEDWAVE_DATA_DIR at a per-test
-# tempdir, so we never touch the developer's real `~/.speedwave/`.
-#
-# `consts::derive_instance_name_from` (called eagerly during CLI
-# startup) asserts that the data-dir basename matches
-# `^[a-z][a-z0-9-]{0,63}$`. `mktemp -d` produces basenames like
-# `tmp.XXXXXX` on macOS / `tmp.XXXX` on Linux, both containing a `.`
-# that breaks the assertion — so we create the tempdir, then nest a
-# clean-named child under it and use *that* as SPEEDWAVE_DATA_DIR.
+# SPEEDWAVE_DATA_DIR basename must match `^[a-z][a-z0-9-]{0,63}$`;
+# `mktemp -d` basenames contain a `.`, so nest a clean-named child.
 setup() {
     TEST_TEMP_DIR="$(mktemp -d)"
     export TEST_TEMP_DIR
@@ -50,12 +37,8 @@ EOF
     [[ "$output" == *"evil"* ]]
 }
 
-# The headline test for PR6: a release CLI must reject unsigned plugins
-# even when SPEEDWAVE_ALLOW_UNSIGNED=1 is set in the environment. The
-# bypass is `cfg(debug_assertions)`-gated, so the env var is dead code
-# in release builds. With a debug build this test is skipped — debug
-# binaries are explicitly allowed to bypass signature checks for dev
-# workflows (`make dev` sets the var).
+# Bypass is `cfg(debug_assertions)`-gated; release ignores the env var,
+# debug builds are skipped.
 @test "release CLI rejects unsigned plugin even with SPEEDWAVE_ALLOW_UNSIGNED=1" {
     if [[ "$SPEEDWAVE_BIN" == *"/debug/"* ]]; then
         skip "Skipping on debug build — bypass is intentionally live there"
@@ -84,9 +67,8 @@ EOF
     [[ "$output" == *"evil"* ]]
 }
 
-# Recovery must target only the named plugin even when a good (or, here,
-# another bad) one is co-installed — otherwise a regression that wires
-# `plugin remove` through `list_verified_plugins` would break it.
+# Recovery must target only the named plugin even when another bad one is
+# co-installed.
 @test "speedwave plugin remove targets only the bad plugin" {
     make_unsigned_plugin_dir "evil"
     make_unsigned_plugin_dir "also-evil"
@@ -96,9 +78,7 @@ EOF
     [ -d "$SPEEDWAVE_DATA_DIR/plugins/also-evil" ]
 }
 
-# The tolerant lister must surface every directory so the user can see
-# which one is broken — hiding unverified plugins would make UI recovery
-# impossible.
+# The tolerant lister must surface every directory, verified or not.
 @test "speedwave plugin list shows both verified and unverified entries" {
     make_unsigned_plugin_dir "evil"
     make_unsigned_plugin_dir "also-evil"

--- a/_tests/e2e/speedwave.bats
+++ b/_tests/e2e/speedwave.bats
@@ -39,23 +39,14 @@ load setup
 }
 
 @test "speedwave check produces a structured verdict" {
-    # `speedwave check` renders compose in-memory from the resolved project
-    # config (no compose file is required on disk) and must terminate with
-    # one of four structured verdicts:
-    #   - "speedwave check OK"           — all security + OS checks passed
-    #   - "speedwave check FAILED"       — at least one security violation
-    #   - "runtime is not running"       — Desktop isn't up, CLI short-circuits
-    #   - "No project configured"        — run from a dir with no project set up
-    # Any other outcome (panic, bare Rust error, silent exit) indicates a
-    # regression in the check pipeline.
+    # Verdicts: "speedwave check OK" / "FAILED" / "runtime is not running" / "No project configured"
     cd "$TEST_TEMP_DIR"
     run "$SPEEDWAVE_BIN" check 2>&1 || true
     [[ "$output" == *"speedwave check OK"* ]] \
         || [[ "$output" == *"speedwave check FAILED"* ]] \
         || [[ "$output" == *"runtime is not running"* ]] \
         || [[ "$output" == *"No project configured"* ]]
-    # Must not crash with a panic — those are real regressions, not expected
-    # failure modes.
+    # Must not crash with a panic
     [[ "$output" != *"panicked"* ]]
     [[ "$output" != *"PANIC"* ]]
 }

--- a/_tests/entrypoint/entrypoint.bats
+++ b/_tests/entrypoint/entrypoint.bats
@@ -161,15 +161,8 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# set -e kills the entrypoint when HOME is not writable (the Windows bug)
-#
-# On Windows the CLAUDE_HOME 9p mount defaulted to uid 0 while the container
-# runs as uid 1000; with metadata enforcing ownership, the entrypoint's first
-# write to ${HOME} hit EACCES and `set -euo pipefail` exited non-zero BEFORE
-# `exec sleep infinity`, so the container went Exited ("cannot exec in a
-# stopped state"). The host-side fix is uid=1000 in the wsl.conf automount
-# options; this test pins the invariant that a non-writable HOME is fatal, so
-# the entrypoint can never silently "succeed" into a half-set-up home.
+# set -e kills the entrypoint when HOME is not writable: non-writable HOME
+# is a fatal error, never a silent half-set-up success.
 # ---------------------------------------------------------------------------
 
 @test "exits non-zero when HOME is not writable (mimics uid-mismatch EACCES)" {
@@ -229,9 +222,8 @@ EOF
 
     run bash "$ENTRYPOINT" true
     [ "$status" -eq 0 ]
-    # skills is a real directory of per-entry symlinks (not a whole-directory
-    # symlink) so per-integration entries can be gated on/off without disturbing
-    # the core entries that share the directory.
+    # skills is a real directory of per-entry symlinks, not a whole-directory
+    # symlink.
     [ -d "$HOME/.claude/skills" ]
     [ ! -L "$HOME/.claude/skills" ]
     [ -L "$HOME/.claude/skills/my-skill.md" ]
@@ -241,17 +233,15 @@ EOF
 @test "resource directory exists but is empty when source is absent" {
     run bash "$ENTRYPOINT" true
     [ "$status" -eq 0 ]
-    # The entrypoint always creates the four resource dirs (so plugin and
-    # integration links can be added per-entry); if the source mount has no
-    # skills/ then the directory just stays empty.
+    # The entrypoint always creates the four resource dirs; an absent source
+    # mount leaves the directory empty.
     [ -d "$HOME/.claude/skills" ]
     [ ! -L "$HOME/.claude/skills" ]
     [ -z "$(ls -A "$HOME/.claude/skills")" ]
 }
 
 @test "links the bundled core web-authoring skills from the real resources tree" {
-    # Point at the real claude-resources tree (not a synthetic fixture) so this
-    # test verifies the actual top-level core skills ship as symlinks. These are
+    # Point at the real claude-resources tree; top-level core skills are
     # unconditionally linked (no integration gating, no ENABLED_SERVICES).
     real_resources="$BATS_TEST_DIRNAME/../../containers/claude-resources"
     export SPEEDWAVE_RESOURCES="$real_resources"
@@ -452,9 +442,7 @@ EOF
 
 # ---------------------------------------------------------------------------
 # ~/.claude.json pre-seed: always pre-accepts the /workspace trust dialog;
-# onboarding only when logged in (ADR-052). Trust is keyed by working_dir and
-# is separate from --dangerously-skip-permissions, so it must be set even with
-# no credentials, while onboarding stays incomplete so `claude` shows OAuth.
+# onboarding completes only when logged in (ADR-052).
 # ---------------------------------------------------------------------------
 
 @test "pre-accepts /workspace trust but skips onboarding when credentials are absent" {
@@ -939,16 +927,12 @@ EOF
 
 # ---------------------------------------------------------------------------
 # Migration: ~/.claude/<resource_type> mode flips between runs.
-# claude-home is a persistent volume, so a stale layout from a previous
-# start can poison the current one if the entrypoint doesn't normalize it.
+# claude-home is a persistent volume; the entrypoint normalizes stale layouts.
 # ---------------------------------------------------------------------------
 
 @test "plugin mode replaces stale whole-directory symlink left from no-plugins run" {
-    # Reproduce the scenario from the bug: project was started without plugins
-    # (skills became a symlink to read-only resources), then a plugin was
-    # installed and the project restarted. Without normalization the per-entry
-    # ln below would resolve through the symlink and try to write into the
-    # read-only resources mount, killing the container with `set -e`.
+    # No-plugins run leaves skills as a symlink to read-only resources; a later
+    # plugin run must replace it instead of writing through it.
     mkdir -p "$RESOURCES_DIR/skills/code-review-basic"
     echo "# Core skill" > "$RESOURCES_DIR/skills/code-review-basic/SKILL.md"
 
@@ -993,9 +977,8 @@ EOF
     mkdir -p "$RESOURCES_DIR/skills/core-skill"
     echo "# Core" > "$RESOURCES_DIR/skills/core-skill/SKILL.md"
 
-    # Simulate a previous plugin run leaving a stale plugin link behind: it must
-    # NOT be tracked in the state file (we did not create it), so the entrypoint
-    # should leave it alone — only links it owns get cleaned up.
+    # Untracked stale plugin link (not in the state file): the entrypoint leaves
+    # it alone — only links it owns get cleaned up.
     mkdir -p "$HOME/.claude/skills"
     ln -sfn "/some/old/plugin/path/leftover" "$HOME/.claude/skills/leftover"
 
@@ -1152,10 +1135,8 @@ setup_integrations_fixture() {
     [ ! -e "${TEST_HOME}/.claude/skills/slack" ]
 }
 
-# Regression guard for the toggle-off path: ~/.claude is persistent across
-# container restarts, so a once-linked integration skill must disappear when
-# the user toggles the integration off. Without state-file cleanup the link
-# would linger and Claude would call tools whose worker is no longer running.
+# ~/.claude persists across restarts; a toggled-off integration link must be
+# cleaned up via the state file.
 @test "toggle off removes previously-linked integration skill" {
     setup_integrations_fixture
 

--- a/_tests/entrypoint/litellm-entrypoint.bats
+++ b/_tests/entrypoint/litellm-entrypoint.bats
@@ -55,9 +55,7 @@ teardown() {
 }
 
 @test "skips provider ids that fail the slug shape" {
-    # Uppercase, dots, and underscores would not have passed host-side slug
-    # validation — the entrypoint must not export them (defense in depth
-    # against a tampered tokens dir injecting arbitrary env names).
+    # Uppercase, dots, underscores fail slug validation; must not export.
     printf 'v' > "$TOKENS_DIR/Bad.Provider_api_key"
     printf 'v' > "$TOKENS_DIR/UPPER_api_key"
     run "$ENTRYPOINT"

--- a/_tests/entrypoint/osc52-copy.bats
+++ b/_tests/entrypoint/osc52-copy.bats
@@ -1,7 +1,6 @@
 #!/usr/bin/env bats
 # Tests for containers/osc52-copy.sh — host-side, no container required.
-# Wrapper has two output channels: ~/.clipboard-bridge file (always written)
-# and OSC 52 sequence on /dev/tty (TTY-only, skipped under bats).
+# Channels: ~/.clipboard-bridge file (always) + OSC 52 on /dev/tty (TTY-only, skipped under bats).
 
 OSC52="$BATS_TEST_DIRNAME/../../containers/osc52-copy.sh"
 CONTAINERFILE="$BATS_TEST_DIRNAME/../../containers/Containerfile.claude"
@@ -135,9 +134,7 @@ teardown() {
 }
 
 @test "command mentioning BOTH Set-Clipboard and Get-Clipboard takes the write path" {
-    # case patterns are tested per-arg in order: Set-Clipboard precedes the
-    # Get-Clipboard arm, so a single -Command token containing both resolves
-    # deterministically to a write (a copy command that also names the reader).
+    # Set-Clipboard arm precedes Get-Clipboard, so a token naming both resolves to write.
     local ps='Set-Clipboard -Value ([Console]::In.ReadToEnd()); Get-Clipboard'
     run bash -c "printf 'both' | HOME='$TMP_HOME' bash '$OSC52' -NoProfile -Command \"\$0\"" "$ps"
     [ "$status" -eq 0 ]
@@ -145,9 +142,8 @@ teardown() {
 }
 
 @test "invoking via the powershell.exe symlink name routes Set-Clipboard to write" {
-    # Claude Code reaches the shim by name (powershell.exe), not by calling
-    # osc52-copy.sh directly — exercise that resolution path, not just the
-    # script. A symlink mirrors the image-time `ln -s` in Containerfile.claude.
+    # Claude Code reaches the shim by name (powershell.exe), not osc52-copy.sh.
+    # Symlink mirrors the image-time `ln -s` in Containerfile.claude.
     local bindir="$TMP_HOME/bin"
     mkdir -p "$bindir"
     ln -s "$OSC52" "$bindir/powershell.exe"
@@ -186,9 +182,7 @@ teardown() {
 # ── SSOT cross-check with the host watcher ──────────────────────────────────
 
 @test "bridge filename matches BRIDGE_FILENAME in clipboard_bridge.rs" {
-    # The shell wrapper writes ~/.clipboard-bridge; the Rust watcher looks for
-    # the same name. If one side is renamed without the other, the bridge
-    # silently stops working — this test catches that.
+    # SSOT: shell wrapper and Rust watcher must use the same ~/.clipboard-bridge name.
     local rs="$BATS_TEST_DIRNAME/../../desktop/src-tauri/src/clipboard_bridge.rs"
     grep -q 'BRIDGE_FILENAME: &str = ".clipboard-bridge"' "$rs"
     grep -q '\.clipboard-bridge' "$OSC52"
@@ -197,9 +191,8 @@ teardown() {
 # ── Error reporting ─────────────────────────────────────────────────────────
 
 @test "reports a stderr error when the bridge file cannot be written" {
-    # HOME points at a path whose parent is not a directory → cannot create
-    # ~/.clipboard-bridge. The wrapper must still exit 0 (so Claude's "press c"
-    # detection keeps working) but print a diagnostic to stderr.
+    # HOME at a non-directory → cannot create ~/.clipboard-bridge.
+    # Wrapper must still exit 0 and print a diagnostic to stderr.
     local notadir="$TMP_HOME/regular-file"
     printf 'x' > "$notadir"
     run bash -c "printf 'hello' | HOME='$notadir' bash '$OSC52'"

--- a/containers/claude-resources/statusline.sh
+++ b/containers/claude-resources/statusline.sh
@@ -1,15 +1,6 @@
 #!/bin/bash
-# Speedwave statusline for Claude Code — displays model, context usage,
-# rate limits, and cost. Reads JSON from stdin (Claude Code pipes
-# conversation state). Outputs a single line for the status bar.
-#
-# Security: no network calls, no token access, no credentials — safe for the
-# Speedwave container (cap_drop: ALL, no-new-privileges). Reads .git for
-# branch name only (no secrets in .git/HEAD).
-#
-# JSON parsing: regex-based, no jq dependency. Handles flat and 2-level
-# nested keys. Input is collapsed to a single line before extraction
-# to handle both minified and pretty-printed JSON from Claude Code.
+# Speedwave statusline for Claude Code — reads JSON state from stdin, outputs
+# a single status-bar line (model, context usage, rate limits, cost).
 
 set -f
 
@@ -26,9 +17,7 @@ WHITE='\033[37m'
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
-# build_bar <percent> → colored bar "██░░░" (5 chars)
-# Sets global BAR_COLOR for caller to reuse on percentage text.
-# Thresholds: <50% green, 50-75% yellow, 76-90% red, >90% bold red.
+# build_bar <percent> → colored bar "██░░░" (5 chars); sets global BAR_COLOR.
 BAR_COLOR=""
 build_bar() {
     local pct="$1"
@@ -76,15 +65,12 @@ if [ ! -t 0 ]; then
     INPUT="$(cat)"
 fi
 
-# Collapse to single line — makes regex extraction safe for both
-# minified and pretty-printed JSON. This is the key simplification:
-# instead of building a multi-line-aware parser, normalize the input.
+# Collapse to single line for regex extraction.
 INPUT="$(printf '%s' "$INPUT" | tr '\n' ' ')"
 
 # ── JSON extraction helpers ──────────────────────────────────────────────────
 
-# Safe JSON field extraction using regex — no jq dependency.
-# Works on single-line JSON (input is collapsed above).
+# JSON field extraction via regex, no jq — operates on single-line input.
 extract_json_string() {
     local json="$1" key="$2"
     local pattern="\"${key}\"[[:space:]]*:[[:space:]]*\""
@@ -110,9 +96,8 @@ extract_json_float() {
     fi
 }
 
-# extract_block "json" "key" → returns content between { and } for "key": { ... }
-# Limitation: handles 1 level of nesting only. Sufficient for rate_limits.five_hour
-# and cost objects. If Claude Code ever nests deeper, this needs revisiting.
+# extract_block "json" "key" → content between { and } for "key": { ... }
+# Handles 1 level of nesting only.
 extract_block() {
     local json="$1" key="$2"
     local pattern="\"${key}\"[[:space:]]*:[[:space:]]*\{"
@@ -143,9 +128,7 @@ used_pct_raw="$(extract_json_float "$INPUT" "used_percentage")"
 used_pct="${used_pct_raw%%.*}"
 used_pct="${used_pct:-0}"
 
-# Rate limits — detect presence of rate_limits key, then extract five_hour/seven_day
-# directly from INPUT. Extracting sub-blocks directly avoids the %%\}* limitation
-# (which would stop at the first } inside a nested object when extracting rl_block).
+# Rate limits — detect rate_limits key, then extract five_hour/seven_day from INPUT.
 has_rl_key=false
 rl_pattern='"rate_limits"[[:space:]]*:[[:space:]]*\{'
 if [[ "$INPUT" =~ $rl_pattern ]]; then
@@ -187,10 +170,8 @@ if [[ -z "$total_cost" ]]; then
 fi
 
 # ── Git branch ───────────────────────────────────────────────────────────────
-# Read current branch from workspace if it's a git repo. Graceful fallback:
-# no git, no repo, worktree, detached HEAD — all handled silently.
-# Skips the [ -d .git ] check: in git worktrees .git is a file, not a dir.
-# STATUSLINE_WORKSPACE_DIR allows tests to override the workspace path.
+# No [ -d .git ] check: in git worktrees .git is a file, not a dir.
+# STATUSLINE_WORKSPACE_DIR overrides the workspace path (tests).
 
 WORKSPACE="${STATUSLINE_WORKSPACE_DIR:-/workspace}"
 git_branch=""

--- a/containers/compose.template.yml
+++ b/containers/compose.template.yml
@@ -26,12 +26,7 @@ services:
       - CLAUDE_VERSION=${CLAUDE_VERSION}
       - MCP_HUB_PORT=${PORT_HUB}
       - CLAUDE_CODE_IDE_HOST_OVERRIDE=${IDE_HOST_OVERRIDE}
-      # Connect to the Speedwave IDE Bridge on start so the user does not have to
-      # run /ide and pick "Speedwave" by hand. The bridge lock file is always
-      # mounted at ~/.claude/ide; this var forces the attempt even though the
-      # container TTY is not a recognised IDE integrated terminal (the documented
-      # "auto-detection fails" case). Value is the string `true` (not 1) per the
-      # Claude Code env-vars reference.
+      # Auto-connect IDE bridge; value is literal `true` per Claude Code env-vars.
       - CLAUDE_CODE_AUTO_CONNECT_IDE=true
       - ANTHROPIC_LOG=debug
     working_dir: /workspace
@@ -43,24 +38,13 @@ services:
           cpus: '${CLAUDE_CPUS}'
           memory: ${CLAUDE_MEMORY}
 
-  # LiteLLM proxy (ADR-073): Claude Code's single LLM endpoint. Routes to the
-  # configured providers; subscription OAuth passes through /anthropic
-  # untouched. Worker-class token holder: per-provider API keys mount at
-  # /tokens:ro, never enter the claude container. No host port — reachable
-  # only on the per-project network. extra_hosts: local LLM backends on the
-  # host (Ollama/LM Studio/llama.cpp) are reached via host.docker.internal
-  # (ADR-062).
+  # LiteLLM proxy (ADR-073): Claude routes through here; tokens mount :ro per-provider (ADR-062).
   litellm:
     image: ${IMAGE_LITELLM}
     pull_policy: never
     container_name: ${COMPOSE_PREFIX}_${PROJECT_NAME}_litellm
     environment:
-      # Force /v1/chat/completions for OpenAI-compatible backends. The
-      # default Responses-API bridge bypasses llama-server's prompt cache
-      # (a ~20k-token Claude Code prompt reprocesses from scratch — ~50 s
-      # per turn on a Mac-class host) and ignores --chat-template-kwargs
-      # (re-enabling Qwen's silent thinking). Chat completions is the path
-      # validated in the ADR-073 spike.
+      # Use OpenAI-compatible /v1/chat/completions for local LLM backends (ADR-073).
       - LITELLM_USE_CHAT_COMPLETIONS_URL_FOR_ANTHROPIC_MESSAGES=true
       # Not read by litellm — forces container recreation on config-up
       # when the rendered config or a provider key changed.
@@ -160,10 +144,7 @@ services:
     tmpfs:
       - /tmp:noexec,nosuid,size=${MCP_SHAREPOINT_TMPFS}
     volumes:
-      # :ro per ADR-060 — OAuth token refresh moved to the host-side `oauth`
-      # worker. The SharePoint container only reads access_token / site_id /
-      # base_path; refresh writes happen on the host (oauth worker) which
-      # updates /tokens/access_token visible through this read-only mount.
+      # :ro per ADR-060 (OAuth refresh on host-side oauth worker); token writes flow through here.
       - ${TOKENS_DIR}/sharepoint:/tokens:ro
       - ${PROJECT_DIR}:/workspace:rw
     environment:
@@ -274,8 +255,7 @@ services:
           cpus: '${MCP_ATLASSIAN_CPUS}'
           memory: ${MCP_ATLASSIAN_MEM}
 
-  # Office documents worker — a pure file processor: no service credentials, no /tokens mount,
-  # and NO network egress (attached only to the internal ${NETWORK_NAME}_office network — see ADR-055).
+  # Office worker — pure file processor: no /tokens, no egress (internal ${NETWORK_NAME}_office, ADR-055).
   # Mounts the project workspace read-write; outputs land under /workspace/.speedwave/office/.
   mcp-office:
     image: ${IMAGE_MCP_OFFICE}
@@ -323,16 +303,10 @@ services:
       - ALL
     security_opt:
       - no-new-privileges:true
-    # Host gateway alias so Claude and plugins can navigate Playwright to
-    # local dev servers (e.g. `http://host.docker.internal:4200` for Angular).
-    # See ADR-062. The IP routing to the VM gateway already exists for every
-    # container in the project network; this extra_hosts entry only adds the
-    # canonical DNS name so callers don't need to know per-platform gateway IPs.
+    # Host gateway alias for dev servers (e.g. Angular on localhost:4200); see ADR-062.
     extra_hosts:
       - "host.docker.internal:${HOST_GATEWAY}"
     # Chromium uses /tmp for page caches and screenshot compositing.
-    # tmpfs lives in RAM — keep it lean. Heavy screenshots return inline
-    # as base64, not via /tmp.
     tmpfs:
       - /tmp:noexec,nosuid,size=${MCP_PLAYWRIGHT_TMPFS}
     # Chromium IPC shared-memory requirement; the 64 MiB default causes ENOMEM
@@ -342,9 +316,7 @@ services:
     # No /workspace mount in v1 — outputs return as base64 to shrink attack surface.
     environment:
       - PORT=${PORT_WORKER}
-      # MCP-level request/response logging (uses the `debug` npm package;
-      # output goes to stderr, visible in Desktop UI → System Health logs).
-      # Covers tools/call, tool responses, and errors. Set to `pw:*` for full verbosity.
+      # MCP request/response logging (debug npm package); set to `pw:*` for full verbosity.
       - DEBUG=pw:mcp:*
     networks:
       - ${NETWORK_NAME}

--- a/containers/entrypoint.sh
+++ b/containers/entrypoint.sh
@@ -24,19 +24,14 @@ if ! command -v claude &> /dev/null; then
     echo "Claude Code not found — installing via install-claude.sh (${CLAUDE_VERSION})..."
     /usr/local/bin/install-claude.sh "${CLAUDE_VERSION}"
 else
-    # Surface image/env version skew (stale image after an interrupted update).
-    # Not auto-repaired: launchers exec the absolute /usr/local/bin/claude on
-    # the read-only image layer, so only an image rebuild can fix it.
+    # Surface image/env version skew; not auto-repaired (needs image rebuild).
     installed_version="$(claude --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1 || true)"
     if [ -n "$installed_version" ] && [ "$installed_version" != "$CLAUDE_VERSION" ]; then
         echo "WARNING: image has Claude Code ${installed_version} but the pinned version is ${CLAUDE_VERSION} — run 'speedwave update' to rebuild the image" >&2
     fi
 fi
 
-# Ensure ~/.local/bin is in PATH for interactive shells (nerdctl exec runs bash).
-# Claude Code checks if ~/.local/bin/claude is in PATH and warns if not.
-# The real binary is baked into /usr/local/bin in the image layer (fast ext4).
-# The symlink at ~/.local/bin/claude points to it on the VirtioFS volume.
+# Symlink ~/.local/bin/claude → /usr/local/bin/claude so exec shells find it on PATH.
 if [ -x /usr/local/bin/claude ]; then
     mkdir -p "${HOME}/.local/bin"
     ln -sf /usr/local/bin/claude "${HOME}/.local/bin/claude"
@@ -50,10 +45,8 @@ fi
 # Ensure ~/.claude exists before symlinking anything
 mkdir -p "${HOME}/.claude"
 
-# Symlink claude-resources per-entry into real dirs. Core entries always-on;
-# integrations/<svc>/ gated by ENABLED_SERVICES. Links the script owns are
-# tracked in ~/.claude/.speedwave-managed-links so toggle-off cleans them up.
-# See ADR-022 for the design rationale.
+# Symlink claude-resources per-entry; integrations/<svc>/ gated by ENABLED_SERVICES.
+# Owned links tracked in ~/.claude/.speedwave-managed-links. See ADR-022.
 
 # Reverse migration: an older run may have left whole-directory symlinks.
 for resource_type in skills commands agents hooks; do
@@ -138,9 +131,8 @@ for resource_type in skills commands agents hooks; do
         echo "${link}" >> "${new_state}"
     done
 
-    # Integration-bound entries — only symlinked when their config_key is in ENABLED_SERVICES.
-    # `os` itself never has its own integration skill: only its sub-services (reminders,
-    # calendar, mail, notes), so we filter it out here and handle the sub-services below.
+    # Integration-bound entries — symlinked when config_key in ENABLED_SERVICES.
+    # `os` is filtered here; its sub-services are handled below.
     integrations_dir="${src_dir}/integrations"
     if [ -d "${integrations_dir}" ] && [ "${#ENABLED_SVCS[@]}" -gt 0 ]; then
         for svc in "${ENABLED_SVCS[@]}"; do
@@ -173,11 +165,8 @@ for resource_file in statusline.sh CLAUDE.md; do
     fi
 done
 
-# settings.json must be a WRITABLE copy, not a symlink: Claude Code writes it
-# (`/effort`, `/model` persist the choice) and the resources mount is read-only
-# (EROFS otherwise). Replace a stale symlink (older builds linked it).
-# Key-level merge: template keys missing from the on-disk file are added so new
-# Speedwave defaults reach existing users without overwriting their choices.
+# settings.json must be a WRITABLE copy, not a symlink (Claude Code writes it).
+# Replace a stale symlink, then key-merge template keys absent from the on-disk file.
 if [ -L "${HOME}/.claude/settings.json" ]; then
     rm -f "${HOME}/.claude/settings.json"
 fi
@@ -233,9 +222,8 @@ if [ -n "${SPEEDWAVE_PLUGINS:-}" ]; then
     done
 fi
 
-# Atomically replace the state file. Sorted+deduplicated so successive idempotent runs
-# produce byte-identical state files. On sort failure keep the previous state_file untouched
-# (the EXIT trap cleans up new_state).
+# Atomically replace the state file (sorted+deduplicated).
+# On sort failure the previous state_file is kept untouched.
 if sort -u "${new_state}" -o "${new_state}"; then
     mv "${new_state}" "${state_file}"
 else
@@ -259,9 +247,8 @@ cat > "${HOME}/.claude/mcp-config.json" << EOF
 }
 EOF
 
-# Pre-seed .claude.json: always pre-accept the /workspace trust dialog (keyed by
-# working_dir, separate from --dangerously-skip-permissions); set onboarding only
-# when logged in, else leave it incomplete so `claude` shows the OAuth flow.
+# Pre-seed .claude.json: pre-accept the /workspace trust dialog.
+# Set onboarding only when logged in, else leave it for the OAuth flow.
 creds_valid() {
     local f="${HOME}/.claude/.credentials.json"
     # Non-empty and ends with `}` (a complete JSON object, not a truncated write).
@@ -288,13 +275,7 @@ EOF
 fi
 
 
-# Wait for MCP hub to accept connections before Claude starts. Without this,
-# the first claude session hits `ConnectionRefused` on http://mcp-hub:4000
-# during compose-up race (claude container ready before hub), and runs with
-# zero tools — listFiles, search_tools, sharepoint.* all unavailable until
-# user opens a fresh chat. Hub typically responds within a second; bail
-# after ~30s so a broken hub doesn't lock the container forever.
-# Set `SPEEDWAVE_SKIP_HUB_WAIT=1` in tests or single-container runs.
+# Wait for MCP hub to accept connections before Claude starts; bail after ~30s.
 if [ -z "${SPEEDWAVE_SKIP_HUB_WAIT:-}" ]; then
     wait_for_hub() {
         local host="mcp-hub" port="${MCP_HUB_PORT}" attempts=30
@@ -318,9 +299,7 @@ touch "${CLAUDE_READY_MARKER:-/tmp/claude-ready}"
 if [ $# -gt 0 ]; then
     exec "$@"
 else
-    # PID1 must trap TERM — bare `sleep` ignores it and compose down waits
-    # 10s. Kill the background sleep too: an orphan would outlive the shell
-    # (and wedge the bats harness waiting on its output pipe).
+    # PID1 must trap TERM and kill the background sleep on exit.
     trap 'kill "$!" 2>/dev/null; exit 0' TERM INT
     while :; do sleep 86400 & wait $!; done
 fi

--- a/containers/install-claude.sh
+++ b/containers/install-claude.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-# Reusable Claude Code installer — SSOT for both Containerfile and entrypoint.sh.
-# Uses the official native installer (bootstrap.sh) which downloads the binary
-# from GCS and verifies its SHA256 against a version-pinned manifest.json.
+# Claude Code installer — SSOT for both Containerfile and entrypoint.sh.
 #
 # Usage: install-claude.sh <version>
 #   version: a semver like "2.1.76" (required, no default)
@@ -11,10 +9,7 @@ set -euo pipefail
 CLAUDE_VERSION="${1:?Usage: install-claude.sh <version>}"
 INSTALLER_URL="https://claude.ai/install.sh"
 
-# Use $HOME/.cache as temp dir to avoid /tmp:noexec issues at runtime.
-# At runtime the container mounts /tmp as tmpfs with noexec — the Claude installer
-# downloads binaries there and tries to exec them, which fails. $HOME is a writable
-# VirtioFS volume mount without noexec restrictions.
+# Temp dir under $HOME avoids the runtime /tmp:noexec mount the installer cannot exec from.
 INSTALL_TMPDIR="${HOME}/.cache/speedwave-install"
 mkdir -p "$INSTALL_TMPDIR"
 
@@ -24,6 +19,5 @@ trap 'rm -f "$INSTALLER_TMP"' EXIT
 curl --proto '=https' --tlsv1.2 -fsSL --connect-timeout 10 --max-time 30 \
     -o "$INSTALLER_TMP" "$INSTALLER_URL"
 
-# The official installer verifies the downloaded binary's SHA256 against
-# a version-pinned manifest.json from GCS. We trust this verification chain.
+# Installer verifies the binary's SHA256 against a version-pinned manifest.json.
 TMPDIR="$INSTALL_TMPDIR" bash "$INSTALLER_TMP" "$CLAUDE_VERSION"

--- a/containers/litellm/entrypoint.sh
+++ b/containers/litellm/entrypoint.sh
@@ -1,20 +1,7 @@
 #!/bin/sh
 # Entrypoint for the Speedwave LiteLLM proxy container.
-#
-# Exports per-provider API keys from the read-only /tokens mount as
-# SPW_KEY_<PROVIDER_ID> environment variables, then execs litellm.
-#
-# Token files are written by speedwave-runtime as
-# ~/.speedwave/tokens/<project>/llm/<provider_id>_api_key (0600) and mounted
-# at /tokens:ro. provider_id is slug-validated host-side
-# (^[a-z][a-z0-9-]{0,63}$); hyphens map to underscores in the env name,
-# mirroring derive_worker_env.
-#
-# INVARIANT (ADR-073): keys must NEVER be exported under canonical provider
-# names (ANTHROPIC_API_KEY, ANTHROPIC_AUTH_TOKEN, OPENAI_API_KEY, ...).
-# The /anthropic passthrough route forwards the client's Authorization header
-# (subscription OAuth) only while the proxy holds no Anthropic credential of
-# its own — a canonical name would silently override every passthrough call.
+# Exports /tokens/<provider_id>_api_key as SPW_KEY_<PROVIDER_ID>, then execs litellm.
+# INVARIANT (ADR-073): keys are NEVER exported under canonical provider names.
 set -eu
 
 TOKENS_DIR="${SPW_TOKENS_DIR:-/tokens}"
@@ -24,12 +11,8 @@ if [ -d "$TOKENS_DIR" ]; then
         [ -f "$token_file" ] || continue
         base="$(basename "$token_file")"
         provider_id="${base%_api_key}"
-        # Defense in depth: skip names that fail the host-side slug shape
-        # `^[a-z][a-z0-9-]{0,63}$` (also guards env-name injection). LC_ALL=C
-        # below because `case` ranges are locale-collated (would accept upper).
+        # Skip names that fail the host-side slug shape `^[a-z][a-z0-9-]{0,63}$`.
         [ -n "$provider_id" ] || continue
-        # First char must be [a-z] — the charset check below misses a leading
-        # digit/hyphen.
         case "$(printf '%s' "$provider_id" | cut -c1)" in
             [abcdefghijklmnopqrstuvwxyz]) ;;
             *) continue ;;

--- a/crates/speedwave-cli/src/main.rs
+++ b/crates/speedwave-cli/src/main.rs
@@ -21,19 +21,13 @@ fn sanitize_output_line(line: &str) -> String {
     speedwave_runtime::log_sanitizer::sanitize(line)
 }
 
-/// Redact secrets from an error before it is interpolated into user-facing
-/// output. Error chains from config/compose/OAuth handling can carry tokens;
-/// sanitizing at the interpolation site (not only in [`emit`]) keeps the
-/// diagnostic useful while guaranteeing no secret reaches the terminal.
+/// Redact secrets from an error before interpolating it into user-facing output.
 fn redact_err(e: &impl std::fmt::Display) -> String {
     sanitize_output_line(&e.to_string())
 }
 
-/// Single output sink. CLI user-facing output legitimately goes to
-/// stdout/stderr (per logging.md); routing every `out!`/`err!` through this
-/// one function localizes the print lint here instead of a crate-level allow.
-/// Every line passes through the `log_sanitizer` SSOT so a secret can never
-/// reach the terminal even if an upstream error string carries one.
+/// Single output sink for `out!`/`err!`; every line passes through the
+/// `log_sanitizer` SSOT before reaching the terminal.
 #[allow(clippy::print_stdout, clippy::print_stderr)]
 fn emit(to_stderr: bool, args: std::fmt::Arguments<'_>) {
     let line = sanitize_output_line(&args.to_string());
@@ -85,11 +79,8 @@ fn parse_project_flag(args: &[String], subcommand: &str) -> Result<String, Strin
 }
 
 /// Parses an optional `--project <value>` / `--project=<value>` flag from the
-/// argv tail that follows a subcommand. `tail` is the slice *after* the
-/// subcommand token (e.g. `args[2..]` for `login`, `args[1..]` for the leading
-/// bare-run form). The only accepted token is the project flag; any other
-/// token — a stray positional, an unknown flag, a second `--project` — is a
-/// hard error. Returns `Ok(None)` when the tail is empty.
+/// argv `tail` (slice after the subcommand token). Any other token is a hard
+/// error; returns `Ok(None)` when the tail is empty.
 fn parse_optional_project_tail(
     tail: &[String],
     subcommand: &str,
@@ -214,14 +205,8 @@ const REPO_NAME: &str = "speedwave";
 const UPDATE_CHECK_INTERVAL_SECS: u64 =
     speedwave_runtime::consts::UPDATE_CHECK_INTERVAL_HOURS as u64 * 3600;
 
-/// Returns true for actions that must run even when one or more
-/// installed plugins fail signature verification. Without these
-/// skips, `speedwave plugin remove <bad>` would refuse to run while
-/// `<bad>` is the plugin causing the failure — leaving the user with
-/// no recovery path other than manually editing `~/.speedwave/`.
-///
-/// Help and self-update are handled earlier in `main` and never reach
-/// the audit; they are intentionally not listed here.
+/// Returns true for actions that must run even when an installed plugin fails
+/// signature verification (recovery actions like `plugin remove`).
 fn skip_plugin_audit(action: &CliAction) -> bool {
     matches!(
         action,
@@ -334,14 +319,8 @@ fn maybe_print_update_hint() {
     });
 }
 
-/// Re-exec the given binary with `update` arg to rebuild container images.
-/// Must re-exec because the current process has a stale `bundle_id` compiled
-/// into `env!("CARGO_PKG_VERSION")` — only the new binary knows the correct
-/// image tags.
-///
-/// CWD is intentionally inherited from the caller. If the user runs
-/// `speedwave self-update` from a non-project directory, `update` will fail
-/// to resolve a project — the error message guides them to run it manually.
+/// Re-exec the new binary with `update` to rebuild container images with the
+/// correct image tags; CWD is inherited from the caller.
 fn run_rebuild(exe: &std::path::Path) -> anyhow::Result<()> {
     let status = std::process::Command::new(exe)
         .arg("update")
@@ -485,10 +464,8 @@ fn main() -> anyhow::Result<()> {
         })
         .init();
 
-    // If SPEEDWAVE_RESOURCES_DIR is not set, try reading the marker file written
-    // by the Desktop app (e.g. ~/.speedwave/resources-dir → "/usr/lib/Speedwave").
-    // This lets the CLI find bundled binaries (nerdctl, node) without inheriting
-    // the Desktop's environment.
+    // If SPEEDWAVE_RESOURCES_DIR is unset, read the marker file the Desktop app
+    // writes (e.g. ~/.speedwave/resources-dir → "/usr/lib/Speedwave").
     if std::env::var(consts::BUNDLE_RESOURCES_ENV).is_err() {
         let marker = consts::data_dir().join(consts::RESOURCES_MARKER);
         if let Ok(contents) = std::fs::read_to_string(&marker) {
@@ -507,14 +484,8 @@ fn main() -> anyhow::Result<()> {
         std::process::exit(1);
     });
 
-    // `--help` / `-h` / `help` must print usage without touching the runtime
-    // so users can discover commands when Desktop isn't running (or while
-    // troubleshooting a broken setup).
-    //
-    // NOTE: `main_handles_help_before_runtime_check` in the tests below
-    // asserts that the literal string `if action == CliAction::Help` appears
-    // before any `runtime_not_available()` call site inside `fn main()`. If
-    // you rename either identifier, update the test assertion too.
+    // `--help` must print usage without touching the runtime; ordering pinned
+    // by `main_handles_help_before_runtime_check`.
     if action == CliAction::Help {
         print_help();
         std::process::exit(0);
@@ -533,10 +504,7 @@ fn main() -> anyhow::Result<()> {
     // Non-blocking update hint (max once per day, cached)
     maybe_print_update_hint();
 
-    // Hard-fail on tampered plugins. Recovery actions (remove, list,
-    // install) and project setup (init) skip the audit so a user with
-    // a bad plugin can still use the CLI to recover. Help/self-update
-    // already exited above.
+    // Hard-fail on tampered plugins, except for recovery actions.
     if !skip_plugin_audit(&action) {
         if let Err(failures) = speedwave_runtime::plugin::audit_all() {
             err!("Plugin verification failed:");
@@ -610,9 +578,8 @@ fn main() -> anyhow::Result<()> {
         }
     }
 
-    // Handle `speedwave logout` — deletes Claude Code's credential files
-    // (~/.claude/.credentials.json and ~/.claude.json) from the per-project
-    // CLAUDE_HOME mount. No runtime needed.
+    // Handle `speedwave logout` — deletes Claude Code's credential files from
+    // the per-project CLAUDE_HOME mount; no runtime needed.
     if let CliAction::Logout(_) = action {
         let user_config = config::load_user_config().unwrap_or_else(|e| {
             err!("Failed to load config: {err}", err = redact_err(&e));
@@ -658,10 +625,7 @@ fn main() -> anyhow::Result<()> {
             std::process::exit(0);
         }
         CliAction::PluginList => {
-            // Tolerant listing: never fails, reports a verification status
-            // per plugin so the user can see *why* a plugin was rejected
-            // (this command intentionally skips the startup audit so it
-            // stays usable as a recovery/diagnostic path).
+            // Tolerant listing: never fails, reports verification status per plugin.
             let plugins = plugin::list_for_ui();
             if plugins.is_empty() {
                 out!("No plugins installed");
@@ -699,13 +663,8 @@ fn main() -> anyhow::Result<()> {
             service_id,
             project,
         } => {
-            // Enabling requires a *verified* plugin — the same gate the
-            // Desktop `set_plugin_enabled` command enforces. The
-            // startup audit already ran (PluginEnable is not in the
-            // skip-list), but a plugin tampered between two audit runs
-            // must still be rejected here. `list_for_ui` is tolerant
-            // (other unverified plugins don't block the lookup) and
-            // exposes `verification_status` per entry.
+            // Enabling requires a verified plugin — same gate as the Desktop
+            // `set_plugin_enabled` command.
             let entries = plugin::list_for_ui();
             let entry = entries
                 .iter()
@@ -755,9 +714,8 @@ fn main() -> anyhow::Result<()> {
             service_id,
             project,
         } => {
-            // Disabling does NOT require verification — the user must
-            // always be able to turn off a bad plugin. Use the tolerant
-            // lister so an unverified plugin elsewhere doesn't block it.
+            // Disabling does NOT require verification — a bad plugin must
+            // always be turn-off-able. `list_for_ui` is tolerant.
             let entries = plugin::list_for_ui();
             let entry = entries
                 .iter()
@@ -804,9 +762,8 @@ fn main() -> anyhow::Result<()> {
         runtime_not_available();
     }
 
-    // Align the in-distro nerdctl to the pin (Windows; no-op elsewhere) —
-    // CLI-only users must not stay on a version with divergent compose-up
-    // semantics. Warn-only and Once-guarded inside.
+    // Align in-distro nerdctl to the pin (Windows; no-op elsewhere). Warn-only,
+    // Once-guarded inside.
     speedwave_runtime::provision::ensure_nerdctl_version();
 
     // Load config once — used for both project resolution and compose rendering
@@ -820,10 +777,8 @@ fn main() -> anyhow::Result<()> {
     // Validate project name is safe for container naming
     validate_project_name(&project_name).map_err(|e| anyhow::anyhow!(e))?;
 
-    // Project dir comes from config (authoritative). resolve_action_project
-    // already rejected an explicit `--project` naming a missing project; an
-    // unresolved name here means a stale active/first entry, which we reject
-    // with a clear error rather than silently mounting the working directory.
+    // Project dir comes from config (authoritative); an unresolved name is a
+    // hard error, never a working-directory fallback.
     let project_dir = user_config
         .find_project(&project_name)
         .map(|p| std::path::PathBuf::from(&p.dir))
@@ -842,34 +797,20 @@ fn main() -> anyhow::Result<()> {
     let (resolved, integrations) =
         config::resolve_project_config(&project_dir, &user_config, &project_name);
 
-    // Sanitise any v1 SharePoint secrets still sitting in the worker-mounted
-    // token dir (refresh_token / client_id / tenant_id). Idempotent — no-op
-    // when no project has the legacy layout. Secrets are never migrated.
+    // Sanitise v1 SharePoint secrets from the worker-mounted token dir.
+    // Idempotent; secrets are never migrated.
     let cleaned = speedwave_runtime::legacy_token_cleanup::run_legacy_token_cleanup_at_startup();
     if cleaned > 0 {
         log::info!("legacy_token_cleanup: {cleaned} project(s) sanitised");
     }
 
-    // Self-heal legacy/partial oauth.json whose clientId/tenantId sit top-level
-    // instead of under providerData (ADR-060 addendum). Shape-only, idempotent.
-    // It logs its own summary; do not re-log the return value (CodeQL taints it).
+    // Self-heal legacy/partial oauth.json shape (ADR-060 addendum); idempotent.
+    // Do not re-log the return value (CodeQL taints it).
     let _ = speedwave_runtime::oauth_state_migration::run_oauth_state_migration_at_startup();
 
-    // Host workers (oauth, mcp-os) are owned by the Desktop app. The CLI must
-    // NOT spawn its own — two supervisors for one worker kill each other's
-    // process via `kill_stale_node`, cycling every ~20s and crashing the
-    // interactive Claude exec (exit 137). render_compose reads the Desktop-held
-    // `lock.json` + bearer-map from disk, so no CLI-side spawn is needed.
-    //
-    // NOTE: the availability gate above checks the VM/engine is Running, NOT
-    // that the Desktop *process* is alive — the Lima VM outlives a Desktop quit
-    // on the orphaned path. If Desktop was hard-killed (kill -9/crash) while the
-    // VM lingers, the oauth worker (a Desktop child) is dead and nothing
-    // respawns it, so SharePoint OAuth refresh silently stops for this session.
-    // A clean Desktop quit stops the VM, so the gate then correctly refuses.
-    // Reconstruct host-bridge registrations from disk (ADR-074) so a
-    // terminal-launched worker reaches the Desktop-hosted bridge; without a
-    // minted token the worker degrades to BRIDGE_NOT_CONFIGURED.
+    // Host workers (oauth, mcp-os) are Desktop-owned; the CLI must NOT spawn its
+    // own. render_compose reads the Desktop-held lock + bearer-map from disk.
+    // Reconstruct host-bridge registrations from disk (ADR-074).
     let host_bridges = compose::host_bridges_from_disk();
 
     let compose_yml = compose::render_compose(
@@ -964,10 +905,7 @@ fn main() -> anyhow::Result<()> {
         std::process::exit(1);
     }
 
-    // Save compose file and start containers.
-    // Build missing images first (outside the compose lock, ADR-066) —
-    // pull_policy:never would fail a CLI run made after an app update but
-    // before Desktop reconciles (ADR-072).
+    // Build missing images before compose-up, outside the compose lock (ADR-066).
     let bundle_manifest = speedwave_runtime::bundle::load_current_bundle_manifest()?;
     let enabled_imgs = speedwave_runtime::build::enabled_images(&integrations);
     let prior_state = speedwave_runtime::bundle::load_bundle_state();
@@ -979,8 +917,7 @@ fn main() -> anyhow::Result<()> {
     .map_err(|e| anyhow::anyhow!("container image build failed: {}", redact_err(&e)))?;
     if built > 0 {
         out!("Built {built} container image(s) for this app version");
-        // Prune superseded tags — warn-only, Desktop reconcile is the authoritative GC
-        // path but CLI-only users would otherwise leak one tag generation per update.
+        // Prune superseded tags (warn-only) so CLI-only users don't leak a tag generation.
         speedwave_runtime::build::prune_superseded_images(
             &runtime,
             &prior_state.applied_image_hashes,
@@ -992,12 +929,9 @@ fn main() -> anyhow::Result<()> {
     plugin::ensure_plugin_images(&runtime, &enabled_plugin_ids)
         .map_err(|e| anyhow::anyhow!("plugin image build failed: {}", redact_err(&e)))?;
 
-    // compose_up is idempotent (no --force-recreate) — nerdctl
-    // recreates containers whose config changed. Skip the expensive compose_ps
-    // call over SSH; just call compose_up unconditionally and let the engine
-    // decide what needs recreating. Wrapped in a per-project transaction so a
-    // concurrent Desktop process restarting the same project cannot overwrite
-    // compose.yml between save and up (see ADR-066).
+    // compose_up is idempotent (no --force-recreate). Wrapped in a per-project
+    // transaction so a concurrent Desktop process can't overwrite compose.yml
+    // between save and up (ADR-066).
     runtime.transaction(&project_name, |runtime| -> anyhow::Result<()> {
         compose::save_compose(&project_name, &compose_yml)?;
         speedwave_runtime::runtime::compose_validate_with_retry(runtime, &project_name)?;
@@ -1010,10 +944,8 @@ fn main() -> anyhow::Result<()> {
     let container_name = format!("{}_{}_claude", consts::compose_prefix(), project_name);
     ensure_exec_healthy(&runtime, &project_name, &container_name)?;
 
-    // Handle `speedwave login` — runs `claude` interactively with the same
-    // resolved flags as a normal start (--dangerously-skip-permissions etc.).
-    // User types /login; Claude writes ~/.claude/.credentials.json to the
-    // per-project CLAUDE_HOME mount. Speedwave persists nothing itself.
+    // Handle `speedwave login` — runs `claude` interactively with the resolved
+    // flags. The user types /login; Claude writes credentials to the mount.
     if let CliAction::Login(_) = action {
         err!("Starting Claude Code. Type /login at the prompt, then /quit when done.");
         let mut exec_cmd: Vec<&str> = vec![consts::CLAUDE_BINARY];
@@ -1042,18 +974,14 @@ fn main() -> anyhow::Result<()> {
     if is_oom {
         err!("{}", speedwave_runtime::resources::OOM_MESSAGE);
     }
-    // Normalize: when OOM is detected via signal()==Some(9) (Linux),
-    // code() returns None. Return 137 for consistency with macOS
-    // (where nerdctl translates SIGKILL → exit code 137).
+    // Normalize OOM-via-SIGKILL (code()==None on Linux) to 137 for macOS parity.
     let code = status.code().unwrap_or(if is_oom { 137 } else { 1 });
     std::process::exit(code);
 }
 
 /// Picks the project an action operates on. An explicit `--project` override
-/// on `run`/`login`/`logout`/`update` wins and must name a real project
-/// (`require_project`); otherwise the active project (Desktop selector) is
-/// used, then the first configured project. The working directory is never
-/// consulted.
+/// wins and must name a real project; otherwise falls back to the active then
+/// first configured project. The working directory is never consulted.
 fn resolve_action_project(
     action: &CliAction,
     user_config: &config::SpeedwaveUserConfig,
@@ -1063,9 +991,7 @@ fn resolve_action_project(
         | CliAction::Login(Some(name))
         | CliAction::Logout(Some(name))
         | CliAction::Update(Some(name)) => {
-            // An explicit `--project` must name a real project. Without this
-            // guard a typo'd name passes syntactic validation and main()
-            // silently mounts the working directory instead (defect #6).
+            // An explicit `--project` must name a real project.
             user_config.require_project(name)?;
             Ok(name.clone())
         }
@@ -1073,11 +999,9 @@ fn resolve_action_project(
     }
 }
 
-/// Resolves the project to act on when no explicit `--project` was given.
-/// The active project (set by the Desktop selector) is authoritative; the
-/// first configured project is the fallback when none is active. The working
-/// directory is intentionally NOT consulted — the selector is the single
-/// source of truth.
+/// Resolves the project when no explicit `--project` was given: the active
+/// project is authoritative, else the first configured project. The working
+/// directory is never consulted.
 fn resolve_project_fallback(user_config: &config::SpeedwaveUserConfig) -> anyhow::Result<String> {
     user_config
         .active_project
@@ -1183,10 +1107,7 @@ mod tests {
         assert_eq!(parse_action(&args).unwrap(), CliAction::Help);
     }
 
-    /// Regression guard: the Help action must be reachable without touching
-    /// the runtime. If the main() ordering ever changes so that runtime
-    /// detection runs before Help is handled, users lose `--help` whenever
-    /// Desktop isn't running — defeating the purpose of the flag.
+    /// Regression guard: `main()` must handle Help before any runtime check.
     #[test]
     fn main_handles_help_before_runtime_check() {
         let source = include_str!("main.rs");
@@ -1384,9 +1305,7 @@ mod tests {
 
     #[test]
     fn parse_action_leading_flag_before_subcommand_errors() {
-        // Defect #1: `speedwave --project acme login` must NOT silently run
-        // acme and drop `login`. The leading `--project acme` is consumed as
-        // the bare-run override, then `login` is trailing garbage → error.
+        // `speedwave --project acme login` must error: `login` is trailing garbage.
         let args = argv(&["speedwave", "--project", "acme", "login"]);
         let err = parse_action(&args).unwrap_err();
         assert!(
@@ -1527,10 +1446,7 @@ mod tests {
 
     #[test]
     fn print_help_lists_login_and_logout() {
-        // Source-level check: `include_str!` embeds main.rs at compile time,
-        // then we assert at runtime that the `print_help` body mentions both
-        // subcommands. Avoids subprocess-based stdout capture while keeping
-        // user-facing help in sync with the CliAction variants.
+        // Source-level check that the `print_help` body documents both subcommands.
         let source = include_str!("main.rs");
         let help_start = source
             .find("fn print_help() {")
@@ -1558,10 +1474,8 @@ mod tests {
 
     #[test]
     fn oauth_state_migration_runs_after_cleanup_and_before_render() {
-        // Structural guard (ADR-060 addendum): the providerData self-heal must run
-        // after legacy_token_cleanup (both are best-effort startup sanitation) and
-        // before render_compose reads the oauth lock/bearer-map, so render never
-        // sees a pre-migration (malformed) oauth.json.
+        // Structural guard (ADR-060 addendum): self-heal must run after
+        // legacy_token_cleanup and before render_compose.
         let source = include_str!("main.rs");
         let cleanup_idx = source
             .find("run_legacy_token_cleanup_at_startup()")
@@ -1955,9 +1869,8 @@ mod tests {
 
     #[test]
     fn test_check_includes_os_prereqs() {
-        // Structural test: verify that `speedwave check` calls
-        // os_prereqs::check_os_prereqs() BEFORE SecurityCheck::run,
-        // and that prereq violations are printed in the expected format.
+        // Structural test: `speedwave check` runs prereqs before SecurityCheck
+        // and prints violations in the expected format.
         let source = include_str!("main.rs");
 
         // Locate the check subcommand handler
@@ -1995,10 +1908,8 @@ mod tests {
 
     #[test]
     fn test_check_does_not_autofix_permissions() {
-        // Structural test: `speedwave check` must NOT call ensure_data_dir_permissions.
-        // Check is diagnostic-only — it reports violations without fixing them.
-        // Behavioral coverage: see
-        // fs_security::tests::test_ensure_roundtrip_fixes_then_check_passes
+        // `speedwave check` is diagnostic-only: must NOT call ensure_data_dir_permissions.
+        // Behavioral coverage: fs_security::tests::test_ensure_roundtrip_fixes_then_check_passes
         let source = include_str!("main.rs");
         let check_start = source
             .find("if action == CliAction::Check")
@@ -2048,15 +1959,11 @@ mod tests {
     }
 
     // ── plugin audit skip-list ────────────────────────────────────────────
-    // Pin which actions run with a tampered plugin on disk: a regression
-    // either way (extra runtime action skipped, or recovery action gated)
-    // is silent without these.
+    // Pin which actions run with a tampered plugin on disk.
 
     #[test]
     fn skip_plugin_audit_skips_recovery_actions() {
-        // These actions MUST run even when another plugin fails audit,
-        // otherwise a user with a bad plugin has no way to fix it from
-        // the CLI.
+        // Recovery actions must run even when another plugin fails audit.
         assert!(skip_plugin_audit(&CliAction::Init(None)));
         assert!(skip_plugin_audit(&CliAction::Init(Some("foo".into()))));
         assert!(skip_plugin_audit(&CliAction::PluginInstall(
@@ -2068,10 +1975,7 @@ mod tests {
 
     #[test]
     fn skip_plugin_audit_does_not_skip_runtime_actions() {
-        // These actions touch the runtime / config in ways that depend
-        // on every installed plugin being trusted. The audit must
-        // gate them — a regression that flips any of these to `true`
-        // silently disables the runtime-invariant promise.
+        // Runtime/config actions must be gated by the audit.
         assert!(!skip_plugin_audit(&CliAction::Run(None)));
         assert!(!skip_plugin_audit(&CliAction::Check));
         assert!(!skip_plugin_audit(&CliAction::Update(None)));
@@ -2088,9 +1992,7 @@ mod tests {
     // ── self-update rebuild structural tests ─────────────────────────────
 
     /// Extract the body of a top-level function from source, stopping at the
-    /// next top-level `fn ` definition. This prevents structural tests from
-    /// accidentally matching strings in test code that appears later in the
-    /// file.
+    /// next top-level `fn ` definition.
     fn extract_fn_body<'a>(source: &'a str, signature: &str) -> &'a str {
         let fn_start = source
             .find(signature)
@@ -2124,9 +2026,7 @@ mod tests {
             !fn_body[..render_pos].contains(&empty_default),
             "main() must not pass an empty HostBridgesInfo to render_compose"
         );
-        // The default-needle check only scans before the call; also assert the
-        // call site actually receives &host_bridges as its argument (guards a
-        // refactor that passes a default *inside* the render_compose(...) args).
+        // Assert the call site receives &host_bridges (not an inline default).
         let call = &fn_body[render_pos..];
         let call_end = call
             .find(';')
@@ -2139,12 +2039,8 @@ mod tests {
 
     #[test]
     fn test_self_update_captures_exe_before_update() {
-        // Structural test: verify that run_self_update() captures current_exe()
-        // BEFORE calling .update(), and calls run_rebuild inside the
-        // status.updated() branch. On Linux, current_exe() after self-replace
-        // returns a dead /proc/self/exe path, so capture must come first.
-        // This test intentionally checks source structure — update it if
-        // the function or its callees are renamed.
+        // Structural test: run_self_update() captures current_exe() BEFORE
+        // .update() and calls run_rebuild inside the status.updated() branch.
         let source = include_str!("main.rs");
         let fn_body = extract_fn_body(source, "fn run_self_update(");
 
@@ -2171,11 +2067,8 @@ mod tests {
 
     #[test]
     fn test_self_update_does_not_propagate_rebuild_error() {
-        // The rebuild error must NOT propagate via `?` because the caller
-        // prints "Self-update failed: ..." which is misleading after a
-        // successful binary replacement. Verify `if let Err` pattern is used.
-        // This test intentionally checks source structure — update it if
-        // the error handling pattern changes.
+        // The rebuild error must NOT propagate via `?` (the caller's
+        // "Self-update failed" message would be misleading); verify `if let Err`.
         let source = include_str!("main.rs");
         let fn_body = extract_fn_body(source, "fn run_self_update(");
 
@@ -2187,9 +2080,8 @@ mod tests {
 
     #[test]
     fn test_run_rebuild_clears_resources_env() {
-        // The subprocess must NOT inherit SPEEDWAVE_RESOURCES_DIR from the
-        // parent, so it reads the fresh marker file instead of a stale value.
-        // This test intentionally checks source structure.
+        // The subprocess must NOT inherit SPEEDWAVE_RESOURCES_DIR so it reads
+        // the fresh marker file instead of a stale value.
         let source = include_str!("main.rs");
         let fn_body = extract_fn_body(source, "fn run_rebuild(");
 
@@ -2201,9 +2093,8 @@ mod tests {
 
     #[test]
     fn test_self_update_rebuild_only_when_updated() {
-        // run_rebuild must be called inside the `status.updated()` branch,
-        // not unconditionally. Verify it appears between the updated check
-        // and the "Already up to date" branch.
+        // run_rebuild must appear between the `status.updated()` check and the
+        // "Already up to date" branch, not unconditionally.
         let source = include_str!("main.rs");
         let fn_body = extract_fn_body(source, "fn run_self_update(");
 
@@ -2260,10 +2151,8 @@ mod tests {
         assert!(msg.contains("Failed to run"), "unexpected error: {msg}");
     }
 
-    // No Windows equivalent of run_rebuild_failing_command: /usr/bin/false
-    // ignores args, but Windows has no built-in that exits non-zero when
-    // given an arbitrary argument. The nonexistent-binary test covers the
-    // Windows error path.
+    // No Windows equivalent of run_rebuild_failing_command; the
+    // nonexistent-binary test covers the Windows error path.
 
     #[test]
     fn emit_output_line_redacts_secrets() {

--- a/crates/speedwave-cli/src/paste_watcher.rs
+++ b/crates/speedwave-cli/src/paste_watcher.rs
@@ -1,9 +1,4 @@
 //! Host-side clipboard watcher for CLI paste (ADR-065).
-//!
-//! Polls `arboard` every 250 ms; when an image change is detected, encodes
-//! PNG and atomically replaces `<project_dir>/.speedwave/pastes/clip.png`.
-//! Claude Code TUI's `xclip -t image/png -o` (proxied by `osc52-copy.sh`)
-//! reads that file.
 
 use anyhow::{Context, Result};
 use arboard::Clipboard;

--- a/crates/speedwave-runtime/src/binary.rs
+++ b/crates/speedwave-runtime/src/binary.rs
@@ -14,10 +14,8 @@ const PATH_SEP: char = ';';
 #[cfg(not(windows))]
 const PATH_SEP: char = ':';
 
-/// Windows OS commands that are never bundled, so the "falling back to system
-/// PATH" debug log is noise for them (`wsl.exe` is called on every health poll).
-/// Windows-only on purpose: on macOS resolving one of these is a real misconfig
-/// worth logging, so suppression must not apply there.
+/// Windows OS commands that are never bundled; the fallback-to-PATH debug log
+/// is suppressed for them.
 #[cfg(windows)]
 const ALWAYS_SYSTEM_COMMANDS: &[&str] = &["wsl.exe", "powershell.exe", "cmd.exe"];
 
@@ -35,21 +33,13 @@ fn is_always_system_command(cmd: &str) -> bool {
         .any(|c| c.eq_ignore_ascii_case(name))
 }
 
-/// Resolves the path to a binary command.
-///
-/// Lima (macOS), Node.js, and the native macOS CLI helpers (`reminders-cli`,
-/// `audio-capture-cli`, …) are bundled in the app resources directory. WSL2
-/// uses the nerdctl bundle installed inside the distro, not on the host.
+/// Resolves the path to a binary command via bundled resources or system PATH.
 ///
 /// Resolution order (each step only if `SPEEDWAVE_RESOURCES_DIR` is set):
 /// 1. `<dir>/lima/bin/<cmd>` (macOS Lima bundle).
-/// 2. `<dir>/nerdctl-full/bin/<cmd>` — reserved for any future host-side
-///    nerdctl-full bundle layout; not currently populated in production
-///    (kept so `command()` can set CNI_PATH + PATH for callers that *do*
-///    drop a nerdctl tree under `Resources/`, e.g. in tests).
+/// 2. `<dir>/nerdctl-full/bin/<cmd>` (reserved layout, not populated in prod).
 /// 3. `<dir>/nodejs/bin/<cmd>` (Unix) or `<dir>/nodejs/<cmd>.exe` (Windows).
-/// 4. `<dir>/<cmd>` — native CLI helpers placed at the top of `Resources/`
-///    (matches `tauri.macos.conf.json` `bundle.resources`).
+/// 4. `<dir>/<cmd>` (native CLI helpers at the top of `Resources/`).
 /// 5. Otherwise the bare command name (system PATH lookup).
 pub fn resolve_binary(cmd: &str) -> String {
     if let Ok(resources_dir) = std::env::var(BUNDLE_RESOURCES_ENV) {
@@ -86,8 +76,7 @@ pub fn resolve_binary(cmd: &str) -> String {
             }
         }
 
-        // Native CLI helpers (reminders-cli, audio-capture-cli, …) live at the
-        // top of Resources/ per tauri.macos.conf.json `bundle.resources`.
+        // Native CLI helpers live at the top of Resources/ per tauri.macos.conf.json.
         let top_level = resources.join(cmd);
         if top_level.exists() {
             return top_level.to_string_lossy().to_string();
@@ -107,28 +96,19 @@ pub fn resolve_binary(cmd: &str) -> String {
     cmd.to_string()
 }
 
-/// Windows process creation flag that prevents a visible console window from
-/// being allocated for child processes. Applied to all background subprocesses
-/// so that `wsl.exe`, `powershell.exe`, `node.exe`, etc. do not flash a black
-/// console window over the Desktop app's UI.
-///
-/// **Warning:** `Command::creation_flags()` is a setter, not OR. Calling it
-/// twice replaces the previous value. If you need additional flags, OR them
-/// with this constant.
+/// Windows process creation flag preventing a visible console window on child
+/// processes. `Command::creation_flags()` is a setter, not OR — apply once.
 #[cfg(target_os = "windows")]
 const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
 /// Creates a `Command` for the given binary with bundled-binary resolution.
 ///
-/// - Applies `CREATE_NO_WINDOW` on Windows to prevent console window flashing.
+/// - Applies `CREATE_NO_WINDOW` on Windows.
 /// - For `limactl`, sets `LIMA_HOME` to the isolated Speedwave directory.
-/// - For bundled binaries, prepends their parent directory to `PATH` so that
-///   child processes (e.g. `buildctl` spawned by `nerdctl build`) can find
-///   sibling binaries in the same bundle.
+/// - For bundled binaries, prepends their parent directory to `PATH`.
 ///
-/// **Note:** `container_exec()` methods intentionally bypass this function
-/// and use raw `Command::new()` because interactive TTY sessions need a
-/// console window on Windows.
+/// `container_exec()` bypasses this and uses raw `Command::new()` (TTY needs a
+/// console window on Windows).
 pub fn command(cmd: &str) -> Command {
     let resolved = resolve_binary(cmd);
     let mut command = Command::new(&resolved);
@@ -139,8 +119,7 @@ pub fn command(cmd: &str) -> Command {
         command.creation_flags(CREATE_NO_WINDOW);
     }
 
-    // If the resolved path is absolute (= bundled), prepend its parent dir to PATH
-    // and set CNI_PATH for nerdctl-full bundles (CNI plugins live in libexec/cni/).
+    // For bundled (absolute) paths, prepend parent dir to PATH and set CNI_PATH.
     let resolved_path = std::path::Path::new(&resolved);
     if resolved_path.is_absolute() {
         if let Some(bin_dir) = resolved_path.parent() {
@@ -154,8 +133,6 @@ pub fn command(cmd: &str) -> Command {
             }
 
             // nerdctl-full bundles CNI plugins in <bundle>/libexec/cni/.
-            // Without CNI_PATH, nerdctl defaults to /opt/cni/bin which doesn't
-            // exist on systems where nerdctl-full is installed as a .deb resource.
             if let Some(bundle_root) = bin_dir.parent() {
                 let cni_dir = bundle_root.join("libexec").join("cni");
                 if cni_dir.is_dir() {
@@ -204,12 +181,9 @@ pub fn system_command(program: &str) -> Command {
     command
 }
 
-/// Runs a command with a timeout. Kills the process if it exceeds the deadline.
-/// Polls `child.try_wait()` every 200ms. On timeout, kills the child process
-/// (logging a warning if kill fails) and bails with a descriptive error.
-///
-/// Does not capture stdout/stderr — output goes to the parent's streams.
-/// Do not use with `Stdio::piped()` as that risks pipe-buffer deadlock.
+/// Runs a command with a timeout, killing the process if it exceeds the deadline.
+/// Polls `child.try_wait()` every 200ms; does not capture stdout/stderr.
+/// Do not use with `Stdio::piped()` (pipe-buffer deadlock risk).
 pub fn run_with_timeout(
     cmd: &mut std::process::Command,
     timeout: std::time::Duration,
@@ -238,15 +212,14 @@ pub fn run_with_timeout(
     }
 }
 
-/// Returns the isolated LIMA_HOME directory: `~/.speedwave/lima`.
-///
-/// Speedwave uses a dedicated LIMA_HOME so that its VM data does not collide
-/// with a user-installed Lima (`~/.lima`).
+/// Returns the isolated LIMA_HOME directory `~/.speedwave/lima` (avoids
+/// collision with a user-installed Lima at `~/.lima`).
 pub fn lima_home() -> Option<PathBuf> {
     Some(consts::data_dir().join(consts::LIMA_SUBDIR))
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 pub(crate) mod tests {
     use super::*;
     use std::env;
@@ -300,8 +273,7 @@ pub(crate) mod tests {
         env::remove_var(BUNDLE_RESOURCES_ENV);
     }
 
-    // Never-bundled OS commands are recognised (case-insensitive) so the
-    // fallback debug log is suppressed; everything else still logs. Windows-only.
+    // Never-bundled OS commands are recognised case-insensitively (Windows-only).
     #[cfg(windows)]
     #[test]
     fn always_system_commands_recognised() {
@@ -331,10 +303,7 @@ pub(crate) mod tests {
 
     #[test]
     fn resolve_binary_top_level_native_cli_helper() {
-        // Native CLIs (audio-capture-cli, reminders-cli, …) sit at the top of
-        // Resources/, not under lima/nerdctl-full/nodejs — resolve_binary must
-        // find them there (regression: the audio-capture backend resolves its
-        // CLI via this path in a packaged app).
+        // Native CLIs sit at the top of Resources/, not under lima/nerdctl-full/nodejs.
         let _guard = ENV_LOCK.lock().unwrap();
         let tmp = tempfile::tempdir().expect("tempdir");
         let cli_path = tmp.path().join("audio-capture-cli");
@@ -429,10 +398,7 @@ pub(crate) mod tests {
 
     #[test]
     fn lima_home_returns_expected_path() {
-        // Assert the structural invariant (`<data_dir>/lima`) without naming the
-        // production `data_dir()` singleton: the final component is LIMA_SUBDIR
-        // and a non-empty data-dir parent precedes it. Holds under any isolated
-        // tempdir data dir, and is separator-agnostic (Path tail, not string).
+        // Structural invariant `<data_dir>/lima`, separator-agnostic (Path tail).
         let path = lima_home().expect("lima_home should resolve");
         assert!(
             path.ends_with(consts::LIMA_SUBDIR),
@@ -461,10 +427,7 @@ pub(crate) mod tests {
             .expect("LIMA_HOME env should be set for limactl");
 
         let value = lima_home_env.1.expect("LIMA_HOME should have a value");
-        // Structural invariant only (`<data_dir>/lima`), tempdir-safe — no bare
-        // `data_dir()` resolution. `command("limactl")` creates the dir, so the
-        // value is the canonicalized LIMA_HOME; checking the tail is portable
-        // and separator-agnostic (Path tail, not string).
+        // Structural invariant `<data_dir>/lima`, separator-agnostic (Path tail).
         let value_path = std::path::Path::new(value);
         assert!(
             value_path.ends_with(consts::LIMA_SUBDIR),

--- a/crates/speedwave-runtime/src/build.rs
+++ b/crates/speedwave-runtime/src/build.rs
@@ -24,9 +24,6 @@ pub struct ImageDef {
 /// config key (`speedwave-mcp-slack` ↔ `slack`). Same naming rule as compose names.
 const MCP_IMAGE_PREFIX: &str = "speedwave-mcp-";
 
-/// SSOT for all container images — used by both Desktop (setup wizard) and the update flow.
-///
-/// All paths are relative to the build root returned by `resolve_build_root()`.
 /// Build args for the Claude container — passes the pinned version to Containerfile.claude.
 const CLAUDE_BUILD_ARGS: &[(&str, &str)] = &[("CLAUDE_VERSION", crate::defaults::CLAUDE_VERSION)];
 
@@ -62,8 +59,7 @@ pub const IMAGES: &[ImageDef] = &[
         context_dir: "containers",
         containerfile: "containers/Containerfile.claude",
         build_args: CLAUDE_BUILD_ARGS,
-        // Explicit file list: containers/ also holds claude-resources/ (synced +
-        // mounted, never baked) and compose.template.yml — neither may rebuild claude.
+        // Explicit file list: containers/ also holds non-baked assets that must not rebuild claude.
         hash_inputs: &[
             "containers/Containerfile.claude",
             "containers/entrypoint.sh",
@@ -222,8 +218,6 @@ const DEFAULT_BUILD_WORKER_FALLBACK: usize = 4;
 const TRANSIENT_BUILD_RETRIES: u32 = 2;
 
 /// Base wait before the first transient retry; the Nth retry waits `BASE * N`.
-/// Sized so the VM's `systemd-resolved` has time to fall back from EDNS0 to plain
-/// UDP, while two attempts (3s + 6s) don't noticeably stall a genuinely-down network.
 /// Near-zero under `cfg(test)` so retry-path tests don't actually sleep.
 #[cfg(not(test))]
 const TRANSIENT_BUILD_RETRY_BASE_DELAY: std::time::Duration = std::time::Duration::from_secs(3);
@@ -257,11 +251,9 @@ where
     crate::runtime::compose_locks::with_file_lock_in(&BUILD_LOCK, &data_dir.join("build.lock"), f)
 }
 
-/// `true` if every image that should exist for `integrations` is present —
-/// only [`enabled_images`], since disabled integrations have no image under
-/// lazy builds. Pass the union across projects when reconciling. Call
-/// `rt.ensure_ready()` first; do not guard with `is_available()` (a stopped
-/// VM is false there but `ensure_ready()` starts it).
+/// `true` if every [`enabled_images`] image for `integrations` is present.
+/// Pass the union across projects when reconciling. Call `rt.ensure_ready()`
+/// first; do not guard with `is_available()`.
 pub fn images_exist(
     rt: &super::runtime::LockedRuntime,
     integrations: &ResolvedIntegrationsConfig,
@@ -298,10 +290,6 @@ pub fn images_exist_with_manifest(
 /// 1. `SPEEDWAVE_RESOURCES_DIR` env var → `<dir>/build-context/` (production — Tauri sets this)
 /// 2. `CARGO_MANIFEST_DIR` parent chain (baked at compile time — dev source tree)
 /// 3. `~/.speedwave/resources-dir` marker file → `<dir>/build-context/` (CLI reads Desktop's marker)
-///
-/// Step 2 before 3 ensures `make dev` uses local sources instead of a stale
-/// bundle path written by the installed app — same rationale as
-/// `resolve_mcp_os_script_inner`.
 pub fn resolve_build_root() -> anyhow::Result<PathBuf> {
     resolve_build_root_with_home(dirs::home_dir())
 }
@@ -333,8 +321,7 @@ fn resolve_build_root_inner(
         );
     }
 
-    // 2. Dev source tree — prefer local sources over marker so `make dev`
-    //    picks up code changes instead of a stale installed bundle.
+    // 2. Dev source tree — preferred over marker so `make dev` picks up local code changes.
     if let Some(ref root) = dev_root {
         if root.join("containers").exists() {
             return Ok(root.clone());
@@ -360,9 +347,6 @@ fn resolve_build_root_inner(
 /// 1. `SPEEDWAVE_RESOURCES_DIR` env var → `<dir>/mcp-os/os/dist/index.js`
 /// 2. `CARGO_MANIFEST_DIR` source tree → `<repo>/mcp-servers/os/dist/index.js`
 /// 3. `~/.speedwave/resources-dir` marker → `<dir>/mcp-os/os/dist/index.js`
-///
-/// Step 2 before 3 ensures `make dev` uses local sources (with hoisted
-/// `node_modules`) instead of a stale bundle path written by the installed app.
 pub fn resolve_mcp_os_script() -> Option<std::path::PathBuf> {
     let dev = repo_dev_path("mcp-servers/os/dist/index.js");
     resolve_worker_script_inner(
@@ -413,10 +397,8 @@ fn resolve_mcp_os_script_inner(
     )
 }
 
-/// Resolve a host-side worker script via the three-tier fallback shared by all
-/// bundled workers (`mcp-os`, `oauth`, …): SPEEDWAVE_RESOURCES_DIR (bundle)
-/// → repo source tree (`make dev`) → `~/.speedwave/resources-dir` marker (CLI).
-/// `bundled_subpath` is the path *inside* the resources dir; `label` drives logs.
+/// Resolve a host-side worker script: SPEEDWAVE_RESOURCES_DIR → repo source tree → marker.
+/// `bundled_subpath` is the path inside the resources dir; `label` drives logs.
 fn resolve_worker_script_inner(
     label: &str,
     bundled_subpath: &[&str],
@@ -440,8 +422,7 @@ fn resolve_worker_script_inner(
         log::warn!("{label} not found at bundled path: {}", p.display());
     }
 
-    // 2. Repo source tree — prefer local sources over the marker so `make dev`
-    //    picks up hoisted node_modules from the workspace.
+    // 2. Repo source tree — preferred over marker so `make dev` picks up workspace node_modules.
     if let Some(ref p) = dev_path {
         if p.exists() {
             return dev_path;
@@ -469,11 +450,9 @@ fn resolve_worker_script_inner(
     None
 }
 
-/// Reads the `~/.speedwave/resources-dir` marker file and returns the build-context
-/// path if the marker points to a valid directory containing `containers/`.
-///
-/// Consumer: called by `resolve_build_root()`. Writer: Desktop app `main.rs` on startup
-/// via `write_resources_marker()`.
+/// Reads the `~/.speedwave/resources-dir` marker and returns the build-context path
+/// if it points to a valid directory containing `containers/`.
+/// Read by `resolve_build_root()`; written by Desktop via `write_resources_marker()`.
 fn resolve_from_marker(home: &std::path::Path) -> Option<PathBuf> {
     let marker = home
         .join(crate::consts::DATA_DIR)
@@ -509,9 +488,7 @@ fn resolve_from_marker(home: &std::path::Path) -> Option<PathBuf> {
     }
 }
 
-/// Writes the `~/.speedwave/resources-dir` marker file atomically.
-///
-/// Uses write-to-tmp + rename to prevent the CLI from reading a partial path.
+/// Writes the `~/.speedwave/resources-dir` marker file atomically (write-to-tmp + rename).
 /// Called by the Desktop app on startup so the CLI can locate bundled resources.
 pub fn write_resources_marker(resources_dir: &std::path::Path) -> anyhow::Result<()> {
     let marker_dir = crate::consts::data_dir();
@@ -539,11 +516,8 @@ fn write_resources_marker_to(
 }
 
 /// Containerd overlayfs snapshotter corruption that survived a prune attempt.
-///
-/// Produced by [`with_build_recovery`] (bundle and plugin builds) when a
-/// snapshotter error persists after `system_prune` + `prune_buildkit_cache` and
-/// a retry. Bundle-build callers (setup wizard, reconcile) downcast it to
-/// restart the container engine; other callers surface its `Display` hint.
+/// Produced by [`with_build_recovery`] when the error persists after prune + retry;
+/// bundle-build callers downcast it to restart the engine, others surface its `Display` hint.
 #[derive(Debug)]
 pub struct SnapshotterRecoveryFailed {
     /// The underlying build error after prune-and-retry also failed.
@@ -710,10 +684,9 @@ pub(crate) fn prune_replaced_images(
     Ok(())
 }
 
-/// Warn-only post-restore prune under the build lock: per-image replaced tags,
-/// plus one-time legacy single-id tags (pre-ADR-072 state without a map).
-/// Callers MUST invoke only after new containers are confirmed running —
-/// ordering pinned by `reconcile_prunes_old_images_after_full_restore`.
+/// Warn-only post-restore prune under the build lock: per-image replaced tags
+/// plus one-time legacy single-id tags. Callers MUST invoke only after new
+/// containers are confirmed running.
 pub fn prune_superseded_images(
     runtime: &crate::runtime::LockedRuntime,
     applied_image_hashes: &std::collections::BTreeMap<String, String>,
@@ -724,8 +697,7 @@ pub fn prune_superseded_images(
         if let Err(e) = prune_replaced_images(runtime, applied_image_hashes, manifest) {
             log::warn!("Failed to prune replaced image tags: {e}");
         }
-        // Legacy pre-ADR-072 state (no per-image map): the old tags share one
-        // `name:<old_bundle_id>` suffix — prune them once on migration.
+        // Legacy pre-ADR-072 tags share one `name:<old_bundle_id>` suffix — prune once on migration.
         if applied_image_hashes.is_empty() {
             if let Some(old_id) = should_prune_bundle(applied_bundle_id, &manifest.bundle_id) {
                 if let Err(e) = prune_old_bundle_images(runtime, old_id) {
@@ -829,9 +801,8 @@ pub fn build_images_for_bundle_in(
 }
 
 /// Runs `attempt`; on a recoverable failure (disk-full, snapshotter corruption,
-/// transient I/O/DNS) prunes the matching cache and retries. Snapshotter
-/// corruption surviving the retry becomes [`SnapshotterRecoveryFailed`] — bundle
-/// callers downcast it to restart the engine; plugin builds surface its hint.
+/// transient I/O/DNS) prunes the matching cache and retries. Snapshotter corruption
+/// surviving the retry becomes [`SnapshotterRecoveryFailed`].
 pub(crate) fn with_build_recovery<T>(
     runtime: &crate::runtime::LockedRuntime,
     mut attempt: impl FnMut() -> anyhow::Result<T>,
@@ -844,8 +815,7 @@ pub(crate) fn with_build_recovery<T>(
             if let Err(prune_err) = runtime.prune_unused_images() {
                 log::warn!("prune_unused_images failed: {prune_err}");
             }
-            // `nerdctl system prune` does not clear BuildKit cache-mounts; under
-            // disk pressure the cache must go too (ADR-072).
+            // `nerdctl system prune` does not clear BuildKit cache-mounts (ADR-072).
             if let Err(prune_err) = runtime.prune_buildkit_cache() {
                 log::warn!("prune_buildkit_cache failed: {prune_err}");
             }
@@ -857,8 +827,7 @@ pub(crate) fn with_build_recovery<T>(
             if let Err(prune_err) = runtime.system_prune() {
                 log::warn!("system prune failed: {prune_err}");
             }
-            // A poisoned BuildKit cache key can pin a vanished snapshot
-            // ("failed to stat parent"); system prune leaves cache-mounts.
+            // system prune leaves cache-mounts, which can pin a vanished snapshot.
             if let Err(prune_err) = runtime.prune_buildkit_cache() {
                 log::warn!("prune_buildkit_cache failed: {prune_err}");
             }
@@ -866,9 +835,7 @@ pub(crate) fn with_build_recovery<T>(
                 anyhow::Error::new(SnapshotterRecoveryFailed { inner: second_err })
             })
         } else if is_transient_build_error(&first_err) {
-            // Transient — usually the boot-time DNS-fallback race (see
-            // `is_transient_build_error`). A few seconds' wait lets the resolver
-            // settle; two backed-off attempts cover a slow fallback.
+            // Transient (see `is_transient_build_error`): back off and retry.
             let mut last_err = first_err;
             for attempt_no in 1..=TRANSIENT_BUILD_RETRIES {
                 let delay = TRANSIENT_BUILD_RETRY_BASE_DELAY * attempt_no;
@@ -932,8 +899,7 @@ fn try_build_images(
         chunks.len()
     );
 
-    // Per-worker results collected into a flat Vec; Mutex poison unreachable
-    // (thread::scope re-panics on the calling thread if any worker panics).
+    // Mutex poison unreachable: thread::scope re-panics on the calling thread if a worker panics.
     let results = std::sync::Mutex::new(Vec::<(usize, anyhow::Result<()>)>::with_capacity(total));
 
     std::thread::scope(|s| {
@@ -942,8 +908,7 @@ fn try_build_images(
                 for &idx in *chunk {
                     let img = images[idx];
                     let tag = tags[idx].clone();
-                    // vm_path_join, not PathBuf::join: vm_root may be a WSL/Linux
-                    // path on Windows where PathBuf::join mangles /-rooted strings.
+                    // vm_path_join, not PathBuf::join: PathBuf::join mangles /-rooted WSL paths on Windows.
                     let abs_context = crate::engine_path::vm_path_join(root_str, img.context_dir);
                     let abs_containerfile =
                         crate::engine_path::vm_path_join(root_str, img.containerfile);
@@ -981,15 +946,10 @@ fn try_build_images(
 
     let mut outcomes = results.into_inner().unwrap_or_else(|p| p.into_inner());
 
-    // Sort by IMAGES index so the classifier picks the lowest-indexed error in each
-    // priority class, independent of thread completion order. Without this sort,
-    // "the first transient error" would mean "whichever worker happened to finish
-    // first", which is non-deterministic across runs and breaks the doc claim below.
+    // Sort by IMAGES index so the classifier is deterministic, not thread-completion-ordered.
     outcomes.sort_by_key(|(idx, _)| *idx);
 
-    // Single-pass classifier: snapshotter errors require system_prune before retry;
-    // transient errors need only a plain retry. Priority: snapshotter > transient > first by index.
-    // Overflow errors (beyond one per class) are logged immediately in the loop.
+    // Single-pass classifier, priority snapshotter > transient > first by index.
     let mut snapshotter: Option<(usize, anyhow::Error)> = None;
     let mut transient: Option<(usize, anyhow::Error)> = None;
     let mut first: Option<(usize, anyhow::Error)> = None;
@@ -1042,7 +1002,6 @@ fn try_build_images(
         e
     } else {
         // Unreachable: total_errors > 0 guarantees at least one error slot is filled.
-        // Returning Err (not Ok) protects callers from acting on a broken build tree.
         return Err(anyhow::anyhow!(
             "internal bug: build_images recorded {total_errors} error(s) but no error slot was filled"
         ));
@@ -1059,9 +1018,7 @@ fn try_build_images(
 }
 
 /// `true` if `err` mentions ENOSPC anywhere in its chain.
-/// Recovery: `prune_unused_images` + retry. Covers cross-worktree image
-/// accumulation that `prune_old_bundle_images` cannot see (it only knows this
-/// worktree's last `applied_bundle_id`).
+/// Recovery: `prune_unused_images` + retry.
 fn is_disk_full_error(err: &anyhow::Error) -> bool {
     for cause in err.chain() {
         let msg = cause.to_string().to_ascii_lowercase();
@@ -1072,12 +1029,8 @@ fn is_disk_full_error(err: &anyhow::Error) -> bool {
     false
 }
 
-/// Returns `true` if the error looks like a containerd overlayfs snapshotter bug.
-///
-/// Iterates the full error chain (`err.chain()`) so that wrapped/context errors
-/// are checked too — not just the top-level message.
-///
-/// Known error patterns from containerd (stable in Go source since 2023):
+/// `true` if any error in the chain looks like a containerd overlayfs snapshotter bug.
+/// Known containerd patterns:
 /// - `"apply layer error"` — wrapper from containerd's differ
 /// - `"failed to prepare extraction snapshot"` — from snapshotter.Prepare()
 /// - `"failed to rename"` + `"file exists"` — OS-level rename failure on stale snapshot
@@ -1096,31 +1049,14 @@ fn is_snapshotter_error(err: &anyhow::Error) -> bool {
     false
 }
 
-/// Registry hostnames that our `FROM` lines reference. A DNS failure mentioning
-/// one of these is the boot-time-resolver race (see `is_transient_build_error`),
-/// not a user typo — so it's worth a retry. A DNS failure for some *other* host
-/// is more likely a real misconfiguration and is left to fail fast.
+/// Registry hostnames our `FROM` lines reference; DNS failures naming these are retried
+/// (see `is_transient_build_error`), failures for other hosts fail fast.
 const BASE_IMAGE_REGISTRY_HOSTS: &[&str] =
     &["registry-1.docker.io", "docker.io", "mcr.microsoft.com"];
 
-/// Returns `true` if the build error looks transient (I/O timeout, connection reset,
-/// temporary unavailable, or a DNS hiccup resolving a base-image registry). These may
-/// succeed on retry without any recovery action.
-///
-/// The DNS cases matter for first runs behind a VPN: when the Lima VM boots, its
-/// `systemd-resolved` initially tries `UDP+EDNS0`, whose large responses do not
-/// survive a low-MTU tunnel (e.g. Tailscale's 1380). It takes a second or two to
-/// detect that and fall back to plain UDP — but BuildKit fires its
-/// `FROM <base-image>` metadata fetch inside that window, so the resolver returns
-/// `SERVFAIL` (`server misbehaving` / `failed to resolve source metadata`) or even
-/// `NXDOMAIN` (`no such host`) for `docker.io` / `mcr.microsoft.com`. A retry a few
-/// seconds later hits the now-degraded resolver and succeeds. *All* DNS-shaped cases
-/// are scoped to `BASE_IMAGE_REGISTRY_HOSTS` so a typo'd — or rogue — custom registry
-/// URL fails fast instead of silently retrying (it could otherwise embed any of these
-/// strings in its error body to force up to `TRANSIENT_BUILD_RETRIES` retries).
-///
-/// Uses case-insensitive matching because kernel/libc/BuildKit error messages vary
-/// in casing across distros and locales.
+/// `true` if the build error is transient (I/O timeout, connection reset, temporary
+/// unavailable, or a DNS hiccup naming a base-image registry) and may succeed on retry.
+/// DNS-shaped cases are scoped to `BASE_IMAGE_REGISTRY_HOSTS`; matching is case-insensitive.
 fn is_transient_build_error(err: &anyhow::Error) -> bool {
     for cause in err.chain() {
         let msg = cause.to_string().to_ascii_lowercase();
@@ -1129,8 +1065,7 @@ fn is_transient_build_error(err: &anyhow::Error) -> bool {
             || msg.contains("connection reset")
             || msg.contains("temporary failure")
             || msg.contains("resource temporarily unavailable")
-            // DNS hiccups (SERVFAIL / NXDOMAIN / dial-lookup) are transient only when
-            // they name one of our base-image registries — see the doc above.
+            // DNS hiccups are transient only when they name a base-image registry.
             || (is_dns_shaped(&msg) && mentions_base_image_registry(&msg))
         {
             return true;
@@ -1159,9 +1094,7 @@ fn is_dns_shaped(msg: &str) -> bool {
 fn is_network_build_error(err: &anyhow::Error) -> bool {
     for cause in err.chain() {
         let msg = cause.to_string().to_ascii_lowercase();
-        // Both branches are scoped to a base-image registry: the network
-        // enrichment names docker.io / mcr.microsoft.com, so a reset during an
-        // apt layer (registry not involved) must NOT route here.
+        // Scoped to a base-image registry so a reset during an apt layer does not route here.
         if (is_dns_shaped(&msg) || msg.contains("connection reset"))
             && mentions_base_image_registry(&msg)
         {
@@ -1172,7 +1105,7 @@ fn is_network_build_error(err: &anyhow::Error) -> bool {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 
@@ -1252,10 +1185,7 @@ mod tests {
     /// source change would not change the image hash and ship stale code.
     #[test]
     fn every_base_image_is_digest_pinned() {
-        // Retained BuildKit cache (ADR-072) freezes whatever base was first
-        // pulled; a floating tag would silently diverge between users and
-        // never receive upstream security patches. Every external FROM must
-        // carry an @sha256 digest; bumping a base is a deliberate edit.
+        // Every external FROM must carry an @sha256 digest (ADR-072).
         let root = repo_root();
         let mut violations = Vec::new();
         for img in IMAGES {
@@ -1351,8 +1281,7 @@ mod tests {
 
     #[test]
     fn claude_hash_inputs_exclude_resources_and_template() {
-        // claude-resources are synced + mounted (never baked into the image);
-        // the compose template is embedded in the binary. Neither may rebuild claude.
+        // claude-resources (mounted) and the compose template (embedded) must not rebuild claude.
         let claude = IMAGES.iter().find(|i| i.name == IMAGE_CLAUDE).unwrap();
         for input in claude.hash_inputs {
             assert!(
@@ -1408,12 +1337,8 @@ mod tests {
         }
     }
 
-    /// Verifies that shell scripts COPY'd into Containerfile.claude have their
-    /// shebang interpreter (`bash`) explicitly installed via `apt-get install`.
-    ///
-    /// node:24-bookworm-slim does NOT include bash — only dash (/bin/sh).
-    /// If a COPY'd script uses `#!/bin/bash` but the Containerfile doesn't
-    /// `apt-get install bash`, the build fails with "not found" at runtime.
+    /// Verifies shell scripts COPY'd into Containerfile.claude have their shebang
+    /// interpreter (`bash`) installed via `apt-get install` — bookworm-slim ships only dash.
     #[test]
     fn test_containerfile_claude_installs_bash_for_copied_scripts() {
         let _guard = crate::binary::tests::ENV_LOCK.lock().unwrap();
@@ -1784,8 +1709,7 @@ mod tests {
     fn test_resolve_mcp_os_script_dev_mode() {
         let _guard = crate::binary::tests::ENV_LOCK.lock().unwrap();
         std::env::remove_var(crate::consts::BUNDLE_RESOURCES_ENV);
-        // In dev mode with None home, it falls through to CARGO_MANIFEST_DIR.
-        // The script may or may not exist depending on whether mcp-os was built.
+        // Dev mode with None home falls through to CARGO_MANIFEST_DIR (script existence depends on build).
         let result = resolve_mcp_os_script_with_home(None);
         // Just verify it doesn't panic — existence depends on build state
         let _ = result;
@@ -1867,8 +1791,7 @@ mod tests {
 
     #[test]
     fn test_images_count() {
-        // Catalogue size, not build behaviour — the build set is filtered per
-        // project by `enabled_images`. Bump this when adding a built-in worker.
+        // Catalogue size (not the per-project build set) — bump when adding a built-in worker.
         assert_eq!(IMAGES.len(), 12);
     }
 
@@ -1911,9 +1834,7 @@ mod tests {
 
     #[test]
     fn test_every_worker_image_maps_to_a_toggleable_service() {
-        // SSOT tie: every non-claude/mcp-hub image name's `speedwave-mcp-<key>`
-        // suffix must be a known integration config key, so `enabled_images`
-        // can never silently drop (or keep) a worker.
+        // SSOT tie: every non-claude/mcp-hub image's `speedwave-mcp-<key>` suffix must be a known config key.
         for img in IMAGES {
             let Some(suffix) = img.name.strip_prefix(MCP_IMAGE_PREFIX) else {
                 assert!(
@@ -2030,8 +1951,7 @@ mod tests {
 
     #[test]
     fn test_is_snapshotter_error_rejects_missing_copy_source() {
-        // A missing build-context file is a real user error — fail fast, never
-        // prune-and-retry on it.
+        // A missing build-context file is a real user error — fail fast, never prune-and-retry.
         let err = anyhow::anyhow!(
             "failed to compute cache key: failed to calculate checksum of ref: \
              \"/app/missing.txt\": not found"
@@ -2041,8 +1961,7 @@ mod tests {
 
     #[test]
     fn test_is_snapshotter_error_rejects_stat_parent_outside_snapshotter() {
-        // "failed to stat parent" without a snapshots/ path is not our corruption
-        // signature (e.g. user RUN output) — must not prune-and-retry.
+        // "failed to stat parent" without a snapshots/ path is not the corruption signature.
         let err = anyhow::anyhow!(
             "failed to stat parent: stat /home/user/app: no such file or directory"
         );
@@ -2060,8 +1979,7 @@ mod tests {
             .with_prepare_build_context_root(translated.clone())
             .build();
 
-        // Explicit fake build root keeps the test off SPEEDWAVE_RESOURCES_DIR and
-        // the production marker; the mock returns the translated path regardless.
+        // Explicit fake build root keeps the test off SPEEDWAVE_RESOURCES_DIR and the production marker.
         let (_tmp, root) = create_fake_build_root();
         let bundle_id = "test-bundle";
         let result = build_all_for_bundle(&rt, bundle_id, &root);
@@ -2133,10 +2051,8 @@ mod tests {
         }
     }
 
-    /// Build a `MockRuntimeBuilder` configured for retry-with-prune tests:
-    /// `prepare_build_context` returns `build_root`, and `build_image(tag)`
-    /// fails on the (tag, attempt) pairs listed in `fail_on` (keyed as
-    /// `"{tag}:{attempt}"`, mirroring the old `RetryMockRuntime` contract).
+    /// `MockRuntimeBuilder` for retry-with-prune tests: `prepare_build_context` returns
+    /// `build_root`; `build_image(tag)` fails on the `"{tag}:{attempt}"` pairs in `fail_on`.
     fn retry_mock(
         build_root: PathBuf,
         fail_on: std::collections::HashMap<String, String>,
@@ -2219,10 +2135,8 @@ mod tests {
         (tmp, root)
     }
 
-    /// Build a mock with `image_exists(tag) = true` for any tag whose image
-    /// name contains one of the `present` substrings. Mirrors the old
-    /// `LazyBuildMock` contract: tags whose name matches one of `present`
-    /// resolve to true; everything else resolves to false.
+    /// Build a mock where `image_exists(tag)` is `true` iff the tag's image name
+    /// contains one of the `present` substrings.
     fn lazy_build_mock(
         build_root: PathBuf,
         present: Vec<&str>,
@@ -2230,17 +2144,10 @@ mod tests {
         crate::runtime::LockedRuntime,
         crate::runtime::mock_runtime::MockHandles,
     ) {
-        // `images_exist`-style queries pass the full bundle-suffixed tag; the
-        // substring check `tag.contains(image_name)` is the legal-equivalent
-        // of the old `LazyBuildMock` lookup. We layer one "present" substring
-        // per requested image name on top of `image_exists_default(false)`.
+        // Layer one "present" entry per requested image name on top of default-false existence.
         let mut b = crate::runtime::mock_runtime::MockRuntimeBuilder::new()
             .with_prepare_build_context_root(build_root);
-        // Seed each image name as a "present" override via per-(name, bundle)
-        // entries — but builder's exact-match table can't substring. Instead,
-        // we use the inverse: default false (so absent images report false),
-        // and explicitly seed every IMAGES name across the bundle ids these
-        // tests use. Since the test only uses bundle id "b1", that's enough.
+        // Seed present IMAGES names for bundle id "b1" (default false covers absent images).
         for img in IMAGES {
             if present.iter().any(|p| img.name.contains(p)) {
                 let tag = image_ref(img.name, "b1");
@@ -2397,8 +2304,7 @@ mod tests {
 
     #[test]
     fn test_disk_full_unrecovered_gets_friendly_error() {
-        // Disk-full on attempts 1 AND 2 → prune attempted, build still fails,
-        // and the user-facing message must mention disk space (not "VM memory").
+        // Disk-full on attempts 1 AND 2 → message must mention disk space, not "VM memory".
         let mut fail_on = std::collections::HashMap::new();
         for attempt in 1..=2 {
             fail_on.insert(
@@ -2827,9 +2733,7 @@ mod tests {
         use crate::runtime::mock_runtime::MockRuntimeBuilder;
 
         /// `image_exists(tag)` returns `true` unless `tag` contains one of
-        /// `missing_name_substrings`. Mirrors the old `ImageCheckRuntime`
-        /// substring contract for `images_exist`, which queries by a runtime-
-        /// computed bundle id we cannot enumerate up front.
+        /// `missing_name_substrings`.
         fn image_check_mock(missing_name_substrings: &[&str]) -> crate::runtime::LockedRuntime {
             let mut b = MockRuntimeBuilder::new().with_image_exists_default(true);
             for s in missing_name_substrings {
@@ -2955,8 +2859,7 @@ mod tests {
 
     #[test]
     fn test_connection_reset_off_registry_is_not_network() {
-        // Reset during an apt layer (no base-image registry) must NOT route to
-        // the network message that names docker.io / mcr.microsoft.com.
+        // Reset during an apt layer (no base-image registry) must NOT route to the network message.
         let err = anyhow::anyhow!("apt: connection reset by peer (deb.debian.org)");
         assert!(!is_network_build_error(&err));
         assert!(is_transient_build_error(&err), "still transient → retried");
@@ -3012,8 +2915,6 @@ mod tests {
 
     // -----------------------------------------------------------------------
     // is_transient_build_error() — DNS hiccup while pulling a base image
-    // (VM's systemd-resolved still falling back from EDNS0 right after boot;
-    // BuildKit's `FROM <image>` metadata fetch lands in that window).
     // -----------------------------------------------------------------------
 
     #[test]
@@ -3051,30 +2952,25 @@ mod tests {
 
     #[test]
     fn test_is_transient_build_error_plain_dial_tcp_without_lookup_is_not_transient() {
-        // A bare `dial tcp` without a DNS lookup (e.g. connection refused to a fixed IP)
-        // is not the DNS-fallback race; don't widen the net unnecessarily.
+        // A bare `dial tcp` without a DNS lookup is not the DNS-fallback race.
         let err = anyhow::anyhow!("dial tcp 10.0.0.5:443: connect: connection refused");
         assert!(!is_transient_build_error(&err));
     }
 
     #[test]
     fn test_is_transient_build_error_dns_for_unknown_registry_is_not_transient() {
-        // NXDOMAIN / dial-lookup failure for a host that is NOT one of our base-image
-        // registries — most likely a typo'd custom registry URL. Should fail fast, not
-        // silently retry (the host scoping in `is_transient_build_error`).
+        // NXDOMAIN / dial-lookup for a non-base-image-registry host must fail fast.
         let nxdomain = anyhow::anyhow!("dial tcp: lookup myregistry.example.com: no such host");
         assert!(!is_transient_build_error(&nxdomain));
         let dial_lookup =
             anyhow::anyhow!("dial tcp: lookup ghcr.io on 127.0.0.53:53: server can't find ghcr.io");
-        // `ghcr.io` isn't in BASE_IMAGE_REGISTRY_HOSTS — a DNS-shaped error for it fails fast
-        // regardless of which DNS-failure string it carries.
+        // `ghcr.io` isn't in BASE_IMAGE_REGISTRY_HOSTS — a DNS-shaped error for it fails fast.
         assert!(!is_transient_build_error(&dial_lookup));
     }
 
     #[test]
     fn test_is_transient_build_error_servfail_for_known_registry_is_transient() {
-        // SERVFAIL-shaped errors that DO name a base-image registry are the boot-time
-        // resolver race — transient.
+        // SERVFAIL-shaped errors that name a base-image registry are transient.
         let servfail = anyhow::anyhow!(
             "Head \"https://registry-1.docker.io/v2/\": dial tcp: lookup registry-1.docker.io: server misbehaving"
         );
@@ -3087,9 +2983,7 @@ mod tests {
 
     #[test]
     fn test_is_transient_build_error_servfail_for_unknown_host_is_not_transient() {
-        // SERVFAIL / "failed to resolve source metadata" for a host that is NOT a base-image
-        // registry must fail fast — a rogue or typo'd custom registry could otherwise embed
-        // these strings to force retries.
+        // SERVFAIL / "failed to resolve source metadata" for a non-base-image host must fail fast.
         let servfail = anyhow::anyhow!("Head \"https://example.invalid/v2/\": server misbehaving");
         assert!(!is_transient_build_error(&servfail));
         let no_metadata = anyhow::anyhow!("foo:bar: failed to resolve source metadata for foo/bar");
@@ -3271,9 +3165,7 @@ mod tests {
 
     #[test]
     fn test_prune_old_bundle_images_keeps_buildkit_cache() {
-        // ADR-072: routine pruning must NOT clear the BuildKit cache — apt/npm
-        // layers are reused across updates. Cache is pruned only on disk
-        // pressure or snapshotter recovery (see with_build_recovery).
+        // ADR-072: routine pruning must NOT clear the BuildKit cache.
         let (rt, handles) = crate::runtime::mock_runtime::MockRuntimeBuilder::new().build();
         prune_old_bundle_images(&rt, "abc123").unwrap();
 
@@ -3327,9 +3219,7 @@ mod tests {
 
     #[test]
     fn test_prune_replaced_images_never_touches_current_tags() {
-        // Adversarial: applied hash differs, but the OLD tag equals another
-        // image's CURRENT tag must never happen by construction (tags embed the
-        // image name); verify removal list contains only `name:old_hash` pairs.
+        // Tags embed the image name, so an old tag never equals another image's current tag.
         let manifest = crate::bundle::BundleManifest::for_tests("cur");
         let mut applied = manifest.image_hashes.clone();
         applied.insert(IMAGE_MCP_HUB.to_string(), "old".to_string());
@@ -3344,8 +3234,7 @@ mod tests {
 
     #[test]
     fn test_prune_replaced_images_rmi_failure_propagates_to_warn_only_callers() {
-        // remove_images error propagates; callers (maybe_prune_previous_bundle,
-        // reconcile) downgrade it to a warning — pin the Err here.
+        // remove_images error propagates; callers downgrade it to a warning — pin the Err here.
         let manifest = crate::bundle::BundleManifest::for_tests("new1");
         let mut applied = manifest.image_hashes.clone();
         applied.insert(IMAGE_CLAUDE.to_string(), "old1".to_string());
@@ -3402,12 +3291,9 @@ mod tests {
         let result = try_build_all(&rt, &build_root, "test-bundle");
         assert!(result.is_err());
         let err = result.unwrap_err();
-        // Use {:#} to print the full chain; the chosen slack error is wrapped by a
-        // context message because multiple errors occurred.
+        // Use {:#} to print the full error chain.
         let msg = format!("{err:#}");
-        // Both errors are transient. After sorting outcomes by IMAGES index, the
-        // lowest-indexed transient error wins deterministically. Slack (index 2)
-        // beats GitLab (index 5).
+        // Lowest IMAGES index wins among transient errors: Slack (index 2) beats GitLab (index 5).
         assert!(
             msg.contains("slack"),
             "expected earliest-indexed transient error (slack) to win, got: {msg}"
@@ -3459,9 +3345,7 @@ mod tests {
 
     #[test]
     fn test_parallel_build_transient_error_retries_without_prune() {
-        // Injects exactly one transient failure (attempt 1), so the first retry succeeds —
-        // see `test_parallel_build_dns_error_retries_then_succeeds_on_second_attempt` for the
-        // path where it takes more than one retry (TRANSIENT_BUILD_RETRIES = 2).
+        // One transient failure (attempt 1), so the first retry succeeds.
         let mut fail_on = std::collections::HashMap::new();
         fail_on.insert(
             format!("{}:1", image_ref(IMAGE_MCP_HUB, "test-bundle")),
@@ -3488,8 +3372,7 @@ mod tests {
 
     #[test]
     fn test_parallel_build_dns_error_retries_then_succeeds_on_second_attempt() {
-        // The DNS-fallback race: attempts 1 AND 2 fail with `server misbehaving`,
-        // attempt 3 succeeds (resolver has settled). Exercises the >1 retry path.
+        // Attempts 1 and 2 fail, attempt 3 succeeds — exercises the >1 retry path.
         let mut fail_on = std::collections::HashMap::new();
         let tag = image_ref(IMAGE_MCP_GITHUB, "test-bundle");
         fail_on.insert(
@@ -3589,16 +3472,13 @@ mod tests {
 
     #[test]
     fn test_parallel_build_worker_panic_propagates() {
-        // `std::thread::scope` re-panics on the calling thread when a spawned thread
-        // panics, so a panicking `build_image` will propagate out of `try_build_all`.
-        // This verifies that worker panics are not silently swallowed.
+        // thread::scope re-panics on the calling thread, so a panicking build_image propagates out.
         let (_tmp, build_root) = create_fake_build_root();
         let (rt, _handles) = crate::runtime::mock_runtime::MockRuntimeBuilder::new()
             .with_prepare_build_context_root(build_root.clone())
             .with_build_panic_for("speedwave-mcp-slack")
             .build();
-        // std::thread::scope re-panics on the calling thread when any spawned thread
-        // panics — wrap in catch_unwind here at the test boundary only.
+        // catch_unwind at the test boundary: thread::scope re-panics on the calling thread.
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             try_build_all(&rt, &build_root, "test-bundle")
         }));

--- a/crates/speedwave-runtime/src/bundle.rs
+++ b/crates/speedwave-runtime/src/bundle.rs
@@ -70,9 +70,7 @@ const COMMON_BUNDLED_ASSETS: &[BundledAssetSpec] = &[
         path: "mcp-os/os/node_modules/@speedwave/mcp-shared",
         kind: BundledAssetKind::Directory,
     },
-    // `oauth` worker (ADR-060) — a host process like `mcp-os` (not a
-    // container, not in `build::IMAGES`), bundled the same way. Resolved
-    // by `build::resolve_oauth_script` at `oauth/oauth/dist/index.js`.
+    // `oauth` worker (ADR-060): host process like `mcp-os`, not in `build::IMAGES`.
     BundledAssetSpec {
         path: "oauth/oauth/dist/index.js",
         kind: BundledAssetKind::File,
@@ -256,9 +254,7 @@ pub fn load_current_bundle_manifest() -> anyhow::Result<BundleManifest> {
 }
 
 /// Env-free core of [`load_current_bundle_manifest`]: takes an explicit build
-/// root so tests can inject a path and never read the process-global
-/// `SPEEDWAVE_RESOURCES_DIR` (which other tests mutate — see the test-isolation
-/// guard). The public no-arg shim resolves the root from env at the call site.
+/// root instead of reading `SPEEDWAVE_RESOURCES_DIR` from env.
 pub fn load_current_bundle_manifest_from(build_root: &Path) -> anyhow::Result<BundleManifest> {
     let manifest_path = build_root.join(BUNDLE_MANIFEST_FILE);
     if manifest_path.exists() {
@@ -621,9 +617,7 @@ fn collect_directory_entries(
     if !dir.exists() {
         anyhow::bail!("Missing path for bundle digest: {}", dir.display());
     }
-    // Single-file hash input (e.g. containers/entrypoint.sh) — see ADR-072.
-    // is_file()/is_dir() follow symlinks — the copier dereferences them, so
-    // a symlinked input could change image content without changing the hash.
+    // Reject symlinks: the copier dereferences them, changing content without changing the hash.
     if dir.is_symlink() {
         anyhow::bail!(
             "symlink not allowed in image hash inputs: {}",
@@ -641,15 +635,11 @@ fn collect_directory_entries(
     children.sort();
 
     for child in children {
-        // node_modules is gitignored and never copied into the build context
-        // (only `--from=builder` stage copies), so its internal `.bin/*`
-        // symlinks are not image content — skip it to keep the hash honest.
+        // node_modules is not copied into the build context, so it is not image content.
         if child.is_dir() && child.file_name().is_some_and(|n| n == "node_modules") {
             continue;
         }
-        // Fail loud: the build-context copier dereferences symlinks, so a
-        // silently-skipped link would change image content WITHOUT changing
-        // the hash — users would keep the stale tag after an update.
+        // Reject symlinks: the copier dereferences them, changing content without changing the hash.
         if child.is_symlink() {
             anyhow::bail!(
                 "symlink not allowed in image hash inputs: {}",
@@ -751,8 +741,7 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn collect_directory_entries_skips_node_modules_with_bin_symlink() {
-        // The exact CI failure: npm creates node_modules/.bin/<tool> symlinks.
-        // The walk must skip node_modules entirely rather than bail on them.
+        // node_modules/.bin/<tool> symlinks must be skipped, not bailed on.
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path().join("hub");
         std::fs::create_dir_all(dir.join("node_modules/.bin")).unwrap();
@@ -793,8 +782,7 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn node_modules_changes_do_not_alter_manifest_hash() {
-        // ADR-072: node_modules is not image content, so adding it (symlinks
-        // and all) under a hash input must leave every image hash unchanged.
+        // node_modules is not image content; adding it must not change any image hash (ADR-072).
         let tmp = tempfile::tempdir().unwrap();
         write_build_tree(tmp.path());
         let before = generate_bundle_manifest("1.0.0", "2.0.0", tmp.path()).unwrap();
@@ -1164,8 +1152,7 @@ mod tests {
 
     #[test]
     fn new_state_file_readable_by_legacy_shape() {
-        // Downgrade safety: old releases deserialize the new file (serde
-        // ignores unknown fields) and fall back to a full rebuild via id mismatch.
+        // Old releases deserialize the new file (serde ignores unknown fields).
         #[derive(Deserialize)]
         struct LegacyBundleState {
             applied_bundle_id: Option<String>,

--- a/crates/speedwave-runtime/src/claude_home.rs
+++ b/crates/speedwave-runtime/src/claude_home.rs
@@ -1,9 +1,6 @@
 //! Per-project Claude Code home directory (`<data_dir>/claude-home/<project>/`).
-//!
-//! This is the bind-mount target Claude Code writes its credentials, sessions,
-//! and onboarding state into. Speedwave never reads the credentials — but it
-//! does need to *locate* the directory (compose mount) and *clear* it
-//! (`speedwave logout`). Both live here so the path layout has one definition.
+//! Bind-mount target for Claude Code credentials/sessions/onboarding state;
+//! Speedwave only locates (compose mount) and clears it (`speedwave logout`).
 
 use std::io;
 use std::path::{Path, PathBuf};
@@ -18,9 +15,7 @@ pub fn claude_home_dir(data_dir: &Path, project: &str) -> PathBuf {
 
 /// Removes Claude Code's credential files (`.claude/.credentials.json` and
 /// `.claude.json`) from the project's claude-home directory. Returns the count
-/// of files actually removed. A missing file is not an error (idempotent
-/// logout); any other I/O error on either file is reported, but both files are
-/// always attempted so a lock on one does not leave the other behind.
+/// removed; missing files are not an error (idempotent), both are attempted.
 pub fn remove_claude_credentials(data_dir: &Path, project: &str) -> io::Result<usize> {
     let home = claude_home_dir(data_dir, project);
     let targets = [
@@ -87,8 +82,7 @@ mod tests {
 
     #[test]
     fn remove_is_scoped_to_project_dir() {
-        // A project name that's a plain component cannot reach outside its dir;
-        // this just documents that the path is built under claude-home/<project>.
+        // A plain project component cannot reach outside claude-home/<project>.
         let tmp = tempfile::tempdir().unwrap();
         let home = claude_home_dir(tmp.path(), "proj-a");
         std::fs::create_dir_all(home.join(".claude")).unwrap();

--- a/crates/speedwave-runtime/src/cloudstorage.rs
+++ b/crates/speedwave-runtime/src/cloudstorage.rs
@@ -1,35 +1,19 @@
 //! CloudStorage TCC detection, probe, classification, and upstream helper.
-//!
-// macOS CloudStorage services (OneDrive, Dropbox, Google Drive) require
-// Transparency Consent and Control (TCC) permission before the app can
-// read directories managed by those services. When TCC is missing,
-// `read_dir` returns EPERM (errno 13). This module centralizes all
-// detection and reporting logic so every Tauri command entry point uses
-// the same probe.
 
 use std::io::ErrorKind;
 use std::path::Path;
 use std::time::Duration;
 
-/// Error prefix embedded in `Err(...)` strings when a CloudStorage TCC
-/// permission failure is detected. Format: `"CloudStorage TCC required: {stable_id}|{dir}"`.
-/// Recognized by `restore_projects` (reconcile.rs) for substitution and by
-/// `compute_project_switch_failure_payload` (main.rs) for UI routing.
-///
+/// Error prefix for CloudStorage TCC failure: `"CloudStorage TCC required: {stable_id}|{dir}"`.
 /// SSOT — TypeScript callers mirror this via `cloudstorage-prefix.ts`.
 pub use crate::consts::CLOUDSTORAGE_TCC_PREFIX;
 
-/// User-facing substituted message used by both interactive and
-/// non-interactive surfaces when a CloudStorage TCC failure is detected.
-/// SSOT — Rust callers use it directly; TypeScript callers can use a
-/// matching constant in cloudstorage-prefix.ts (test-asserted to match).
+/// User-facing message for a CloudStorage TCC failure.
+/// SSOT — TypeScript mirror in cloudstorage-prefix.ts (test-asserted to match).
 pub const TCC_USER_REMEDIATION_MESSAGE: &str =
     "Cloud storage permission required. Open the project from the project view to resolve.";
 
 /// Probe timeout for a single `read_dir` attempt on a CloudStorage path.
-/// CloudStorage directories under TCC denial respond immediately with EPERM,
-/// so 5 s is generous — the timeout primarily guards against unexpected
-/// network-backed mounts stalling.
 const PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Known CloudStorage provider identifiers.
@@ -77,13 +61,9 @@ impl CloudStorageProvider {
 /// Detects whether `path` is inside a known CloudStorage managed directory.
 ///
 /// Returns `Some(provider)` if the path is under a recognized CloudStorage
-/// root, `None` otherwise. macOS-only detection; other platforms always
-/// return `None`.
-///
-/// Provider tokens are matched only at component boundaries — i.e. either
-/// directly under `~/Library/CloudStorage/<Token>...` or as a top-level
-/// subdirectory of the user's home (`/Users/<u>/<Token>...`). A path like
-/// `/Users/alice/Projects/NotOneDriveBackup` is **not** matched.
+/// root, `None` otherwise. macOS-only; other platforms always return `None`.
+/// Tokens match only at component boundaries (`~/Library/CloudStorage/<Token>...`
+/// or top-level `~/<Token>...`).
 #[cfg(target_os = "macos")]
 pub fn detect_cloudstorage_provider(path: &Path) -> Option<CloudStorageProvider> {
     /// Returns true if `haystack` contains `needle` followed by a path
@@ -114,8 +94,7 @@ pub fn detect_cloudstorage_provider(path: &Path) -> Option<CloudStorageProvider>
             None => return false,
         };
         let after_user = &after_users[username_end + 1..];
-        // The remaining path must start with `<token>` and the next byte
-        // must be a component boundary.
+        // Tail must start with `<token>` then a component boundary.
         if let Some(tail) = after_user.strip_prefix(token) {
             return tail.is_empty() || tail.starts_with('/') || tail.starts_with('-');
         }
@@ -158,12 +137,9 @@ pub fn is_permission_error(err: &std::io::Error) -> bool {
     matches!(err.kind(), ErrorKind::PermissionDenied)
 }
 
-/// Probes whether `path` is readable with a timeout.
-///
-/// Spawns a blocking thread and joins with a timeout. If `read_dir` returns
-/// a permission error, classifies it as a TCC failure. Other errors and
-/// timeouts return `Ok(())` (non-CloudStorage failure — let the caller
-/// handle it normally).
+/// Probes whether `path` is readable, bounded by `PROBE_TIMEOUT`.
+/// A permission error is returned as the TCC failure; other errors and
+/// timeouts return `Ok(())` for the caller to handle normally.
 pub fn check_path_readable_with_timeout(path: &Path) -> Result<(), std::io::Error> {
     let path_owned = path.to_path_buf();
     let (tx, rx) = std::sync::mpsc::channel();
@@ -195,12 +171,8 @@ pub fn check_cloudstorage_readability(path: &Path) -> Result<(), CloudStoragePro
     }
 }
 
-/// Pre-flight check for Tauri command entry points.
-///
-/// If `project_path` is under a CloudStorage provider and reading it fails
-/// with EPERM, returns a prefix-encoded error string. The prefix is recognized
-/// by `restore_projects` (for substitution) and `compute_project_switch_failure_payload`
-/// (for UI routing). On non-macOS platforms or non-CloudStorage paths, returns `Ok(())`.
+/// Pre-flight check for Tauri: returns a prefix-encoded error if a CloudStorage
+/// `project_path` fails with EPERM, else `Ok(())`. macOS-only detection.
 pub fn check_project_readable_or_err(project_path: &Path) -> Result<(), String> {
     match check_cloudstorage_readability(project_path) {
         Ok(()) => Ok(()),
@@ -353,8 +325,7 @@ mod tests {
 
     #[test]
     fn detect_substring_false_positive_is_none() {
-        // Regression: a directory whose name contains "OneDrive" mid-token
-        // (e.g. "NotOneDriveBackup") must NOT be misclassified as OneDrive.
+        // Regression: "OneDrive" mid-token must not be misclassified.
         let path = Path::new("/Users/alice/Projects/NotOneDriveBackup");
         assert!(detect_cloudstorage_provider(path).is_none());
     }
@@ -367,8 +338,7 @@ mod tests {
 
     #[test]
     fn detect_onedrive_outside_users_is_none() {
-        // Token at component boundary but not under /Users/ — not a real
-        // CloudStorage mount. Avoids matching test fixtures and tmp paths.
+        // Token at a boundary but not under /Users/ is not a real mount.
         let path = Path::new("/tmp/OneDrive/foo");
         assert!(detect_cloudstorage_provider(path).is_none());
     }
@@ -404,9 +374,7 @@ mod tests {
 
     #[test]
     fn check_project_readable_or_err_error_contains_prefix() {
-        // This test simulates what would happen on macOS with a TCC-denied path.
-        // Since we can't reproduce the actual TCC denial in a unit test, we verify
-        // the error format by calling the formatting logic directly.
+        // Verifies the TCC error format directly (TCC denial is unreproducible in a unit test).
         let provider = CloudStorageProvider::OneDrive;
         let path = Path::new("/Users/alice/Library/CloudStorage/OneDrive-Personal/Projects/foo");
         let formatted = format!(

--- a/crates/speedwave-runtime/src/compose/addressing.rs
+++ b/crates/speedwave-runtime/src/compose/addressing.rs
@@ -95,6 +95,7 @@ fn current_computer() -> std::sync::Arc<dyn HostAddressingComputer> {
 
 /// Test-only: inject a fixture computer. Pair with `#[serial_test::serial]`.
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 pub fn set_host_addressing_computer_for_test(computer: std::sync::Arc<dyn HostAddressingComputer>) {
     *COMPUTER.write().expect("COMPUTER write lock") = Some(computer);
     invalidate_host_addressing_cache();
@@ -102,6 +103,7 @@ pub fn set_host_addressing_computer_for_test(computer: std::sync::Arc<dyn HostAd
 
 /// Test-only: restore the platform default computer.
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 pub fn reset_host_addressing_computer_for_test() {
     *COMPUTER.write().expect("COMPUTER write lock") = None;
     invalidate_host_addressing_cache();
@@ -247,6 +249,7 @@ mod host_addressing_impls {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod resolver_tests {
     use super::*;
 
@@ -318,10 +321,6 @@ mod resolver_tests {
         reset_host_addressing_computer_for_test();
     }
 
-    // FailingComputer is exercised directly (not via the global slot) so this
-    // test cannot poison concurrent render_compose tests that consume the
-    // production computer through host_gateway_ip(). The Err propagation path
-    // in host_addressing() is identical regardless of which computer raised.
     #[test]
     fn failing_computer_returns_err() {
         let computer = FailingComputer("wsl probe failed".into());
@@ -366,7 +365,7 @@ mod resolver_tests {
         }
         let n = calls.load(std::sync::atomic::Ordering::SeqCst);
         assert!(
-            n >= 1 && n <= 4,
+            (1..=4).contains(&n),
             "computer called {n} times — expected 1..=4 (one wins; losers see cached or recompute under race)"
         );
 

--- a/crates/speedwave-runtime/src/compose/litellm.rs
+++ b/crates/speedwave-runtime/src/compose/litellm.rs
@@ -6,13 +6,9 @@
 //! `os.environ/SPW_KEY_<PROVIDER_ID>`, resolved inside the container by
 //! the entrypoint from the `/tokens` mount.
 //!
-//! INVARIANT (validated in the Phase 0 spike): the rendered config and the
-//! container environment must never define Anthropic credentials under
-//! their canonical names (`ANTHROPIC_API_KEY`/`ANTHROPIC_AUTH_TOKEN`).
-//! LiteLLM's `/anthropic` passthrough route forwards the client's
-//! `Authorization` header (the subscription OAuth token) only while the
-//! proxy itself holds no Anthropic credential — a canonical name would
-//! silently override every passthrough call.
+//! INVARIANT: the rendered config and container env must never define
+//! Anthropic credentials under `ANTHROPIC_API_KEY`/`ANTHROPIC_AUTH_TOKEN`
+//! (canonical names override the `/anthropic` passthrough route).
 
 use crate::config::{LlmConfig, LlmProviderKind};
 use std::path::{Path, PathBuf};
@@ -47,17 +43,14 @@ pub fn render_litellm_config(llm: &LlmConfig) -> String {
     let mut model_list = String::new();
 
     for entry in &llm.providers {
-        // ids are slug-validated on resolve (migrate_llm_to_v2); the YAML
-        // below embeds them bare, so re-check defensively.
+        // Re-check: ids are embedded bare in the YAML below.
         if !crate::plugin::is_valid_slug(&entry.id) {
             log::warn!("litellm config: skipping provider with invalid id");
             continue;
         }
         let key_ref = format!("os.environ/{}", spw_key_env_name(&entry.id));
         match entry.kind {
-            // Subscription traffic never enters model_list: it rides the
-            // built-in /anthropic passthrough with the client's own OAuth
-            // Authorization header.
+            // Subscription rides the /anthropic passthrough, never model_list.
             LlmProviderKind::AnthropicOauth => {}
             LlmProviderKind::AnthropicApiKey => {
                 model_list.push_str(&format!(
@@ -77,8 +70,7 @@ pub fn render_litellm_config(llm: &LlmConfig) -> String {
                     );
                     continue;
                 };
-                // Defense in depth: re-validate before embedding bare in YAML
-                // (pure check; the save path already gates it).
+                // Re-validate before embedding bare in YAML.
                 if let Err(e) = super::llm::validate_base_url(base_url) {
                     log::warn!(
                         "litellm config: provider '{}' has invalid base_url — skipped: {e}",
@@ -86,15 +78,12 @@ pub fn render_litellm_config(llm: &LlmConfig) -> String {
                     );
                     continue;
                 }
-                // Container-side URL: the claude/litellm containers reach a
-                // host-side server via host.docker.internal (ADR-062); the
-                // stored base_url already uses that alias (validate_base_url).
+                // Container-side URL: base_url already uses host.docker.internal (ADR-062).
                 let api_base = ensure_v1_suffix(base_url);
                 let api_key = if entry.has_api_key {
                     key_ref.clone()
                 } else {
-                    // llama.cpp/Ollama ignore the key but litellm's OpenAI
-                    // client requires one.
+                    // litellm's OpenAI client requires a key even when ignored.
                     "\"dummy\"".to_string()
                 };
                 model_list.push_str(&format!(
@@ -129,20 +118,13 @@ fn ensure_v1_suffix(base_url: &str) -> String {
 }
 
 /// Usage-callback source, embedded at compile time. LiteLLM resolves the
-/// `callbacks: litellm_callback.…` module RELATIVE TO THE CONFIG FILE's
-/// directory when started with `--config` (its `get_instance_fn` requires
-/// `<config dir>/litellm_callback.py` to exist and never falls back to
-/// PYTHONPATH) — so the renderer must place the module next to config.yaml.
-/// The copy baked into the image at /opt/speedwave is unreachable for this
-/// purpose.
+/// callbacks module relative to the config dir, so it must sit next to config.yaml.
 const LITELLM_CALLBACK_SRC: &str =
     include_str!("../../../../containers/litellm/litellm_callback.py");
 
-/// Renders and atomically persists the config (0600 + fsync) under
-/// `<data_dir>/litellm/<project>/config.yaml`, alongside the usage-callback
-/// module litellm imports from the same directory. Also lifts a legacy
-/// `local-llm/api_key` into the llm token namespace so a migrated `local`
-/// entry's `SPW_KEY_LOCAL` reference resolves (ADR-073 migration).
+/// Renders and atomically persists the config (0600 + fsync) plus the
+/// usage-callback module under `<data_dir>/litellm/<project>/`. Also lifts a
+/// legacy `local-llm/api_key` into the llm token namespace (ADR-073 migration).
 pub fn write_litellm_config_in(
     data_dir: &Path,
     project: &str,
@@ -165,12 +147,8 @@ pub fn write_litellm_config_in(
 }
 
 /// `SPW_CONFIG_DIGEST` value: sha256 over every rendered `/config` file and
-/// every key file's NAME + CONTENT HASH. Key values are folded in as their
-/// own sha256, not raw — the digest is a one-way fingerprint that can't
-/// reveal a secret, and content-hashing (not size/mtime) means a rotated
-/// same-length key always changes it. litellm reads both config and keys
-/// only at container start, so any change here must alter the compose
-/// definition to force a recreate.
+/// every key file's name + content hash (key values folded in as their own
+/// sha256, never raw). Changing it forces a litellm container recreate.
 pub(crate) fn litellm_state_digest_in(data_dir: &Path, project: &str) -> String {
     use sha2::{Digest, Sha256};
     let mut hasher = Sha256::new();
@@ -211,12 +189,8 @@ pub(crate) fn litellm_state_digest_in(data_dir: &Path, project: &str) -> String 
     crate::bundle::bytes_to_hex(&hasher.finalize())
 }
 
-/// v1→v2 key-file migration: the legacy `local` provider stored its Bearer
-/// at `tokens/<project>/local-llm/api_key`; the litellm entrypoint reads
-/// `tokens/<project>/llm/local_api_key`. Copy once when the target is
-/// missing — the legacy file stays for the kill-switch direct path.
-/// Failures are non-fatal (the proxy then sends the dummy key, exactly the
-/// pre-migration behaviour for keyless servers).
+/// v1→v2 key-file migration: copies legacy `local-llm/api_key` into the llm
+/// token namespace once when the target is missing. Non-fatal on failure.
 fn migrate_legacy_local_key_in(data_dir: &Path, project: &str, llm: &LlmConfig) {
     let needs_local_key = llm
         .providers
@@ -243,9 +217,8 @@ fn migrate_legacy_local_key_in(data_dir: &Path, project: &str, llm: &LlmConfig) 
 }
 
 /// Validates and persists one provider's API key under the llm token
-/// namespace. Mirrors the ADR-040 local-llm key rules: strips an
-/// accidental `Bearer ` prefix, rejects control characters (CRLF header
-/// injection), rejects empty values.
+/// namespace: strips a `Bearer ` prefix, rejects control chars and empty
+/// values (ADR-040 rules).
 pub fn write_llm_provider_key_in(
     data_dir: &Path,
     project: &str,
@@ -412,9 +385,7 @@ general_settings: {}
 
     #[test]
     fn render_skips_provider_with_invalid_base_url() {
-        // Defense in depth: a corrupted/replayed base_url (credentials, traversal,
-        // non-http scheme) is re-validated at render time and the entry dropped
-        // rather than embedded bare in the YAML.
+        // A corrupted base_url is re-validated at render time and dropped.
         for bad in [
             "http://user:pass@host.docker.internal:9000",
             "file:///etc/passwd",
@@ -459,9 +430,7 @@ general_settings: {}
             let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
             assert_eq!(mode, 0o600, "config must be owner-only");
         }
-        // litellm resolves the callbacks module relative to the config file's
-        // directory — the module MUST land next to config.yaml or the proxy
-        // fails startup with "Could not find module file".
+        // The callback module must land next to config.yaml.
         let callback = path.parent().unwrap().join("litellm_callback.py");
         assert!(
             callback.is_file(),
@@ -557,8 +526,7 @@ general_settings: {}
         assert_ne!(d1, d2);
         assert!(!d2.contains("sk-or-v1-abc"));
 
-        // Same-length rotation must still flip the digest — it hashes key
-        // content, not size/mtime (the metadata-only digest could collide).
+        // Same-length rotation must flip the digest: it hashes content, not size/mtime.
         write_llm_provider_key_in(dir.path(), "proj", "openrouter", "sk-or-v1-xyz").unwrap();
         let d3 = litellm_state_digest_in(dir.path(), "proj");
         assert_ne!(d2, d3, "same-length key rotation must change the digest");

--- a/crates/speedwave-runtime/src/compose/llm.rs
+++ b/crates/speedwave-runtime/src/compose/llm.rs
@@ -8,9 +8,7 @@ use crate::consts;
 use std::path::Path;
 
 /// Applies LLM provider switching. Local-LLM token reads resolve under the
-/// explicit `data_dir` so callers (and tests) never touch the production
-/// `~/.speedwave/tokens`. The only caller is `render_compose_in`, which
-/// already threads the data dir.
+/// explicit `data_dir`.
 pub(crate) fn apply_llm_config_in(
     data_dir: &Path,
     yaml: &str,
@@ -19,9 +17,7 @@ pub(crate) fn apply_llm_config_in(
 ) -> anyhow::Result<String> {
     if llm.proxy_enabled.unwrap_or(true) {
         if let Some(entry) = llm.active_provider() {
-            // Local custom headers are addressed to the LLM server itself;
-            // LiteLLM would consume rather than forward them. Those setups
-            // stay on the direct path until the proxy learns to relay them.
+            // Local custom headers are unsupported by the proxy — stay on direct path.
             let needs_direct = entry.kind == LlmProviderKind::Local && entry.has_custom_headers;
             if !needs_direct {
                 return apply_llm_config_proxy(yaml, llm);
@@ -34,19 +30,6 @@ pub(crate) fn apply_llm_config_in(
 
 /// ADR-073 proxy path: every session talks to the litellm service; the
 /// provider kind picks the route and model prefix.
-///
-/// Auth rules (validated in the Phase 0 spike):
-/// - `AnthropicOauth`: passthrough route, and **no** `ANTHROPIC_AUTH_TOKEN` /
-///   `ANTHROPIC_API_KEY` may be injected — any of them disables Claude
-///   Code's OAuth. The OAuth `Authorization` header transits LiteLLM
-///   untouched because the proxy holds no canonical Anthropic credential.
-/// - `AnthropicApiKey`: same passthrough route; the key keeps riding the
-///   claude env (`apply_auth_config_in`) as `x-api-key`, which the
-///   passthrough forwards. This keeps `/model` aliases and the `[1m]`
-///   suffix semantics identical to the direct path.
-/// - Everything else: the unified `/v1/messages` root with a dummy Bearer
-///   (OAuth intentionally disabled) and a `<provider_id>/<model>` name that
-///   matches the wildcard route in the rendered litellm config.
 fn apply_llm_config_proxy(yaml: &str, llm: &LlmConfig) -> anyhow::Result<String> {
     let entry = llm
         .active_provider()
@@ -78,9 +61,7 @@ fn apply_llm_config_proxy(yaml: &str, llm: &LlmConfig) -> anyhow::Result<String>
                     entry.id
                 );
             }
-            // `<id>/<model>` matches the per-provider wildcard route in the
-            // rendered litellm config (OpenRouter models already carry the
-            // `openrouter/` prefix as their provider id by convention).
+            // `<id>/<model>` matches the per-provider wildcard route in the litellm config.
             let routed_model = if model.starts_with(&format!("{}/", entry.id)) {
                 model.to_string()
             } else {
@@ -91,16 +72,13 @@ fn apply_llm_config_proxy(yaml: &str, llm: &LlmConfig) -> anyhow::Result<String>
                     "ANTHROPIC_BASE_URL".to_string(),
                     super::LITELLM_BASE_URL.to_string(),
                 ),
-                // Dummy Bearer: disables OAuth (intended — these sessions
-                // never reach Anthropic) and satisfies servers that demand a
-                // non-empty Authorization.
+                // Dummy Bearer: disables OAuth and satisfies non-empty Authorization.
                 (
                     "ANTHROPIC_AUTH_TOKEN".to_string(),
                     "sk-no-key-required".to_string(),
                 ),
                 ("ANTHROPIC_MODEL".to_string(), routed_model.clone()),
-                // Subagents / background tasks default to a haiku alias no
-                // non-Anthropic backend knows — pin them to the same model.
+                // Pin the subagent/background haiku alias to the same model.
                 (
                     "ANTHROPIC_SMALL_FAST_MODEL".to_string(),
                     routed_model.clone(),
@@ -148,12 +126,7 @@ fn apply_llm_config_legacy_in(
     }
     match provider {
         "anthropic" => {
-            // ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU}_MODEL pin each alias to the
-            // SSOT-latest model id with a `[1m]` suffix where the model
-            // supports a 1M-token context window. Without this, Max/Team
-            // subscribers see their 1M models capped at the 200k base spec
-            // (anthropics/claude-code#34083). Generated dynamically so a SSOT
-            // bump (Opus 4.8 etc.) propagates without touching this branch.
+            // Pins each ANTHROPIC_DEFAULT_*_MODEL alias to the SSOT-latest id with `[1m]` where supported.
             let mut extra_env = crate::defaults::anthropic_default_models_env();
             let model = llm.model.as_deref().map(str::trim).unwrap_or("");
             if !model.is_empty() {
@@ -161,9 +134,7 @@ fn apply_llm_config_legacy_in(
             }
             inject_claude_env(yaml, &extra_env)
         }
-        // All local providers (legacy aliases + `local`) share the same env
-        // injection. `LOCAL_PROVIDERS` is the SSOT — adding a new local name
-        // there propagates here automatically.
+        // All `LOCAL_PROVIDERS` (SSOT) share the same env injection.
         local if crate::config::LOCAL_PROVIDERS.contains(&local) => {
             let base_url = llm
                 .base_url
@@ -180,10 +151,7 @@ fn apply_llm_config_legacy_in(
                 )
             })?;
 
-            // Resolve Bearer auth token. If a per-project key file exists, use
-            // it; otherwise inject the documented `sk-no-key-required` dummy so
-            // Claude Code keeps the Authorization header present (some local
-            // servers expect *any* non-empty Bearer).
+            // Resolve Bearer auth token: per-project key file, else dummy.
             const DUMMY_TOKEN: &str = "sk-no-key-required";
             let auth_token = if llm.has_api_key {
                 read_local_llm_token_opt_in(data_dir, project, "api_key").unwrap_or_else(|| {
@@ -220,12 +188,7 @@ fn apply_llm_config_legacy_in(
                 ),
             ]);
 
-            // Custom HTTP headers — stored as `Name: Value` per line for
-            // human-friendly editing, flattened to a comma-separated single
-            // line here because nerdctl-compose rejects YAML block literals
-            // inside an `environment:` sequence. `Authorization` is rejected
-            // defensively (a stale token file must not smuggle a header that
-            // would collide with the `ANTHROPIC_AUTH_TOKEN` Bearer).
+            // Flatten `Name: Value` header lines to one comma-separated line; drop `Authorization`.
             if llm.has_custom_headers {
                 if let Some(headers) =
                     read_local_llm_token_opt_in(data_dir, project, "custom_headers")
@@ -251,8 +214,7 @@ fn apply_llm_config_legacy_in(
 
             inject_claude_env(yaml, &extra_env)
         }
-        // Unreachable: the early guard above filters all non-LOCAL_PROVIDERS
-        // and non-"anthropic" values before this match.
+        // Unreachable: provider filtered by the early guard above.
         _ => unreachable!("provider validated by early guard"),
     }
 }
@@ -289,9 +251,7 @@ pub fn strip_trailing_v1(url: &str) -> String {
 }
 
 /// Returns the default base URL for a known local model provider.
-/// Used by the frontend to show a placeholder without duplicating the URL logic.
-/// `"local"` defaults to the Ollama port — the most common starting point;
-/// users typically replace it when pointing at a different server.
+/// `"local"` defaults to the Ollama port.
 pub fn default_base_url(provider: &str) -> Option<String> {
     let host = consts::HOST_GATEWAY_ALIAS;
     match provider {
@@ -303,11 +263,6 @@ pub fn default_base_url(provider: &str) -> Option<String> {
 }
 
 /// Human-readable label for a local LLM provider.
-///
-/// Invariant: the only callers (`custom_model_display_name` and
-/// `custom_model_description`) are reached only after `apply_llm_config`
-/// narrows the provider to one of the local values below. Any other
-/// value at this point indicates a programmer error in `apply_llm_config`.
 pub(crate) fn provider_display_label(provider: &str) -> &'static str {
     match provider {
         "ollama" => "Ollama",
@@ -327,15 +282,9 @@ fn custom_model_description(provider: &str) -> String {
 }
 
 /// Validates a base URL for local model providers. Rejects non-HTTP schemes,
-/// credentials, query strings, and fragments.
-///
-/// Path policy: accepts `/` (or empty), or a single-segment prefix matching
-/// `^/[A-Za-z0-9_-]+$` (e.g. LiteLLM's `/anthropic`, AWS gateway's `/v1`).
-/// Multi-segment paths, `..`, and trailing slashes on segments are rejected.
+/// credentials, query strings, fragments, and multi-segment paths.
 pub fn validate_base_url(raw: &str) -> anyhow::Result<()> {
-    // Reject `..` / `.` segments in the *raw* input before url::Url parses, as
-    // the URL crate normalizes them away (`http://host/..` parses to path `/`).
-    // Without this, a malicious URL could slip through traversal checks.
+    // Reject `..` / `.` segments before url::Url parses, as it normalizes them away.
     if raw.contains("/..") || raw.contains("/./") || raw.ends_with("/.") {
         anyhow::bail!("base_url must not contain '..' or '.' path segments");
     }
@@ -350,9 +299,7 @@ pub fn validate_base_url(raw: &str) -> anyhow::Result<()> {
     }
     let path = parsed.path();
     if path != "/" && !path.is_empty() {
-        // Allow a single-segment path prefix (LiteLLM `/anthropic`,
-        // AWS-style `/v1`). Anything multi-segment, traversal, or trailing
-        // slash on the segment is rejected.
+        // Allow only a single-segment path prefix.
         if !path.starts_with('/') {
             anyhow::bail!("base_url path must start with '/', got '{}'", path);
         }

--- a/crates/speedwave-runtime/src/compose/mod.rs
+++ b/crates/speedwave-runtime/src/compose/mod.rs
@@ -85,10 +85,7 @@ use workers::{
     apply_worker_auth_tokens_with_dir, mcp_os_gateway_url, read_lock_port, remove_env_from,
 };
 
-// Test-only override for the bundle build root, so `render_compose_in` resolves
-// the manifest from an injected path instead of the process-global
-// `SPEEDWAVE_RESOURCES_DIR` env var (which other tests mutate). Thread-local so
-// parallel tests don't perturb each other.
+// Test-only bundle build root override; thread-local for parallel test safety.
 #[cfg(test)]
 thread_local! {
     static TEST_BUILD_ROOT: std::cell::RefCell<Option<PathBuf>> = const { std::cell::RefCell::new(None) };
@@ -126,10 +123,8 @@ const IMAGE_PLACEHOLDERS: &[(&str, &str)] = &[
     ("${IMAGE_MCP_CONTEXT7}", build::IMAGE_MCP_CONTEXT7),
 ];
 
-/// One live host-side bridge that compose can advertise to a container
-/// worker. The plugin manifest's `host_bridge` declaration drives both
-/// `slug` (which plugin to match) and the env-var names; the Desktop
-/// process supplies the runtime values (`port`, `auth_token`).
+/// One live host-side bridge compose advertises to a worker. The plugin manifest's
+/// `host_bridge` drives `slug` + env-var names; Desktop supplies `port`/`auth_token`.
 #[derive(Clone)]
 pub struct HostBridgeRegistration {
     /// Plugin slug — matched against `PluginManifest.slug` during
@@ -258,10 +253,8 @@ pub fn render_compose(
     )
 }
 
-/// Env-free core of [`render_compose`]: every data-dir-rooted path is derived
-/// from the explicit `data_dir`, so tests pass a tempdir and never touch the
-/// production `~/.speedwave`. The public no-arg shim resolves `data_dir()` from
-/// the global singleton at the call site.
+/// Env-free core of [`render_compose`]: paths derive from the explicit `data_dir`
+/// (tests pass a tempdir); the public no-arg shim resolves `data_dir()`.
 pub fn render_compose_in(
     data_dir: &Path,
     project_name: &str,
@@ -311,9 +304,7 @@ pub fn render_compose_in(
     }
     yaml = yaml.replace("${IDE_LOCK_DIR}", &to_engine_path(&ide_lock_dir)?);
 
-    // LiteLLM proxy mounts (ADR-073): rendered config (ro) + usage sink (rw).
-    // Both per-project; the config file is rendered here, inside the same
-    // render transaction as the compose file itself.
+    // LiteLLM proxy per-project mounts (ADR-073): rendered config (ro) + usage sink (rw).
     litellm::write_litellm_config_in(data_dir, project_name, &resolved_config.llm)?;
     let litellm_config_dir = data_dir.join("litellm").join(project_name);
     std::fs::create_dir_all(&litellm_config_dir)?;
@@ -339,9 +330,7 @@ pub fn render_compose_in(
     yaml = yaml.replace("${IDE_HOST_OVERRIDE}", ide_host_override());
     yaml = yaml.replace("${CONTAINER_USER}", container_user());
 
-    // Container resource limits (mem/cpu/tmpfs/shm). SSOT: resources.rs table +
-    // McpServiceDescriptor.resources. Renderer substitutes the placeholders the
-    // template carries instead of YAML literals; drift test enforces parity.
+    // Container resource limits (mem/cpu/tmpfs/shm). SSOT: resources.rs + McpServiceDescriptor.resources.
     yaml = apply_container_resources(&yaml);
 
     // Inject Claude environment variables from resolved config
@@ -350,9 +339,7 @@ pub fn render_compose_in(
     // Handle LLM provider switching
     yaml = apply_llm_config_in(data_dir, &yaml, &resolved_config.llm, project_name)?;
 
-    // Ensure plugin images exist (builds pending and missing) before compose generation.
-    // Scoped to plugins enabled for this project — a broken plugin in another project
-    // does not block this one.
+    // Build pending plugin images before compose; scoped to project-enabled plugins.
     if let Some(rt) = runtime {
         let enabled_ids = integrations.enabled_plugin_service_ids();
         plugin::ensure_plugin_images(rt, &enabled_ids)?;
@@ -375,11 +362,7 @@ pub fn render_compose_in(
     let host_tz = crate::tz::detect_host_timezone();
     yaml = inject_host_timezone(&yaml, &host_tz)?;
 
-    // Inject Anthropic API key from secrets if configured.
-    // Skipped when a local LLM provider is active — the dummy
-    // ANTHROPIC_AUTH_TOKEN=sk-no-key-required is all Claude Code needs, and
-    // leaking the real key into a container pointed at a local server would
-    // violate least-privilege for no benefit.
+    // Inject Anthropic API key; skipped when a local LLM provider is active (leak mitigation).
     let provider = resolved_config
         .llm
         .provider
@@ -392,9 +375,7 @@ pub fn render_compose_in(
     // Inject mcp-os config into hub if auth token exists
     yaml = apply_mcp_os_config_in(data_dir, &yaml)?;
 
-    // Inject oauth worker URL + per-service bearer mount into OAuth-consuming worker
-    // containers (today: mcp-sharepoint). No-op if the oauth worker is not running
-    // for this project (ADR-060). Hub is NOT touched — the oauth worker is internal.
+    // Inject oauth worker URL + per-service bearer mount; no-op if oauth not running for project (ADR-060).
     yaml = apply_oauth_config_in(data_dir, &yaml, project_name)?;
 
     // Inject per-worker Bearer auth tokens (SEC-035)
@@ -403,15 +384,10 @@ pub fn render_compose_in(
     // Filter services based on integrations config
     yaml = apply_integrations_filter(&yaml, integrations, &network_name)?;
 
-    // Per-worker credentials digest — a token rotation must change the
-    // worker's config-hash so idempotent `up` recreates it (SEC: bytes
-    // themselves never enter the YAML, only a SHA-256 prefix).
+    // Per-worker credentials digest: token rotation changes config-hash for idempotent recreate.
     yaml = workers::apply_credentials_digests_in(data_dir, &yaml, project_name)?;
 
-    // Final hardening: re-quote any `environment:` value carrying a YAML flow
-    // indicator (e.g. the `[1m]` 1M-context suffix) that libyaml emits
-    // unquoted but nerdctl's Go YAML parser rejects. Must run last — after
-    // every env-injection pass has contributed its entries.
+    // Re-quote env values with YAML flow indicators (e.g. `[1m]` suffix); must run after all env-injection.
     yaml = harden_env_scalar_quoting(&yaml)?;
 
     Ok(yaml)
@@ -427,11 +403,9 @@ fn format_cpus(cpus: f32) -> String {
     format!("{cpus:.1}")
 }
 
-/// Substitutes every `${…_MEM|_CPUS|_TMPFS|_SHM}` placeholder in the compose
-/// template from the resource SSOT (resources.rs table +
-/// `McpServiceDescriptor.resources`). Memory/tmpfs/shm are always emitted in
-/// MiB (`Nm`) for one canonical format; CPU as one-decimal (`2.0`). The
-/// resource-drift test asserts the template carries exactly these placeholders.
+/// Substitutes every `${…_MEM|_CPUS|_TMPFS|_SHM}` placeholder from the resource SSOT
+/// (resources.rs + `McpServiceDescriptor.resources`). Mem/tmpfs/shm emitted as MiB
+/// (`Nm`), CPU as one-decimal (`2.0`); the resource-drift test pins the placeholders.
 fn apply_container_resources(yaml: &str) -> String {
     use crate::resources::{
         ContainerResources, CLAUDE_RESOURCES, HUB_RESOURCES, LITELLM_RESOURCES,
@@ -449,10 +423,7 @@ fn apply_container_resources(yaml: &str) -> String {
 
     let mut out = yaml.to_string();
 
-    // Only Claude's mem placeholder is special-cased: it uses the legacy
-    // ${CLAUDE_MEMORY} name, not the uniform ${CLAUDE_MEM} that `apply` emits.
-    // CPUS and TMPFS already match the ${CLAUDE_*} shape, so `apply` handles
-    // them (and its ${CLAUDE_MEM} replace no-ops — that placeholder is absent).
+    // Claude's mem uses the legacy ${CLAUDE_MEMORY}; CPUS/TMPFS use uniform ${CLAUDE_*}.
     out = out.replace("${CLAUDE_MEMORY}", &format_mib(CLAUDE_RESOURCES.mem_mib));
     apply(&mut out, "CLAUDE", &CLAUDE_RESOURCES);
     apply(&mut out, "MCP_HUB", &HUB_RESOURCES);
@@ -552,17 +523,10 @@ pub(crate) const UNDEFINED_NETWORK_ERROR_FRAGMENT: &str = "undefined network";
 /// `runtime::is_propagation_error` for retry-on-propagation-lag.
 pub(crate) const INVALID_COMPOSE_PROJECT_ERROR_FRAGMENT: &str = "invalid compose project";
 
-/// SSOT for compose schema/parse error fragments that appear when the VM-side
-/// engine reads a stale or torn virtiofs/9p page — e.g. the networks section
-/// (last in the file) truncated mid-`driver:` yields a null driver ("must be a
-/// string"), or a mid-line cut yields a YAML parse error. Recognised by
-/// `runtime::is_propagation_error` for retry-on-propagation-lag.
+/// SSOT for compose schema/parse error fragments seen on a stale/torn virtiofs
+/// read; recognised by `runtime::is_propagation_error` for retry-on-propagation-lag.
 pub(crate) const COMPOSE_SCHEMA_VALIDATION_ERROR_FRAGMENTS: &[&str] = &[
-    // A torn/stale virtiofs page truncates a scalar, so compose-go's schema
-    // validator reports the field as the wrong type. Each fragment is scoped to
-    // a specific generated field (path + type), never the bare "must be a
-    // string" — our renderer always emits valid values, so any of these can
-    // only mean a truncated read, which a retry resolves. See ADR-068.
+    // Field-specific fragments (path + type), never bare "must be a string". See ADR-068.
     "driver must be a string",         // networks.<n>.driver torn
     "cpus must be a number or string", // deploy.resources.limits.cpus torn
     "memory must be a string",         // deploy.resources.limits.memory torn
@@ -723,13 +687,8 @@ fn inject_host_timezone(yaml: &str, tz: &str) -> anyhow::Result<String> {
         .map_err(|e| anyhow::anyhow!("inject_host_timezone: failed to serialize compose YAML: {e}"))
 }
 
-/// Injects the Anthropic API key (legacy credential) into the `claude`
-/// service environment when one is stored at
-/// `secrets/<project>/anthropic_api_key`. OAuth credentials are managed by
-/// Claude Code itself inside the `CLAUDE_HOME` bind-mount — Speedwave never
-/// reads or writes them. On the host they live at
-/// `<data_dir>/claude-home/<project>/.claude/.credentials.json`. See ADR-052.
-/// Resolves the legacy API key path under an explicit data directory.
+/// Injects the legacy Anthropic API key into the `claude` service env when
+/// stored at `secrets/<project>/anthropic_api_key`. See ADR-052.
 pub(crate) fn apply_auth_config_in(
     yaml: &str,
     project: &str,
@@ -791,27 +750,17 @@ pub(crate) fn add_service_env_var(
     Ok(())
 }
 
-/// Injects mcp-os configuration into the mcp-hub container if the
-/// auth token file exists at ~/.speedwave/mcp-os-auth-token.
-/// This allows the hub to forward requests to the mcp-os worker on the host.
-///
-/// Injections into mcp-hub:
+/// Injects mcp-os config into mcp-hub if the auth token file exists. Injections:
 ///   - WORKER_OS_URL env var (platform-specific gateway URL)
 ///   - /secrets/os-auth-token:ro bind-mount (token as file, not env var)
-///
-/// Claude container is NOT modified — it only sees the hub.
-/// Resolves the mcp-os lock/token paths under an explicit data dir so render
-/// under a tempdir never reads the global `~/.speedwave`.
 fn apply_mcp_os_config_in(data_dir: &std::path::Path, yaml: &str) -> anyhow::Result<String> {
     let lock_path = data_dir.join(consts::MCP_OS_LOCK_FILE);
     let token_mount_path = data_dir.join(consts::MCP_OS_AUTH_TOKEN_FILE);
     apply_mcp_os_config_with_path(yaml, &token_mount_path, &lock_path)
 }
 
-/// Test-only alias preserved so existing fixtures keep working. `lock_path`
-/// is the unified `lock.json`; `token_mount_path` is the standalone
-/// token file bind-mounted into the hub (dual-write contract — see
-/// `mcp_os_process::spawn_in`).
+/// Test-only alias. `lock_path` is the unified `lock.json`; `token_mount_path`
+/// is the standalone token file bind-mounted into the hub (see `mcp_os_process::spawn_in`).
 fn apply_mcp_os_config_with_path(
     yaml: &str,
     token_mount_path: &std::path::Path,
@@ -828,15 +777,9 @@ fn apply_mcp_os_config_with_path(
     )
 }
 
-/// Inject `WORKER_OAUTH_URL` + per-service bearer mount into each OAuth-consuming
-/// worker container if the oauth worker is up for this project. The consumer
-/// list is derived from `McpServiceDescriptor::uses_oauth_refresh` — adding a
-/// new OAuth-using integration is a one-line flag flip on its descriptor (ADR-060
-/// §"Compose injection"). Hub is not touched — the oauth worker is internal.
-///
-/// Per-service bearer: each consumer gets its own bearer at
-/// `/secrets/oauth-auth-token-<config_key>:ro`. The bearer values come from
-/// `<oauth-state-dir>/.bearer-map.json` (bearer → service).
+/// Inject `WORKER_OAUTH_URL` + per-service bearer mount into each OAuth-consuming worker if oauth is up
+/// (consumers from `McpServiceDescriptor::uses_oauth_refresh`, ADR-060). Bearer at
+/// `/secrets/oauth-auth-token-<config_key>:ro` from `<oauth-state-dir>/.bearer-map.json`.
 fn apply_oauth_config_in(
     data_dir: &std::path::Path,
     yaml: &str,
@@ -855,11 +798,7 @@ fn apply_oauth_config_with_paths(
     lock_path: &std::path::Path,
     bearer_map_path: &std::path::Path,
 ) -> anyhow::Result<String> {
-    // A Desktop hard-kill (kill -9 / crash) orphans the VM but never runs the
-    // graceful `cleanup_files()` path, so `lock.json` survives pointing at a
-    // dead worker. Injecting that stale port would make every container-side
-    // OAuth refresh hit connection-refused — worse than the "not configured"
-    // state. Gate on PID liveness: a dead/absent worker is treated as absent.
+    // Stale lock.json survives a dead Desktop; gate on PID liveness to avoid injecting a dead port.
     let lock = match crate::host_mcp_process::lock::read(
         lock_path,
         crate::host_mcp_process::lock::LockService::Oauth,
@@ -879,10 +818,7 @@ fn apply_oauth_config_with_paths(
 
     let mut doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(yaml)?;
 
-    // Inject for every consumer in the bearer-map. The map is the SSOT for who
-    // consumes oauth — the supervisor writes it from the spawn consumer list
-    // (built-ins AND plugins), so this loop needs no hardcoded service list and
-    // covers plugins through the same code path.
+    // Inject for every bearer-map consumer; the map is SSOT and covers plugins dynamically.
     for (bearer, service_id) in &bearer_map {
         let compose_service = oauth_consumer_compose_name(service_id);
         let bearer_file = state_dir.join(format!("bearer-{service_id}"));
@@ -916,10 +852,8 @@ pub fn oauth_consumer_compose_name(service_id: &str) -> String {
         .unwrap_or_else(|| crate::plugin::derive_compose_name(service_id))
 }
 
-/// The OAuth consumer service ids enabled for a project: built-ins with
-/// `uses_oauth_refresh` plus plugins whose manifest declares `oauth`. SSOT for
-/// the spawn consumer list — the same set the bearer-map (and thus compose
-/// injection) is built from, so spawn-decision and injection cannot diverge.
+/// OAuth consumer service ids for a project: built-ins with `uses_oauth_refresh`
+/// plus plugins declaring `oauth`. SSOT for the spawn consumer list + bearer-map.
 pub fn oauth_consumer_service_ids(
     resolved: &crate::config::ResolvedIntegrationsConfig,
     enabled_plugins: &[crate::plugin::PluginManifest],
@@ -952,40 +886,22 @@ fn read_oauth_bearer_map(
     Some(map)
 }
 
-/// Returns the UID:GID to set as `user:` in compose services.
-///
-/// Both supported platforms (macOS via Lima, Windows via WSL2) run containerd
-/// as root inside a VM, so UID 1000 maps directly to UID 1000 inside the
-/// container — no user-namespace remapping. We always use the unprivileged
-/// user as defense-in-depth.
+/// Returns the unprivileged `user:` (UID:GID) for compose services. Both platforms
+/// run containerd as root in a VM, so UID 1000 maps 1:1 — no user-namespace remapping.
 pub fn container_user() -> &'static str {
     consts::CONTAINER_USER_UNPRIVILEGED // "1000:1000"
 }
 
-/// Returns the hostname Claude Code should use for IDE WebSocket connections.
-/// Set as `CLAUDE_CODE_IDE_HOST_OVERRIDE` in the container environment.
-/// Overrides Claude Code's hardcoded `ws://127.0.0.1` so it reaches the IDE
-/// Bridge on the host via the gateway alias resolved by `extra_hosts`.
+/// Returns the IDE WebSocket host (set as `CLAUDE_CODE_IDE_HOST_OVERRIDE`),
+/// overriding Claude Code's hardcoded `ws://127.0.0.1` to reach the host IDE
+/// Bridge via the gateway alias in `extra_hosts`.
 fn ide_host_override() -> &'static str {
     consts::HOST_GATEWAY_ALIAS
 }
 
-/// Verifies that a plugin's `claude-resources` directory and every entry
-/// underneath it is a real, non-symlink path inside the canonicalised
-/// plugin directory. Bind-mounting `claude-resources` into the claude
-/// container makes every file beneath it readable from inside; without
-/// this check, an attacker could:
-///
-///   - replace `claude-resources` itself with a symlink to `/etc`, so
-///     the container sees host configuration files at
-///     `/speedwave/plugins/<slug>/`, or
-///
-///   - drop `claude-resources/skills/foo.md → ~/.ssh/id_rsa` so the
-///     mount surfaces user secrets one level deeper.
-///
-/// The plugin signing model has no notion of legitimate symlinks, so
-/// any encountered symlink is fatal — same invariant as
-/// `compute_plugin_digest` in `signing.rs`.
+/// Verifies a plugin's `claude-resources` dir and every entry beneath is a real,
+/// non-symlink path inside the canonicalised plugin dir; any symlink is fatal
+/// (same invariant as `compute_plugin_digest` in `signing.rs`).
 pub(crate) fn ensure_resources_dir_safe(plugin_dir: &Path, resources: &Path) -> anyhow::Result<()> {
     use std::fs;
     let resources_meta = fs::symlink_metadata(resources)?;
@@ -1092,11 +1008,9 @@ pub(crate) fn add_hub_volume(doc: &mut serde_yaml_ng::Value, mount: &str) {
     add_service_volume(doc, "mcp-hub", mount)
 }
 
-/// Idempotently ensures `<service>.extra_hosts` contains an entry mapping
-/// `HOST_GATEWAY_ALIAS` to the host gateway IP. Called AFTER `${HOST_GATEWAY}`
-/// substitution — inserts a literal IP, not a placeholder.
-/// Idempotency by hostname prefix: replaces an existing canonical entry (any IP)
-/// rather than appending a duplicate.
+/// Ensures `<service>.extra_hosts` maps `HOST_GATEWAY_ALIAS` to the gateway IP.
+/// Called after `${HOST_GATEWAY}` substitution (literal IP). Idempotent by
+/// hostname prefix: replaces an existing entry rather than appending a duplicate.
 pub(crate) fn ensure_host_gateway_extra_host(
     doc: &mut serde_yaml_ng::Value,
     service: &str,
@@ -1153,6 +1067,7 @@ pub(crate) fn add_claude_env_var(doc: &mut serde_yaml_ng::Value, key: &str, valu
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use strum::IntoEnumIterator;
@@ -1170,10 +1085,8 @@ mod tests {
             .to_path_buf()
     }
 
-    /// Isolated `render_compose` for tests: roots every data-dir path at the
-    /// caller's `data_dir` (a tempdir) and resolves the bundle manifest from the
-    /// repo build root via `TEST_BUILD_ROOT` — so the test touches neither the
-    /// production `~/.speedwave` nor the global `SPEEDWAVE_RESOURCES_DIR` env.
+    /// Isolated `render_compose` for tests: roots data-dir paths at the caller's tempdir
+    /// and resolves the bundle manifest via `TEST_BUILD_ROOT` — no global `~/.speedwave` or env.
     fn render_compose_isolated(
         data_dir: &Path,
         project_name: &str,
@@ -1204,11 +1117,8 @@ mod tests {
         )
     }
 
-    /// Render the same compose template via `render_compose` with a local
-    /// LLM provider + multi-line custom_headers token, and check the result
-    /// re-parses. This is the production code path; if it diverges from
-    /// `inject_claude_env_multiline_value_keeps_yaml_parseable`, the bug
-    /// is elsewhere in the pipeline (token reader, env merger, host_tz, …).
+    /// Renders via `render_compose` with a local LLM provider + multi-line
+    /// custom_headers and checks the result re-parses (production code path).
     #[test]
     #[serial_test::serial(host_addressing)]
     fn render_compose_with_multiline_custom_headers_is_valid_yaml() {
@@ -1252,15 +1162,10 @@ mod tests {
         )
         .expect("render must succeed");
 
-        // Sanitised in the panic message — the rendered YAML contains the
-        // injected ANTHROPIC_AUTH_TOKEN, which CodeQL flags as cleartext
-        // secret logging. The parse error alone identifies the regression.
+        // Sanitise panic message: rendered YAML carries cleartext ANTHROPIC_AUTH_TOKEN (CodeQL).
         let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(&yaml)
             .unwrap_or_else(|e| panic!("rendered compose YAML must re-parse: {e}"));
-        // Custom headers must survive intact AND be on a single line —
-        // nerdctl/docker-compose YAML parsers reject block literals inside
-        // an `environment:` sequence (manifested as `line N: could not find
-        // expected ':'`), so the headers are joined with `, ` separators.
+        // Custom headers must be single-line: nerdctl/docker-compose reject block literals in environment.
         let env_seq = doc["services"]["claude"]["environment"]
             .as_sequence()
             .expect("claude.environment must be a sequence");
@@ -1275,9 +1180,7 @@ mod tests {
         );
         assert!(header_entry.contains("X-Tenant-ID: foo"));
         assert!(header_entry.contains("X-Subscription-ID: bar"));
-        // The rendered scalar must also be a plain scalar in the raw YAML —
-        // a block literal (`|-`, `>`) would still parse via serde_yaml_ng but
-        // breaks nerdctl-compose, which is what triggered the original bug.
+        // Rendered scalar must be plain in raw YAML: block literals break nerdctl-compose.
         assert!(
             !yaml.contains("ANTHROPIC_CUSTOM_HEADERS=\n")
                 && !yaml.contains("- |-")
@@ -1292,13 +1195,8 @@ mod tests {
         let _ = std::fs::remove_dir(&tokens_dir);
     }
 
-    /// Regression for the unquoted `[1m]` 1M-context suffix that nerdctl's Go
-    /// YAML parser rejected with `could not find expected ":"`. The default
-    /// Anthropic provider injects `ANTHROPIC_DEFAULT_OPUS_MODEL=<id>[1m]`; the
-    /// rendered file must (a) re-parse and (b) carry the bracketed entry as a
-    /// quoted scalar so a strict parser accepts it. The pre-existing
-    /// substring/`from_str` tests missed this because serde_yaml_ng's libyaml
-    /// emitter leaves the bracket unquoted and re-reads it without complaint.
+    /// Regression for the unquoted `[1m]` suffix nerdctl's Go YAML parser rejects;
+    /// rendered file must re-parse and carry the bracketed entry as a quoted scalar.
     #[test]
     #[serial_test::serial(host_addressing)]
     fn render_compose_quotes_bracketed_model_env_and_round_trips() {
@@ -1351,12 +1249,8 @@ mod tests {
             "1M-context suffix must survive intact, got: {opus:?}"
         );
 
-        // (b) Across EVERY service, each `environment:` entry that carries a
-        // YAML flow indicator must be a quoted scalar in the RAW serialized
-        // form — the property the Go parser needs and the old tests never
-        // checked. Scope to env values (via the parsed doc) so non-env lines
-        // that legitimately contain flow indicators (e.g. the tmpfs mount
-        // `/tmp:noexec,nosuid,size=512m`) are not mistaken for env entries.
+        // (b) Across every service, each env entry with a flow indicator must be a
+        // quoted scalar in raw YAML; scoped to env values only (not tmpfs mounts etc).
         let services = doc["services"].as_mapping().expect("services mapping");
         for (_, svc) in services {
             let Some(env) = svc.get("environment").and_then(|e| e.as_sequence()) else {
@@ -1441,10 +1335,8 @@ mod tests {
         let _ = std::fs::remove_dir(&tokens_dir);
     }
 
-    /// Repro for the broken compose YAML observed when a user saves custom
-    /// HTTP headers for a local LLM. Multi-line `ANTHROPIC_CUSTOM_HEADERS`
-    /// values must serialise as a quoted scalar so the YAML parser does not
-    /// treat the second line as a new top-level key.
+    /// Multi-line `ANTHROPIC_CUSTOM_HEADERS` must serialise as a quoted scalar so the
+    /// YAML parser does not treat the second line as a new top-level key.
     #[test]
     fn inject_claude_env_multiline_value_keeps_yaml_parseable() {
         let yaml = "services:\n  claude:\n    image: x\n    environment:\n    - PORT=4000\n";
@@ -1489,10 +1381,7 @@ mod tests {
             .map(|s| s[prefix.len()..].to_string())
     }
 
-    /// Returns VALID_COMPOSE with hardcoded user values replaced by the value
-    /// from `container_user()` ("1000:1000" on both supported platforms).
-    /// Kept as a helper so the existing fixture string stays the SSOT for the
-    /// rest of the compose shape.
+    /// Returns VALID_COMPOSE with user values replaced by `container_user()` ("1000:1000").
     fn valid_compose_yaml() -> String {
         VALID_COMPOSE.replace(
             "user: \"1000:1000\"",
@@ -1891,9 +1780,7 @@ services:
     #[test]
     fn test_security_check_external_llm_keys_covers_major_providers() {
         let data_dir = tempfile::tempdir().unwrap();
-        // Each prefix on its own line — one violation per leaked key. We assert the
-        // rule fires for every major third-party LLM vendor, not just the four
-        // originally hard-coded.
+        // One violation per leaked key; covers every major third-party LLM vendor.
         for key in [
             "OPENAI_API_KEY=sk-x",
             "AZURE_OPENAI_API_KEY=az-x",
@@ -2169,10 +2056,8 @@ services:
             crate::consts::PORT_WORKER
         );
 
-        // ADR-062: mcp-playwright resolves `host.docker.internal` to the platform
-        // gateway IP so Claude and plugins can navigate to host-local services
-        // (e.g. local dev servers). Verifies the rendered compose — not the
-        // template — so the `${HOST_GATEWAY}` substitution must have occurred.
+        // ADR-062: mcp-playwright resolves host.docker.internal to the gateway IP.
+        // Verifies the rendered compose, not the template (${HOST_GATEWAY} substituted).
         let extra_hosts = pw
             .get("extra_hosts")
             .and_then(|v| v.as_sequence())
@@ -2369,9 +2254,7 @@ services:
     }
 
     /// mcp-github must render with the standard worker hardening, the read-only
-    /// project-scoped `/tokens` mount, and `PORT=PORT_WORKER`. Its memory cap
-    /// comes from the SSOT (McpServiceDescriptor.resources) and is guarded by
-    /// `resources_render_from_ssot`, not duplicated here.
+    /// project-scoped `/tokens` mount, and `PORT=PORT_WORKER` (mem cap guarded by `resources_render_from_ssot`).
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_render_compose_github_service_present() {
@@ -2497,8 +2380,10 @@ services:
     /// and the `WORKER_GITHUB_URL` hub env entry.
     #[test]
     fn test_apply_integrations_filter_disables_github() {
-        let mut integrations = ResolvedIntegrationsConfig::default();
-        integrations.github = false;
+        let integrations = ResolvedIntegrationsConfig {
+            github: false,
+            ..Default::default()
+        };
 
         let filtered =
             apply_integrations_filter(VALID_COMPOSE, &integrations, "speedwave_test_network")
@@ -2507,7 +2392,7 @@ services:
 
         let services = doc.get("services").and_then(|s| s.as_mapping()).unwrap();
         assert!(
-            !services.contains_key(&serde_yaml_ng::Value::String("mcp-github".into())),
+            !services.contains_key(serde_yaml_ng::Value::String("mcp-github".into())),
             "mcp-github must be removed when disabled"
         );
         let hub_env = get_hub_env_seq(&doc);
@@ -2521,8 +2406,10 @@ services:
     /// the WORKER_PLAYWRIGHT_URL hub env entry.
     #[test]
     fn test_apply_integrations_filter_disables_playwright() {
-        let mut integrations = ResolvedIntegrationsConfig::default();
-        integrations.playwright = false;
+        let integrations = ResolvedIntegrationsConfig {
+            playwright: false,
+            ..Default::default()
+        };
 
         let filtered =
             apply_integrations_filter(VALID_COMPOSE, &integrations, "speedwave_test_network")
@@ -2531,7 +2418,7 @@ services:
 
         let services = doc.get("services").and_then(|s| s.as_mapping()).unwrap();
         assert!(
-            !services.contains_key(&serde_yaml_ng::Value::String("mcp-playwright".into())),
+            !services.contains_key(serde_yaml_ng::Value::String("mcp-playwright".into())),
             "mcp-playwright must be removed when disabled"
         );
 
@@ -2635,9 +2522,7 @@ services:
         let worker_port_line = format!("PORT={}", crate::consts::PORT_WORKER);
         for (name_value, svc) in services {
             let name = name_value.as_str().unwrap_or("");
-            // Only workers have PORT=; claude does not define PORT, and
-            // litellm listens on a fixed port baked into its entrypoint
-            // (ADR-073) — it is not an MCP worker.
+            // Only workers define PORT; claude and litellm do not (litellm uses a fixed entrypoint port, ADR-073).
             if name == "claude" || name == "mcp-hub" || name == "litellm" {
                 continue;
             }
@@ -2682,11 +2567,7 @@ services:
         for entry in get_hub_env_seq(&serde_yaml_ng::from_str(&yaml).unwrap()) {
             if let Some((key, value)) = entry.split_once('=') {
                 if key.starts_with("WORKER_") && key.ends_with("_URL") {
-                    // WORKER_OS_URL is a host-side gateway (host.docker.internal)
-                    // with a dynamically assigned port — the worker runs on the
-                    // host, not in the compose network. ADR-038's "every
-                    // WORKER_*_URL points at :PORT_WORKER" rule applies only to
-                    // in-cluster (containerized) workers.
+                    // WORKER_OS_URL is a host-side gateway with a dynamic port; ADR-038 applies only to in-cluster workers.
                     if key == "WORKER_OS_URL" {
                         continue;
                     }
@@ -2932,10 +2813,7 @@ services:
 
     #[test]
     fn test_compose_template_all_services_have_pull_policy_never() {
-        // All images are built locally — nerdctl must never attempt to pull from a
-        // remote registry. Without `pull_policy: never`, nerdctl resolves unqualified
-        // image names (e.g. `speedwave-mcp-hub:tag`) as `docker.io/library/...` and
-        // fails with "pull access denied".
+        // Images built locally; without `pull_policy: never` nerdctl pulls unqualified names from docker.io/library.
         let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(COMPOSE_TEMPLATE).unwrap();
         let services = doc.get("services").unwrap().as_mapping().unwrap();
         for (name, svc) in services {
@@ -3004,9 +2882,7 @@ services:
         )
         .unwrap();
         let tmp = tempfile::tempdir().unwrap();
-        // Expected paths must derive from the SAME data_dir the render used —
-        // `compute()` reads the production singleton, which diverges from the
-        // tempdir-rooted tokens mount (litellm always mounts tokens/<p>/llm).
+        // Expected paths must derive from the render's data_dir; compute() reads the production singleton.
         let tokens_dir = data_dir.path().join("tokens").join("test-project");
         let violations = SecurityCheck::run_with_data_dir(
             &yaml,
@@ -3050,10 +2926,7 @@ services:
         );
     }
 
-    /// Second call with the same key must REPLACE, not duplicate. Both claude and
-    /// hub receive ENABLED_SERVICES via this helper; re-renders would otherwise
-    /// accumulate stale entries in env sequences. Test both services so a future
-    /// regression that breaks the replace-path for one container is caught.
+    /// Second call with the same key must REPLACE, not duplicate; tested on both claude and hub.
     #[test]
     fn test_inject_env_into_idempotent() {
         for service in ["mcp-hub", "claude"] {
@@ -3466,9 +3339,7 @@ services:
             &HostBridgesInfo::default(),
         )
         .unwrap();
-        // Default anthropic (legacy direct path): the litellm SERVICE exists in
-        // every rendered compose (ADR-073) but the claude container's env must
-        // not be redirected at it until the proxy injection path is active.
+        // Default anthropic: litellm service always exists (ADR-073) but claude env is not redirected until proxy injection active.
         assert!(
             !yaml.contains("llm-proxy"),
             "Default anthropic provider should not add llm-proxy"
@@ -3714,10 +3585,9 @@ services:
             .collect()
     }
 
-    /// ADR-073: the litellm service renders in every compose with the locally
-    /// built image, hardened mounts (config ro, tokens ro, usage rw), no host
-    /// ports, and the per-project network — and its host-side mount dirs are
-    /// created by the renderer.
+    /// ADR-073: litellm renders in every compose with the local image, hardened mounts
+    /// (config ro, tokens ro, usage rw), no host ports, the per-project network, and
+    /// renderer-created mount dirs.
     #[test]
     #[serial_test::serial(host_addressing)]
     fn test_litellm_service_rendered() {
@@ -4022,10 +3892,7 @@ services:
     #[serial_test::serial(host_addressing)]
     fn test_custom_provider_rejected_after_removal() {
         let data_dir = tempfile::tempdir().unwrap();
-        // Regression guard: the `custom` provider value was removed end-to-end.
-        // Any lingering config that still sets `provider = "custom"` must now
-        // fall through to the same unknown-provider path used by any other
-        // unsupported value (e.g. `openrouter`), not a bespoke `custom` branch.
+        // Regression guard: provider="custom" removed end-to-end; falls through to the unknown-provider path.
         let config = ResolvedClaudeConfig {
             env: crate::defaults::base_env(),
             flags: default_flags(),
@@ -4067,9 +3934,7 @@ services:
         assert_eq!(strip_trailing_v1("http://x:8080"), "http://x:8080");
         assert_eq!(strip_trailing_v1(""), "");
         assert_eq!(strip_trailing_v1("http://x:8080/v1/v1"), "http://x:8080/v1");
-        // Regression: trailing slash without /v1 must be stripped too,
-        // otherwise ANTHROPIC_BASE_URL ends with '/' and produces
-        // double-slash request paths.
+        // Regression: trailing slash without /v1 must be stripped too, else double-slash request paths.
         assert_eq!(strip_trailing_v1("http://x:8080/"), "http://x:8080");
         assert_eq!(strip_trailing_v1("http://x:8080///"), "http://x:8080");
     }
@@ -4191,9 +4056,7 @@ services:
 
     #[test]
     fn compose_template_claude_has_canonical_host_gateway_entry() {
-        // Static template guard — `claude` and `mcp-playwright` must list the
-        // canonical host gateway alias in extra_hosts (ADR-062). Other services
-        // receive it dynamically through `ensure_host_gateway_extra_host`.
+        // Static template guard: claude and mcp-playwright must list the host gateway alias in extra_hosts (ADR-062).
         let expected = format!(r#"- "{}:${{HOST_GATEWAY}}""#, consts::HOST_GATEWAY_ALIAS);
         assert!(
             COMPOSE_TEMPLATE.lines().any(|l| l.trim() == expected),
@@ -4233,10 +4096,7 @@ services:
         }
     }
 
-    /// ADR-062: the `mcp-playwright` block in the template must declare
-    /// the canonical `extra_hosts` entry so Claude and plugins can navigate
-    /// to host-local services. This guard catches removal of the alias from
-    /// the template, independent of the rendered-compose test.
+    /// ADR-062: the `mcp-playwright` template block must declare the canonical `extra_hosts` entry.
     #[test]
     fn mcp_playwright_section_has_extra_hosts_in_template() {
         let needle = "\n  mcp-playwright:\n";
@@ -4250,9 +4110,7 @@ services:
             .unwrap_or(COMPOSE_TEMPLATE.len());
         let pw_block = &COMPOSE_TEMPLATE[pw_start..next_service];
         let expected = format!(r#"- "{}:${{HOST_GATEWAY}}""#, consts::HOST_GATEWAY_ALIAS);
-        // Match an actual YAML list item, not the same string inside a comment.
-        // `lines().any(|l| l.trim() == expected)` rejects commented-out lines
-        // (they start with `#` after trim), unlike `contains()` on the whole block.
+        // Match an actual YAML list item, not the string inside a comment; lines().any() rejects commented-out lines.
         assert!(
             pw_block.lines().any(|l| l.trim() == expected),
             "mcp-playwright section in compose.template.yml must declare extra_hosts '{expected}' (ADR-062)"
@@ -4266,11 +4124,7 @@ services:
     }
 
     // --- Resource SSOT works (ADR-068) -----------------------------------------
-    // One test proving the centralization holds: the renderer fills every
-    // container's mem/cpu/tmpfs/shm from the SSOT (resources.rs table +
-    // McpServiceDescriptor.resources), and no resource placeholder is left
-    // behind. If the renderer stops reading the SSOT, a service's value drifts,
-    // or a placeholder is misnamed, this fails.
+    // Renderer fills every container's mem/cpu/tmpfs/shm from the SSOT, no placeholder left (ADR-068).
 
     /// Reads a service's mem/cpu/tmpfs/shm out of the rendered doc and asserts
     /// they equal its SSOT entry. Iterating callers stay literal-free.
@@ -4315,9 +4169,7 @@ services:
         for svc in crate::consts::TOGGLEABLE_MCP_SERVICES {
             assert_resources_from_ssot(&doc, svc.compose_name, &svc.resources);
         }
-        // No RESOURCE placeholder left unsubstituted. Only the families this
-        // function owns — other ${…} (IMAGE_*, NETWORK_NAME, …) are filled by
-        // later render stages and are intentionally still present here.
+        // No resource placeholder left unsubstituted; IMAGE_*, NETWORK_NAME are filled later.
         for marker in ["_MEM}", "_CPUS}", "_TMPFS}", "_SHM}", "${CLAUDE_MEMORY}"] {
             assert!(
                 !yaml.contains(marker),
@@ -4325,9 +4177,7 @@ services:
             );
         }
 
-        // The RAW template must carry a placeholder for each worker's mem/cpu —
-        // catches a regression where a literal equal to the SSOT value is
-        // hardcoded back in (which the rendered-value check above would miss).
+        // Raw template must carry a placeholder for each worker's mem/cpu; catches a re-hardcoded literal.
         for svc in crate::consts::TOGGLEABLE_MCP_SERVICES {
             let prefix = svc.compose_name.to_ascii_uppercase().replace('-', "_");
             assert!(
@@ -4340,19 +4190,13 @@ services:
                 "{}: template must carry ${{{prefix}_CPUS}}, not a literal",
                 svc.compose_name
             );
-            // tmpfs is the axis most prone to a silent re-hardcode (SSOT value
-            // often equals the literal, e.g. size=64m), so it needs the same
-            // raw-template presence guard as _MEM/_CPUS — the rendered-value
-            // check alone would not catch a literal that coincidentally matches.
+            // tmpfs is most prone to a silent re-hardcode; needs the same raw-template guard as _MEM/_CPUS.
             assert!(
                 COMPOSE_TEMPLATE.contains(&format!("${{{prefix}_TMPFS}}")),
                 "{}: template must carry ${{{prefix}_TMPFS}}, not a literal",
                 svc.compose_name
             );
-            // A `_SHM` placeholder must exist in the template IFF the descriptor
-            // sets shm_mib. A descriptor with Some(shm) but no placeholder would
-            // silently never apply (apply() no-ops); a placeholder with None
-            // would survive as a leftover marker. Assert both directions.
+            // _SHM placeholder must exist IFF the descriptor sets shm_mib; assert both directions.
             assert_eq!(
                 COMPOSE_TEMPLATE.contains(&format!("${{{prefix}_SHM}}")),
                 svc.resources.shm_mib.is_some(),
@@ -4361,9 +4205,7 @@ services:
             );
         }
 
-        // Same raw-template guard for the always-on containers — a literal
-        // equal to the SSOT value passes the rendered check, only the
-        // placeholder proves the template still defers. (claude mem is legacy.)
+        // Same raw-template guard for the always-on containers (claude mem is legacy).
         for placeholder in [
             "${CLAUDE_MEMORY}",
             "${CLAUDE_CPUS}",
@@ -4567,10 +4409,7 @@ services:
         );
     }
 
-    // SSOT-definition guards: literal expected values for each local provider.
-    // Render tests above use `default_base_url()` to avoid drift; these tests
-    // pin the actual literal so that breaking BOTH the function AND the render
-    // assertion in lockstep would still fail here.
+    // SSOT-definition guards: pin the literal expected base_url for each local provider.
 
     #[test]
     fn test_default_base_url_ollama_returns_canonical_url() {
@@ -4599,11 +4438,7 @@ services:
     #[test]
     fn test_anthropic_with_model_injects_anthropic_model_env() {
         let data_dir = tempfile::tempdir().unwrap();
-        // Settings → LLM Provider → Model dropdown writes the chosen value
-        // into claude.llm.model. compose must translate that into the
-        // ANTHROPIC_MODEL env var so Claude Code respects the user's pick
-        // (without this, the dropdown was silently ignored — Claude Code
-        // kept falling back to its built-in default).
+        // claude.llm.model must translate into the ANTHROPIC_MODEL env var so Claude Code respects the pick.
         let llm = LlmConfig {
             provider: Some("anthropic".to_string()),
             model: Some("claude-sonnet-4-6".to_string()),
@@ -4678,12 +4513,8 @@ services:
     #[test]
     fn test_anthropic_injects_default_alias_env_vars() {
         let data_dir = tempfile::tempdir().unwrap();
-        // Workaround for anthropics/claude-code#34083 — without
-        // ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU}_MODEL pointing to the
-        // `[1m]` variant, Max/Team subscribers see their 1M models capped
-        // at 200k. compose must inject these regardless of whether the
-        // user pinned an explicit model, because the alias resolution is
-        // what unlocks the upgraded window.
+        // Workaround for anthropics/claude-code#34083: inject ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU}_MODEL
+        // `[1m]` variants regardless of an explicit pinned model.
         let llm = LlmConfig {
             provider: Some("anthropic".to_string()),
             model: None,
@@ -5188,10 +5019,7 @@ services:
 
     #[test]
     fn test_mcp_os_config_skipped_when_token_path_does_not_exist() {
-        // The desktop process can delete and recreate ~/.speedwave/mcp-os-*
-        // files at any moment (mcp-os respawn). Treat a missing token file
-        // the same as an empty/absent config — never bubble up `os error 2`
-        // and abort `render_compose`.
+        // A missing mcp-os token file is treated as absent config; never abort render_compose with os error 2.
         let tmp = tempfile::tempdir().unwrap();
         let token_path = tmp.path().join("does-not-exist");
         let port_path = tmp.path().join("does-not-exist-port");
@@ -5414,10 +5242,7 @@ services:
 
     #[test]
     fn test_oauth_config_injects_into_plugin_consumer() {
-        // A plugin slug in the bearer-map must get WORKER_OAUTH_URL + bearer
-        // mount on its derived compose service (`mcp-<slug>`), with no built-in
-        // descriptor entry — the injection loop is bearer-map-driven, not
-        // descriptor-driven.
+        // A plugin slug in the bearer-map gets WORKER_OAUTH_URL + bearer mount on its derived service (mcp-<slug>), no descriptor entry.
         let compose = r#"
 services:
   mcp-hub:
@@ -5568,11 +5393,7 @@ services:
         }
     }
 
-    /// Negative-injection test (plan §PR2:259):
-    /// `apply_oauth_config` must NOT touch services other than SharePoint.
-    /// Without this fixture (slack + redmine alongside sharepoint), the
-    /// happy-path test only proves "hub is untouched" — a regression that
-    /// blanket-injects WORKER_OAUTH_URL into every worker would still pass.
+    /// Negative-injection test: `apply_oauth_config` must NOT touch services other than SharePoint.
     #[test]
     fn test_oauth_config_injects_url_and_bearer_into_slack_consumer() {
         // ADR-071: slack consumes the host oauth worker exactly like sharepoint.
@@ -5680,10 +5501,7 @@ services:
         }
     }
 
-    /// Regression guard: after a Desktop hard-kill the graceful cleanup never
-    /// runs, so `lock.json` survives pointing at a dead PID. The injection path
-    /// must treat that as absent (no `WORKER_OAUTH_URL`) instead of wiring up a
-    /// dead port that fails every container-side refresh with connection-refused.
+    /// Regression guard: a stale `lock.json` with a dead PID is treated as absent (no `WORKER_OAUTH_URL`).
     #[test]
     fn test_oauth_config_skipped_when_worker_pid_is_dead() {
         // Reap a real child so its PID is deterministically dead (not merely
@@ -5910,8 +5728,7 @@ services:
     #[test]
     fn test_security_check_wrong_user_value() {
         let data_dir = tempfile::tempdir().unwrap();
-        let yaml = format!(
-            r#"
+        let yaml = r#"
 version: "3"
 services:
   evil-addon:
@@ -5922,7 +5739,7 @@ services:
     security_opt:
       - no-new-privileges:true
 "#
-        );
+        .to_string();
         let violations = SecurityCheck::run_with_data_dir(
             &yaml,
             "test",
@@ -6524,11 +6341,13 @@ services:
 
         // Verify mcp-slack exists before filtering
         let services = doc.get("services").unwrap().as_mapping().unwrap();
-        assert!(services.contains_key(&serde_yaml_ng::Value::String("mcp-slack".into())));
+        assert!(services.contains_key(serde_yaml_ng::Value::String("mcp-slack".into())));
 
         // Disable slack
-        let mut integrations = ResolvedIntegrationsConfig::default();
-        integrations.slack = false;
+        let integrations = ResolvedIntegrationsConfig {
+            slack: false,
+            ..Default::default()
+        };
 
         let yaml = serde_yaml_ng::to_string(&doc).unwrap();
         let filtered =
@@ -6538,16 +6357,18 @@ services:
         let filtered_services = filtered_doc.get("services").unwrap().as_mapping().unwrap();
 
         // mcp-slack should be removed
-        assert!(!filtered_services.contains_key(&serde_yaml_ng::Value::String("mcp-slack".into())));
+        assert!(!filtered_services.contains_key(serde_yaml_ng::Value::String("mcp-slack".into())));
         // claude and mcp-hub must remain
-        assert!(filtered_services.contains_key(&serde_yaml_ng::Value::String("claude".into())));
-        assert!(filtered_services.contains_key(&serde_yaml_ng::Value::String("mcp-hub".into())));
+        assert!(filtered_services.contains_key(serde_yaml_ng::Value::String("claude".into())));
+        assert!(filtered_services.contains_key(serde_yaml_ng::Value::String("mcp-hub".into())));
     }
 
     #[test]
     fn test_integrations_filter_removes_worker_url_from_hub() {
-        let mut integrations = ResolvedIntegrationsConfig::default();
-        integrations.gitlab = false;
+        let integrations = ResolvedIntegrationsConfig {
+            gitlab: false,
+            ..Default::default()
+        };
 
         let filtered =
             apply_integrations_filter(VALID_COMPOSE, &integrations, "speedwave_test_network")
@@ -6575,11 +6396,13 @@ services:
 
     #[test]
     fn test_integrations_filter_injects_enabled_services() {
-        let mut integrations = ResolvedIntegrationsConfig::default();
-        integrations.slack = true;
-        integrations.sharepoint = true;
-        integrations.gitlab = true;
-        integrations.os_calendar = true;
+        let integrations = ResolvedIntegrationsConfig {
+            slack: true,
+            sharepoint: true,
+            gitlab: true,
+            os_calendar: true,
+            ..Default::default()
+        };
 
         let filtered =
             apply_integrations_filter(VALID_COMPOSE, &integrations, "speedwave_test_network")
@@ -6630,17 +6453,19 @@ services:
         let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(&filtered).unwrap();
         let services = doc.get("services").unwrap().as_mapping().unwrap();
 
-        assert!(services.contains_key(&serde_yaml_ng::Value::String("claude".into())));
-        assert!(services.contains_key(&serde_yaml_ng::Value::String("mcp-hub".into())));
+        assert!(services.contains_key(serde_yaml_ng::Value::String("claude".into())));
+        assert!(services.contains_key(serde_yaml_ng::Value::String("mcp-hub".into())));
         // No MCP worker services should remain
-        assert!(!services.contains_key(&serde_yaml_ng::Value::String("mcp-slack".into())));
+        assert!(!services.contains_key(serde_yaml_ng::Value::String("mcp-slack".into())));
     }
 
     #[test]
     fn test_integrations_filter_disabled_os_services_injected() {
-        let mut integrations = ResolvedIntegrationsConfig::default();
-        integrations.os_calendar = true;
-        integrations.os_notes = true;
+        let integrations = ResolvedIntegrationsConfig {
+            os_calendar: true,
+            os_notes: true,
+            ..Default::default()
+        };
         // reminders and mail remain false (default)
 
         let filtered =
@@ -6659,11 +6484,13 @@ services:
 
     #[test]
     fn test_integrations_filter_no_disabled_os_when_all_os_enabled() {
-        let mut integrations = ResolvedIntegrationsConfig::default();
-        integrations.os_reminders = true;
-        integrations.os_calendar = true;
-        integrations.os_mail = true;
-        integrations.os_notes = true;
+        let integrations = ResolvedIntegrationsConfig {
+            os_reminders: true,
+            os_calendar: true,
+            os_mail: true,
+            os_notes: true,
+            ..Default::default()
+        };
 
         let filtered =
             apply_integrations_filter(VALID_COMPOSE, &integrations, "speedwave_test_network")
@@ -6690,7 +6517,7 @@ services:
         let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(&filtered).unwrap();
 
         let services = doc.get("services").unwrap().as_mapping().unwrap();
-        assert!(services.contains_key(&serde_yaml_ng::Value::String("mcp-office".into())));
+        assert!(services.contains_key(serde_yaml_ng::Value::String("mcp-office".into())));
         let office_nets: Vec<&str> = services
             .get(serde_yaml_ng::Value::String("mcp-office".into()))
             .and_then(|s| s.get("networks"))
@@ -6727,7 +6554,7 @@ services:
         let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(&filtered).unwrap();
 
         let services = doc.get("services").unwrap().as_mapping().unwrap();
-        assert!(!services.contains_key(&serde_yaml_ng::Value::String("mcp-office".into())));
+        assert!(!services.contains_key(serde_yaml_ng::Value::String("mcp-office".into())));
         assert!(doc
             .get("networks")
             .and_then(|n| n.get("speedwave_test_network_office"))
@@ -6754,11 +6581,13 @@ services:
             flags: default_flags(),
             llm: LlmConfig::default(),
         };
-        let mut integrations = ResolvedIntegrationsConfig::default();
-        integrations.sharepoint = true;
-        integrations.gitlab = true;
-        integrations.github = true;
-        integrations.os_calendar = true;
+        let integrations = ResolvedIntegrationsConfig {
+            sharepoint: true,
+            gitlab: true,
+            github: true,
+            os_calendar: true,
+            ..Default::default()
+        };
         // slack, redmine remain disabled (default)
         // os_reminders, os_mail, os_notes remain disabled (default)
 
@@ -6780,18 +6609,18 @@ services:
 
         // mcp-slack should be removed (disabled by default)
         assert!(
-            !services.contains_key(&serde_yaml_ng::Value::String("mcp-slack".into())),
+            !services.contains_key(serde_yaml_ng::Value::String("mcp-slack".into())),
             "mcp-slack should be removed when slack is disabled"
         );
 
         // claude and mcp-hub must still be present
-        assert!(services.contains_key(&serde_yaml_ng::Value::String("claude".into())));
-        assert!(services.contains_key(&serde_yaml_ng::Value::String("mcp-hub".into())));
+        assert!(services.contains_key(serde_yaml_ng::Value::String("claude".into())));
+        assert!(services.contains_key(serde_yaml_ng::Value::String("mcp-hub".into())));
 
         // Enabled services should be present
-        assert!(services.contains_key(&serde_yaml_ng::Value::String("mcp-sharepoint".into())));
-        assert!(services.contains_key(&serde_yaml_ng::Value::String("mcp-gitlab".into())));
-        assert!(services.contains_key(&serde_yaml_ng::Value::String("mcp-github".into())));
+        assert!(services.contains_key(serde_yaml_ng::Value::String("mcp-sharepoint".into())));
+        assert!(services.contains_key(serde_yaml_ng::Value::String("mcp-gitlab".into())));
+        assert!(services.contains_key(serde_yaml_ng::Value::String("mcp-github".into())));
 
         // ENABLED_SERVICES should be in hub env
         let env = get_hub_env_seq(&doc);
@@ -6840,15 +6669,15 @@ services:
         let services = doc.get("services").unwrap().as_mapping().unwrap();
 
         // No MCP worker services should remain
-        assert!(!services.contains_key(&serde_yaml_ng::Value::String("mcp-slack".into())));
+        assert!(!services.contains_key(serde_yaml_ng::Value::String("mcp-slack".into())));
         assert!(
-            !services.contains_key(&serde_yaml_ng::Value::String("mcp-sharepoint".into()))
+            !services.contains_key(serde_yaml_ng::Value::String("mcp-sharepoint".into()))
                 || !VALID_COMPOSE.contains("mcp-sharepoint")
         );
 
         // claude and mcp-hub must remain
-        assert!(services.contains_key(&serde_yaml_ng::Value::String("claude".into())));
-        assert!(services.contains_key(&serde_yaml_ng::Value::String("mcp-hub".into())));
+        assert!(services.contains_key(serde_yaml_ng::Value::String("claude".into())));
+        assert!(services.contains_key(serde_yaml_ng::Value::String("mcp-hub".into())));
 
         let env = get_hub_env_seq(&doc);
 
@@ -6919,8 +6748,10 @@ services:
 
     #[test]
     fn test_single_enabled_keeps_only_that_service() {
-        let mut integrations = ResolvedIntegrationsConfig::default();
-        integrations.slack = true;
+        let integrations = ResolvedIntegrationsConfig {
+            slack: true,
+            ..Default::default()
+        };
 
         let filtered =
             apply_integrations_filter(VALID_COMPOSE, &integrations, "speedwave_test_network")
@@ -6929,12 +6760,12 @@ services:
         let services = doc.get("services").unwrap().as_mapping().unwrap();
 
         // mcp-slack should remain
-        assert!(services.contains_key(&serde_yaml_ng::Value::String("mcp-slack".into())));
+        assert!(services.contains_key(serde_yaml_ng::Value::String("mcp-slack".into())));
 
         // Other MCP services in VALID_COMPOSE should be gone (only mcp-slack was in template)
         // claude and mcp-hub must remain
-        assert!(services.contains_key(&serde_yaml_ng::Value::String("claude".into())));
-        assert!(services.contains_key(&serde_yaml_ng::Value::String("mcp-hub".into())));
+        assert!(services.contains_key(serde_yaml_ng::Value::String("claude".into())));
+        assert!(services.contains_key(serde_yaml_ng::Value::String("mcp-hub".into())));
 
         let env = get_hub_env_seq(&doc);
 
@@ -7703,7 +7534,7 @@ services:
         // Verify the service appears
         let services = doc.get("services").unwrap().as_mapping().unwrap();
         assert!(
-            services.contains_key(&serde_yaml_ng::Value::String("mcp-example-plugin".into())),
+            services.contains_key(serde_yaml_ng::Value::String("mcp-example-plugin".into())),
             "Enabled plugin service mcp-example-plugin should appear in compose"
         );
     }
@@ -7765,7 +7596,7 @@ services:
         let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(VALID_COMPOSE).unwrap();
         let services = doc.get("services").unwrap().as_mapping().unwrap();
         assert!(
-            !services.contains_key(&serde_yaml_ng::Value::String("mcp-example-plugin".into())),
+            !services.contains_key(serde_yaml_ng::Value::String("mcp-example-plugin".into())),
             "Disabled plugin service should NOT appear in compose"
         );
     }
@@ -7775,7 +7606,7 @@ services:
         // Simulate apply_plugins injecting WORKER_EXAMPLE_PLUGIN_URL into mcp-hub
         let mut doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(VALID_COMPOSE).unwrap();
         let worker_env = plugin::derive_worker_env("example-plugin");
-        let url = format!("http://mcp-example-plugin:4010");
+        let url = "http://mcp-example-plugin:4010".to_string();
         inject_worker_env(&mut doc, &worker_env, &url);
 
         let env = get_hub_env_seq(&doc);
@@ -7791,7 +7622,7 @@ services:
     fn test_apply_plugins_speedwave_plugins_env() {
         // Simulate apply_plugins setting SPEEDWAVE_PLUGINS in claude container
         let mut doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(VALID_COMPOSE).unwrap();
-        let slugs = vec!["example-plugin".to_string(), "analytics".to_string()];
+        let slugs = ["example-plugin".to_string(), "analytics".to_string()];
         add_claude_env_var(&mut doc, "SPEEDWAVE_PLUGINS", &slugs.join(","));
 
         let claude = doc.get("services").unwrap().get("claude").unwrap();
@@ -8333,17 +8164,16 @@ services:
         // Verify no mcp-* service was added
         let services = doc.get("services").unwrap().as_mapping().unwrap();
         assert!(
-            !services.contains_key(&serde_yaml_ng::Value::String("mcp-skills-pack".into())),
+            !services.contains_key(serde_yaml_ng::Value::String("mcp-skills-pack".into())),
             "resource-only plugin should NOT have a compose service"
         );
     }
 
-    // Note: these tests verify the `service_id.unwrap_or(slug)` key lookup
-    // used in apply_plugins (compose.rs:325). We test the components (is_plugin_enabled
-    // + key derivation) rather than calling apply_plugins directly because apply_plugins
-    // reads from ~/.speedwave/plugins/ on the filesystem.
+    // Verify the `service_id.unwrap_or(slug)` key lookup via its components (is_plugin_enabled + key derivation),
+    // not apply_plugins directly (it reads the plugins filesystem).
 
     #[test]
+    #[allow(clippy::unnecessary_literal_unwrap)] // mirrors production `service_id.unwrap_or(slug)` key derivation
     fn test_resource_only_plugin_enabled_by_slug_appears_in_speedwave_plugins() {
         // A plugin without service_id should be toggled by slug.
         // When enabled by slug, it should appear in SPEEDWAVE_PLUGINS.
@@ -8362,6 +8192,7 @@ services:
     }
 
     #[test]
+    #[allow(clippy::unnecessary_literal_unwrap)] // mirrors production `service_id.unwrap_or(slug)` key derivation
     fn test_resource_only_plugin_disabled_by_slug_excluded() {
         // A plugin without service_id should be excluded when disabled.
         let integrations = ResolvedIntegrationsConfig {
@@ -8378,6 +8209,7 @@ services:
     }
 
     #[test]
+    #[allow(clippy::unnecessary_literal_unwrap)] // mirrors production `service_id.unwrap_or(slug)` key derivation
     fn test_resource_only_plugin_absent_from_config_is_disabled() {
         // A freshly installed plugin not in config should be disabled.
         let integrations = ResolvedIntegrationsConfig::default();
@@ -9509,15 +9341,11 @@ services:
 
     #[test]
     fn test_security_check_run_delegates_without_panic() {
-        // Calls run() which uses consts::data_dir() internally.
-        // Verifies the delegation from run() to run_with_data_dir() works
-        // without panicking. On dev machines, real files may exist and produce
-        // violations — that's fine, we only check that it doesn't crash.
+        // Verifies run() delegates to run_with_data_dir() without panicking (real files may produce violations).
         let yaml = valid_compose_yaml();
         let _violations =
             SecurityCheck::run(&yaml, "nonexistent-project", &[], &test_expected_paths());
-        // No assertion on violations — dev machines may have real files with
-        // various permissions. The test verifies the delegation path works.
+        // No assertion on violations — dev machines may have real files.
     }
 
     #[cfg(unix)]
@@ -10353,12 +10181,7 @@ services:
         assert!(err.to_string().contains("symlink"));
     }
 
-    /// `claude-resources/` must be a real directory on disk, not a
-    /// regular file dressed up as the resources root. Without this,
-    /// `add_claude_volume` would still emit a bind-mount entry whose
-    /// host source is a single file — and depending on the engine
-    /// either fails opaquely at start, or surfaces the file in place
-    /// of a directory inside the container.
+    /// `claude-resources/` must be a real directory on disk, not a regular file.
     #[test]
     fn test_ensure_resources_dir_safe_rejects_non_directory() {
         let tmp = tempfile::tempdir().unwrap();
@@ -10645,13 +10468,8 @@ services:
         assert!(dbg.contains("60123"));
     }
 
-    /// `apply_plugins` re-runs `validate_manifest` so a manifest whose
-    /// fields would now fail the (potentially stricter) ruleset is
-    /// rejected at render time, not silently rendered. We can't
-    /// hand-craft a "post-install rule violation" without breaking
-    /// other tests, so we verify the call chain by passing a
-    /// manifest with a value that would fail the cap (`mem_limit`
-    /// above PLUGIN_MEM_LIMIT_MAX_MIB).
+    /// `apply_plugins` re-runs `validate_manifest`, rejecting at render time a manifest
+    /// that fails the ruleset (here: `mem_limit` above PLUGIN_MEM_LIMIT_MAX_MIB).
     #[test]
     fn test_apply_plugins_revalidates_manifest() {
         let tmp = tempfile::tempdir().unwrap();
@@ -10676,25 +10494,14 @@ services:
         assert!(err.to_string().contains("exceeds maximum"));
     }
 
-    /// `apply_plugins` MUST reject a plugin whose derived compose name
-    /// would overwrite an existing `services.<name>` entry. Without
-    /// this check, `serde_yaml_ng`'s mapping insert silently replaces
-    /// the built-in entry — defeating the hub's zero-token guarantee.
-    /// The slug-collision rule in `validate_manifest` already blocks
-    /// the obvious "slug: hub" case at install, so the render-time
-    /// check is defence in depth — but a regression in either layer
-    /// is invisible without a test that pins the contract.
+    /// `apply_plugins` MUST reject a plugin whose derived compose name would overwrite an
+    /// existing `services.<name>` entry (defence in depth beyond `validate_manifest`).
     #[test]
     fn test_apply_plugins_rejects_compose_name_collision() {
         let tmp = tempfile::tempdir().unwrap();
         let plugin_dir = tmp.path().join("decoy");
         std::fs::create_dir_all(&plugin_dir).unwrap();
-        // We can't construct a manifest with `slug: "hub"` —
-        // `validate_manifest` rejects it. Instead, hand-build YAML
-        // that already contains the service name a plugin would
-        // produce, and pass a plugin whose service_id derives that
-        // name. Pre-populating `services.mcp-decoy` simulates the
-        // race where two render passes try to claim the same name.
+        // Hand-built YAML pre-populating a plugin-produced service name, plus a plugin whose service_id derives it.
         let yaml = r#"
 services:
   claude:
@@ -10728,11 +10535,7 @@ services:
         );
     }
 
-    /// Sanity: a verified plugin not blocked by validate_manifest and
-    /// not colliding renders successfully. Pins the happy path so a
-    /// regression that always returns Err (e.g. someone tightening
-    /// validate_manifest in a way that breaks all in-tree manifests)
-    /// is caught here rather than at the user's first launch.
+    /// Sanity: a verified plugin that passes validate_manifest and doesn't collide renders (happy path).
     #[test]
     fn test_apply_plugins_renders_enabled_plugin() {
         let tmp = tempfile::tempdir().unwrap();
@@ -10760,13 +10563,8 @@ services:
         assert!(yaml.contains("SPEEDWAVE_PLUGINS=ok-plugin"));
     }
 
-    /// If the canonical resolution of `claude-resources` escapes the
-    /// canonical plugin tree, the helper bails. We can't trivially
-    /// build such a path without symlinks (which `walk_reject_symlinks`
-    /// already catches), but we can at least pin the invariant by
-    /// verifying that a deeply-nested real directory tree IS accepted
-    /// — regression test for "I broke the canonicalize check by
-    /// being too strict".
+    /// A deeply-nested real directory tree under `claude-resources` is accepted
+    /// (the canonicalize check must not be over-strict).
     #[test]
     fn test_ensure_resources_dir_safe_accepts_deep_nesting() {
         let tmp = tempfile::tempdir().unwrap();
@@ -11228,12 +11026,8 @@ services:
         assert_eq!(provider_display_label("local"), "Local");
     }
 
-    /// Crash recovery invariant: if `update_llm_config` writes the token file
-    /// but a crash kills the process before `save_user_config` flips the
-    /// `has_api_key=true` flag, the orphaned token file is left on disk with
-    /// `has_api_key=false` in config. `apply_llm_config` must **ignore the
-    /// orphaned file** and fall back to the documented dummy. Otherwise an
-    /// abandoned token could silently leak into a future container render.
+    /// Crash recovery: with an orphaned token file but `has_api_key=false` in config,
+    /// `apply_llm_config` must ignore the file and fall back to the dummy.
     #[test]
     fn apply_llm_config_ignores_orphaned_token_when_flag_is_false() {
         let data_dir = tempfile::tempdir().unwrap();
@@ -11277,22 +11071,12 @@ services:
         let _ = std::fs::remove_dir(&dir);
     }
 
-    /// CRITICAL: multi-line `ANTHROPIC_CUSTOM_HEADERS` (one `Name: Value` per
-    /// line in the on-disk token file) must be flattened to a single-line,
-    /// comma-separated env entry before injection. nerdctl-compose / Docker
-    /// Compose YAML parsers reject block literals inside an `environment:`
-    /// sequence — a multi-line scalar produces `yaml: line N: could not find
-    /// expected ':'` and `compose up` fails. Claude Code's
-    /// `ANTHROPIC_CUSTOM_HEADERS` parser accepts both newline- and
-    /// comma-separated forms, so flattening is lossless.
-    ///
-    /// Test guarantees:
+    /// Multi-line `ANTHROPIC_CUSTOM_HEADERS` must flatten to a single-line,
+    /// comma-separated env entry (nerdctl-compose rejects block literals). Guarantees:
     /// 1. The injected env var value is present in the YAML environment list.
-    /// 2. The value is a single line (no `\n`), with each header joined by
-    ///    `, ` separators.
+    /// 2. The value is a single line (no `\n`), headers joined by `, `.
     /// 3. Every original header survives intact.
-    /// 4. The rendered YAML re-parses cleanly (defensive check against future
-    ///    regressions that might re-introduce block-literal serialisation).
+    /// 4. The rendered YAML re-parses cleanly.
     #[test]
     fn apply_llm_config_multiline_custom_headers_survives_yaml_roundtrip() {
         let data_dir = tempfile::tempdir().unwrap();
@@ -11558,10 +11342,7 @@ networks:
 
     #[test]
     fn save_compose_read_back_io_error_has_actionable_context() {
-        // Inject an IO error via the test seam by setting FORCE_DISK_GARBAGE
-        // to an empty string (which is valid YAML but parseable to an empty
-        // doc — so validate_compose_network_refs passes); then assert that
-        // *valid* disk content does NOT fail the read-back branch.
+        // Inject FORCE_DISK_GARBAGE = empty string (valid YAML); assert valid disk content does not fail read-back.
         let project = format!("save-readback-ok-{}", std::process::id());
         let valid_yaml = r#"
 services:

--- a/crates/speedwave-runtime/src/compose/plugins.rs
+++ b/crates/speedwave-runtime/src/compose/plugins.rs
@@ -11,26 +11,9 @@ use crate::consts;
 use crate::engine_path::to_engine_path;
 use crate::plugin;
 
-/// Applies all installed and enabled plugins to the compose YAML:
-/// - Generates MCP service definitions for enabled plugins with service_id
-/// - Injects WORKER_<PLUGIN>_URL into mcp-hub environment
-/// - Adds plugin resource volume mounts to claude container
-/// - Sets SPEEDWAVE_PLUGINS env var in claude container
-///
-/// Loads plugins via [`plugin::list_verified_plugins`], which fails the
-/// compose render if any installed plugin has a missing/invalid signature
-/// or a directory/manifest slug mismatch — a missing fail-closed loader
-/// here would let an attacker who tampered with one plugin still get the
-/// rest of the compose to render and run. Manifests are re-validated at
-/// render time so a post-install tamper that only changed the manifest
-/// (not enough to change the digest, e.g. a different field semantic)
-/// would still be caught by the same code that gates install.
-///
-/// **Host-gateway note:** `ensure_host_gateway_extra_host` is intentionally NOT
-/// called for plugin services. Plugin workers communicate with `mcp-hub` over
-/// the internal compose network — they have no direct host-side dependency.
-/// If a future plugin needs to reach the host, the helper must be called for
-/// that plugin's compose service.
+/// Applies installed+enabled plugins to compose YAML: generates MCP services,
+/// injects WORKER_*_URL, mounts resources, sets SPEEDWAVE_PLUGINS.
+/// Manifests are re-validated at render time (ADR-051).
 pub(crate) fn apply_plugins(yaml: &str, ctx: &ApplyPluginsCtx<'_>) -> anyhow::Result<String> {
     let plugins = plugin::list_verified_plugins()?;
     apply_plugins_from_verified(yaml, ctx, &plugins)
@@ -48,14 +31,8 @@ pub(crate) struct ApplyPluginsCtx<'a> {
     pub bridges: &'a HostBridgesInfo,
 }
 
-/// Test-friendly variant of [`apply_plugins`] — accepts a pre-built
-/// list of `VerifiedPlugin` instead of consulting the on-disk
-/// `~/.speedwave/plugins/`. Production callers go through
-/// `apply_plugins`; tests inject crafted scenarios (forged manifest,
-/// dangling `claude-resources` symlink, slug collision) without
-/// touching the user's real data dir.
-// Internal helper exposed only for tests that need to inject crafted
-// `VerifiedPlugin` fixtures; the public entrypoint is `apply_plugins`.
+/// Test-friendly variant of [`apply_plugins`] accepting pre-verified plugins
+/// instead of consulting disk. Production goes through `apply_plugins`.
 pub(crate) fn apply_plugins_from_verified(
     yaml: &str,
     ctx: &ApplyPluginsCtx<'_>,
@@ -82,12 +59,6 @@ pub(crate) fn apply_plugins_from_verified(
         let slug = &manifest.slug;
         let service_id = manifest.service_id.as_deref();
 
-        // Re-validate the manifest at render time. The signature already
-        // covers the manifest bytes, but re-running validate_manifest gives
-        // us a single rendering of the post-install rules (built-in slug
-        // collision, reserved env keys, mem/cpu caps) — useful when
-        // validate_manifest grows new rules and we don't want any installed
-        // plugin to silently survive a stricter ruleset.
         plugin::validate_manifest(manifest, plugin_dir)?;
 
         // Check if plugin is enabled (by service_id for MCP plugins, by slug otherwise)
@@ -111,12 +82,7 @@ pub(crate) fn apply_plugins_from_verified(
                 tokens_dir,
                 project_dir,
             )?;
-            // Insert into doc["services"]["mcp-<service_id>"]. Refuse to
-            // overwrite a built-in service already present in the YAML —
-            // validate_manifest blocks the obvious "slug: hub" case at
-            // install, but a future change there should not silently
-            // re-open the door here. serde_yaml_ng's mapping insert
-            // overwrites on key collision; we want a hard failure instead.
+            // Refuse to overwrite a built-in service (validate_manifest gates the obvious cases at install).
             let compose_name = plugin::derive_compose_name(sid);
             if let Some(services) = doc.get_mut("services").and_then(|v| v.as_mapping_mut()) {
                 let key = serde_yaml_ng::Value::String(compose_name.clone());
@@ -127,9 +93,7 @@ pub(crate) fn apply_plugins_from_verified(
                 }
                 services.insert(key, service_value);
             }
-            // Inject WORKER_*_URL into hub. All workers share PORT_WORKER —
-            // each container has its own network namespace, so port reuse is
-            // safe and DNS disambiguates. See ADR-038.
+            // Inject WORKER_*_URL into hub; all workers share PORT_WORKER (ADR-038).
             if let Some(declared) = manifest.port {
                 if declared != consts::PORT_WORKER {
                     log::warn!(
@@ -149,9 +113,7 @@ pub(crate) fn apply_plugins_from_verified(
             );
             inject_worker_env(&mut doc, &worker_env, &url);
 
-            // Plugin's manifest may declare a host-side WebSocket bridge
-            // (see ADR-063). When the Desktop has registered one for this
-            // slug, inject the env vars the plugin asked for.
+            // Inject host-bridge env vars when Desktop registered one for this slug (ADR-063).
             if manifest.host_bridge.is_some() {
                 if let Some(registration) = bridges.bridges.iter().find(|r| r.plugin_slug == *slug)
                 {
@@ -175,10 +137,7 @@ pub(crate) fn apply_plugins_from_verified(
             }
         }
 
-        // Mount claude-resources to claude container. The resources dir
-        // must be a *real* directory inside the verified plugin tree —
-        // a symlink (or anything that escapes the tree under canonicalize)
-        // would let an attacker bind-mount /etc into the claude container.
+        // Validate claude-resources is a real dir, not a symlink (ADR-051 security model).
         let plugin_resources = plugin_dir.join("claude-resources");
         if plugin_resources.exists() {
             ensure_resources_dir_safe(plugin_dir, &plugin_resources)
@@ -192,10 +151,7 @@ pub(crate) fn apply_plugins_from_verified(
         }
     }
 
-    // SPEEDWAVE_PLUGINS in claude: slug per enabled plugin; the digest goes
-    // into a SEPARATE var so a plugin upgrade changes claude's config-hash
-    // (recreate -> entrypoint relinks resources) without altering the slug
-    // list the entrypoint iterates (plugin contract, CLAUDE.md).
+    // slug in SPEEDWAVE_PLUGINS; digest in separate var for config-hash recreation (plugin contract).
     if !plugin_slugs.is_empty() {
         let slugs: Vec<&str> = plugin_slugs
             .iter()

--- a/crates/speedwave-runtime/src/compose/quoting.rs
+++ b/crates/speedwave-runtime/src/compose/quoting.rs
@@ -1,14 +1,8 @@
 //! Final compose-YAML hardening pass that re-quotes `environment:` scalars
 //! carrying YAML flow indicators libyaml emits unquoted but nerdctl rejects.
 
-/// YAML flow indicators that are legal inside a *block-context* plain scalar
-/// per the YAML 1.2 spec, so libyaml (serde_yaml_ng's emitter) leaves them
-/// unquoted — but nerdctl's Go YAML parser (gopkg.in/yaml.v3 via compose-go)
-/// rejects them, failing the whole file with `could not find expected ":"`
-/// several lines later. Any env value containing one of these MUST be emitted
-/// as an explicitly quoted scalar. `[`/`]` cover the documented `[1m]`
-/// 1M-context suffix (anthropics/claude-code#34083 workaround); the rest make
-/// the rule general so any future value (`{`, `}`, `,`) is safe too.
+/// YAML flow indicators libyaml leaves unquoted in plain scalars but nerdctl's
+/// Go parser rejects. Env values containing one MUST be emitted quoted.
 const YAML_PLAIN_UNSAFE_CHARS: &[char] = &['[', ']', '{', '}', ','];
 
 /// True when `entry` (a `KEY=VALUE` env line) would round-trip through every
@@ -18,17 +12,9 @@ pub(crate) fn env_entry_needs_quoting(entry: &str) -> bool {
     entry.contains(YAML_PLAIN_UNSAFE_CHARS)
 }
 
-/// Final SSOT pass over rendered compose YAML: re-quotes every `environment:`
-/// sequence entry whose value contains a YAML flow indicator that libyaml
-/// emits unquoted but nerdctl's stricter Go parser rejects.
-///
-/// Scoped to `environment:` blocks (tracked by indentation) so it never
-/// touches images, volumes, or networks. The replacement scalar is produced
-/// with `serde_json::to_string`, whose escaping is a valid YAML 1.2
-/// double-quoted scalar (YAML is a JSON superset) — no hand-rolled escaping.
-/// Idempotent: already-quoted entries (those that don't re-parse as a bare
-/// `KEY=VALUE` plain scalar) are left untouched. Assumes the renderer emits no
-/// YAML comments inside `environment:` (a same-indent `#` line closes the block).
+/// Re-quotes `environment:` sequence entries whose value carries a YAML flow
+/// indicator nerdctl's Go parser rejects. Scoped to `environment:` blocks by
+/// indentation; uses `serde_json::to_string` escaping; idempotent.
 pub(crate) fn harden_env_scalar_quoting(yaml: &str) -> anyhow::Result<String> {
     let mut out = String::with_capacity(yaml.len());
     // Indentation (column) of the active `environment:` key, if inside one.
@@ -38,11 +24,7 @@ pub(crate) fn harden_env_scalar_quoting(yaml: &str) -> anyhow::Result<String> {
         let indent = body.len() - body.trim_start().len();
         let trimmed = body.trim_start();
 
-        // Leaving the active environment block. Compose renders sequence
-        // items at the SAME column as the `environment:` key (`- ITEM`
-        // aligned under `environment:`), so same-indent `- ` lines stay in
-        // the block; any non-sequence line, or a line indented less than the
-        // key, closes it.
+        // Close the block on an outdent or any non-sequence line.
         if let Some(env_col) = env_indent {
             let is_seq_item = trimmed.starts_with("- ") || trimmed == "-";
             if !body.trim().is_empty() && (indent < env_col || !is_seq_item) {
@@ -59,8 +41,7 @@ pub(crate) fn harden_env_scalar_quoting(yaml: &str) -> anyhow::Result<String> {
         if env_indent.is_some() {
             if let Some(rest) = trimmed.strip_prefix("- ") {
                 let value = rest.trim();
-                // Only touch bare (unquoted) `KEY=VALUE` plain scalars that
-                // carry an unsafe char; quoted/escaped entries are skipped.
+                // Only touch bare unquoted `KEY=VALUE` plain scalars.
                 let is_bare_plain = !value.starts_with('"')
                     && !value.starts_with('\'')
                     && !value.starts_with('|')
@@ -83,6 +64,7 @@ pub(crate) fn harden_env_scalar_quoting(yaml: &str) -> anyhow::Result<String> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 
@@ -92,14 +74,11 @@ mod tests {
         assert!(!env_entry_needs_quoting("ANTHROPIC_MODEL=claude-opus-4-8"));
         assert!(!env_entry_needs_quoting("PORT=4000"));
         assert!(!env_entry_needs_quoting("TZ=Europe/Warsaw"));
-        // A single `: ` mid-scalar is plain-safe (the Go parser accepts it);
-        // no flow indicator means no quoting.
+        // A `: ` mid-scalar has no flow indicator, so no quoting.
         assert!(!env_entry_needs_quoting(
             "ANTHROPIC_CUSTOM_HEADERS=X-Tenant-ID: foo"
         ));
-        // …but the multi-header flattened form joins with `, ` — the comma is
-        // a flow indicator, so it must now be quoted too (defends the same
-        // nerdctl-compose breakage the multiline headers fix addressed).
+        // The flattened multi-header form joins with `, ` — comma needs quoting.
         assert!(env_entry_needs_quoting(
             "ANTHROPIC_CUSTOM_HEADERS=X-Tenant-ID: foo, X-Subscription-ID: bar"
         ));
@@ -144,9 +123,7 @@ mod tests {
 
     #[test]
     fn harden_env_scalar_quoting_is_idempotent_and_scoped() {
-        // Already-quoted entries and non-environment flow indicators (the
-        // `networks: {}` mapping, an image with no brackets) are untouched;
-        // running twice is a no-op.
+        // Already-quoted entries and non-environment flow indicators stay untouched; idempotent.
         let yaml = "services:\n  claude:\n    image: registry/x:1\n    environment:\n    \
                     - \"ALREADY=quoted[1m]\"\n    - PLAIN=ok\n    volumes:\n    \
                     - /a:/b\nnetworks:\n  net: {}\n";
@@ -167,9 +144,7 @@ mod tests {
 
     #[test]
     fn harden_env_scalar_quoting_reopens_block_for_second_service() {
-        // Two services, each with a bracketed env value separated by the first
-        // service's `networks`/`image` lines: the block must CLOSE after svc-a's
-        // env and RE-OPEN for svc-b's, so both bracketed values get quoted.
+        // Block closes after svc-a's env and re-opens for svc-b's; both get quoted.
         let yaml = "services:\n  a:\n    environment:\n    \
                     - MODEL_A=x[1m]\n    image: reg/a:1\n  b:\n    environment:\n    \
                     - MODEL_B=y[1m]\nnetworks: {}\n";

--- a/crates/speedwave-runtime/src/compose/security_check.rs
+++ b/crates/speedwave-runtime/src/compose/security_check.rs
@@ -74,10 +74,6 @@ pub(crate) fn extract_volume_for_target(
 pub struct SecurityCheck;
 
 /// Compile-time enumeration of every security rule enforced by [`SecurityCheck`].
-///
-/// Using an enum instead of `&'static str` guarantees that rule identifiers are
-/// unique and typo-free — a misspelled variant is a compile error, whereas a
-/// misspelled string literal would silently pass.
 #[derive(
     Debug,
     Clone,
@@ -263,11 +259,6 @@ pub enum SecurityRule {
 
 impl SecurityRule {
     /// Returns `true` for SharePoint-specific rules.
-    ///
-    /// Note: there is no `SharepointTokenMountMode` after ADR-060/PR3.
-    /// SharePoint mounts `/tokens:ro` like every other built-in worker; a `:rw`
-    /// regression is caught by `PluginTokenMountMode` (re-used for built-ins)
-    /// via the shared `validate_service_volume_mounts` machinery.
     pub fn is_sharepoint(self) -> bool {
         matches!(
             self,
@@ -367,10 +358,6 @@ impl SecurityCheck {
     }
 
     /// Testable version that accepts an explicit data_dir for host filesystem checks.
-    ///
-    /// Separated from `run()` so tests can pass a temp directory for
-    /// `check_file_security()` without depending on `consts::data_dir()`.
-    /// On non-Unix platforms, `check_file_security()` is a no-op.
     pub(crate) fn run_with_data_dir(
         compose_yml: &str,
         project: &str,
@@ -735,11 +722,9 @@ impl SecurityCheck {
         violations
     }
 
-    /// claude container must not have external LLM API keys
-    /// (OPENAI_*, AZURE_OPENAI_*, GEMINI_*, DEEPSEEK_*, OPENROUTER_*, COHERE_*,
-    /// MISTRAL_*, TOGETHER_*, GROQ_* — these prefixes are forbidden because external
-    /// LLM API keys must never enter the claude container. Only the dummy
-    /// ANTHROPIC_AUTH_TOKEN (sk-no-key-required) is permitted for local model providers.)
+    /// claude container must not have external LLM API keys (OPENAI_*, AZURE_OPENAI_*,
+    /// GEMINI_*, DEEPSEEK_*, OPENROUTER_*, COHERE_*, MISTRAL_*, TOGETHER_*, GROQ_*).
+    /// Only the dummy ANTHROPIC_AUTH_TOKEN (sk-no-key-required) is permitted.
     fn check_no_external_llm_keys_claude(doc: &serde_yaml_ng::Value) -> Vec<SecurityViolation> {
         let mut violations = Vec::new();
         let services = match get_services(doc) {
@@ -1143,27 +1128,9 @@ impl SecurityCheck {
         violations
     }
 
-    /// Validates file permissions and ownership on sensitive host paths.
-    ///
-    /// Unlike other `check_*` methods which validate in-memory compose YAML,
-    /// this method performs filesystem I/O — it reads metadata from host paths
-    /// under `data_dir`. This is intentional: host file permissions are a
-    /// security property that cannot be derived from the compose template.
-    ///
-    /// Rules:
-    /// - Files containing secrets must be 0o600 (owner rw only).
-    /// - Directories containing secrets must be 0o700 (owner rwx only).
-    /// - All sensitive files/dirs must be owned by the current user (UID match).
-    /// - Missing paths are silently skipped — they may not exist yet.
-    /// - Symlinks are skipped (not followed) to prevent traversal attacks.
-    ///
-    /// Known limitations: validates mode bits and UID only, not ACLs or xattrs.
-    /// TOCTOU: permissions are checked before container start; a concurrent
-    /// change between check and start is theoretically possible but acceptable.
-    ///
-    /// Performance: scans 1-2 directory levels (not recursive). Bounded by
-    /// the number of configured services per project — typically under 10 files.
-    /// Negligible compared to compose_up latency.
+    /// Validates file permissions and ownership on sensitive host paths under `data_dir`.
+    /// Secret files must be 0o600, secret dirs 0o700, all owned by the current UID.
+    /// Missing paths and symlinks are skipped.
     #[cfg(unix)]
     pub(crate) fn check_file_security(
         data_dir: &std::path::Path,
@@ -1287,8 +1254,6 @@ impl SecurityCheck {
 }
 
 /// Per-rule names and remediation strings for volume validation.
-/// Each constant preserves the exact rule names and messages used by plugin
-/// and SharePoint security checks so that existing tests and monitoring remain stable.
 struct VolumeCheckRules {
     volume_long_form: SecurityRule,
     volume_long_form_msg: &'static str,
@@ -1401,10 +1366,8 @@ struct VolumeCheckParams<'a> {
     expected_workspace_path: &'a str,
     /// Expected token mount mode: "ro" or "rw"
     expected_token_mode: &'a str,
-    /// Additional read-only mount targets that are permitted on this service.
-    /// Used by OAuth-consuming workers (ADR-060) to permit their per-service bearer
-    /// mount at `/secrets/oauth-auth-token-<service>:ro`. Each entry is matched as
-    /// an exact `target` path; the mount must be `:ro` to pass.
+    /// Additional read-only mount targets permitted on this service (ADR-060 OAuth
+    /// bearer). Each entry is matched as an exact `target`; the mount must be `:ro`.
     extra_allowed_ro_targets: &'a [String],
     rules: VolumeCheckRules,
 }

--- a/crates/speedwave-runtime/src/compose/tokens.rs
+++ b/crates/speedwave-runtime/src/compose/tokens.rs
@@ -9,10 +9,8 @@ pub(crate) fn resolve_tokens_dir_in(data_dir: &Path, project_name: &str) -> Path
     data_dir.join("tokens").join(project_name)
 }
 
-/// Creates the secrets directory for a project with restrictive permissions (chmod 700).
-/// Path: `~/.speedwave/secrets/<project>/`
-///
-/// Also sets `0o700` on the parent `secrets/` directory.
+/// Creates `~/.speedwave/secrets/<project>/` with `0o700` on it and the
+/// parent `secrets/` directory.
 pub fn init_secrets_dir(project: &str) -> anyhow::Result<PathBuf> {
     init_secrets_dir_in(consts::data_dir(), project)
 }
@@ -39,24 +37,14 @@ pub(crate) fn init_secrets_dir_in(data_dir: &Path, project: &str) -> anyhow::Res
 }
 
 // ── Local-LLM token paths ────────────────────────────────────────────────
-//
-// Per-project secrets for the "local" LLM provider (Bearer token + custom
-// headers) live at `~/.speedwave/tokens/<project>/local-llm/<file>` with
-// owner-only perms (Unix 0o600 files, 0o700 dirs; Windows ACL deny-others).
-//
-// `tokens_path` and `ensure_token_dir` are the SSOT for resolving these paths.
-// Service and file names are whitelisted to prevent path traversal — adding a
-// new local-LLM artifact = edit one constant, not the helper signature.
 
 /// Services with token files under `~/.speedwave/tokens/<project>/<service>/`.
 /// Whitelist enforced by `tokens_path`. Plugins use a separate path discipline
 /// (validated by `plugin::validate_manifest`).
 const ALLOWED_TOKEN_SERVICES: &[&str] = &["local-llm", LLM_TOKEN_SERVICE];
 
-/// LiteLLM per-provider key namespace (ADR-073). Mounted `:ro` at `/tokens`
-/// in the litellm container; its entrypoint exports each file as
-/// `SPW_KEY_<PROVIDER_ID>`. The namespace is reserved against plugin slugs
-/// in `consts::BUILT_IN_SERVICE_IDS`.
+/// LiteLLM per-provider key namespace (ADR-073), reserved against plugin
+/// slugs in `consts::BUILT_IN_SERVICE_IDS`.
 pub const LLM_TOKEN_SERVICE: &str = "llm";
 
 /// Suffix every LiteLLM provider key file carries: `<provider_id>_api_key`.
@@ -67,9 +55,7 @@ pub const LLM_TOKEN_FILE_SUFFIX: &str = "_api_key";
 const ALLOWED_TOKEN_FILES_LOCAL_LLM: &[&str] = &["api_key", "custom_headers"];
 
 /// Validates a file name for the given token service. `local-llm` uses a
-/// static whitelist; `llm` file names embed a user-defined provider id, so
-/// the id segment is validated against the plugin-grade slug shape instead
-/// (`^[a-z][a-z0-9-]{0,63}$` — no dots, no slashes, no traversal).
+/// static whitelist; `llm` file names embed a slug-validated provider id.
 fn validate_token_file(service: &str, file: &str) -> anyhow::Result<()> {
     match service {
         "local-llm" => {

--- a/crates/speedwave-runtime/src/compose/workers.rs
+++ b/crates/speedwave-runtime/src/compose/workers.rs
@@ -18,13 +18,10 @@ use crate::plugin;
 /// - Injects `MCP_<SERVICE>_AUTH_TOKEN=<token>` env var into the worker container
 /// - Mounts the token file as `/secrets/<service>-auth-token:ro` into the hub
 ///
-/// Hub reads tokens from `/secrets/` files (auth-tokens.ts), not env vars.
-/// Workers read tokens from env vars. This asymmetry is enforced by `check_no_tokens_in_hub`.
-/// Creates the per-project secrets dir under an explicit data dir so render
-/// under a tempdir never writes the global `~/.speedwave/secrets`.
-/// Injects `SPW_CREDENTIALS_DIGEST` into every enabled MCP worker so a
-/// credential rotation changes that worker's config-hash and idempotent
-/// `compose up` recreates exactly it (token bytes never enter the YAML).
+/// Hub reads tokens from `/secrets/` files (auth-tokens.ts); workers from env
+/// vars — asymmetry enforced by `check_no_tokens_in_hub`.
+/// Injects `SPW_CREDENTIALS_DIGEST` into every enabled MCP worker so credential
+/// rotation changes its config-hash (token bytes never enter the YAML).
 pub(crate) fn apply_credentials_digests_in(
     data_dir: &std::path::Path,
     yaml: &str,
@@ -49,8 +46,7 @@ fn apply_credentials_digests(yaml: &str, tokens_root: &std::path::Path) -> anyho
         })
         .unwrap_or_default();
     for name in service_names {
-        // strip_prefix once — trim_start_matches would over-strip a plugin
-        // service_id that itself starts with "mcp-" (compose name mcp-mcp-x).
+        // strip_prefix once — not trim_start_matches (over-strips mcp-mcp-x).
         let key = name.strip_prefix("mcp-").unwrap_or(&name);
         match credentials_digest(&tokens_root.join(key)) {
             Ok(Some(digest)) => {
@@ -148,11 +144,7 @@ fn ensure_worker_auth_token(
     let token_file_name = format!("{token_key}-auth-token");
     let token_path = secrets_dir.join(&token_file_name);
 
-    // Reject symlinks before is_file() — is_file() follows symlinks and would
-    // return true for a symlink pointing at a regular file, letting an
-    // attacker with write access to the secrets dir substitute the auth
-    // token. Falls through to the cleanup branch which logs and removes the
-    // planted symlink.
+    // Reject symlinks before is_file() — is_file() follows symlinks.
     let token = if !token_path.is_symlink() && token_path.is_file() {
         let content = std::fs::read_to_string(&token_path)?.trim().to_string();
         if content.is_empty() {
@@ -181,9 +173,7 @@ fn ensure_worker_auth_token(
         uuid::Uuid::new_v4().to_string()
     };
 
-    // Atomic write with 0o600 permissions (pattern from update.rs).
-    // Use a unique suffix to avoid collisions when multiple callers write
-    // the same token file concurrently (e.g., parallel tests or processes).
+    // Atomic write with 0o600; unique suffix avoids concurrent-write collisions.
     let tmp_name = format!("{}.{}.tmp", token_file_name, uuid::Uuid::new_v4());
     let tmp_path = secrets_dir.join(&tmp_name);
     std::fs::write(&tmp_path, &token)?;
@@ -313,9 +303,7 @@ pub(crate) fn apply_integrations_filter(
             }
         }
         remove_env_from(&mut doc, "mcp-hub", svc.worker_env);
-        // An egress-less worker (e.g. office, ADR-055) has its own internal network
-        // `{NETWORK_NAME}_{config_key}`; when it is disabled, drop that network and the
-        // hub's attachment to it so the rendered compose has no dangling internal network.
+        // Disabled egress-less worker (ADR-055): drop its internal network + hub attachment.
         if svc.egress_less {
             let net = format!("{network_name}_{}", svc.config_key);
             if let Some(map) = doc.get_mut("networks").and_then(|n| n.as_mapping_mut()) {
@@ -391,8 +379,7 @@ pub(crate) fn remove_env_from(doc: &mut serde_yaml_ng::Value, service: &str, env
 
 /// Inject `<env_var>=<gateway-url>` + mount `<token_mount_path>:/secrets/<secret_name>:ro`
 /// into the hub iff `lock.json` is readable and the mount-token file exists.
-/// No-op (returns unchanged YAML) when files absent — any read failure is
-/// treated as not running (avoids TOCTOU vs runtime respawn).
+/// No-op (unchanged YAML) when files absent; any read failure is treated as not running.
 pub(crate) fn apply_worker_config(
     yaml: &str,
     label: &str,
@@ -402,8 +389,7 @@ pub(crate) fn apply_worker_config(
     env_var: &str,
     secret_name: &str,
 ) -> anyhow::Result<String> {
-    // PID-liveness gate (symmetric to apply_oauth_config_with_paths): a stale
-    // lock.json after a Desktop hard-kill would inject a dead WORKER_*_URL.
+    // PID-liveness gate: a stale lock.json must not inject a dead WORKER_*_URL.
     let port = match crate::host_mcp_process::lock::read(lock_path, service) {
         Some(l) if crate::host_mcp_process::probe::is_pid_alive(l.pid) => l.port,
         _ => return Ok(yaml.to_string()),
@@ -463,7 +449,7 @@ mod credentials_digest_tests {
     const YAML: &str = "services:\n  mcp-hub:\n    image: hub\n  mcp-slack:\n    image: slack\n  mcp-github:\n    image: gh\n";
     const YAML2: &str = "services:\n  mcp-hub:\n    image: hub\n  mcp-sharepoint:\n    image: sp\n";
 
-    fn env_of<'a>(yaml: &'a str, svc: &str) -> Option<String> {
+    fn env_of(yaml: &str, svc: &str) -> Option<String> {
         let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(yaml).unwrap();
         let env = doc["services"][svc].get("environment")?;
         env.as_sequence()?
@@ -536,9 +522,7 @@ mod credentials_digest_tests {
     #[test]
     #[cfg(unix)]
     fn transient_unreadable_dir_skips_worker_not_whole_render() {
-        // A permission error on one worker's token dir must not abort the entire
-        // compose render — other services must still start. The affected worker
-        // runs without SPW_CREDENTIALS_DIGEST for this session.
+        // One token dir's permission error must not abort the whole render.
         use std::os::unix::fs::PermissionsExt;
         let tmp = tempfile::tempdir().unwrap();
         let tokens = tmp.path().join("tokens");
@@ -590,10 +574,7 @@ mod credentials_digest_tests {
 
     #[test]
     fn write_in_progress_tmp_file_does_not_change_digest() {
-        // writeRestrictedSecret (mcp-servers/shared) writes access_token.tmp.<pid>.<rand>
-        // then renames to access_token. A digest walk that catches the tmp file mid-rename
-        // would spuriously flip SPW_CREDENTIALS_DIGEST and force a worker recreate on every
-        // routine OAuth refresh. Verify that .tmp. files are excluded from the digest.
+        // Verify .tmp. write-in-progress files are excluded from the digest.
         let tmp = tempfile::tempdir().unwrap();
         let tokens = tmp.path().join("tokens");
         let slack_dir = tokens.join("slack");

--- a/crates/speedwave-runtime/src/config.rs
+++ b/crates/speedwave-runtime/src/config.rs
@@ -68,15 +68,9 @@ pub struct LlmActive {
     pub model: Option<String>,
 }
 
-/// LLM provider selection and model settings.
-///
-/// Two coexisting shapes (ADR-073 migration):
-/// - **v1 (legacy, flat)**: `provider`/`model`/`base_url`/`context_tokens`/
-///   `has_api_key`/`has_custom_headers`. Still WRITTEN on save for one
-///   release so an older Speedwave reads the config without losing the
-///   active selection (downgrade story).
-/// - **v2**: `providers` list + `active` selection + `schema_version=2`.
-///   [`migrate_llm_to_v2`] lifts v1 data into v2 on resolve.
+/// LLM provider selection and model settings (ADR-073 migration).
+/// v1 (legacy, flat): `provider`/`model`/`base_url`/`context_tokens`/`has_api_key`/`has_custom_headers`.
+/// v2: `providers` list + `active` selection + `schema_version=2`.
 #[derive(Serialize, Deserialize, Default, Clone, Debug)]
 pub struct LlmConfig {
     /// Provider id (`anthropic` | `local`; legacy aliases accepted on read).
@@ -85,12 +79,7 @@ pub struct LlmConfig {
     pub model: Option<String>,
     /// Base URL for a local Anthropic-Messages server (user-only).
     pub base_url: Option<String>,
-    /// Context window of the active model, in tokens.
-    /// For Anthropic this is resolved from the static SSOT
-    /// (`defaults::ANTHROPIC_MODELS`); for local providers it comes from the
-    /// real provider API and is persisted alongside the model id so the
-    /// chat footer can render an honest `used / max` ratio without keeping a
-    /// duplicate hard-coded table on the frontend.
+    /// Context window of the active model, in tokens; persisted per provider.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub context_tokens: Option<u32>,
     /// True when an API key file exists at `tokens/<project>/local-llm/api_key`.
@@ -175,9 +164,7 @@ pub fn migrate_llm_to_v2(llm: &mut LlmConfig, has_anthropic_secret: bool) {
     }
     llm.schema_version = Some(LLM_SCHEMA_VERSION);
 
-    // Repo `.speedwave.json` may suggest a model (merge_llm_repo writes the
-    // flat field only) — lift it into the active selection when the user has
-    // not pinned one. Also covers the v1→v2 lift for user-set legacy models.
+    // Lift model suggestion into active selection when user has not pinned.
     if let Some(active) = &mut llm.active {
         if active.model.is_none() && llm.model.is_some() {
             active.model.clone_from(&llm.model);
@@ -229,8 +216,7 @@ pub fn sync_llm_legacy_fields(llm: &mut LlmConfig) {
             llm.has_api_key = false;
             llm.has_custom_headers = false;
         }
-        // No v1 equivalent — an older Speedwave treats these as anthropic
-        // (its safest default); the v2 fields keep the real selection.
+        // No v1 equivalent — legacy fields set to anthropic; v2 fields keep the real selection.
         LlmProviderKind::OpenRouter | LlmProviderKind::OpenAiCompat => {
             llm.provider = Some("anthropic".to_string());
             llm.base_url = None;
@@ -612,17 +598,10 @@ pub fn resolve_project_config(
         }
     }
 
-    // Lift the merged result into the v2 provider-list shape (ADR-073). The
-    // anthropic-secret presence decides AnthropicApiKey vs AnthropicOauth for
-    // legacy `provider=anthropic` configs.
+    // Lift merged result into v2 shape (ADR-073).
     migrate_llm_to_v2(&mut llm, anthropic_secret_exists(project_name));
 
-    // Local LLMs receive the full default Claude Code system prompt (Unsloth-style
-    // routing). Modern local models commonly ship with 32K-128K context windows
-    // that absorb the ~30K-token baseline (system prompt + tool definitions). This
-    // also lets `outputStyle` from settings.json reach local LLMs uniformly with
-    // Anthropic-hosted models. The model itself is selected via `ANTHROPIC_MODEL`
-    // env injected by `compose::apply_llm_config` — no per-provider CLI flags here.
+    // Local LLMs get the full default Claude Code system prompt.
     let flags: Vec<String> = defaults::DEFAULT_FLAGS
         .iter()
         .map(|s| s.to_string())
@@ -754,15 +733,12 @@ pub(crate) fn save_user_config_to(config: &SpeedwaveUserConfig, path: &Path) -> 
         std::fs::create_dir_all(parent)?;
     }
     let content = serde_json::to_string_pretty(config)?;
-    // Durable atomic write (fsync data + parent dir) — bare write+rename was the
-    // torn-write pattern that corrupted compose.yml on APFS/virtiofs.
+    // Durable atomic write (fsync data + parent dir).
     crate::fs_perms::write_restricted_file_atomic(path, &content)
 }
 
-/// Acquires an exclusive file lock on `<data_dir>/config.lock` and runs the
-/// closure `f` while the lock is held.  This prevents race conditions between
-/// concurrent processes (CLI vs Desktop) that read-modify-write `config.json`.
-///
+/// Runs `f` while holding an exclusive lock on `<data_dir>/config.lock`
+/// (serialises CLI/Desktop read-modify-write of `config.json`).
 /// Testable variant that accepts an explicit data directory.
 pub fn with_config_lock_in<F, T>(data_dir: &std::path::Path, f: F) -> anyhow::Result<T>
 where
@@ -812,11 +788,9 @@ const REPO_ENV_DENY_ANTHROPIC: &[&str] = &[
     "ANTHROPIC_CUSTOM_HEADERS",
 ];
 
-/// Strips security-class keys from a repo-layer `claude.env` overlay before it
-/// is merged. Removes the Anthropic auth/routing keys plus every
-/// `consts::RESERVED_ENV_KEYS` linker/runtime/shell hijack vector. Comparison is
-/// case-insensitive — the env-injection point is case-sensitive but a cloned
-/// repo shipping `Ld_Preload` would still be a hijack. User config is unaffected.
+/// Strips security-class keys from a repo-layer `claude.env` overlay before
+/// merge (Anthropic auth/routing + every `consts::RESERVED_ENV_KEYS` vector),
+/// case-insensitively. User config is unaffected.
 fn sanitize_repo_env(env: Option<HashMap<String, String>>) -> Option<HashMap<String, String>> {
     env.map(|mut map| {
         map.retain(|key, _| !repo_env_key_is_denied(key));
@@ -866,25 +840,17 @@ fn merge_llm(base: &mut LlmConfig, overlay: &LlmConfig) {
     }
 }
 
-/// Merge LLM config from repo source (.speedwave.json).
-/// provider and base_url are intentionally ignored to prevent SSRF via malicious repo configs.
-/// Only model is merged, allowing repos to suggest a default model name.
-/// The v2 fields (`providers`, `active`, `schema_version`) are equally
-/// ignored — a repo must never add providers, redirect base URLs, or switch
-/// the active provider (ADR-073 keeps the ADR-040 rule). The model
-/// suggestion reaches `active.model` via the lift in [`migrate_llm_to_v2`]
-/// only when the user has not pinned a model.
+/// Merge LLM config from repo source; provider/base_url/v2-fields ignored (SSRF prevention).
+/// Only model is merged as a suggestion; see ADR-073 for the full SSRF policy.
 fn merge_llm_repo(base: &mut LlmConfig, overlay: &LlmConfig) {
     if overlay.model.is_some() {
         base.model.clone_from(&overlay.model);
     }
 }
 
-/// Removes the obsolete `log_level` field from `<data_dir>/config.json` if
-/// present. Returns `Ok(true)` when the field was removed, `Ok(false)` when
-/// nothing needed to change. Operates on `serde_json::Value` so unknown
-/// future fields are semantically preserved (re-serialised through
-/// `to_string_pretty` — key order and whitespace follow serde-json defaults).
+/// Removes the obsolete `log_level` field from `<data_dir>/config.json`.
+/// `Ok(true)` = field removed, `Ok(false)` = nothing changed; unknown future
+/// fields are preserved (operates on `serde_json::Value`).
 pub fn migrate_drop_log_level_in(data_dir: &Path) -> anyhow::Result<bool> {
     with_config_lock_in(data_dir, || {
         let path = data_dir.join("config.json");
@@ -925,9 +891,7 @@ mod tests {
 
     #[test]
     fn llm_provider_kind_matches_ts_union() {
-        // Cross-language SSOT guard (cf. allowed_auth_field_types_match_ts_union):
-        // the TS union must list exactly the Rust serde strings, so the
-        // provider-save wire contract can't drift.
+        // TS union must list exactly the Rust serde strings (cf. allowed_auth_field_types_match_ts_union).
         let all = [
             LlmProviderKind::AnthropicOauth,
             LlmProviderKind::AnthropicApiKey,
@@ -1034,9 +998,7 @@ mod tests {
 
     #[test]
     fn repo_config_cannot_enable_transcription() {
-        // Decision 13: a checked-in repo .speedwave.json must not turn on host-
-        // audio recording. ProjectRepoConfig has no `transcription` field, so
-        // any unknown `transcription` key in a repo file is silently ignored.
+        // ProjectRepoConfig has no `transcription` field, so a repo key is dropped.
         let repo_json = r#"{
             "claude": null,
             "integrations": null,
@@ -1122,10 +1084,7 @@ mod tests {
 
     #[test]
     fn test_is_local_provider_matches_local_providers_const() {
-        // Regression guard: `is_local_provider` and `LOCAL_PROVIDERS` must
-        // stay in sync. Callers (e.g. the `update_llm_config` model-required
-        // guard in desktop/src-tauri/src/containers_cmd.rs) iterate the
-        // const and expect every element to satisfy the predicate.
+        // `is_local_provider` and `LOCAL_PROVIDERS` must stay in sync.
         for name in LOCAL_PROVIDERS {
             assert!(
                 is_local_provider(Some(name)),
@@ -1210,8 +1169,7 @@ mod tests {
                 claude: Some(ClaudeOverrides {
                     env: Some(HashMap::from([
                         ("CLAUDE_CODE_ENABLE_TELEMETRY".to_string(), "0".to_string()),
-                        // A user who prefers the legacy renderer (or no clipboard
-                        // shim) must be able to override the base_env default.
+                        // User can override the base_env default.
                         ("WAYLAND_DISPLAY".to_string(), "".to_string()),
                     ])),
                     settings: None,
@@ -1284,8 +1242,7 @@ mod tests {
         };
 
         let resolved = resolve_claude_config(tmp.path(), &user_config, "test-project");
-        // User config wins over repo config. The v1→v2 migration (ADR-073)
-        // normalises the legacy `ollama` alias to `local` on resolve.
+        // User config wins; v1→v2 migration normalises `ollama` to `local`.
         assert_eq!(resolved.llm.provider.as_deref(), Some("local"));
         assert_eq!(resolved.llm.model.as_deref(), Some("llama3.3"));
         assert_eq!(
@@ -1324,9 +1281,7 @@ mod tests {
 
         let user_config = SpeedwaveUserConfig::default();
         let resolved = resolve_claude_config(tmp.path(), &user_config, "test-project");
-        // provider and base_url from repo config must be ignored (SSRF
-        // prevention — ADR-040, upheld by ADR-073). Post-migration the
-        // default resolves to anthropic, NOT the repo's "ollama".
+        // Repo provider/base_url ignored (SSRF, ADR-040); default resolves to anthropic.
         assert_eq!(resolved.llm.provider.as_deref(), Some("anthropic"));
         assert_eq!(resolved.llm.base_url, None);
         let active = resolved.llm.active.as_ref().expect("active set");
@@ -1830,18 +1785,15 @@ mod tests {
         assert_eq!(loaded.active_project, Some("test".to_string()));
     }
 
-    /// Durability guard: both config writers must route through the durable
-    /// SSOT helper (`fs_perms::write_restricted_file_atomic` — fsync data +
-    /// parent dir) instead of a bare `fs::write(tmp) + rename`, which is the
-    /// torn-write pattern that corrupted compose.yml on APFS/virtiofs.
+    /// Both config writers must route through the durable SSOT helper
+    /// `fs_perms::write_restricted_file_atomic` (fsync data + parent dir).
     #[test]
     fn test_config_writers_use_durable_helper() {
         let source = include_str!("config.rs");
         for func in ["fn save_user_config_to(", "fn migrate_drop_log_level_in("] {
             let start = source.find(func).expect("function must exist");
             let body = &source[start..];
-            // Bound the slice to this function: stop at the next top-level item
-            // or the test module, whichever comes first.
+            // Bound the slice to this function (stop at next top-level item or test module).
             let end = ["\npub fn ", "\nfn ", "\npub(crate) fn ", "\n#[cfg(test)]"]
                 .iter()
                 .filter_map(|marker| body[1..].find(marker).map(|i| i + 1))
@@ -1972,14 +1924,7 @@ mod tests {
 
     #[test]
     fn resolve_does_not_inject_provider_specific_flags_for_local_provider() {
-        // Local providers are configured entirely through env vars injected by
-        // `compose::apply_llm_config` (ANTHROPIC_BASE_URL, ANTHROPIC_MODEL,
-        // ANTHROPIC_AUTH_TOKEN, ANTHROPIC_CUSTOM_MODEL_OPTION*, etc.) — no
-        // CLI flags are added here. In particular --system-prompt-file and
-        // --append-system-prompt must stay out so `outputStyle` reaches the
-        // local LLM and the KV cache stays warm. --model is also dropped:
-        // ANTHROPIC_MODEL is the primary mechanism per Claude Code docs and
-        // CLI --model would only set a per-session override.
+        // Local providers are configured via env vars (compose::apply_llm_config), not CLI flags.
         let tmp = tempfile::tempdir().unwrap();
         let user_config = make_ollama_user_config(tmp.path(), Some("llama3.3"));
         let resolved = resolve_claude_config(tmp.path(), &user_config, "test-project");
@@ -2051,13 +1996,8 @@ mod tests {
         assert_all_integrations_disabled(&resolved);
     }
 
-    /// Regression guard: `apply_integrations_layer` must propagate *every*
-    /// service listed in `TOGGLEABLE_MCP_SERVICES` to the resolved config.
-    /// If a new descriptor is added to `consts::TOGGLEABLE_MCP_SERVICES` but
-    /// its corresponding `apply_toggle` call is forgotten in
-    /// `apply_integrations_layer`, the toggle gets saved to disk but is
-    /// silently ignored at compose-render time — the exact bug that hit
-    /// Playwright in PR2.
+    /// `apply_integrations_layer` must propagate every service in
+    /// `TOGGLEABLE_MCP_SERVICES` to the resolved config.
     #[test]
     fn test_apply_integrations_layer_propagates_every_toggleable_service() {
         for svc in crate::consts::TOGGLEABLE_MCP_SERVICES {
@@ -2092,21 +2032,15 @@ mod tests {
         }
     }
 
-    /// Upgrade path: a user on an older Speedwave version has a `config.json`
-    /// that pre-dates the `playwright` field. After update, deserializing that
-    /// config must still succeed (with `playwright: None`), the UI toggle must
-    /// be able to flip it to enabled, and the save → load round-trip must
-    /// preserve the new value.
-    ///
-    /// If this test breaks, every existing user loses their config on upgrade
-    /// — a silent regression.
+    /// Upgrade path: a `config.json` pre-dating the `playwright` field still
+    /// deserializes (`playwright: None`), the toggle flips it, and the
+    /// save → load round-trip preserves the new value.
     #[test]
     fn test_existing_user_config_accepts_new_integration() {
         let tmp = tempfile::tempdir().unwrap();
         let config_path = tmp.path().join("config.json");
 
-        // Simulate an on-disk config written by an older Speedwave that had no
-        // `playwright` field. Only slack is configured.
+        // On-disk config with no `playwright` field; only slack configured.
         let legacy_json = r#"{
             "projects": [
                 {
@@ -2286,8 +2220,7 @@ mod tests {
 
         let mut resolved = ResolvedIntegrationsConfig::default();
         apply_integrations_layer(&mut resolved, &integrations);
-        // The legitimate `slack` toggle still applies; the legacy `hostExec`
-        // block enables nothing (the field no longer exists).
+        // `slack` toggle still applies; legacy `hostExec` enables nothing.
         assert!(resolved.slack, "slack toggle still resolves");
         assert!(
             resolved.plugins.is_empty(),
@@ -2951,10 +2884,7 @@ mod tests {
 
     #[test]
     fn migrate_drop_log_level_errs_when_root_is_not_object() {
-        // Cover every non-object JSON root shape — array, null, number, string,
-        // bool — to make sure none of them are silently accepted (a user with
-        // a manually-corrupted config must see an actionable error, not a
-        // no-op success).
+        // Every non-object JSON root shape (array/null/number/string/bool) must error, not be accepted.
         for original in [
             r#"["unexpected","array","root"]"#,
             "null",
@@ -2985,11 +2915,7 @@ mod tests {
 
     #[test]
     fn migrate_drop_log_level_cleans_orphan_tmp_on_rename_failure() {
-        // Simulate the post-condition: even if rename fails, no `.tmp` orphan
-        // is left behind. We can't easily force `rename` to fail, but we can
-        // verify that under normal operation the function does not LEAVE a
-        // `.tmp` file behind on the happy path (sanity check that we always
-        // clean up).
+        // No `.tmp` orphan is left behind on the happy path.
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("config.json");
         std::fs::write(&path, r#"{"projects":[],"log_level":"trace"}"#).unwrap();
@@ -3021,9 +2947,7 @@ mod tests {
         restore.set_mode(0o755);
         std::fs::set_permissions(tmp.path(), restore).unwrap();
 
-        // Either the migration refused (Err) or the read-only dir prevented
-        // the temp-rename pair from running. In neither case may the file
-        // shed `log_level` silently — the user's config must survive.
+        // On failure the file must not silently shed `log_level`; the config must survive.
         match result {
             Err(_) => {}
             Ok(false) => {}

--- a/crates/speedwave-runtime/src/consts.rs
+++ b/crates/speedwave-runtime/src/consts.rs
@@ -402,13 +402,8 @@ impl McpAuthFieldDescriptor {
 }
 
 /// OAuth scopes requested during the SharePoint Device Code Flow.
-///
-/// `Sites.Manage.All` covers `Sites.ReadWrite.All` and `Sites.Read.All` and is
-/// required by Microsoft Graph `createList` (delegated permissions)[^create-list].
-/// It typically requires tenant admin consent — the Speedflow app must be
-/// admin-consented in the Azure AD tenant before users can grant it via the
-/// device-code flow. See `docs/guides/integrations.md` for the admin-consent
-/// prerequisite.
+/// `Sites.Manage.All` covers `Sites.ReadWrite.All`/`Sites.Read.All` and is
+/// required by Microsoft Graph `createList` (delegated)[^create-list].
 ///
 /// [^create-list]: <https://learn.microsoft.com/en-us/graph/api/list-create?view=graph-rest-1.0&tabs=http#permissions>
 pub const SHAREPOINT_OAUTH_SCOPES: &str = "https://graph.microsoft.com/Sites.Manage.All \
@@ -416,17 +411,11 @@ pub const SHAREPOINT_OAUTH_SCOPES: &str = "https://graph.microsoft.com/Sites.Man
      https://graph.microsoft.com/User.Read offline_access";
 
 /// GitHub OAuth App client ID (public identifier — not a secret). Registered
-/// at <https://github.com/settings/developers> by Speednet. Device Flow is
-/// enabled on this app; the same client_id is shared across all Speedwave
-/// users (standard "public confidential client" pattern — same as `gh` CLI).
+/// at <https://github.com/settings/developers> by Speednet, Device Flow enabled.
 pub const GITHUB_OAUTH_CLIENT_ID: &str = "Ov23lifyXPigAcJ0d4tK";
 
-/// GitHub OAuth scopes requested by Speedwave. Derived from the Octokit
-/// surface of the `mcp-github` worker (see `mcp-servers/github/src/client.ts`).
-/// `repo` covers private/public repo R/W including issues, pulls, releases,
-/// Actions; `read:user` is used by `testConnection()` (`GET /user`).
-/// Org/gist scopes intentionally NOT requested — the worker does not call
-/// those endpoints.
+/// GitHub OAuth scopes requested by Speedwave. Derived from the `mcp-github`
+/// worker surface (`mcp-servers/github/src/client.ts`).
 pub const GITHUB_OAUTH_SCOPES: &str = "repo read:user";
 
 /// Slack app client ID (public identifier — not a secret). Registered at
@@ -434,15 +423,8 @@ pub const GITHUB_OAUTH_SCOPES: &str = "repo read:user";
 /// token rotation enabled; shared across all Speedwave users. See ADR-071.
 pub const SLACK_OAUTH_CLIENT_ID: &str = "11058760208.11311852745015";
 
-/// Slack user scopes (`user_scope` — never bot scopes: Slack forbids them on
-/// desktop redirects). Derived from the `mcp-slack` worker surface:
-/// chat.postMessage (channels and DMs), conversations.list/history/replies/open,
-/// users.list/lookupByEmail, files.info.
-///
-/// Adding a scope here requires adding it to the app's **User Token Scopes**
-/// at api.slack.com first — otherwise authorize fails with `invalid_scope`.
-/// Existing grants become a strict subset and the Desktop re-auth banner
-/// fires (`required_scopes_for` in `integrations_cmd.rs`).
+/// Slack user scopes (`user_scope` — never bot scopes). Derived from the
+/// `mcp-slack` worker surface; must match the app's User Token Scopes.
 pub const SLACK_OAUTH_USER_SCOPES: &[&str] = &[
     "chat:write",
     "channels:read",
@@ -653,16 +635,7 @@ pub const TOGGLEABLE_MCP_SERVICES: &[McpServiceDescriptor] = &[
         credential_files: &["access_token", "site_id"],
         oauth_state_fields: Some(&[
             // LOGICAL allowlist of fields the UI may save into oauth.json.
-            // Post-OAuthProvider refactor the on-disk layout nests IdP-specific
-            // keys (`client_id`, `tenant_id`) under `providerData` — this list
-            // still names them in their logical form because:
-            //   * `auth_fields` references them by logical key, and
-            //   * `is_allowed_field` (desktop/src-tauri/src/types.rs) uses this
-            //     allowlist to accept UI form submissions.
-            // The logical→disk mapping lives in `integrations_cmd::get_oauth_field`
-            // / `merge_oauth_state_json`. `scopes` / `grantedScopes` /
-            // `expiresAt` / `lastRefreshAt` are managed exclusively by the
-            // oauth worker (not in `auth_fields`).
+            // logical→disk mapping: `integrations_cmd::{get_oauth_field,merge_oauth_state_json}`.
             "refresh_token",
             "client_id",
             "tenant_id",
@@ -1335,6 +1308,7 @@ pub fn strip_compose_container_prefix<'a>(name: &'a str, project: &str) -> &'a s
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 
@@ -1646,6 +1620,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::assertions_on_constants)] // SSOT guard: asserts SLACK_OAUTH_REDIRECT_PORT stays sane
     fn test_slack_oauth_consts_are_complete() {
         assert!(!SLACK_OAUTH_CLIENT_ID.is_empty());
         // client_id format: <app>.<id> — two numeric segments.
@@ -2032,6 +2007,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::assertions_on_constants)] // SSOT guard: asserts WSL_SERVICE_START_DELAY_SECS stays sane
     fn test_wsl_service_start_delay_is_positive() {
         assert!(
             WSL_SERVICE_START_DELAY_SECS > 0,
@@ -2040,6 +2016,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::assertions_on_constants)] // SSOT guard: asserts WSL_SERVICE_CHECK_MAX_RETRIES stays sane
     fn test_wsl_service_check_max_retries_is_positive() {
         assert!(
             WSL_SERVICE_CHECK_MAX_RETRIES > 0,
@@ -2365,6 +2342,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::assertions_on_constants)] // SSOT guard: asserts EXIT_CLEANUP_TIMEOUT_SECS stays sane
     fn test_exit_cleanup_timeout_is_positive() {
         assert!(
             EXIT_CLEANUP_TIMEOUT_SECS > 0,
@@ -2373,6 +2351,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::assertions_on_constants)] // SSOT guard: asserts LIMA_VM_STOP_TIMEOUT_SECS stays sane
     fn test_lima_vm_stop_timeout_is_positive() {
         assert!(
             LIMA_VM_STOP_TIMEOUT_SECS > 0,
@@ -2407,15 +2386,8 @@ mod tests {
         }
     }
 
-    // SSOT alignment guards (CLAUDE.md "WSL distro name" row).
-    //
-    // The production install path always uses the default data_dir
-    // (`~/.speedwave`), so `derive_wsl_distro_name_from` returns the literal
-    // `"Speedwave"` for it. The installer, E2E provisioning script, and
-    // installation guide all hard-code that production name. These guards
-    // catch accidental renames in any of the three files; non-production
-    // distro names (e.g. dev's `Speedwave-dev`) are derived dynamically and
-    // do not need a sync guard.
+    // SSOT alignment guards (CLAUDE.md "WSL distro name" row): pin the
+    // production literal "Speedwave" across installer, E2E script, install guide.
 
     const PRODUCTION_WSL_DISTRO: &str = "Speedwave";
 
@@ -2550,10 +2522,8 @@ mod tests {
         );
     }
 
-    // Cross-language SSOT for the single host-gateway alias. The TypeScript
-    // MCP-shared module mirrors `HOST_GATEWAY_ALIAS` as `export const`; the
-    // compose template references it as a literal in `extra_hosts`. These
-    // guards catch any drift (string mismatch or accidental removal).
+    // Cross-language SSOT for HOST_GATEWAY_ALIAS: TS MCP-shared mirrors it as
+    // `export const`; compose template references the literal in `extra_hosts`.
 
     #[test]
     fn host_gateway_alias_matches_mcp_shared_ts() {

--- a/crates/speedwave-runtime/src/defaults.rs
+++ b/crates/speedwave-runtime/src/defaults.rs
@@ -10,11 +10,6 @@ pub const MCP_CONFIG_PATH: &str = "/home/speedwave/.claude/mcp-config.json";
 
 /// Per-model price list, USD per 1 million tokens. SSOT for the Desktop
 /// cost meter (`chat/pricing.ts` derives from this via `list_anthropic_models`).
-///
-/// `cached_input` is the prompt-cache read rate; `cache_write` the cache
-/// creation rate. Across the Claude 4.x generation cache-read is 10% of the
-/// base input rate and cache-write 125% — but we store the resolved numbers
-/// rather than ratios so a future per-model deviation is a single edit here.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub struct ModelPricing {
     /// Standard (non-cached) input tokens.
@@ -29,45 +24,25 @@ pub struct ModelPricing {
 
 /// Single source of truth for the Anthropic models surfaced in the
 /// Settings → LLM Provider dropdown and the Desktop cost meter.
-///
-/// Sourced from the official catalog at
-/// <https://platform.claude.com/docs/en/about-claude/models/overview>.
-/// Bump this list when Anthropic ships a new family — every consumer
-/// (frontend dropdown, cost meter, future CLI flags, docs) reads from here.
-///
-/// `latest` flags the actively recommended families (rendered in the
-/// "Latest" optgroup); the rest are legacy entries that still work but
-/// should nudge users toward the current generation.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AnthropicModelInfo {
     /// Stable API alias (no snapshot date). Sent to Claude Code via
-    /// `ANTHROPIC_MODEL`. Pinning the dated form would force a config
-    /// migration on every model snapshot — Anthropic guarantees the alias
-    /// resolves to the current snapshot.
+    /// `ANTHROPIC_MODEL`.
     pub id: &'static str,
     /// Display label shown in the dropdown ("Opus 4.7", "Sonnet 4.6", …).
     pub family: &'static str,
     /// Context window in tokens (1_000_000 for 1M-context models).
     pub context_tokens: u32,
-    /// Whether this entry belongs to the "Latest" group. `false` for
-    /// still-available legacy snapshots; deprecated/retired models are
-    /// removed from the list outright.
+    /// Whether this entry belongs to the "Latest" group.
     pub latest: bool,
     /// Price of the base model id (e.g. `claude-sonnet-4-6`).
     pub pricing: ModelPricing,
     /// Price of the `[1m]` 1M-context variant id (e.g. `claude-sonnet-4-6[1m]`),
-    /// present only when `context_tokens >= 1_000_000`. Some families (Sonnet)
-    /// bill the 1M window at a premium over the base rate; Opus 1M is the base
-    /// rate. `None` for sub-1M models, which have no `[1m]` variant.
+    /// present only when `context_tokens >= 1_000_000`. `None` for sub-1M models.
     pub pricing_1m: Option<ModelPricing>,
 }
 
-// Published per-MTok rates (platform.claude.com/docs/en/pricing). Fable 5 is
-// $10/$50 (1M window is the default, standard-priced). Opus 4.5+ is $5/$25;
-// the full 1M window is standard-priced, so the `[1m]` rate equals the base.
-// Sonnet 4.6 is $3/$15 base with a 1M-context premium ($6/$22.5). Haiku 4.5
-// is $1/$5 and has no 1M variant. Cache-read = 10% of input, cache-write =
-// 125% of input across the 4.x/5 generation.
+// Published per-MTok rates: platform.claude.com/docs/en/pricing.
 const FABLE_PRICING: ModelPricing = ModelPricing {
     input: 10.0,
     cached_input: 1.0,
@@ -101,12 +76,6 @@ const HAIKU_PRICING: ModelPricing = ModelPricing {
 
 /// Curated list of Anthropic models available via Claude Code.
 /// **Order matters** — frontend renders this list as-is.
-///
-/// We surface only the actively-recommended generation. Legacy snapshots
-/// can still be selected by typing the id manually (the frontend "(not in
-/// catalog)" escape hatch handles existing configs that pin a removed
-/// alias), but we don't pre-populate the dropdown with them — encouraging
-/// their use was the opposite of what the `latest` flag intended.
 pub const ANTHROPIC_MODELS: &[AnthropicModelInfo] = &[
     AnthropicModelInfo {
         id: "claude-fable-5",
@@ -158,21 +127,8 @@ pub const ANTHROPIC_MODELS: &[AnthropicModelInfo] = &[
     },
 ];
 
-/// The display label of the Opus model that the `(default)` dropdown option
-/// resolves to at runtime — i.e. what `ANTHROPIC_DEFAULT_OPUS_MODEL` points
-/// at when `model` is left blank. Used by the Settings UI to render an
-/// honest hint like *"Default — Opus 4.7 (switchable via /model)"* instead
-/// of the previous vague *"let Claude Code choose"* placeholder.
-///
-/// Reads from `ANTHROPIC_MODELS` (the SSOT) so a future Opus bump (e.g. 4.9)
-/// updates the UI hint without touching this helper. Returns `None` if the
-/// catalog has no `latest = true` Opus entry — frontend falls back to the
-/// generic placeholder in that case.
-///
-/// Identifies the Opus entry by `id.starts_with("claude-opus-")` rather than
-/// `family.starts_with("Opus")` — the API id is a stable contract with
-/// Anthropic, while the display label is mutable (e.g. someone could relabel
-/// "Opus 4.7" to "Claude Opus 4.7" without rebreaking this lookup).
+/// Display label of the latest Opus entry the `(default)` dropdown option
+/// resolves to. `None` if the catalog has no `latest = true` Opus entry.
 pub fn default_anthropic_family_label() -> Option<&'static str> {
     ANTHROPIC_MODELS
         .iter()
@@ -182,31 +138,12 @@ pub fn default_anthropic_family_label() -> Option<&'static str> {
 
 /// Default Claude Code CLI flags applied to every session.
 pub const DEFAULT_FLAGS: &[&str] = &[
-    // SECURITY RATIONALE: --dangerously-skip-permissions is safe in this context because:
-    // 1. Claude runs in an isolated container (Lima VM / WSL2) — kernel-level isolation
-    // 2. Container has read-only filesystem except /tmp (noexec,nosuid)
-    // 3. Container runs with cap_drop: ALL, no-new-privileges
-    // 4. Container has zero service tokens
-    // 5. Container network is isolated per-project
-    //
-    // IS_SANDBOX=1 in base_env() signals a sandboxed environment to Claude Code,
-    // pre-empting the root-user check that gates --dangerously-skip-permissions.
-    // On macOS Lima / Windows WSL2 the container runs as UID 1000 so the check
-    // is already satisfied; IS_SANDBOX stays for defense-in-depth.
     "--dangerously-skip-permissions",
     // Tells Claude Code where the MCP hub is (generated by entrypoint.sh)
     "--mcp-config",
     MCP_CONFIG_PATH,
     // Only use servers from --mcp-config, ignore any .mcp.json in workspace
     "--strict-mcp-config",
-    // Force thinking content to be returned as `summarized` (the populated text
-    // form) rather than `omitted` (empty thinking blocks with signature only).
-    // Claude Opus 4.7 changed the API default to `omitted`, and the
-    // `showThinkingSummaries: true` settings.json key is NOT wired to this API
-    // parameter in the harness — see anthropics/claude-code#49268. Without this
-    // flag the chat UI never sees the model's reasoning. Safe across models:
-    // 4.6/Sonnet 4.6 already default to `summarized`, so this flag is a no-op
-    // for them and a fix for 4.7+. Remove once #49268 ships in upstream.
     "--thinking-display",
     "summarized",
 ];
@@ -216,38 +153,18 @@ pub fn base_env() -> HashMap<String, String> {
     let mut env = HashMap::new();
     env.insert("CLAUDE_CODE_ENABLE_TELEMETRY".into(), "0".into());
     env.insert("DISABLE_AUTOUPDATER".into(), "1".into());
-    // Signal sandboxed environment to Claude Code so --dangerously-skip-permissions
-    // is accepted regardless of effective UID. Both supported platforms run the
-    // container as UID 1000 (the root check would already pass), so this is a
-    // defense-in-depth setting against future changes.
+    // Signal sandboxed env so --dangerously-skip-permissions is accepted regardless of UID.
     env.insert("IS_SANDBOX".into(), "1".into());
-    // Claude Code focus-view mode: alt-screen + differential rendering emits smaller
-    // ANSI updates instead of full-frame redraws on every stream chunk. Mitigates PTY
-    // write-side backpressure in the CLI (ssh → nerdctl exec → claude) that caused
-    // long streaming sessions to freeze. Introduced upstream in Claude Code 2.1.97.
-    // See issue #451. Users can override via claude.env.CLAUDE_CODE_NO_FLICKER in
-    // .speedwave.json if they prefer the legacy renderer.
+    // Claude Code focus-view mode: emits smaller ANSI updates instead of full-frame redraws (issue #451).
     env.insert("CLAUDE_CODE_NO_FLICKER".into(), "1".into());
-    // Claude Code ≥2.1.161 probes wl-copy only when WAYLAND_DISPLAY is set;
-    // any non-empty value routes copies through the osc52-copy.sh shim (ADR-052).
+    // Non-empty WAYLAND_DISPLAY routes Claude Code copies through the osc52-copy.sh shim (ADR-052).
     env.insert("WAYLAND_DISPLAY".into(), "speedwave-clipboard".into());
     env
 }
 
 /// Generates `ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU}_MODEL` env vars from the
-/// `ANTHROPIC_MODELS` SSOT. Each alias resolves to the latest entry in its
-/// family, with `[1m]` suffixed when the model supports a 1M-token context
-/// window — that suffix is what unlocks the upgraded window for Max/Team
-/// subscribers, fixing the 200k cap reported in anthropics/claude-code#34083.
-/// Remove the `[1m]` suffix logic (and ideally this whole helper) once that
-/// upstream issue ships a fix and the alias resolves to the upgraded window
-/// natively.
-///
-/// Future model bumps (e.g. Opus 4.9) only require editing `ANTHROPIC_MODELS`
-/// in this file: the env vars track the SSOT automatically. Families with no
-/// `latest: true` entry are skipped (no env var emitted) so a partial catalog
-/// never produces a malformed model id. Fable 5 deliberately gets no alias —
-/// Claude Code has no such env var and Fable ships 1M context by default.
+/// `ANTHROPIC_MODELS` SSOT, suffixing `[1m]` for 1M-context models. Families
+/// with no `latest: true` entry are skipped (Fable gets no alias).
 pub fn anthropic_default_models_env() -> HashMap<String, String> {
     let mut env = HashMap::new();
     for (alias, family_prefix) in [("OPUS", "Opus"), ("SONNET", "Sonnet"), ("HAIKU", "Haiku")] {
@@ -271,15 +188,13 @@ pub fn anthropic_default_models_env() -> HashMap<String, String> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 
     #[test]
     fn claude_version_is_pinned_semver() {
         // CLAUDE_VERSION must be a concrete semver — never "latest" or "stable".
-        // The official installer (claude.ai/install.sh) downloads the exact version
-        // and verifies its SHA256 against a version-pinned manifest.json from GCS.
-        // Pinning ensures reproducible builds and limits attack surface to a known release.
         assert_ne!(CLAUDE_VERSION, "latest", "must not be 'latest'");
         assert_ne!(CLAUDE_VERSION, "stable", "must not be 'stable'");
         let re = regex::Regex::new(r"^[0-9]+\.[0-9]+\.[0-9]+$").unwrap();
@@ -294,7 +209,7 @@ mod tests {
     fn base_env_does_not_set_model() {
         let env = base_env();
         assert!(
-            env.get("ANTHROPIC_MODEL").is_none(),
+            !env.contains_key("ANTHROPIC_MODEL"),
             "base_env() must not set ANTHROPIC_MODEL — the user's Claude Code model \
              selection must not be overridden. Users who want a specific model can set \
              claude.env.ANTHROPIC_MODEL in .speedwave.json or ~/.speedwave/config.json."
@@ -332,8 +247,7 @@ mod tests {
 
     #[test]
     fn base_env_sets_wayland_display_for_clipboard_probe() {
-        // Claude Code ≥2.1.161 gates the clipboard-tool probe on this var;
-        // unset = copies never reach the osc52-copy.sh shim (ADR-052).
+        // Claude Code ≥2.1.161 gates the clipboard-tool probe on this var (ADR-052).
         let env = base_env();
         let val = env.get("WAYLAND_DISPLAY").map(|s| s.as_str());
         assert!(
@@ -359,8 +273,7 @@ mod tests {
 
     #[test]
     fn mcp_config_path_points_to_claude_dir() {
-        // entrypoint.sh generates mcp-config.json at this exact path.
-        // If this changes, entrypoint.sh and DEFAULT_FLAGS must be updated together.
+        // entrypoint.sh generates mcp-config.json at this path; keep it in sync with DEFAULT_FLAGS.
         assert_eq!(MCP_CONFIG_PATH, "/home/speedwave/.claude/mcp-config.json");
     }
 
@@ -371,11 +284,7 @@ mod tests {
 
     #[test]
     fn default_flags_force_thinking_summarized() {
-        // Workaround for anthropics/claude-code#49268 — `showThinkingSummaries`
-        // settings.json key is not wired to the API `display` parameter, so
-        // Opus 4.7's new `omitted` default wins and the chat UI never sees
-        // thinking content. The hidden `--thinking-display` CLI flag does
-        // pass through; pin it to `summarized` so reasoning stays visible.
+        // Workaround for anthropics/claude-code#49268: pin --thinking-display to `summarized`.
         let pos = DEFAULT_FLAGS
             .iter()
             .position(|f| *f == "--thinking-display")
@@ -389,15 +298,9 @@ mod tests {
 
     #[test]
     fn anthropic_default_models_env_appends_1m_suffix_for_million_token_models() {
-        // Workaround for anthropics/claude-code#34083 — without `[1m]` suffix
-        // on the model id, Max/Team subscribers see their 1M-context models
-        // capped at 200k. The function must derive these env vars from the
-        // SSOT so a future model bump (Opus 4.9 etc.) propagates by editing
-        // `ANTHROPIC_MODELS` alone.
+        // Workaround for anthropics/claude-code#34083 (1M models capped at 200k without `[1m]`).
         let env = anthropic_default_models_env();
-        // Cross-check every emitted var against SSOT — independent of which
-        // exact model id is `latest` today, so this test stays green when
-        // someone bumps the catalog.
+        // Cross-check every emitted var against SSOT.
         for (var, value) in &env {
             let alias = var
                 .strip_prefix("ANTHROPIC_DEFAULT_")
@@ -432,9 +335,7 @@ mod tests {
 
     #[test]
     fn anthropic_default_models_env_covers_every_latest_family() {
-        // Every family that has a `latest: true` entry in SSOT must produce a
-        // matching env var — otherwise the alias falls back to Anthropic's
-        // server default and we lose the [1m] upgrade for that family.
+        // Every family with a `latest: true` entry in SSOT must produce a matching env var.
         let env = anthropic_default_models_env();
         for prefix in ["Opus", "Sonnet", "Haiku"] {
             let has_latest = ANTHROPIC_MODELS
@@ -452,8 +353,7 @@ mod tests {
 
     #[test]
     fn fable_family_emits_no_default_alias() {
-        // Claude Code has no ANTHROPIC_DEFAULT_FABLE_MODEL — guard against a
-        // future "coverage fix" inventing a nonexistent var.
+        // Claude Code has no ANTHROPIC_DEFAULT_FABLE_MODEL.
         let env = anthropic_default_models_env();
         assert!(
             !env.keys().any(|k| k.contains("FABLE")),
@@ -477,15 +377,13 @@ mod tests {
     #[test]
     fn default_flags_include_mcp_config() {
         // Claude Code must receive --mcp-config pointing to the generated config file.
-        // Without this, /mcp shows "No MCP servers configured".
         assert!(DEFAULT_FLAGS.contains(&"--mcp-config"));
         assert!(DEFAULT_FLAGS.contains(&MCP_CONFIG_PATH));
     }
 
     #[test]
     fn default_flags_mcp_config_before_strict() {
-        // --mcp-config must come before --strict-mcp-config (Claude Code parses
-        // flags sequentially; strict mode validates the config path exists).
+        // --mcp-config must come before --strict-mcp-config.
         let mcp_pos = DEFAULT_FLAGS.iter().position(|f| *f == "--mcp-config");
         let strict_pos = DEFAULT_FLAGS
             .iter()
@@ -512,9 +410,7 @@ mod tests {
 
     #[test]
     fn anthropic_models_list_is_non_empty_and_starts_with_latest() {
-        // The dropdown depends on at least one entry being available. The
-        // first entry is what the UI surfaces as the topmost option in the
-        // "Latest" group, so it must be flagged `latest = true`.
+        // The first entry is the topmost dropdown option, so it must be `latest = true`.
         assert!(!ANTHROPIC_MODELS.is_empty(), "model list must not be empty");
         assert!(
             ANTHROPIC_MODELS[0].latest,
@@ -524,9 +420,7 @@ mod tests {
 
     #[test]
     fn anthropic_model_ids_are_unique_and_well_formed() {
-        // Duplicate IDs would render as duplicate <option>s; malformed IDs
-        // would silently fail when written into ANTHROPIC_MODEL. Catch both
-        // at compile-test time.
+        // Model ids must be unique and start with `claude-`.
         let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
         for m in ANTHROPIC_MODELS {
             assert!(seen.insert(m.id), "duplicate model id: {}", m.id);
@@ -540,10 +434,7 @@ mod tests {
                 "family label must not be empty for {}",
                 m.id
             );
-            // The smallest plausible Claude context window is 200k (Haiku).
-            // A "couple hundred" tokens would clearly be wrong; we use a
-            // floor that catches accidental zeros / typos without coupling
-            // the test to current Anthropic context-window economics.
+            // Smallest plausible context window is 200k (Haiku); catch accidental zeros/typos.
             assert!(
                 m.context_tokens >= 1_000,
                 "context_tokens looks too small for {}: {}",
@@ -555,10 +446,7 @@ mod tests {
 
     #[test]
     fn anthropic_models_have_at_least_one_latest_entry() {
-        // The "Latest" optgroup must render something — without a flagged
-        // entry the dropdown opens on a legacy id, defeating the point of
-        // the flag. (The full Latest-before-Legacy ordering invariant is
-        // checked by `anthropic_models_latest_entries_precede_legacy`.)
+        // At least one `latest: true` entry must exist for the "Latest" optgroup.
         assert!(
             ANTHROPIC_MODELS.iter().any(|m| m.latest),
             "at least one Latest entry required so the dropdown opens with a current option"
@@ -567,11 +455,7 @@ mod tests {
 
     #[test]
     fn anthropic_models_latest_entries_precede_legacy() {
-        // Frontend renders the slice as-is into two optgroups. If a
-        // `latest = false` entry appears before any `latest = true` entry
-        // the optgroup boundary breaks. Guard the structural invariant
-        // explicitly so the comment on `ANTHROPIC_MODELS` remains true
-        // without manual review.
+        // Frontend renders the slice as-is into two optgroups; legacy before latest breaks the boundary.
         let mut seen_legacy = false;
         for m in ANTHROPIC_MODELS {
             if !m.latest {
@@ -588,10 +472,7 @@ mod tests {
 
     #[test]
     fn every_model_has_well_formed_pricing() {
-        // The Desktop cost meter derives from these numbers — a zero or
-        // inverted rate would render a misleading cost. Guard the business
-        // invariants (cache-read cheaper than input, cache-write dearer)
-        // for every catalog entry and its 1M variant.
+        // Cache-read must be cheaper than input, cache-write dearer, for every entry and its 1M variant.
         fn check(label: &str, p: &ModelPricing) {
             assert!(p.input > 0.0, "{label}: input rate must be positive");
             assert!(p.output > 0.0, "{label}: output rate must be positive");
@@ -614,10 +495,7 @@ mod tests {
 
     #[test]
     fn one_m_pricing_present_iff_million_token_context() {
-        // The `[1m]` id only exists for 1M-context families (the suffix that
-        // unlocks the upgraded window — see `anthropic_default_models_env`).
-        // A `pricing_1m` on a sub-1M model, or its absence on a 1M model,
-        // would leave the cost meter unable to price the served id.
+        // `pricing_1m` must be present iff the model has a 1M-token context.
         for m in ANTHROPIC_MODELS {
             let is_million = m.context_tokens >= 1_000_000;
             assert_eq!(
@@ -632,10 +510,7 @@ mod tests {
 
     #[test]
     fn default_anthropic_family_label_returns_latest_opus_family() {
-        // Forces the constant in this assertion to be updated alongside the
-        // SSOT when a new Opus snapshot lands (e.g. Opus 4.9). If the test
-        // breaks on a model bump, the helper still works — the assertion
-        // just needs to follow the family label.
+        // Update this label alongside the SSOT when a new Opus snapshot lands.
         assert_eq!(default_anthropic_family_label(), Some("Opus 4.8"));
     }
 }

--- a/crates/speedwave-runtime/src/diagnostic_sources.rs
+++ b/crates/speedwave-runtime/src/diagnostic_sources.rs
@@ -1,8 +1,6 @@
 //! SSOT registry of diagnostic sources. The `/logs` view and the diagnostics
-//! ZIP both derive their content from `DIAGNOSTIC_SOURCES`, so they cannot drift
-//! (see the parity tests). The only allowed divergence: a non-`displayable`
-//! source (an artifact the line-oriented `/logs` view can't render, e.g.
-//! `compose.yml`) is ZIP-only.
+//! ZIP both derive their content from `DIAGNOSTIC_SOURCES`. Allowed divergence:
+//! a non-`displayable` source is ZIP-only.
 
 use std::path::{Path, PathBuf};
 
@@ -131,9 +129,8 @@ pub const DIAGNOSTIC_SOURCES: &[DiagnosticSource] = &[
 pub const ZIP_ONLY_KEYS: &[&str] = &["compose-yml"];
 
 /// Resolves a `SourceKind::File` source's path by key, gated to the current
-/// platform. Shared by both consumers (/logs + ZIP) so neither hand-rolls the
-/// find + platform-gate + File-extraction chain. Returns `None` for unknown
-/// keys, unavailable platforms, or non-File kinds.
+/// platform. Returns `None` for unknown keys, unavailable platforms, or
+/// non-File kinds.
 pub fn resolve_file_path(key: &str, data_dir: &Path, project: &str) -> Option<PathBuf> {
     DIAGNOSTIC_SOURCES
         .iter()
@@ -202,9 +199,8 @@ mod tests {
         assert_eq!(mac_only, vec!["lima"]);
     }
 
-    /// `zip_entry` literals embed const-owned filenames (the slice needs
-    /// `&'static str`, so they can't be `format!`-ed). Guard against drift if a
-    /// const filename changes.
+    /// Guards against drift if a const filename embedded in a `zip_entry`
+    /// changes.
     #[test]
     fn zip_entries_match_owning_consts() {
         let entry = |key: &str| {
@@ -216,7 +212,6 @@ mod tests {
         };
         assert!(entry("mcp-os").ends_with(consts::MCP_OS_LOG_FILE));
         assert!(entry("claude").ends_with(consts::CLAUDE_SESSION_LOG_FILE));
-        // `lima`/`compose-yml` filenames are Lima's / compose's own conventions,
-        // not Speedwave consts, so there's nothing to drift against.
+        // `lima`/`compose-yml` filenames aren't Speedwave consts, nothing to drift against.
     }
 }

--- a/crates/speedwave-runtime/src/engine_path.rs
+++ b/crates/speedwave-runtime/src/engine_path.rs
@@ -1,16 +1,10 @@
-//! SSOT for host→engine path handling. Every path that becomes an argv token
-//! to `wsl.exe`/`nerdctl`/`limactl`/`compose -f`/`-v`, or a mount source written
-//! into compose YAML, must be produced here — never by a hand-rolled translation
-//! or a raw `PathBuf::join` on an already-translated path. The drift detector
-//! `tests/no_raw_engine_path.rs` enforces this.
+//! SSOT for host→engine path handling, enforced by the drift detector
+//! `tests/no_raw_engine_path.rs`.
 
 use std::path::Path;
 
 /// Converts a host path to the path seen by the container engine.
-///
-/// On Windows, nerdctl runs inside WSL2 so host paths must be translated from
-/// `C:\Users\...` to `/mnt/c/Users/...`. On macOS, Lima mounts the host home
-/// at the same path inside the VM, so paths are returned unchanged.
+/// Windows: `C:\Users\...` → `/mnt/c/Users/...`; macOS: unchanged (1:1 mount).
 pub fn to_engine_path(path: &Path) -> anyhow::Result<String> {
     #[cfg(target_os = "windows")]
     {
@@ -29,12 +23,8 @@ pub fn str_to_engine_path(path: &str) -> anyhow::Result<String> {
 }
 
 /// Joins a child onto an already-engine-side (Linux/WSL) directory with `/`.
-///
-/// `vm_root` is a path bound for inside the VM/container (`/mnt/c/...` on
-/// Windows). `PathBuf::join` must NOT be used: on Windows it inserts a backslash
-/// and mishandles the `/`-rooted string, mangling `<root>/<child>` into garbage
-/// (the `examplePluginContainerfile` plugin-build bug). Trailing slashes on `vm_root`
-/// collapse so the result has exactly one separator.
+/// Always `/`, never `PathBuf::join` (backslash on Windows); trailing slashes
+/// on `vm_root` collapse to one separator.
 pub fn vm_path_join(vm_root: &str, child: &str) -> String {
     debug_assert!(
         !child.starts_with('/'),
@@ -44,13 +34,13 @@ pub fn vm_path_join(vm_root: &str, child: &str) -> String {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 
     #[test]
     fn vm_path_join_inserts_single_separator() {
-        // The case the plugin build hit: a WSL root + "Containerfile" must yield
-        // exactly one "/", never the dropped-separator "examplePluginContainerfile".
+        // WSL root + "Containerfile" yields exactly one "/" separator.
         assert_eq!(
             vm_path_join(
                 "/mnt/c/Users/u/.speedwave/plugins/example-plugin",
@@ -62,8 +52,7 @@ mod tests {
 
     #[test]
     fn vm_path_join_collapses_trailing_slashes_and_keeps_forward_slash() {
-        // Trailing slashes collapse; separator is always "/" on every host OS
-        // (no backslash even on Windows).
+        // Trailing slashes collapse; separator is always "/" on every host OS.
         assert_eq!(
             vm_path_join("/mnt/c/x/", "Containerfile"),
             "/mnt/c/x/Containerfile"

--- a/crates/speedwave-runtime/src/fs_perms.rs
+++ b/crates/speedwave-runtime/src/fs_perms.rs
@@ -1,14 +1,5 @@
-//! Cross-platform owner-only file/directory permission utilities.
-//!
-//! All worker auth tokens, PID files, OAuth state, pasted attachments, and
-//! plugin credentials must be readable only by the current user. Unix:
-//! `chmod 0o600` (files) / `0o700` (dirs). Windows: the DACL is replaced with a
-//! single `GENERIC_ALL` ACE for the current user (`SetNamedSecurityInfoW`) — one
-//! mechanism, no subprocess and no PATH dependence.
-//!
-//! Single SSOT — both the runtime supervisors and the Desktop layer call these.
-//! Previously the Win32 DACL helper lived separately in
-//! `desktop/src-tauri/src/fs_perms.rs`; it was consolidated here.
+//! Cross-platform owner-only file/directory permission utilities (chmod 0o600/0o700 Unix / DACL Windows).
+//! SSOT for runtime supervisors + Desktop layer.
 
 use std::io::Write;
 use std::path::Path;
@@ -49,9 +40,8 @@ fn set_owner_only_with_mode(path: &Path, _mode: u32) -> Result<(), String> {
 }
 
 /// Restrict a file or directory to the current user only via a Windows DACL.
-/// **Returns `Err` on any Win32 failure** — the caller must treat the target as
-/// world-readable and remove/quarantine it, since a silent failure would leave
-/// secrets exposed on disk.
+/// **Returns `Err` on any Win32 failure** — caller must remove/quarantine the
+/// target.
 #[cfg(windows)]
 #[allow(unsafe_code)]
 fn set_windows_acl_owner_only(path: &Path) -> Result<(), String> {
@@ -126,27 +116,22 @@ fn set_windows_acl_owner_only(path: &Path) -> Result<(), String> {
     }
 }
 
-/// Flushes a file's data to stable media. On macOS plain `fsync` returns before
-/// APFS hits the platter, so `F_FULLFSYNC` is preferred; if the filesystem
-/// doesn't support it (network mounts: SMB/NFS return ENOTSUP) it falls back to
-/// plain `fsync`, then to a best-effort no-op — degrading to pre-fsync durability
-/// rather than failing the write. Other Unix uses `fsync`; Windows is a no-op.
+/// Flushes file data to stable media. macOS: `F_FULLFSYNC` with fallback to
+/// `fsync` then best-effort no-op on unsupported fs (SMB/NFS). Other Unix:
+/// `fsync`. Windows: no-op.
 #[cfg(unix)]
 pub(crate) fn fsync_file_durable(file: &std::fs::File) -> std::io::Result<()> {
     #[cfg(target_os = "macos")]
     {
         use rustix::io::Errno;
-        // `F_FULLFSYNC` unsupported on this fs/device → fall back. EINVAL here
-        // means "unknown fcntl command"; ENOTSUP/EOPNOTSUPP: network mounts
-        // (SMB/NFS); ENODEV: char devices.
+        // `F_FULLFSYNC` unsupported on this fs/device → fall back to `fsync`.
         let fcntl_unsupported = |e: &Errno| {
             matches!(
                 *e,
                 Errno::NOTSUP | Errno::OPNOTSUPP | Errno::INVAL | Errno::NODEV
             )
         };
-        // Plain `fsync` fallback: only a filesystem capability gap is best-effort.
-        // EINVAL from `fsync` is a bad fd (programming error) — must propagate.
+        // EINVAL from `fsync` is a bad fd → must propagate, so it's excluded here.
         let fsync_unsupported =
             |e: &Errno| matches!(*e, Errno::NOTSUP | Errno::OPNOTSUPP | Errno::NODEV);
         match rustix::fs::fcntl_fullfsync(file) {
@@ -177,8 +162,7 @@ pub(crate) fn fsync_file_durable(_file: &std::fs::File) -> std::io::Result<()> {
 #[cfg(unix)]
 fn fsync_parent_dir(dir: &Path) {
     if let Ok(handle) = std::fs::File::open(dir) {
-        // Best-effort: the data blocks are already durable (file fsync ran
-        // first), so a dir-fsync failure is non-fatal.
+        // Best-effort: a dir-fsync failure is non-fatal.
         let _ = rustix::fs::fsync(&handle);
     }
 }
@@ -186,28 +170,9 @@ fn fsync_parent_dir(dir: &Path) {
 #[cfg(not(unix))]
 fn fsync_parent_dir(_dir: &Path) {}
 
-/// Write `content` to `path` with owner-only permissions.
-///
-/// Both platforms now use the same write-then-atomic-rename pattern via
-/// `tempfile::NamedTempFile`. The destination path never sees a world-readable
-/// state: the file is created in `path`'s parent directory with owner-only
-/// permissions, written, locked down, then atomically renamed into place.
-///
-/// - Unix: `NamedTempFile` opens with `O_CREAT | mode 0o600`. We explicitly
-///   re-`chmod` after writing so a pre-existing destination file's old (possibly
-///   world-readable) bits are replaced too. `persist()` is atomic on Unix —
-///   the destination is the new file or the old one, never a partial write.
-/// - Windows: tightens the ACL on the tempfile **before** rename, so the
-///   destination path never appears world-readable to a concurrent reader.
-///   Previous behavior (`fs::write(dest) + ACL on dest`) opened a TOCTOU window
-///   where the destination file existed with the inherited (potentially
-///   world-readable) DACL between the two syscalls. `persist()` uses
-///   `MoveFileExW(MOVEFILE_REPLACE_EXISTING)`, which is atomic on NTFS.
-///   **A DACL failure returns `Err`** — the tempfile is dropped before ever
-///   appearing at `path`, so no secret leaks. ADR-009 makes Windows ACL
-///   failure a hard error so the owner-only invariant is real.
-///
-/// Existing directories at `path` are removed first (consistent with prior behavior).
+/// Write `content` to `path` with owner-only permissions via write-then-atomic-rename;
+/// the destination path never appears world-readable. Windows DACL failure returns
+/// `Err` (ADR-009). Existing directories at `path` are removed first.
 pub fn write_restricted_file(path: &Path, content: &str) -> anyhow::Result<()> {
     // Direct callers: `path` is the final name, so commit its directory entry.
     write_restricted_file_synced(path, content, true)
@@ -228,8 +193,7 @@ fn write_restricted_file_synced(
         std::fs::remove_dir_all(path)?;
     }
 
-    // Tempfile must live on the same filesystem as `path` — otherwise
-    // `persist()` falls back to a copy and the rename is not atomic.
+    // Tempfile must live on the same filesystem as `path` for an atomic rename.
     let parent = path.parent().ok_or_else(|| {
         anyhow::anyhow!(
             "write_restricted_file: path {} has no parent directory",
@@ -243,20 +207,13 @@ fn write_restricted_file_synced(
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        // `NamedTempFile` already creates with mode 0o600, but on overwrite of
-        // an existing file `persist()` replaces the target inode entirely — the
-        // bits we set here are what the destination ends up with. Belt-and-suspenders.
+        // Re-chmod so the bits survive `persist()` replacing the target inode.
         std::fs::set_permissions(tmp.path(), std::fs::Permissions::from_mode(0o600))?;
     }
 
     #[cfg(windows)]
     {
-        // Tighten the DACL on the **tempfile** before rename. The tempfile path
-        // is in the same parent directory as the destination (so rename is
-        // atomic), but the random prefix makes a concurrent reader unable to
-        // guess it. After `persist()` the destination already has the
-        // restricted DACL. A failure drops `tmp` (removing it) and bails —
-        // the destination path is never touched, so no secret leaks.
+        // Tighten the DACL on the tempfile before rename (atomic delivery with restricted perms).
         set_windows_acl_owner_only(tmp.path()).map_err(|e| {
             anyhow::anyhow!(
                 "DACL tighten failed on tempfile for {}: {} — refusing to leave a world-readable secret",
@@ -282,8 +239,7 @@ fn write_restricted_file_synced(
         )
     })?;
 
-    // Atomic rename. On error, `tmp` is dropped (cleanup on Unix; on Windows
-    // the tempfile path may linger but never as `path`).
+    // Atomic rename. On error `tmp` is dropped, never appearing as `path`.
     tmp.persist(path)
         .map_err(|e| anyhow::anyhow!("failed to persist tempfile to {}: {}", path.display(), e))?;
 
@@ -295,12 +251,9 @@ fn write_restricted_file_synced(
     Ok(())
 }
 
-/// Atomic variant of [`write_restricted_file`]: writes to a sibling `.tmp`
-/// file with owner-only perms, then `rename`s into place. Crash between write
-/// and rename leaves the destination untouched (no truncated secret on disk).
-///
-/// Used by `save_compose` and `update_llm_config` where partial writes would
-/// corrupt a render or token.
+/// Atomic variant of [`write_restricted_file`]: writes to a sibling `.tmp` file
+/// with owner-only perms, then `rename`s into place. Crash between write and
+/// rename leaves the destination untouched.
 pub fn write_restricted_file_atomic(path: &Path, content: &str) -> anyhow::Result<()> {
     let parent = path
         .parent()
@@ -309,8 +262,7 @@ pub fn write_restricted_file_atomic(path: &Path, content: &str) -> anyhow::Resul
         .file_name()
         .and_then(|n| n.to_str())
         .ok_or_else(|| anyhow::anyhow!("path has no file name: {}", path.display()))?;
-    // Per-write unique tmp name — `<pid>` alone collides across threads in
-    // one process; the atomic counter makes every call's sibling unique.
+    // Atomic counter makes the tmp name unique per call (pid collides across threads).
     use std::sync::atomic::{AtomicU64, Ordering};
     static COUNTER: AtomicU64 = AtomicU64::new(0);
     let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
@@ -332,12 +284,9 @@ pub fn write_restricted_file_atomic(path: &Path, content: &str) -> anyhow::Resul
     Ok(())
 }
 
-/// Creates `path` (if missing) and sets it to owner-only perms.
-/// Unix: `chmod 0o700`. Windows: DACL with a single `GENERIC_ALL` ACE for the
-/// current user.
-///
-/// Idempotent: re-runs harmless. Callers iterate parents themselves
-/// (e.g. `tokens/` → `tokens/<project>/` → `tokens/<project>/<service>/`).
+/// Creates `path` (if missing) and sets it to owner-only perms. Unix: `chmod
+/// 0o700`. Windows: DACL with a single `GENERIC_ALL` ACE for the current user.
+/// Idempotent.
 pub fn ensure_owner_only_dir(path: &Path) -> anyhow::Result<()> {
     std::fs::create_dir_all(path)?;
 
@@ -485,15 +434,8 @@ mod tests {
 
     // ── write_restricted_file (atomic via NamedTempFile::persist) ───────
 
-    /// TOCTOU regression guard: prior implementation did `fs::write(dest) + chmod/icacls(dest)`,
-    /// which opened a window where the destination existed with looser bits. The
-    /// tempfile-based implementation must never expose a world-readable file at the
-    /// destination path.
-    ///
-    /// On Unix we prove this indirectly by checking that the tempfile produced by
-    /// `NamedTempFile::with_prefix_in` is already 0o600 at the moment of creation —
-    /// before any write, before `persist`. That is the only state the destination
-    /// can transition from, so the destination cannot be world-readable.
+    /// TOCTOU regression guard: tempfile must be 0o600 before persist so the
+    /// destination cannot be world-readable.
     #[cfg(unix)]
     #[test]
     fn tempfile_is_0o600_before_persist() {
@@ -524,8 +466,7 @@ mod tests {
         std::fs::write(&path, "old").unwrap();
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
 
-        // Overwrite — must end with 0o600 and new content. Because persist is
-        // a single rename, intermediate states are not observable.
+        // Overwrite — must end with 0o600 and new content.
         write_restricted_file(&path, "new").unwrap();
 
         let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
@@ -541,9 +482,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("token");
 
-        // Write must succeed even when the system tempdir is a different fs
-        // (we can't easily simulate that, but `with_prefix_in(parent)` is the
-        // structural fix and this test exercises the code path).
+        // Exercises the `with_prefix_in(parent)` code path.
         write_restricted_file(&path, "x").unwrap();
         assert!(path.exists());
     }
@@ -606,15 +545,10 @@ mod tests {
 
     #[test]
     fn atomic_recovers_when_stale_tmp_exists() {
-        // A prior crash may have left a `.tmp.<pid>.<seq>` orphan on disk.
-        // The next call uses a fresh sequence and is not affected — the
-        // happy path still writes the destination atomically. Stale tmp
-        // files are not actively cleaned by the helper (each call has its
-        // own sequence), but they never interfere with a subsequent write.
+        // A stale `.tmp.<pid>.<seq>` orphan must not affect the next call.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("secret");
-        // Manual orphan with an old shape — the helper uses `.tmp.<pid>.<seq>`
-        // so this exact name won't collide with the next call.
+        // Manual orphan with a legacy shape that won't collide with the next call.
         let stale_tmp = dir
             .path()
             .join(format!(".secret.tmp.{}.legacy", std::process::id()));
@@ -633,10 +567,8 @@ mod tests {
         assert!(write_restricted_file_atomic(&path, "x").is_err());
     }
 
-    /// Crash recovery: simulate a process that died between the `.tmp` write
-    /// and the `rename`. The destination file must remain in its prior
-    /// state — never truncated, never half-written, never replaced by the
-    /// orphaned tmp content.
+    /// Crash recovery: a process dying between `.tmp` write and `rename` must
+    /// leave the destination in its prior state, never truncated or half-written.
     #[test]
     fn atomic_crash_before_rename_leaves_destination_with_old_content() {
         let dir = tempfile::tempdir().unwrap();
@@ -646,9 +578,7 @@ mod tests {
         write_restricted_file_atomic(&path, "old-content").unwrap();
         assert_eq!(std::fs::read_to_string(&path).unwrap(), "old-content");
 
-        // Simulate a crash: write a `.tmp` file that "would have been" the
-        // next atomic write's intermediate state — but the rename never
-        // happened. The destination must still hold the OLD content.
+        // Simulate a crash: orphaned `.tmp` with the rename never happening.
         let crashed_tmp = dir.path().join(format!(
             ".secret.tmp.{}.simulated-crash",
             std::process::id()
@@ -660,9 +590,7 @@ mod tests {
             "destination must be untouched while tmp orphan exists"
         );
 
-        // Subsequent successful write replaces the destination cleanly. The
-        // orphaned tmp from the simulated crash is left for OS-level cleanup
-        // (it cannot interfere — each call uses a fresh sequence).
+        // Subsequent write replaces the destination cleanly despite the orphan.
         write_restricted_file_atomic(&path, "fresh").unwrap();
         assert_eq!(std::fs::read_to_string(&path).unwrap(), "fresh");
     }
@@ -677,11 +605,7 @@ mod tests {
         let path_a = path.clone();
         let path_b = path.clone();
 
-        // Two concurrent writers. They share the same destination, so the
-        // serialization is at the rename step, not the write step — both
-        // .tmp files coexist briefly (different PIDs), then rename wins
-        // one-at-a-time. Both calls must Ok and `path` must end up with
-        // ONE of the two written values (never empty, never partial).
+        // Two concurrent writers; `path` must end up with one writer's value.
         let (a, b) = tokio::join!(
             tokio::task::spawn_blocking(move || {
                 write_restricted_file_atomic(&path_a, "writer-a")

--- a/crates/speedwave-runtime/src/fs_security.rs
+++ b/crates/speedwave-runtime/src/fs_security.rs
@@ -122,8 +122,7 @@ pub(crate) fn collect_security_paths(
         data_dir.join("secrets"),
         data_dir.join("snapshots"),
         data_dir.join("tokens"),
-        // ADR-060: per-project OAuth state dir; refreshToken / clientId live here,
-        // never inside the SharePoint container's mount. Must be 0o700.
+        // ADR-060: per-project OAuth state dir, must be 0o700.
         data_dir.join(consts::OAUTH_SUBDIR),
         // Per-project directories
         data_dir.join("secrets").join(project),
@@ -136,8 +135,7 @@ pub(crate) fn collect_security_paths(
     let mut files: Vec<std::path::PathBuf> = Vec::new();
 
     // --- tokens/<project>/<service>/ subdirectories ---
-    // Single read_dir pass collects both directory paths (for 0o700)
-    // and credential file paths (for 0o600).
+    // Collects both directory paths (0o700) and credential file paths (0o600).
     let tokens_project_dir = data_dir.join("tokens").join(project);
     if let Ok(services) = std::fs::read_dir(&tokens_project_dir) {
         for entry in services.flatten() {
@@ -160,9 +158,7 @@ pub(crate) fn collect_security_paths(
 
     // --- Root-level files ---
     files.push(data_dir.join("bundle-state.json"));
-    // ADR-054: mcp-os is a singleton — its unified lock lives at the data
-    // dir root (not under a per-project subdir). Holds the worker's auth
-    // token, so must be 0o600.
+    // ADR-054: mcp-os unified lock at data dir root, must be 0o600.
     files.push(data_dir.join(consts::MCP_OS_LOCK_FILE));
 
     // --- secrets/<project>/* (worker auth tokens) ---
@@ -203,10 +199,7 @@ pub(crate) fn collect_security_paths(
     }
 
     // --- oauth/<project>/* (ADR-060 OAuth worker state) ---
-    // Every file under here must be 0o600: oauth.json (refreshToken,
-    // clientId, tenantId, grantedScopes), `.bearer-map.json` (consumer
-    // → service map), per-consumer `bearer-<service>` tokens, the unified
-    // `lock.json` (pid/port/authToken), rotating `audit.log` / `.1`.
+    // Every file here must be 0o600.
     let oauth_project_dir = data_dir.join(consts::OAUTH_SUBDIR).join(project);
     if let Ok(entries) = std::fs::read_dir(&oauth_project_dir) {
         for entry in entries.flatten() {
@@ -303,10 +296,7 @@ mod tests {
 
         let (dirs, files) = collect_security_paths(data_dir, "proj");
 
-        // Expected dirs (14): secrets, secrets/proj, snapshots, snapshots/proj,
-        // tokens, tokens/proj, tokens/proj/slack, tokens/proj/gitlab,
-        // tokens/proj/github, tokens/proj/atlassian, tokens/proj/empty-service,
-        // ide-bridge, oauth, oauth/proj
+        // Expected 14 dirs.
         assert_eq!(dirs.len(), 14, "expected 14 dirs, got: {dirs:?}");
         assert!(dirs.contains(&data_dir.join("secrets")));
         assert!(dirs.contains(&data_dir.join("secrets/proj")));
@@ -323,15 +313,7 @@ mod tests {
         assert!(dirs.contains(&data_dir.join("oauth")));
         assert!(dirs.contains(&data_dir.join("oauth/proj")));
 
-        // Expected files (15): 8 legacy + 6 oauth + 1 mcp-os singleton
-        // (post-PR3 unified lock layout). Pre-PR3 oauth had
-        // `auth-token`/`port`/`pid` as three separate 0o600 files; PR3
-        // collapsed them into a single `lock.json` per worker.
-        //   secrets/proj/worker-auth-token, tokens/proj/{slack,gitlab,github}/...
-        //   tokens/proj/atlassian/api_token, snapshots/proj/snapshot.json,
-        //   ide-bridge/1234.lock, bundle-state.json, mcp-os.lock.json,
-        //   oauth/proj/{sharepoint.json,.bearer-map.json,bearer-sharepoint,
-        //     lock.json,audit.log,audit.log.1}
+        // Expected 15 files: 8 legacy + 6 oauth + 1 mcp-os singleton.
         assert_eq!(files.len(), 15, "expected 15 files, got: {files:?}");
         assert!(files.contains(&data_dir.join("secrets/proj/worker-auth-token")));
         assert!(files.contains(&data_dir.join("tokens/proj/slack/token.txt")));
@@ -542,12 +524,12 @@ mod tests {
 
         // Make some even worse
         std::fs::set_permissions(
-            &data_dir.join("tokens"),
+            data_dir.join("tokens"),
             std::fs::Permissions::from_mode(0o777),
         )
         .unwrap();
         std::fs::set_permissions(
-            &data_dir.join("bundle-state.json"),
+            data_dir.join("bundle-state.json"),
             std::fs::Permissions::from_mode(0o666),
         )
         .unwrap();

--- a/crates/speedwave-runtime/src/host_mcp_process/drain.rs
+++ b/crates/speedwave-runtime/src/host_mcp_process/drain.rs
@@ -1,14 +1,6 @@
-//! Stdout/stderr drain shared by every host MCP worker manager.
-//!
-//! After spawning the Node child, the manager must:
-//! 1. Read the first stdout line as `{"port": N}` to learn the OS-assigned port.
-//! 2. Keep draining stdout/stderr for the rest of the child's lifetime — if
-//!    either pipe blocks or closes, Node dies (SIGPIPE / write block).
-//!
-//! Both pipes are appended to a per-worker audit log. The drain handles
-//! returned by `drain_and_read_port` must be joined by the caller in
-//! `stop()` so the log-file handles are released before the file is
-//! truncated or rotated.
+//! Stdout/stderr drain shared by every host MCP worker manager: reads
+//! the `{"port": N}` line, keeps draining both pipes, and appends them to
+//! a per-worker audit log. Drain handles must be joined by the caller.
 
 use std::io::BufRead;
 use std::path::Path;
@@ -32,13 +24,12 @@ pub fn parse_port_line(line: &str) -> Option<u16> {
     u16::try_from(port).ok()
 }
 
-/// Spawn background threads to drain both stdout and stderr of the
-/// child, then wait for the `{"port": N}` JSON line on stdout.
-/// Returns the port and the join handles for both drain threads so the
-/// caller can join them on stop.
+/// Spawn background threads to drain both stdout and stderr of the child,
+/// wait for the `{"port": N}` JSON line on stdout, and return the port plus
+/// the join handles for both drain threads.
 ///
-/// `service_tag` is included in `log::debug`/`log::warn` output and in
-/// the log-file row prefix so multi-worker logs are diagnosable.
+/// `service_tag` is included in `log::debug`/`log::warn` output and in the
+/// log-file row prefix.
 pub fn drain_and_read_port(
     child: &mut Child,
     log_path: &Path,
@@ -115,9 +106,7 @@ pub(crate) mod test_support {
     use std::process::{Child, Stdio};
 
     /// Spawn a `bash -c` child whose stdout emits the given lines (one
-    /// per `printf '%s\n'`). Test-only fixture shared by every worker's
-    /// drain tests; lets them exercise `drain_and_read_port` without
-    /// pulling Node into the test binary.
+    /// per `printf '%s\n'`).
     pub fn spawn_stdout_lines(lines: &[&str]) -> Child {
         let mut script = String::new();
         for line in lines {
@@ -134,11 +123,8 @@ pub(crate) mod test_support {
             .unwrap()
     }
 
-    /// Minimal Node "fake worker" used by every host MCP worker manager's
-    /// spawn tests. Binds 127.0.0.1 on an OS-assigned port, announces it
-    /// on stdout as `{"port":N}` (the universal handshake — see
-    /// [`super::parse_port_line`]), then sleeps so the parent can probe
-    /// PID / port / lock.json before the child exits.
+    /// Minimal Node "fake worker": binds 127.0.0.1 on an OS-assigned port,
+    /// announces it on stdout as `{"port":N}`, then sleeps.
     pub const FAKE_WORKER_JS: &str = r#"
 const http = require('http');
 const srv = http.createServer((_, r) => { r.end('ok'); });
@@ -157,10 +143,6 @@ setTimeout(() => {}, 60000);
     }
 
     /// Block (up to ~1 s) until `is_node_process(pid)` reports true.
-    /// Linux CI has a fork/execve race where the child PID exists but
-    /// `/proc/<pid>/comm` is still the parent shell briefly; this
-    /// pollster lets stale-detection tests skip past that window
-    /// instead of asserting under the race.
     pub fn wait_for_node_comm(pid: u32) {
         for _ in 0..40 {
             if super::super::stale::is_node_process(pid) {
@@ -172,7 +154,7 @@ setTimeout(() => {}, 60000);
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::test_support::spawn_stdout_lines;
     use super::*;
@@ -259,14 +241,9 @@ mod tests {
     }
 
     // ── test_support smoke tests ────────────────────────────────────────
-    // These keep the shared fixtures (FAKE_WORKER_JS, write_fake_worker,
-    // wait_for_node_comm) compiling and exercised until the per-worker
-    // managers consume them directly.
 
     #[test]
     fn fake_worker_js_announces_a_port_and_is_picked_up_by_drain() {
-        // End-to-end smoke: write the fake worker, spawn Node on it,
-        // and confirm `drain_and_read_port` reads a non-zero port.
         // Skips when Node is not on PATH (e.g. a stripped CI image).
         if std::process::Command::new("node")
             .arg("--version")
@@ -298,10 +275,7 @@ mod tests {
 
     #[test]
     fn wait_for_node_comm_returns_quickly_for_definitely_not_node_pid() {
-        // PID 1 is init/launchd on every Unix and System on Windows —
-        // never node. `wait_for_node_comm` polls up to ~1 s; this test
-        // confirms it returns without hanging when the PID will never
-        // match. We do not assert timing — only that it returns.
+        // PID 1 is never node; this confirms it returns without hanging.
         super::test_support::wait_for_node_comm(1);
     }
 }

--- a/crates/speedwave-runtime/src/host_mcp_process/env_policy.rs
+++ b/crates/speedwave-runtime/src/host_mcp_process/env_policy.rs
@@ -1,9 +1,6 @@
 //! Child-process environment policy shared by every host MCP worker.
-//!
-//! `apply_child_env` clears the inherited environment so secrets in the
-//! parent (API keys, tokens) cannot leak to the worker, then re-adds
-//! only the variables the child needs. The `EnvSource` indirection lets
-//! tests inject a `FakeEnv` instead of mutating process-global state.
+//! `apply_child_env` clears the inherited environment, then re-adds only
+//! the variables the child needs.
 
 use std::process::Command;
 
@@ -46,12 +43,9 @@ impl EnvSource for CurrentProcessEnv {
     }
 }
 
-/// Apply the child-process environment policy to `cmd`.
-///
-/// Clears the inherited environment then re-adds only PATH,
-/// HOME/USERPROFILE, optional Windows CSPRNG vars, and
-/// `SPEEDWAVE_RESOURCES_DIR`/`SPEEDWAVE_PROD` when the parent is a
-/// bundled .app. The inherited PATH is forwarded as-is.
+/// Apply the child-process environment policy to `cmd`: clear inherited
+/// env, then re-add PATH, HOME, optional Windows CSPRNG vars, and the
+/// bundle `SPEEDWAVE_RESOURCES_DIR`/`SPEEDWAVE_PROD` pair.
 pub fn apply_child_env(cmd: &mut Command, env: &dyn EnvSource) {
     cmd.env_clear();
 

--- a/crates/speedwave-runtime/src/host_mcp_process/job_object.rs
+++ b/crates/speedwave-runtime/src/host_mcp_process/job_object.rs
@@ -28,8 +28,6 @@ mod imp {
             // SAFETY: owned handle from CreateJobObjectW, not closed before.
             let ok = unsafe { CloseHandle(self.0) };
             if ok == 0 {
-                // CloseHandle failure indicates a double-close bug or kernel
-                // quota pressure — keep at warn so it surfaces in prod logs.
                 log::warn!(
                     "Job Object: CloseHandle failed ({}); possible double-close or handle leak",
                     std::io::Error::last_os_error()
@@ -52,8 +50,7 @@ mod imp {
             );
             return None;
         }
-        // From here on the handle is owned by `JobHandle` — every early
-        // return drops it and CloseHandle runs.
+        // From here on the handle is owned by `JobHandle`.
         let handle = JobHandle(job);
 
         let mut info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = unsafe { std::mem::zeroed() };
@@ -109,8 +106,7 @@ mod imp {
     use std::cell::Cell;
     use std::marker::PhantomData;
 
-    // PhantomData<Cell<()>> mirrors Windows variant: Send but !Sync. No
-    // `unsafe impl` needed — auto-traits handle it.
+    // PhantomData<Cell<()>> mirrors Windows variant: Send but !Sync.
     pub struct JobHandle(PhantomData<Cell<()>>);
 
     pub fn attach_to_kill_on_close_job(_child: &std::process::Child) -> Option<JobHandle> {
@@ -128,8 +124,7 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     #[test]
     fn stub_returns_none_without_panic() {
-        // `/bin/sh -c "exit 0"` is more robust than bare `true` against
-        // minimal containers / sandboxed PATH.
+        // `/bin/sh -c "exit 0"` works under minimal/sandboxed PATH.
         let child = std::process::Command::new("/bin/sh")
             .args(["-c", "exit 0"])
             .spawn()
@@ -162,9 +157,7 @@ mod tests {
         };
         drop(job);
 
-        // Child must die within 2 s of dropping the job; the 30 s sleep
-        // cannot exit naturally in that window. Windows exit codes from
-        // job termination vary, so we only assert "no longer running".
+        // Child must die within 2 s of dropping the job; assert "no longer running".
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
         loop {
             match child.try_wait() {

--- a/crates/speedwave-runtime/src/host_mcp_process/lock.rs
+++ b/crates/speedwave-runtime/src/host_mcp_process/lock.rs
@@ -176,7 +176,7 @@ fn cleanup_legacy_files(state_dir: &Path, port_file: &str, pid_file: &str) {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     fn fixture() -> LockFile {

--- a/crates/speedwave-runtime/src/host_mcp_process/mod.rs
+++ b/crates/speedwave-runtime/src/host_mcp_process/mod.rs
@@ -1,19 +1,5 @@
-//! Shared infrastructure for host-side Node MCP worker process managers.
-//!
-//! Two workers (mcp-os, oauth) all spawn a Node child, read a
-//! `{"port": N}` handshake on stdout, drain stdio into an audit log,
-//! and persist `lock.json` for compose injection. This module holds
-//! the SSOT pieces:
-//!
-//! - `drain` — stdout/stderr drain + handshake.
-//! - `env_policy` — `env_clear()` + minimal re-add, `EnvSource` trait
-//!   so tests inject `FakeEnv` instead of mutating `std::env`.
-//! - `lock` — unified `lock.json` schema + idempotent migration from
-//!   the legacy three-file layout (`port` + `pid` + `auth-token`).
-//! - `probe` — `is_pid_alive` + `probe_tcp` with retry/backoff.
-//! - `stale` — kill confirmed-node stale PIDs left by prior sessions.
-//! - `process` — generic [`HostMcpProcess<S: WorkerSpec>`] all three
-//!   per-worker managers use as a type alias.
+//! Shared SSOT infrastructure for host-side Node MCP worker process
+//! managers (spawn, port handshake, stdio drain, `lock.json`).
 
 pub mod drain;
 pub mod env_policy;
@@ -37,7 +23,5 @@ pub use process::{HostMcpProcess, LivenessProbe, SpawnContext, WorkerSpec};
 pub use stale::{is_node_process, kill_process};
 
 /// Timeout shared by every drain reader when waiting for the worker's
-/// initial `{"port": N}` line. 10 s is long enough for Node + V8 startup
-/// on Windows under cold cache; short enough that a hung worker fails
-/// loudly instead of stalling the host indefinitely.
+/// initial `{"port": N}` handshake line.
 pub const PORT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);

--- a/crates/speedwave-runtime/src/host_mcp_process/probe.rs
+++ b/crates/speedwave-runtime/src/host_mcp_process/probe.rs
@@ -1,10 +1,6 @@
 //! Liveness probes shared by every host MCP worker manager.
-//!
-//! `is_pid_alive` is the cross-platform check used by both
-//! per-process `is_alive()` accessors and the singleton mcp-os
-//! health endpoint. `probe_tcp` provides a TCP connect with optional
-//! retry+backoff — oauth needs the retry (compose cascades on a
-//! flaky probe); a single attempt suffices elsewhere.
+//! `is_pid_alive` is a cross-platform PID check; `probe_tcp` is a
+//! TCP connect with optional retry+backoff.
 
 use std::net::{IpAddr, SocketAddr, TcpStream};
 #[cfg(unix)]
@@ -24,10 +20,7 @@ pub fn is_pid_alive(pid: u32) -> bool {
 
 #[cfg(windows)]
 pub fn is_pid_alive(pid: u32) -> bool {
-    // `tasklist /FI "PID eq N" /NH` prints "INFO: No tasks are running..."
-    // when the PID does not exist. Substring-matching the PID in the output
-    // is unsafe (memory/session columns may contain the same digits), so we
-    // check for absence of the "INFO:" marker instead.
+    // `tasklist /NH` prints an "INFO:" marker when no PID matches.
     crate::binary::system_command("tasklist")
         .args(["/FI", &format!("PID eq {pid}"), "/NH"])
         .output()
@@ -96,10 +89,7 @@ mod tests {
 
     #[test]
     fn is_pid_alive_false_for_definitely_dead_pid() {
-        // PID 999999 should not exist on a normal system; if it does, the
-        // test is harmless because is_pid_alive will return true and we'd
-        // skip the assertion. To keep this deterministic we just verify the
-        // function does not panic.
+        // Just verify the function does not panic for an unlikely PID.
         let _ = is_pid_alive(999_999);
     }
 

--- a/crates/speedwave-runtime/src/host_mcp_process/process.rs
+++ b/crates/speedwave-runtime/src/host_mcp_process/process.rs
@@ -1,7 +1,6 @@
-//! Generic [`HostMcpProcess<S>`] — the SSOT spawn/stop/respawn/cleanup
-//! lifecycle the host MCP worker managers (mcp-os, oauth) share. Each
-//! manager keeps only its worker-specific data and protocol in a
-//! [`WorkerSpec`] impl; the generic struct handles everything else.
+//! Generic [`HostMcpProcess<S>`] — SSOT spawn/stop/respawn/cleanup
+//! lifecycle shared by host MCP worker managers (mcp-os, oauth) via a
+//! [`WorkerSpec`] impl per manager.
 
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
@@ -25,10 +24,8 @@ pub trait WorkerSpec: Send + 'static {
     fn log_tag(&self) -> &'static str;
 
     /// File name of the unified lock file relative to `state_dir`.
-    /// Per-project workers use `consts::PER_PROJECT_LOCK_FILE` (the
-    /// default); mcp-os singleton lives in `data_dir` directly with
-    /// `consts::MCP_OS_LOCK_FILE` to avoid colliding with other
-    /// top-level state files.
+    /// Default `consts::PER_PROJECT_LOCK_FILE`; mcp-os singleton uses
+    /// `consts::MCP_OS_LOCK_FILE` in `data_dir`.
     fn lock_file_name(&self) -> &'static str {
         crate::consts::PER_PROJECT_LOCK_FILE
     }
@@ -38,24 +35,21 @@ pub trait WorkerSpec: Send + 'static {
     /// the impl can wire `<X>_AUTH_TOKEN`, `<X>_CONFIG_PATH`, etc.
     fn apply_env(&self, cmd: &mut Command, ctx: &SpawnContext);
 
-    /// Hook invoked after `state_dir` is created and stale-PID cleanup
-    /// has run but BEFORE the Node child is spawned. Worker writes
-    /// anything it needs in the worker's environment view of the disk
-    /// here (oauth bearer map + per-service bearer files).
+    /// Hook invoked after `state_dir` creation and stale-PID cleanup,
+    /// before the Node spawn. Worker writes its disk state here (oauth
+    /// bearer map + per-service bearer files).
     fn pre_spawn(&self, _ctx: &SpawnContext) -> anyhow::Result<()> {
         Ok(())
     }
 
     /// Liveness probe variant. mcp_os does pid+TCP via
-    /// `is_mcp_os_alive_in`; oauth is 3-attempt TCP with backoff (a flake
-    /// on the probe cascades into a container recreate so the retry
-    /// matters — ADR-060).
+    /// `is_mcp_os_alive_in`; oauth is 3-attempt TCP with backoff
+    /// (retries matter — ADR-060).
     fn probe(&self) -> LivenessProbe;
 
     /// Extra files removed alongside `lock.json` on
     /// [`HostMcpProcess::cleanup_files`]. Per-service bearer files and
-    /// `oauth.json` are NOT in this list (they are mounted into
-    /// consumer containers; they must survive a supervisor respawn).
+    /// `oauth.json` are NOT in this list (they survive supervisor respawn).
     fn extra_cleanup_files(&self, _ctx: &SpawnContext) -> Vec<PathBuf> {
         Vec::new()
     }
@@ -131,31 +125,12 @@ pub struct HostMcpProcess<S: WorkerSpec> {
     pub(crate) script_path: String,
     /// Cleared by `respawn()` before `*self = new` so the dropped old
     /// instance does not delete the replacement's on-disk artifacts.
-    /// Kept private — only `spawn_with_spec`, `respawn`, and `Drop`
-    /// inside this module may mutate it.
     cleanup_on_drop: bool,
 }
 
 impl<S: WorkerSpec> HostMcpProcess<S> {
-    /// Spawn the worker. `state_dir` is whatever the per-manager wrapper
-    /// computes (e.g. `<data_dir>` for mcp-os singleton,
-    /// `<data_dir>/oauth/<project>` for oauth). Blocks up to
-    /// 10 s waiting for the `{"port":N}` handshake on stdout.
-    ///
-    /// Sequence:
-    /// 1. `create_dir_all(state_dir)`
-    /// 2. Idempotent upgrade-time migration of any pre-PR3 legacy
-    ///    3-file layout into `lock.json` (caller is expected to wire
-    ///    `lock::migrate_legacy` separately for service-specific
-    ///    legacy file names — happens before this call).
-    /// 3. Stale-PID cleanup from existing `lock.json` (kills only
-    ///    confirmed node processes).
-    /// 4. `WorkerSpec::pre_spawn` — config snapshot, bearer map, …
-    /// 5. Mint UUID v4 auth-token; spawn `node <script_path>` with the
-    ///    SSOT env policy + `WorkerSpec::apply_env`.
-    /// 6. Drain stdout/stderr; read port from first JSON line (10 s).
-    /// 7. Write `lock.json` with `{service, pid, port, authToken,
-    ///    transport}`.
+    /// Spawn the worker into `state_dir` (per-manager wrapper computes it).
+    /// Blocks up to 10 s waiting for the `{"port":N}` handshake on stdout.
     pub fn spawn_with_spec(
         spec: S,
         data_dir: &Path,
@@ -188,8 +163,7 @@ impl<S: WorkerSpec> HostMcpProcess<S> {
         let mut cmd = crate::binary::command("node");
         cmd.arg(script_path);
         apply_child_env(&mut cmd, &CurrentProcessEnv);
-        // SSOT: macOS 127.0.0.1, Windows WSL adapter IP — must match host_gateway_ip
-        // so container reaches the worker via extra_hosts: host.docker.internal:<gateway>.
+        // SSOT bind host — must match host_gateway_ip for container extra_hosts.
         cmd.env("MCP_LISTEN_HOST", crate::compose::host_bind_address()?);
         spec.apply_env(&mut cmd, &ctx);
         cmd.stdin(Stdio::null())
@@ -287,10 +261,9 @@ impl<S: WorkerSpec> HostMcpProcess<S> {
 }
 
 impl<S: WorkerSpec + Clone> HostMcpProcess<S> {
-    /// Stop the old worker and spawn a fresh one at the same script
-    /// path with the same spec. Disarms the old instance's `Drop` so it
-    /// cannot delete the replacement's `lock.json` or spec-extras
-    /// (token mount files, bearer files) when it goes out of scope.
+    /// Stop the old worker and spawn a fresh one at the same script/spec.
+    /// Disarms the old instance's `Drop` so it cannot delete the
+    /// replacement's `lock.json` or spec-extras on scope exit.
     pub fn respawn(&mut self) -> anyhow::Result<u16> {
         if let Some(mut child) = self.child.take() {
             child.kill().ok();
@@ -340,12 +313,7 @@ pub fn kill_stale_node(pid: u32, service_tag: &str) {
         log::debug!("{service_tag}: stale PID {pid} is not a node process — skipping kill");
         return;
     }
-    // `is_node_process` already confirmed PID is alive (ps -p succeeded),
-    // so no second liveness probe is needed. A LIVE node here is a smell:
-    // the sole owner's watchdog respawns only when its worker is dead, so a
-    // live worker at spawn time means a second supervisor is racing us (the
-    // dual-supervisor exit-137 bug — see ADR-060 / project_oauth_dual_supervisor_137).
-    // WARN, not INFO, so the next occurrence is a single greppable line.
+    // Live node at spawn means a second supervisor is racing us (exit-137 bug, ADR-060).
     log::warn!(
         "{service_tag}: {KILL_STALE_LOG_MARKER} (PID {pid}) at spawn — possible second supervisor racing this one"
     );
@@ -404,7 +372,7 @@ pub(crate) mod test_support {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::test_support::FakeSpec;
     use super::*;
@@ -465,9 +433,6 @@ mod tests {
     #[test]
     fn fake_spec_records_hook_order() {
         // Spawn-sequence contract: pre_spawn → apply_env → spawn → write_atomic.
-        // Without a real node binary we can't test the full sequence
-        // end-to-end, but we can prove the order pre_spawn → apply_env
-        // by invoking them directly the way `spawn_in` would.
         let spec = FakeSpec::new(LockService::Oauth, "fake");
         let tmp = tempfile::tempdir().unwrap();
         let lock_path = tmp.path().join("lock.json");
@@ -494,10 +459,7 @@ mod tests {
 
     #[test]
     fn kill_stale_node_warn_uses_shared_marker() {
-        // The WARN line MUST carry KILL_STALE_LOG_MARKER — that const is the
-        // grep hint embedded in resources::OOM_MESSAGE. Source-string guard so a
-        // refactor can't drop the marker from the format string while keeping
-        // the const, which would silently break the exit-137 diagnostic.
+        // Source-string guard: WARN line must carry KILL_STALE_LOG_MARKER (grep hint in resources::OOM_MESSAGE).
         let source = include_str!("process.rs");
         assert!(
             source.contains("{service_tag}: {KILL_STALE_LOG_MARKER} (PID {pid})"),

--- a/crates/speedwave-runtime/src/host_mcp_process/stale.rs
+++ b/crates/speedwave-runtime/src/host_mcp_process/stale.rs
@@ -1,10 +1,5 @@
 //! Stale-process detection helpers shared by every host MCP worker
 //! manager.
-//!
-//! The generic [`super::process::HostMcpProcess::spawn_with_spec`]
-//! reads the PID from `lock.json` and gates the kill behind
-//! `is_node_process` so a recycled PID for a non-node process is not
-//! touched.
 
 #[cfg(unix)]
 use std::process::Command;

--- a/crates/speedwave-runtime/src/http_debug_collator.rs
+++ b/crates/speedwave-runtime/src/http_debug_collator.rs
@@ -1,12 +1,6 @@
 //! Collapses + summarises multi-line `ANTHROPIC_LOG=debug` blocks emitted by
 //! Claude Code into single, human-readable log entries.
 //!
-//! Claude Code's HTTP debug logging is a known Anthropic bug — `console.log`
-//! sends `util.inspect()` pretty-printed JS objects to stdout instead of
-//! stderr (anthropics/claude-agent-sdk-typescript#157, anthropics/claude-code
-//! #4859). Each HTTP transaction spans 60–80 physical lines that would
-//! otherwise spam the System Health UI with one event per line.
-//!
 //! Three stages:
 //!   1. [`Collator`] groups continuation lines into one logical block (any
 //!      line ending in `{` opens a block, the matching outer `}` closes it).
@@ -121,8 +115,7 @@ impl Collator {
         self.depth += delta;
         if self.depth > 0 {
             if self.buffer.len() >= MAX_BUFFERED_LINES {
-                // Malformed input — release buffered content verbatim and reset
-                // so the collator does not grow unbounded.
+                // Malformed input — release buffered content verbatim and reset.
                 let joined = self.drain_buffer().unwrap_or_default();
                 self.depth = 0;
                 return vec![joined];
@@ -155,9 +148,6 @@ impl Collator {
     }
 
     /// Emit a merged summary line for every pending response and clear them.
-    /// Exposed so the stdout reader can call this on Claude Code stream
-    /// markers (`RESULT:`, `SYSTEM:`, `SESSION:`, `RATE_LIMIT:`) that signal
-    /// in-flight HTTP transactions are done.
     pub fn flush_all_pending_responses(&mut self) -> Vec<String> {
         let order: Vec<String> = self.pending_order.drain(..).collect();
         order
@@ -178,8 +168,7 @@ impl Collator {
             return out;
         }
 
-        // Same-id sending request flushes any previously-pending response
-        // for that id (defensive — the SDK could in theory reuse an id).
+        // Same-id sending request flushes any previously-pending response for that id.
         if let Some(id) = extract_log_id(&line) {
             if line.contains("sending request") {
                 if let Some(merged) = self.flush_pending_response(&id) {
@@ -257,9 +246,7 @@ fn brace_delta(line: &str) -> i32 {
 // ---------------------------------------------------------------------------
 
 fn re(pat: &str) -> Regex {
-    // `.expect()` is forbidden in prod by clippy::expect_used (CLAUDE.md rule);
-    // the panic body is the same — these patterns are static, panics surface
-    // any malformed regex on first use in tests.
+    // Static patterns; panic on a malformed regex (`.expect()` is clippy-forbidden in prod).
     Regex::new(pat).unwrap_or_else(|e| panic!("static regex must compile: {e}"))
 }
 
@@ -307,9 +294,7 @@ fn parse_response_fragment(line: &str) -> Option<ResponseFields> {
     let log_id = if is_response_start {
         extract_log_id(line)?
     } else {
-        // The headers block has no `[log_id]` of its own — Claude SDK emits
-        // it immediately after `[log_xxx] post … succeeded`. We can't merge
-        // it without an id. Skip and let format_block render it standalone.
+        // Headers block has no `[log_id]`; skip and let format_block render it standalone.
         return None;
     };
 
@@ -346,8 +331,7 @@ pub fn format_block(block: &str) -> String {
     if block.starts_with("response ") && block.contains("Headers {") {
         return format_response_full(block);
     }
-    // Response start / parsed blocks: emitted before merging — render anyway
-    // for the case where the merge never happens (unknown id, EOF, etc.).
+    // Response start / parsed blocks: render standalone when the merge never happens.
     if block.contains("response start") || block.contains("response parsed") {
         return format_response_start(block, log_id.as_deref());
     }
@@ -727,8 +711,7 @@ mod tests {
     #[test]
     fn buffer_overflow_releases_content_and_resets() {
         let mut c = Collator::new();
-        // Open a block, then exceed MAX_BUFFERED_LINES with content that never
-        // closes — collator must release the buffer and not grow unbounded.
+        // Open a block, then exceed MAX_BUFFERED_LINES with never-closing content.
         c.push("[log_abc] sending request {".into());
         let mut emitted = None;
         for i in 0..MAX_BUFFERED_LINES + 5 {
@@ -748,8 +731,7 @@ mod tests {
     #[test]
     fn pending_response_overflow_evicts_oldest() {
         let mut c = Collator::new();
-        // Insert MAX_PENDING_RESPONSES + 1 distinct response fragments — the
-        // oldest must be evicted to keep memory bounded.
+        // Insert more than MAX_PENDING_RESPONSES distinct fragments; oldest evicted.
         for i in 0..MAX_PENDING_RESPONSES + 5 {
             c.push(format!("[log_{i:06x}] response start {{"));
             c.push(format!(r#"  url: "http://x/{i}","#));
@@ -774,8 +756,7 @@ mod tests {
         }
         let flushed = c.flush_all_pending_responses();
         assert_eq!(flushed.len(), 3);
-        // Insertion order preserved (not alphabetic — would be coincident here,
-        // but the order field guarantees insertion-order on any input).
+        // Insertion order preserved.
         assert!(flushed[0].contains("[log_aaa111]"));
         assert!(flushed[1].contains("[log_bbb222]"));
         assert!(flushed[2].contains("[log_ccc333]"));

--- a/crates/speedwave-runtime/src/legacy_token_cleanup.rs
+++ b/crates/speedwave-runtime/src/legacy_token_cleanup.rs
@@ -17,10 +17,8 @@ pub fn run_legacy_token_cleanup_at_startup() -> usize {
     run_with_data_dir(consts::data_dir())
 }
 
-/// Inner entry point parameterised by the data dir. Production goes through
-/// `run_legacy_token_cleanup_at_startup`; tests pass an explicit tmp dir to
-/// avoid the `consts::data_dir()` `OnceLock` cache shared across the
-/// `cargo test` binary.
+/// Inner entry point parameterised by the data dir. Tests pass an explicit
+/// tmp dir to bypass the cached `consts::data_dir()`.
 fn run_with_data_dir(data_dir: &Path) -> usize {
     let tokens_root = data_dir.join("tokens");
     if !tokens_root.exists() {
@@ -132,8 +130,7 @@ mod tests {
 
     #[test]
     fn does_not_create_oauth_json_during_cleanup() {
-        // Cleanup ≠ migration: the host-only `oauth/<project>/sharepoint.json`
-        // must NOT be created. The user must re-authorize manually.
+        // Cleanup must not create the host-only `oauth/<project>/sharepoint.json`.
         let tmp = make_tmp_data_dir();
         let data_dir = tmp.path();
         let sp_dir = data_dir.join("tokens").join("proj-a").join("sharepoint");
@@ -169,8 +166,7 @@ mod tests {
 
     #[test]
     fn handles_partial_legacy_state() {
-        // Only refresh_token exists — other two missing. Cleanup removes what
-        // is present and reports the project as cleaned.
+        // Only refresh_token exists — other two missing.
         let tmp = make_tmp_data_dir();
         let data_dir = tmp.path();
         let sp_dir = data_dir.join("tokens").join("proj-c").join("sharepoint");
@@ -216,10 +212,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn does_not_crash_on_read_only_sharepoint_dir() {
-        // Sanitation must be best-effort: a read-only sp_dir prevents
-        // `remove_file` from succeeding, but cleanup must keep going (log + skip)
-        // rather than panic. The chmod is reverted before the test ends so the
-        // tempdir cleanup that runs on drop can remove the tree.
+        // A read-only sp_dir must not panic cleanup; perms restored before drop.
         use std::os::unix::fs::PermissionsExt;
         let tmp = make_tmp_data_dir();
         let data_dir = tmp.path();
@@ -229,10 +222,7 @@ mod tests {
 
         std::fs::set_permissions(&sp_dir, std::fs::Permissions::from_mode(0o500)).unwrap();
 
-        // Must not panic. Return value is best-effort; we accept either 0
-        // (remove_file failed, no file actually removed) or 1 (the FS allowed
-        // the unlink despite ro dir mode bits on some platforms — root /
-        // certain CI sandboxes).
+        // Must not panic; return value is best-effort (0 or 1 both accepted).
         let _ = run_with_data_dir(data_dir);
 
         // Restore writable perms so tempdir cleanup can recurse.
@@ -264,8 +254,7 @@ mod tests {
 
     #[test]
     fn ignores_unrelated_files_in_sharepoint_dir() {
-        // A future field added to credential_files (e.g. base_path) must not
-        // be touched by this cleanup — only the SSOT-listed legacy files.
+        // Only the SSOT-listed legacy files are touched; other files survive.
         let tmp = make_tmp_data_dir();
         let data_dir = tmp.path();
         let sp_dir = data_dir.join("tokens").join("proj-e").join("sharepoint");

--- a/crates/speedwave-runtime/src/log_file.rs
+++ b/crates/speedwave-runtime/src/log_file.rs
@@ -5,8 +5,7 @@
 use std::path::Path;
 
 /// Open a log file for appending with chmod 600 on Unix. `None` on error
-/// (logged via the `log` facade — a different sink, so no recursion — so a
-/// path that loses all session logging is visible, not silently swallowed).
+/// (logged via the `log` facade).
 pub fn open_log_file(path: &Path) -> Option<std::fs::File> {
     let mut opts = std::fs::OpenOptions::new();
     opts.append(true).create(true);
@@ -41,11 +40,8 @@ pub fn write_log_line(file: &mut Option<std::fs::File>, prefix: &str, line: &str
 }
 
 /// Rotate a log file if it exceeds `max_bytes` by keeping the last half
-/// (line-aligned). Preserves the most recent entries. Best-effort.
-///
-/// Cheap on the common case: only a `metadata` stat runs when the file
-/// is under the threshold (no full read until truncation is actually
-/// warranted).
+/// (line-aligned). Best-effort. Stat-only when under threshold; full read
+/// only if truncation needed.
 pub fn truncate_if_oversized(path: &Path, max_bytes: u64) {
     match std::fs::metadata(path) {
         Ok(m) if m.len() > max_bytes => {}
@@ -101,8 +97,7 @@ mod tests {
 
     #[test]
     fn open_log_file_returns_none_for_invalid_path() {
-        // Exercises the error arm: returns None (and logs a warn so the
-        // lost-logging condition is visible rather than silently swallowed).
+        // Exercises the error arm: returns None.
         let path = std::path::Path::new("/nonexistent/dir/impossible.log");
         let file = open_log_file(path);
         assert!(file.is_none(), "should return None for invalid path");

--- a/crates/speedwave-runtime/src/log_sanitizer.rs
+++ b/crates/speedwave-runtime/src/log_sanitizer.rs
@@ -10,27 +10,21 @@ struct SanitizeRule {
 }
 
 static RULES: LazyLock<Vec<SanitizeRule>> = LazyLock::new(|| {
-    // Each tuple: (pattern, replacement). If a regex fails to compile (should never
-    // happen with static literals), a CRITICAL warning is printed to stderr.
+    // Each tuple: (pattern, replacement).
     let definitions: Vec<(&str, &'static str)> = vec![
         // PEM private keys (multi-line: mask entire block)
         (
             r"-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----",
             "-----BEGIN PRIVATE KEY-----\n***REDACTED***\n-----END PRIVATE KEY-----",
         ),
-        // Home paths: /Users/<name>, /home/<name>, C:\Users\<name>.
-        // Username segment replaced with `<user>`; following path tail preserved.
+        // Home paths: username segment replaced with `<user>`, path tail preserved.
         (
             r"(?i)(/Users/|/home/|[A-Z]:\\Users\\)[^/\\\s]+",
             "${1}<user>",
         ),
-        // HTTP Cookie / Set-Cookie header values.
-        // Set-Cookie value = `name=value` up to the first `;` (attrs are not
-        // secrets but the name=value pair is). `\S+` would stop at the first
-        // space inside an unusual cookie value and leak the rest.
+        // Set-Cookie value: `name=value` up to the first `;`, attrs preserved.
         (r"(?i)(Set-Cookie:\s*)[^;\r\n]+", "${1}***REDACTED***"),
-        // Cookie request header: anchor at start-of-line/whitespace so
-        // `Set-Cookie:` does not double-match via `\b` on the `-C` boundary.
+        // Cookie request header: anchored at start-of-line/whitespace.
         (r"(?i)(^|\s)(Cookie:\s*)[^\r\n]+", "${1}${2}***REDACTED***"),
         // Bearer tokens: Bearer <token>
         (r"(?i)(Bearer\s+)\S+", "${1}***REDACTED***"),
@@ -41,8 +35,7 @@ static RULES: LazyLock<Vec<SanitizeRule>> = LazyLock::new(|| {
             r"eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+",
             "***REDACTED_JWT***",
         ),
-        // Slack rotating tokens first (xoxe.xoxp-…, xoxe-1-…) so the whole
-        // token is consumed before the xox[bpars]- rule matches its substring.
+        // Slack rotating tokens (xoxe.xoxp-…, xoxe-1-…) — must run before xox[bpars]-.
         (r"xoxe[.-][A-Za-z0-9.-]+", "***REDACTED_SLACK_TOKEN***"),
         // Slack tokens: xoxb-, xoxp-, xoxa-, xoxr-, xoxs-
         (r"xox[bpars]-[A-Za-z0-9-]+", "***REDACTED_SLACK_TOKEN***"),
@@ -64,14 +57,9 @@ static RULES: LazyLock<Vec<SanitizeRule>> = LazyLock::new(|| {
         ),
         // Anthropic API keys: sk-ant- prefixed
         (r"sk-ant-[A-Za-z0-9_-]+", "***REDACTED_ANTHROPIC_KEY***"),
-        // Google API keys (Gemini via LiteLLM, ADR-073): AIza + exactly 35
-        // base64url chars per Google's documented key shape.
+        // Google API keys (ADR-073): AIza + exactly 35 base64url chars.
         (r"\bAIza[0-9A-Za-z_-]{35}\b", "***REDACTED_GOOGLE_KEY***"),
-        // Bare sk-prefixed keys: sk-proj-*, sk-test-*, sk-or-* (OpenRouter),
-        // vLLM/LiteLLM/LM Studio user-configured keys. ≥16 trailing chars to
-        // avoid false positives on short identifiers like "sk-short" or words
-        // ending in "sk-…". Order matters: this runs AFTER sk-ant- so Anthropic
-        // keys keep their dedicated marker.
+        // Bare sk- keys (≥16 trailing chars); runs after sk-ant- to keep its marker.
         (r"\bsk-[A-Za-z0-9_-]{16,}", "***REDACTED_API_KEY***"),
         // URL userinfo credentials: ://user:password@host — redact password
         (r"(://[^:/@\s]+:)[^@\s]+(@)", "${1}***REDACTED***${2}"),
@@ -83,10 +71,7 @@ static RULES: LazyLock<Vec<SanitizeRule>> = LazyLock::new(|| {
         ),
         // Redmine API key header: X-Redmine-API-Key: <value>
         (r"(?i)(X-Redmine-API-Key:\s*)\S+", "${1}***REDACTED***"),
-        // Generic secret assignments: password=<value>, secret=<value>, api_key=<value>
-        // Matches key=value, key="value", and key='value' patterns (not in URLs — no ? or & prefix).
-        // The trailing `"?` catches a lone closing quote that follows an unquoted value
-        // (e.g. password=abc" where the opening quote was on a previous token).
+        // Generic secret assignments: key=value, key="value", key='value' (not in URLs).
         (
             r#"(?i)((?:password|passwd|secret|api_key|apikey|api_secret|access_token|private_key|[a-z0-9_]*_token)\s*[=:]\s*)(?:"[^"]*"|'[^']*'|[^\s"',;&]+)"?"#,
             "${1}***REDACTED***",
@@ -102,9 +87,7 @@ static RULES: LazyLock<Vec<SanitizeRule>> = LazyLock::new(|| {
                     replacement,
                 }),
                 Err(e) => {
-                    // Safety-critical one-time init warning. The logger may not be
-                    // initialized when LazyLock evaluates, so we write stderr
-                    // directly. A dropped rule means secrets leak unredacted.
+                    // Logger may be uninitialized during LazyLock eval — write stderr directly.
                     use std::io::Write;
                     let _ = writeln!(
                         std::io::stderr(),
@@ -117,14 +100,8 @@ static RULES: LazyLock<Vec<SanitizeRule>> = LazyLock::new(|| {
         .collect()
 });
 
-/// Masks known secret patterns in log message content.
-///
-/// This function applies regex-based redaction rules to replace sensitive
-/// data (tokens, keys, passwords, PEM blocks) with `***REDACTED***` markers.
-///
-/// Used in two places:
-/// 1. Real-time in the log pipeline (format callbacks in Desktop/CLI loggers)
-/// 2. In diagnostic export (second pass over container/Lima logs)
+/// Masks secret patterns (tokens, keys, passwords, PEM blocks) in log content
+/// with `***REDACTED***` markers.
 pub fn sanitize(input: &str) -> String {
     if input.is_empty() {
         return String::new();
@@ -139,18 +116,8 @@ pub fn sanitize(input: &str) -> String {
     result
 }
 
-/// Extract a safe string from a `catch_unwind` panic payload.
-///
-/// A `Box<dyn Any + Send>` carries whatever value `panic!` produced — usually
-/// a `String` or `&str`, but in principle anything. We only surface the
-/// `String`/`&str` cases (the common ones for `panic!("…")` / `unwrap_failed`)
-/// and pass them through `sanitize()`. Anything else collapses to
-/// `"unknown panic payload"` so a misbehaving panic value can't leak local
-/// variables into logs via `{:?}` debug format.
-///
-/// This is the helper to use whenever you log a panic — `log::error!("…{e:?}")`
-/// would trip the `rust/cleartext-logging` CodeQL rule because the payload
-/// type is `dyn Any` and the data flow analyzer cannot prove safety.
+/// Extract a sanitized string from a `catch_unwind` panic payload; non-`String`/`&str`
+/// payloads collapse to `"unknown panic payload"`.
 pub fn panic_payload_to_string(payload: &(dyn std::any::Any + Send)) -> String {
     let raw = payload
         .downcast_ref::<String>()
@@ -167,9 +134,7 @@ mod tests {
 
     // ── Guard tests — ensure no rules are silently dropped ────────────────
 
-    /// The definitions vec contains exactly this many rules. If a new rule is
-    /// added to the vec but fails to compile, RULES.len() will be less than
-    /// this constant and the test will fail, catching the silent drop.
+    /// Expected number of compiled rules; a mismatch flags a silently dropped rule.
     const EXPECTED_RULE_COUNT: usize = 23;
 
     #[test]
@@ -187,9 +152,7 @@ mod tests {
 
     #[test]
     fn test_all_static_patterns_are_valid_regex() {
-        // Re-declare the same patterns from the production definitions vec.
-        // If any pattern is invalid, Regex::new will return Err and the test
-        // fails explicitly instead of being silently filtered out.
+        // Re-declared production patterns; each must compile or the test fails explicitly.
         let patterns: &[&str] = &[
             r"-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----",
             r"(?i)(/Users/|/home/|[A-Z]:\\Users\\)[^/\\\s]+",
@@ -451,8 +414,7 @@ mod tests {
 
     #[test]
     fn test_worker_auth_token_uuid_redaction() {
-        // Worker bearer tokens are bare UUIDs in MCP_<SVC>_AUTH_TOKEN env vars —
-        // no sk-/xox- prefix, so only the *_token assignment rule catches them.
+        // Bare-UUID worker token, no sk-/xox- prefix — only the *_token rule catches it.
         let input = "MCP_SLACK_AUTH_TOKEN=550e8400-e29b-41d4-a716-446655440000";
         let output = sanitize(input);
         assert!(
@@ -484,8 +446,7 @@ mod tests {
 
     #[test]
     fn test_bare_uuid_not_redacted() {
-        // A UUID NOT in a *_token= assignment (e.g. a request/container id) must
-        // survive — redacting bare UUIDs would erase debugging context.
+        // A UUID outside a *_token= assignment must survive.
         let input = "request_id 550e8400-e29b-41d4-a716-446655440000 completed";
         let output = sanitize(input);
         assert_eq!(
@@ -496,8 +457,7 @@ mod tests {
 
     #[test]
     fn test_cache_key_not_redacted() {
-        // `_key` suffix is intentionally NOT in the rule: cache_key / sort_key
-        // are common non-secret identifiers. Only `_token` suffix is redacted.
+        // `_key` suffix is not a rule; only `_token` suffix is redacted.
         let input = "cache_key=user_123";
         let output = sanitize(input);
         assert_eq!(output, input, "cache_key must not be redacted: {output}");
@@ -997,8 +957,7 @@ mod tests {
 
     #[test]
     fn test_atlassian_basic_auth_header_redaction() {
-        // base64("bot@acme.com:ATATT3xSecret") — must not leak through the
-        // existing Authorization: header rule.
+        // base64("bot@acme.com:ATATT3xSecret") must not leak through the Authorization rule.
         let input = "header set: Authorization: Basic Ym90QGFjbWUuY29tOkFUQVRUM3hTZWNyZXQ=";
         let output = sanitize(input);
         assert!(
@@ -1042,10 +1001,7 @@ mod tests {
 
     #[test]
     fn test_bare_sk_proj_key_redaction() {
-        // OpenAI project-scoped key shape, also used by self-hosted servers.
-        // `_AUTH_TOKEN=` now also matches the assignment rule, which runs after
-        // the `sk-` rule and collapses the marker to the generic one — either
-        // way the key body is gone, which is the security property that matters.
+        // sk-proj- inside a *_AUTH_TOKEN= assignment: marker collapses, key body is gone.
         let input = "ANTHROPIC_AUTH_TOKEN=sk-proj-abc123def456ghi789xyz";
         let output = sanitize(input);
         assert!(
@@ -1184,13 +1140,9 @@ mod tests {
 
     #[test]
     fn test_redmine_api_key_header_false_positive() {
-        // "X-Redmine-API-Key-Length: 40" — not a key value, just a header name
-        // containing the prefix. The regex matches `\S+` after the colon, so
-        // "40" will be redacted. This is acceptable (security > false negatives).
+        // Different header name (no colon after "Key") — must not match the rule.
         let input = "X-Redmine-API-Key-Length: 40";
         let output = sanitize(input);
-        // The regex pattern `X-Redmine-API-Key:\s*` won't match because the
-        // header name is "X-Redmine-API-Key-Length" (no colon after "Key").
         assert_eq!(
             output, input,
             "X-Redmine-API-Key-Length should not be redacted (different header name)"
@@ -1225,10 +1177,7 @@ mod tests {
 
     #[test]
     fn panic_payload_unknown_type_collapses_to_placeholder() {
-        // A panic that produced an arbitrary struct (rare but legal). We must
-        // NOT leak its Debug representation — collapse to a placeholder so a
-        // misbehaving panic value can't smuggle local-variable contents into
-        // logs and trip the cleartext-logging rule.
+        // An arbitrary struct payload must collapse to a placeholder, not leak its Debug.
         #[derive(Debug)]
         struct SecretCarrier {
             _token: String,
@@ -1243,8 +1192,7 @@ mod tests {
 
     #[test]
     fn panic_payload_string_is_sanitized() {
-        // If a panic message happens to carry a token-shaped substring, the
-        // sanitizer redacts it the same way log lines are redacted.
+        // A token-shaped substring in a panic message is sanitized like a log line.
         let payload: Box<dyn std::any::Any + Send> =
             Box::new("crashed with token xoxb-1234567890-leak".to_string());
         let out = panic_payload_to_string(&*payload);
@@ -1302,9 +1250,7 @@ mod tests {
 
     #[test]
     fn redacts_set_cookie_value_with_embedded_space() {
-        // Non-RFC value with a space — the previous `\S+` regex stopped at the
-        // first space and leaked the trailing token. `[^;\r\n]+` covers the
-        // whole name=value pair up to the attribute separator.
+        // Non-RFC value with a space: whole name=value pair redacted up to the `;`.
         let out = sanitize("Set-Cookie: id=secret extra_data; Path=/");
         assert!(!out.contains("secret"), "first token leaked: {out}");
         assert!(

--- a/crates/speedwave-runtime/src/mcp_os_process.rs
+++ b/crates/speedwave-runtime/src/mcp_os_process.rs
@@ -1,20 +1,6 @@
 //! Process manager for the singleton mcp-os Node MCP worker.
-//!
-//! Thin wrapper: `McpOsProcess` is a type alias over
-//! [`crate::host_mcp_process::HostMcpProcess`] with `McpOsSpec` as the
-//! per-worker `WorkerSpec`. All spawn/stop/respawn/cleanup lifecycle is
-//! handled by the generic struct; this module only carries:
-//!
-//! - `McpOsSpec` — env vars, lock file name, the External liveness
-//!   probe that reads `mcp-os.lock.json` from `data_dir`.
-//! - `spawn()` — singleton entry-point used by Desktop (`main.rs`) and
-//!   the CLI startup helpers.
-//! - `is_mcp_os_alive()` / `is_mcp_os_alive_in()` — SSOT health probe
-//!   re-exported to `desktop::health` and the watchdog.
-//! - `McpOsSpec::pre_spawn` writes the standalone `mcp-os-auth-token`
-//!   mount file (hub bind-mounts it at `/secrets/os-auth-token:ro`).
-//!   Order matters: token lands on disk *before* lock.json so a crash
-//!   in between leaves either zero files or a complete pair.
+//! `McpOsProcess` is a type alias over [`crate::host_mcp_process::HostMcpProcess`]
+//! with `McpOsSpec` as the per-worker `WorkerSpec`.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -43,13 +29,7 @@ impl WorkerSpec for McpOsSpec {
             .env("MCP_OS_AUTH_TOKEN", ctx.auth_token);
     }
     /// Write the standalone token mount file *before* the generic spawn
-    /// writes `lock.json`. Order matters for crash-safety: if the process
-    /// dies between pre_spawn and lock::write, the next start sees no
-    /// lock.json, kill_stale_node runs against nothing, and a fresh spawn
-    /// overwrites the orphan token. If we instead wrote the token AFTER
-    /// lock.json (the previous design), a crash mid-write would leave the
-    /// hub bind-mounting a stale token against a worker expecting a new
-    /// one — every subsequent request 401s until manual cleanup.
+    /// writes `lock.json` (crash-safety order).
     fn pre_spawn(&self, ctx: &SpawnContext) -> anyhow::Result<()> {
         let token_mount_path = ctx.data_dir.join(consts::MCP_OS_AUTH_TOKEN_FILE);
         crate::fs_perms::write_restricted_file(&token_mount_path, ctx.auth_token)
@@ -65,11 +45,8 @@ impl WorkerSpec for McpOsSpec {
     }
 }
 
-/// Static probe wrapper expected by [`LivenessProbe::Custom`]. The
-/// closure-incompatible `fn` pointer means we cannot capture
-/// `data_dir`; instead, the custom probe reads from
-/// `consts::data_dir()` directly. Tests can still inject a temp dir
-/// via [`is_mcp_os_alive_in`] called from the test path.
+/// Static probe wrapper for [`LivenessProbe::Custom`]; the `fn` pointer
+/// cannot capture `data_dir`, so it reads `consts::data_dir()` directly.
 fn is_mcp_os_alive_static(_state_dir: &Path) -> bool {
     is_mcp_os_alive()
 }
@@ -87,10 +64,7 @@ impl McpOsProcess {
     /// Test-only entry point; lets tests redirect lock + audit log to
     /// a temp directory without poking the global `data_dir()` OnceLock.
     pub(crate) fn spawn_with_data_dir(script_path: &str, data_dir: &Path) -> anyhow::Result<Self> {
-        // Idempotent upgrade-time migration: collapse the legacy
-        // 3-file layout (`mcp-os-port`, `mcp-os-pid`,
-        // `mcp-os-auth-token`) into `mcp-os.lock.json`. No-op once
-        // the JSON exists.
+        // Idempotent migration: collapse legacy 3-file layout into `mcp-os.lock.json`.
         let _ = lock::migrate_legacy_with_target(
             data_dir,
             LockService::McpOs,
@@ -100,10 +74,6 @@ impl McpOsProcess {
             consts::MCP_OS_AUTH_TOKEN_FILE,
         );
 
-        // The standalone `mcp-os-auth-token` mount file is written by
-        // `McpOsSpec::pre_spawn` *before* lock.json, so any crash leaves
-        // either zero files or a complete pair — never a stale-token
-        // mismatch against the running worker.
         HostMcpProcess::spawn_with_spec(
             McpOsSpec,
             data_dir,
@@ -146,7 +116,7 @@ pub fn is_mcp_os_alive_in(data_dir: &Path) -> bool {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::host_mcp_process::drain::test_support::write_fake_worker;
@@ -194,9 +164,7 @@ mod tests {
 
     #[test]
     fn pre_spawn_writes_token_mount_before_lock_json() {
-        // Crash-safety contract: standalone token mount file must be on
-        // disk *before* lock.json. Tests the WorkerSpec hook directly so
-        // it covers both the order and the on-disk content.
+        // Token mount file must be on disk *before* lock.json.
         let tmp = tempfile::tempdir().unwrap();
         let lock_path = tmp.path().join(consts::MCP_OS_LOCK_FILE);
         let log_path = tmp.path().join("log");
@@ -282,13 +250,8 @@ mod tests {
         drop(listener);
     }
 
-    /// Regression: an earlier version of `respawn` only cleared
-    /// `lock_path` on the old `self`, so when `*self = new` dropped
-    /// the old instance, `cleanup_files` still walked `data_dir` +
-    /// `extra_cleanup_files` and deleted the freshly-written token
-    /// mount belonging to the replacement. The hub then bind-mounted
-    /// a missing file. Fix: `respawn` disarms `cleanup_on_drop` on
-    /// the old self before the assignment.
+    /// Regression: `respawn` must not let the dropped old instance delete
+    /// the replacement's freshly-written token mount.
     #[cfg(unix)]
     #[test]
     #[serial(env)]
@@ -323,11 +286,8 @@ mod tests {
         proc.stop().unwrap();
     }
 
-    /// End-to-end migration test: a state dir with the legacy 3-file
-    /// layout is silently collapsed into `lock.json` when the singleton
-    /// spawns. Uses a fake stdout-only
-    /// node script (no listening server) so we only verify the
-    /// migration side; full alive-listening probe is covered above.
+    /// Migration e2e: a legacy 3-file layout is collapsed into `lock.json`
+    /// when the singleton spawns.
     #[cfg(unix)]
     #[test]
     #[serial(env)]
@@ -370,10 +330,7 @@ mod tests {
             );
             assert!(
                 !tmp.path().join("mcp-os-auth-token").exists()
-                    // Dual write recreates auth-token under the SAME name
-                    // (legacy const reused). If it exists, it must be the
-                    // standalone mount file with the new token, not the
-                    // legacy migrated content.
+                    // Dual-write reuses the legacy name with the fresh token.
                     || std::fs::read_to_string(tmp.path().join("mcp-os-auth-token"))
                         .map(|s| s != "legacy-token")
                         .unwrap_or(true),
@@ -383,15 +340,8 @@ mod tests {
         }
     }
 
-    /// Full upgrade-path e2e: migration against the *real* bundled mcp-os
-    /// worker (Express server with all routes), not the stub
-    /// `FAKE_WORKER_JS`. Gated behind the `mcp-os-bundle-e2e` feature (not
-    /// `#[ignore]`, which nothing in the test pipeline runs) because it
-    /// depends on the staged desktop bundle. `make test-mcp-os-bundle`
-    /// stages the bundle then runs it under the feature. PID 1 in the
-    /// legacy fixture is the safe stale-PID choice — `kill_stale_node`'s
-    /// `is_node_process` gate ignores init/launchd, keeping the test
-    /// hermetic against the host system.
+    /// Upgrade-path e2e: migration against the *real* bundled mcp-os worker.
+    /// Gated behind `mcp-os-bundle-e2e` (run via `make test-mcp-os-bundle`).
     #[cfg(all(unix, feature = "mcp-os-bundle-e2e"))]
     #[test]
     #[serial(env)]

--- a/crates/speedwave-runtime/src/oauth_persist.rs
+++ b/crates/speedwave-runtime/src/oauth_persist.rs
@@ -200,8 +200,7 @@ mod tests {
 
     #[test]
     fn max_expires_in_matches_oauth_tools_ts() {
-        // Cross-language SSOT guard (cf. allowed_auth_field_types_match_ts_union):
-        // the TS clamp must equal the Rust one so mint and refresh agree.
+        // Cross-language SSOT guard (cf. allowed_auth_field_types_match_ts_union).
         let src = include_str!("../../../mcp-servers/oauth/src/tools.ts");
         let re = regex::Regex::new(r"const\s+MAX_EXPIRES_IN_SECONDS\s*=\s*([^;]+);").unwrap();
         let expr = re

--- a/crates/speedwave-runtime/src/oauth_process.rs
+++ b/crates/speedwave-runtime/src/oauth_process.rs
@@ -1,18 +1,6 @@
 //! Per-project process manager for the `oauth` MCP worker (ADR-060).
-//!
-//! Thin wrapper: `OauthProcess` is a type alias over
-//! [`crate::host_mcp_process::HostMcpProcess`] with `OauthSpec` as the
-//! worker spec. All lifecycle (spawn/stop/respawn/cleanup) lives in
-//! the generic struct; this module only carries worker-specific bits:
-//!
-//! - Per-consumer bearer provisioning (`.bearer-map.json` +
-//!   `bearer-<service>` files) — mounted into consumer containers by
-//!   compose, must survive a supervisor respawn.
-//! - State-dir owner-only perms (0o700, ADR-060).
-//! - The supervisor token + state-dir env vars Node oauth worker reads.
-//! - Custom `is_oauth_alive` with retry + backoff — a transient probe
-//!   failure cascades into recreate of every consumer container, so
-//!   the retry matters (ADR-060).
+//! `OauthProcess` aliases [`crate::host_mcp_process::HostMcpProcess`]
+//! with `OauthSpec`; this module carries only worker-specific bits.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -65,11 +53,7 @@ impl WorkerSpec for OauthSpec {
             .env("OAUTH_TOKENS_BASE", &self.tokens_base);
     }
     fn pre_spawn(&self, ctx: &SpawnContext) -> anyhow::Result<()> {
-        // Per-consumer bearer provisioning. Each consumer gets a fresh
-        // UUID bound to its service id; the worker derives `caller`
-        // from the bearer via `.bearer-map.json` (ADR-060). The bearer
-        // files are mounted into consumer containers (read-only), so
-        // they live as separate on-disk artifacts beside lock.json.
+        // Per-consumer bearer files mapped to service ids via .bearer-map.json (ADR-060).
         let bearer_map_path = ctx.state_dir.join(consts::OAUTH_BEARER_MAP_FILE);
         let mut bearer_map: std::collections::BTreeMap<String, String> =
             std::collections::BTreeMap::new();
@@ -107,10 +91,7 @@ impl OauthProcess {
         data_dir: &Path,
         consumers: &[&str],
     ) -> anyhow::Result<Self> {
-        // The state dir must exist with 0o700 *before* the generic
-        // spawn writes lock.json / bearer files into it, so the perms
-        // are inherited. Subsequent `create_dir_all` inside the generic
-        // is a cheap no-op.
+        // State dir must exist with 0o700 before the generic spawn writes into it.
         let state_dir = oauth_project_dir(data_dir, project);
         std::fs::create_dir_all(&state_dir)?;
         set_dir_owner_only(&state_dir)?;
@@ -140,10 +121,7 @@ impl OauthProcess {
     }
 }
 
-/// TCP liveness probe against `127.0.0.1:<port>`. Retries on failure
-/// with backoff — oauth respawn forces a recreate of every consumer
-/// container, so a transient probe failure (worker mid-refresh,
-/// accept loop briefly stalled) must NOT cascade into a respawn loop.
+/// TCP liveness probe against `127.0.0.1:<port>`, retrying with backoff (ADR-060).
 pub fn is_oauth_alive(port: u16) -> bool {
     if port == 0 {
         return false;
@@ -165,8 +143,7 @@ fn set_dir_owner_only(_dir: &Path) -> anyhow::Result<()> {
         let mode = consts::OAUTH_PROJECT_DIR_MODE;
         std::fs::set_permissions(_dir, std::fs::Permissions::from_mode(mode))?;
     }
-    // On Windows, the parent dir's ACL inherits from `~/.speedwave/` which is
-    // user-owned by default. A future hardening pass can add explicit ACL here.
+    // On Windows the parent dir's ACL inherits from `~/.speedwave/` (user-owned).
     Ok(())
 }
 
@@ -263,11 +240,7 @@ mod tests {
 
     #[test]
     fn pre_spawn_writes_consistent_bearer_files_and_map() {
-        // Invariant: after successful pre_spawn, every bearer-<svc> file
-        // on disk maps to its service via .bearer-map.json. The worker
-        // reads the map at startup and resolves incoming bearers through
-        // it; a mismatch = 401. This test pins the on-disk consistency
-        // contract so a future refactor can't silently desynchronize them.
+        // After pre_spawn every bearer-<svc> file maps to its service via .bearer-map.json.
         let tmp = tempfile::tempdir().unwrap();
         let state_dir = tmp.path().join("state");
         std::fs::create_dir_all(&state_dir).unwrap();
@@ -307,9 +280,7 @@ mod tests {
 
     #[test]
     fn pre_spawn_rejects_invalid_service_slug_without_writing_anything() {
-        // Defense-in-depth: a malformed slug must bail before any bearer
-        // file lands on disk, so a malicious settings inject can't trick
-        // us into writing `bearer-../evil` somewhere.
+        // A malformed slug must bail before any bearer file lands on disk.
         let tmp = tempfile::tempdir().unwrap();
         let state_dir = tmp.path().join("state");
         std::fs::create_dir_all(&state_dir).unwrap();
@@ -336,12 +307,8 @@ mod tests {
             err.to_string().contains("invalid service slug"),
             "error must call out the slug: {err}"
         );
-        // The first iteration wrote `bearer-sharepoint` before the invalid
-        // slug aborted the loop. Document this partial-write window — fixing
-        // it requires building artifacts in a tempdir and rename-once, which
-        // is tracked separately. Restart of the supervisor overwrites.
-        // (No assertion about .bearer-map.json: it is written *after* the
-        // loop, so on bail it must NOT exist.)
+        // The first iteration wrote `bearer-sharepoint` before the invalid slug aborted.
+        // .bearer-map.json is written after the loop, so on bail it must not exist.
         assert!(
             !state_dir.join(consts::OAUTH_BEARER_MAP_FILE).exists(),
             ".bearer-map.json must not be written when pre_spawn bails"

--- a/crates/speedwave-runtime/src/oauth_state_migration.rs
+++ b/crates/speedwave-runtime/src/oauth_state_migration.rs
@@ -1,24 +1,18 @@
-//! Startup self-heal of legacy/partial `oauth/<project>/<service>.json` whose
-//! IdP identity (`clientId` / `tenantId`) sits at top level instead of nested
-//! under `providerData` (ADR-060 §addendum). Shape-only; never fabricates or
-//! moves secrets. Best-effort, idempotent.
+//! Startup self-heal of legacy `oauth/<project>/<service>.json` whose IdP
+//! identity sits at top level instead of nested under `providerData`
+//! (ADR-060 §addendum). Shape-only, best-effort, idempotent.
 
 use std::path::Path;
 
 use crate::consts;
 
-/// Top-level keys lifted into `providerData` — the SSOT for the IdP identity
-/// keys this module (and the Desktop credential-save path) nest. These are the
-/// only `FieldStorage::OAuthStateProviderData` identity keys today (Microsoft);
-/// the nesting rule is provider-agnostic. Pinned to the descriptor SSOT by
+/// Top-level keys lifted into `providerData` — SSOT for the IdP identity keys,
+/// pinned to the descriptor SSOT by
 /// `identity_keys_match_oauth_state_provider_data_descriptors`.
 pub const IDENTITY_KEYS: &[&str] = &["clientId", "tenantId"];
 
-/// Run migration once at startup. Best-effort: each healed file and every
-/// per-file failure is logged from inside the module (path only, never content).
-/// Returns the count of files rewritten — callers must NOT log this return value:
-/// CodeQL traces it back through the oauth.json reads and flags
-/// rust/cleartext-logging (false positive on an integer count).
+/// Run migration once at startup; returns the count of files rewritten.
+/// Callers must NOT log this return value (CodeQL cleartext-logging).
 pub fn run_oauth_state_migration_at_startup() -> usize {
     run_with_data_dir(consts::data_dir())
 }
@@ -92,10 +86,7 @@ fn migrate_project_dir(project_dir: &Path) -> usize {
     migrated
 }
 
-/// Migrate one file. Returns `true` if it was rewritten. Leaves the file
-/// untouched (no rewrite) when it is already well-shaped, unparseable, not a
-/// JSON object, or carries no recoverable top-level identity — never destroys
-/// data.
+/// Migrate one file. Returns `true` if it was rewritten; never destroys data.
 fn migrate_file(path: &Path) -> bool {
     let raw = match std::fs::read_to_string(path) {
         Ok(s) => s,
@@ -171,17 +162,14 @@ fn nest_identity(obj: &mut serde_json::Map<String, serde_json::Value>) -> bool {
     true
 }
 
-/// snake_case descriptor key → camelCase property name used in `oauth.json`.
-/// SSOT for the mapping; the Desktop oauth-state read/write paths delegate here.
-/// An unknown key with an underscore signals a missing arm (debug-assert in dev,
-/// warn in release) rather than silently producing a snake_case JSON key.
+/// snake_case descriptor key → camelCase property name in `oauth.json`.
+/// SSOT for the mapping; the Desktop oauth-state paths delegate here.
 pub fn oauth_json_key_for(key: &str) -> &str {
     match key {
         "client_id" => "clientId",
         "tenant_id" => "tenantId",
         "refresh_token" => "refreshToken",
-        // Never interpolate `other` — it may carry caller-supplied values
-        // (CodeQL cleartext-logging false positive otherwise).
+        // Never interpolate `other` — may carry caller-supplied values (CodeQL false positive).
         other => {
             debug_assert!(
                 !other.contains('_'),
@@ -196,12 +184,8 @@ pub fn oauth_json_key_for(key: &str) -> &str {
     }
 }
 
-/// Guarantee `providerData` is a plain object, healing the legacy ADR-060 layout
-/// in place. If it is already an object, no-op. Otherwise replace it with a fresh
-/// object, lifting any top-level [`IDENTITY_KEYS`] strings into it and dropping
-/// the top-level copies (so a re-save heals the file instead of orphaning them).
-/// Shared SSOT for both the startup migration and the Desktop credential-save
-/// path (`integrations_cmd::merge_oauth_state_json`).
+/// Heal legacy ADR-060 layout in place: ensure `providerData` is a plain object,
+/// lifting [`IDENTITY_KEYS`] strings into it. SSOT for startup + Desktop save.
 pub fn ensure_provider_data_object(obj: &mut serde_json::Map<String, serde_json::Value>) {
     if obj.get("providerData").is_some_and(|v| v.is_object()) {
         return;
@@ -243,11 +227,9 @@ mod tests {
         serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap()
     }
 
-    /// Drift guard: `IDENTITY_KEYS` must equal the camelCase JSON keys of every
-    /// `OAuthStateProviderData`-tagged descriptor field across all services — the
-    /// true SSOT (`consts::TOGGLEABLE_MCP_SERVICES`) — mapped through the same
-    /// `oauth_json_key_for` the production code uses. If a new providerData field
-    /// is added to a descriptor, this fails until `IDENTITY_KEYS` is updated.
+    /// Drift guard: `IDENTITY_KEYS` must match the camelCase JSON keys of every
+    /// `OAuthStateProviderData`-tagged descriptor field, mapped through
+    /// `oauth_json_key_for`.
     #[test]
     fn identity_keys_match_oauth_state_provider_data_descriptors() {
         let mut expected: Vec<String> = consts::TOGGLEABLE_MCP_SERVICES
@@ -308,8 +290,7 @@ mod tests {
 
     #[test]
     fn migrates_partial_identity_without_refresh_token() {
-        // The `presales` shape: only identity, no refreshToken. Nest what
-        // exists; fabricate nothing.
+        // The `presales` shape: only identity, no refreshToken (fabricate nothing).
         let tmp = tempfile::tempdir().unwrap();
         let path = sp_path(tmp.path(), "presales");
         write(
@@ -421,8 +402,7 @@ mod tests {
 
     #[test]
     fn leaves_file_with_no_recoverable_identity_untouched() {
-        // providerData absent and no top-level identity: truly unrecoverable.
-        // Migration must not touch it — Part C surfaces the re-auth banner.
+        // providerData absent and no top-level identity: must not touch it.
         let tmp = tempfile::tempdir().unwrap();
         let path = sp_path(tmp.path(), "p");
         let original = r#"{"provider": "microsoft", "refreshToken": "rt"}"#;
@@ -468,8 +448,7 @@ mod tests {
 
     #[test]
     fn migrates_non_sharepoint_service_json() {
-        // The shape rule is provider-agnostic — a future OAuth service file
-        // with the same legacy layout is healed too.
+        // The shape rule is provider-agnostic, not SharePoint-specific.
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp
             .path()
@@ -540,9 +519,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn does_not_crash_on_read_only_project_dir() {
-        // A read-only project dir blocks the rewrite (tempfile create fails);
-        // migration must log + skip, not panic. Perms restored so tempdir
-        // cleanup can recurse.
+        // A read-only project dir blocks the rewrite: migration must log + skip, not panic.
         use std::os::unix::fs::PermissionsExt;
         let tmp = tempfile::tempdir().unwrap();
         let path = sp_path(tmp.path(), "ro");

--- a/crates/speedwave-runtime/src/os_prereqs.rs
+++ b/crates/speedwave-runtime/src/os_prereqs.rs
@@ -85,8 +85,6 @@ fn check_wsl() -> Vec<PrereqViolation> {
 
 /// Returns non-blocking OS warnings (e.g. low memory, nested virtualization).
 /// Separate from `check_os_prereqs()` which returns blocking errors.
-///
-/// Warnings are logged by callers — they do not block container operations.
 pub fn check_os_warnings() -> Vec<String> {
     let mut warnings = Vec::new();
 
@@ -102,9 +100,7 @@ pub fn check_os_warnings() -> Vec<String> {
 }
 
 /// Warns when the Windows build is older than 22H2 (build 22621), where
-/// `.wslconfig` `networkingMode=mirrored` is silently ignored — corporate
-/// VPN routes never propagate into WSL2 distros. Not a blocker; Speedwave
-/// works otherwise.
+/// `.wslconfig` `networkingMode=mirrored` is silently ignored.
 #[cfg(target_os = "windows")]
 fn check_wsl_mirrored_mode_supported() -> Vec<String> {
     let build = match windows_build_number() {
@@ -172,13 +168,7 @@ fn parse_vm_info(json: &str) -> Option<(String, String)> {
 }
 
 /// Returns `true` if the WMI Model/Manufacturer strings indicate a virtual machine.
-///
-/// Case-insensitive matching. Checks both fields to catch all major hypervisors:
-/// - VMware: model contains "vmware"
-/// - VirtualBox: model contains "virtualbox" OR manufacturer contains "innotek"
-/// - Hyper-V: model contains "virtual machine" AND manufacturer contains "microsoft"
-///   (requires both to avoid false positives on Microsoft Surface hardware)
-/// - QEMU/KVM: manufacturer contains "qemu" (model is generic, e.g. "Standard PC")
+/// Case-insensitive matching against VMware/VirtualBox/Hyper-V/QEMU markers.
 #[cfg(any(target_os = "windows", test))]
 fn is_virtual_machine(model: &str, manufacturer: &str) -> bool {
     let model_lower = model.to_ascii_lowercase();
@@ -205,8 +195,6 @@ fn check_nested_virt() -> Vec<String> {
         .stderr(std::process::Stdio::null());
 
     // No explicit timeout — cmd.output() blocks until PowerShell exits.
-    // PowerShell startup is ~2-3s; the Get-CimInstance query is fast.
-    // If WMI hangs, the warning is skipped (fail-open) on the next startup.
     let output = match cmd.output() {
         Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).to_string(),
         Ok(_) | Err(_) => return Vec::new(), // Fail open

--- a/crates/speedwave-runtime/src/plugin.rs
+++ b/crates/speedwave-runtime/src/plugin.rs
@@ -458,16 +458,7 @@ pub fn plugins_base_dir() -> anyhow::Result<PathBuf> {
 }
 
 /// Returns the base directory for mutable per-plugin state — by default
-/// `~/.speedwave/plugin-state/`. Kept *outside* the signed plugin
-/// directory: markers like `image_pending` (telling the next launch to
-/// retry an image build) used to live inside the plugin tree, but writing
-/// into a tree that we then sign and re-verify is contradictory — any
-/// post-install marker invalidates the digest.
-///
-/// `plugins_dir` ends in `plugins`; we replace that final segment with
-/// `plugin-state` so unit tests pointing `plugins_dir` at a temp dir keep
-/// their state under the same temp root instead of leaking into the user's
-/// real `~/.speedwave/`.
+/// `~/.speedwave/plugin-state/`.
 fn plugin_state_base_for(plugins_dir: &Path) -> PathBuf {
     plugins_dir
         .parent()
@@ -505,8 +496,7 @@ pub(crate) fn read_persistent_bridge_token_from(plugins_dir: &Path, slug: &str) 
 }
 
 fn read_bridge_token_at(path: &Path) -> Option<String> {
-    // Reject symlinks (`read_to_string` follows them); warn-and-ignore only —
-    // the file is Desktop-owned state, so this passive reader never removes it.
+    // Reject symlinks (`read_to_string` follows them).
     if path
         .symlink_metadata()
         .is_ok_and(|m| m.file_type().is_symlink())
@@ -542,14 +532,7 @@ fn image_pending_marker_for(plugins_dir: &Path, slug: &str) -> PathBuf {
 }
 
 /// Returns true if the plugin has a pending image build, looking in both
-/// the new state directory and the legacy in-tree location. Legacy-only
-/// markers are still observed so plugins installed before this change
-/// keep building on next launch. The first fail-closed load
-/// (`audit_all` / `list_verified_*`, both via `verify_one_plugin_dir`)
-/// migrates the in-tree marker into `plugin-state/` via
-/// `migrate_legacy_image_pending`, after which only the new location ever
-/// has the marker. The tolerant `list_for_ui` path does *not* migrate —
-/// it must not mutate a tampered tree.
+/// the new state directory and the legacy in-tree location.
 fn has_pending_image_build_for(plugins_dir: &Path, plugin_dir: &Path, slug: &str) -> bool {
     image_pending_marker_for(plugins_dir, slug).exists()
         || plugin_dir.join(".image_pending").exists()
@@ -573,14 +556,7 @@ fn clear_image_pending_for(plugins_dir: &Path, plugin_dir: &Path, slug: &str) {
 }
 
 /// Moves a legacy marker into the plugin-state dir. Returns `true` only
-/// on a clean relocation. Tries the cheap same-FS `rename` first (which
-/// only re-points the dirent — safe even for a hardlink). On cross-FS
-/// (`rename` fails, e.g. `~/.speedwave/` on a separate volume): Unix
-/// falls back to `write(target) + unlink(legacy)` (hardlinks were ruled
-/// out by the `nlink` check before this is reached); Windows refuses the
-/// fallback entirely because `std::fs::Metadata` exposes no link count,
-/// so an NTFS hardlink can't be excluded. Whenever this returns `false`
-/// the legacy file is still in the tree and audit fails on the next load.
+/// on a clean relocation.
 fn relocate_legacy_marker(slug: &str, legacy: &Path, target: &Path) -> bool {
     if std::fs::rename(legacy, target).is_ok() {
         return true;
@@ -614,22 +590,9 @@ fn relocate_legacy_marker(slug: &str, legacy: &Path, target: &Path) -> bool {
     }
 }
 
-/// Migrates the legacy in-tree `.image_pending` marker out of the
-/// signed plugin tree before the digest is computed. Without this, every
-/// MCP plugin installed under an older Speedwave release fails signature
-/// verification on first launch under a runtime-invariant build — the
-/// in-tree marker was never part of the signed tree, so its presence
-/// changes the digest. Idempotent; missing marker is a no-op.
-///
-/// Only a *root-level, regular-file* `.image_pending` is migrated — a
-/// symlink (or a hardlink, on Unix where we can detect it) is left in
-/// place so the verifier fails loudly rather than us silently relocating
-/// attacker-planted content. Whenever the marker cannot be fully moved
-/// the legacy file stays put and audit fails on the next load; we only
-/// log "migrated" on a clean move.
-///
-/// Run BEFORE every load-side signature check that observes a tree the
-/// user might be upgrading from — `audit_all`, `list_verified_*`.
+/// Migrates the legacy in-tree `.image_pending` marker out of the signed
+/// plugin tree. Idempotent; only root-level regular files, not symlinks.
+/// Run before every load-side signature check (`audit_all`, `list_verified_*`).
 fn migrate_legacy_image_pending(plugins_dir: &Path, plugin_dir: &Path, slug: &str) {
     let legacy = plugin_dir.join(".image_pending");
     let Ok(meta) = std::fs::symlink_metadata(&legacy) else {
@@ -3296,7 +3259,7 @@ mod tests {
             "container_name: {yaml}"
         );
         assert!(yaml.contains("read_only: true"), "read_only: {yaml}");
-        assert!(yaml.contains(&container_user()), "user: {yaml}");
+        assert!(yaml.contains(container_user()), "user: {yaml}");
         assert!(yaml.contains("ALL"), "cap_drop ALL: {yaml}");
         assert!(
             yaml.contains("no-new-privileges:true"),
@@ -8052,11 +8015,8 @@ mod tests {
             .count();
         assert_eq!(builds, 2, "build retried once after prune");
         let prunes = handle.prune_calls.lock().unwrap();
-        assert!(prunes.iter().any(|p| *p == "system"), "system_prune ran");
-        assert!(
-            prunes.iter().any(|p| *p == "buildkit"),
-            "BuildKit cache pruned"
-        );
+        assert!(prunes.contains(&"system"), "system_prune ran");
+        assert!(prunes.contains(&"buildkit"), "BuildKit cache pruned");
     }
 
     /// Expected content-addressed tag for a plugin dir created by a test.

--- a/crates/speedwave-runtime/src/project.rs
+++ b/crates/speedwave-runtime/src/project.rs
@@ -33,12 +33,8 @@ fn cleanup_project_dirs_in(project: &str, data_dir: &Path) {
     }
 }
 
-/// Creates project directories under a given data directory.
-///
-/// Directories are created directly with restrictive `0o700` permissions on
-/// Unix so that `fs_security::ensure_data_dir_permissions` does not have to
-/// chmod them on every app launch (the post-fix runs as a `[WARN]` and is
-/// purely a recovery path for tampered or pre-existing trees).
+/// Creates project directories under a given data directory with restrictive
+/// `0o700` permissions on Unix.
 fn init_project_dirs_in(project: &str, data_dir: &Path) -> anyhow::Result<()> {
     validation::validate_project_name(project)?;
     let tokens_root = data_dir.join("tokens").join(project);
@@ -49,9 +45,7 @@ fn init_project_dirs_in(project: &str, data_dir: &Path) -> anyhow::Result<()> {
             .join(crate::consts::CLAUDE_HOME_SUBDIR)
             .join(project),
     ];
-    // One token dir per credential-bearing service — derived from the SSOT so adding a
-    // service is a single edit in consts.rs (services with no `credential_files`, e.g.
-    // playwright, get no token dir).
+    // One token dir per credential-bearing service, derived from the SSOT in consts.rs.
     for svc in crate::consts::TOGGLEABLE_MCP_SERVICES {
         if !svc.credential_files.is_empty() {
             dirs_to_create.push(tokens_root.join(svc.config_key));
@@ -63,11 +57,8 @@ fn init_project_dirs_in(project: &str, data_dir: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// `create_dir_all` that applies mode `0o700` to every directory level it
-/// creates on Unix. `DirBuilder::recursive(true)` skips already-existing
-/// directories (their permissions are left intact and reconciled by
-/// `fs_security::ensure_data_dir_permissions`). On Windows, ACLs are
-/// inherited from the parent — Windows ignores Unix mode bits.
+/// `create_dir_all` that applies mode `0o700` to each directory level it
+/// creates on Unix; already-existing directories keep their permissions.
 fn create_dir_all_secure(path: &Path) -> std::io::Result<()> {
     let mut builder = std::fs::DirBuilder::new();
     builder.recursive(true);
@@ -89,12 +80,8 @@ fn save_compose_in(project: &str, yaml: &str, data_dir: &Path) -> anyhow::Result
     Ok(())
 }
 
-/// Registers a new project with transactional semantics: validate everything
-/// first, then commit all side-effects.  If a late write fails, previously
-/// created directories are cleaned up.
-///
-/// The entire operation is wrapped in an inter-process file lock so that
-/// concurrent CLI and Desktop invocations cannot corrupt `config.json`.
+/// Registers a new project under an inter-process config lock: validate first,
+/// then commit side-effects; a late write failure rolls back created dirs.
 pub fn add_project(name: &str, dir: &str) -> anyhow::Result<()> {
     config::with_config_lock(|| add_project_inner(name, dir))
 }
@@ -123,9 +110,7 @@ fn add_project_with_data_dir(name: &str, dir: &str, data_dir: &Path) -> anyhow::
             if !info.is_runtime_distro() {
                 anyhow::bail!(crate::consts::wsl_other_distro_msg(&info.distro));
             }
-            // Defense-in-depth: reject root via the dedicated helper so any
-            // future change to `is_wsl_unc_path` trailing-slash normalization
-            // does not silently re-open this hole.
+            // Reject the distro root via the dedicated helper.
             let translated = format!("/{}", info.rest);
             if runtime::wsl::is_root_path(Path::new(&translated)) {
                 anyhow::bail!(
@@ -279,7 +264,7 @@ fn remove_project_with_data_dir(name: &str, data_dir: &Path) -> anyhow::Result<(
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::config::{save_user_config_to, SpeedwaveUserConfig};
@@ -425,9 +410,7 @@ mod tests {
     }
 
     /// Pre-existing directories with looser permissions are left intact —
-    /// `fs_security::ensure_data_dir_permissions` is the SSOT for fixing
-    /// those, and `create_dir_all_secure` must not silently widen its scope
-    /// to chmod existing trees (that would race with the security check).
+    /// `create_dir_all_secure` must not chmod existing trees.
     #[cfg(unix)]
     #[test]
     fn create_dir_all_secure_leaves_existing_dir_perms_alone() {
@@ -438,9 +421,7 @@ mod tests {
         std::fs::create_dir_all(&parent).unwrap();
         std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o755)).unwrap();
 
-        // Re-running create_dir_all_secure on an existing dir is a no-op
-        // for permissions (DirBuilder::recursive matches Rust's
-        // create_dir_all semantics).
+        // Re-running create_dir_all_secure on an existing dir is a no-op for permissions.
         create_dir_all_secure(&parent).unwrap();
         let mode = std::fs::metadata(&parent).unwrap().permissions().mode() & 0o777;
         assert_eq!(
@@ -540,12 +521,7 @@ mod tests {
         std::fs::create_dir_all(&project_dir).unwrap();
         let canonical_dir = std::fs::canonicalize(&project_dir).unwrap();
 
-        // load_user_config_from returns default when config.json is absent, so
-        // init_project_dirs_in runs and creates the per-project dirs inside the
-        // pre-created subdirs below. We then make data_dir itself read-only:
-        // save_user_config_to's atomic write needs to create a sibling temp file
-        // directly in data_dir, which fails — exercising the rollback path
-        // without relying on a fixed `.tmp` sibling name.
+        // A read-only data_dir blocks save_user_config_to's atomic write, exercising the rollback path.
         let data_dir = tmp.path().join("data");
         std::fs::create_dir_all(&data_dir).unwrap();
         for sub in &["compose", "context", crate::consts::CLAUDE_HOME_SUBDIR] {
@@ -704,13 +680,8 @@ mod tests {
         );
     }
 
-    /// Cross-platform sanity check: on Unix, `Path::is_absolute()` returns
-    /// `false` for `\\wsl.localhost\...` (backslash is not a separator),
-    /// so the early `is_absolute` bail catches it BEFORE the UNC dispatch
-    /// can fire. This documents that the UNC branch is genuinely
-    /// Windows-specific — the Windows-only test below covers the dispatch
-    /// itself, and this test ensures non-Windows hosts surface a clean
-    /// error (not a confusing UNC bail) for the same input.
+    /// On Unix, `Path::is_absolute()` is `false` for `\\wsl.localhost\...`, so
+    /// the early `is_absolute` bail catches it before the UNC dispatch fires.
     #[cfg(not(target_os = "windows"))]
     #[test]
     fn add_project_unc_rejected_on_unix_via_absolute_check() {
@@ -741,14 +712,8 @@ mod tests {
         );
     }
 
-    /// Verifies the UNC dispatch in `add_project_with_data_dir` actually
-    /// routes to the WSL UNC branch (not canonicalize) for runtime-distro
-    /// inputs. We can't test full success without a live Speedwave WSL
-    /// distro (that's E2E territory), but we CAN assert the dispatch
-    /// reaches the metadata existence check by feeding a runtime-distro
-    /// UNC path that points to a non-existent subdir: the bail message
-    /// ("does not exist or is not a directory") with the raw UNC string
-    /// (NOT a canonicalized form) proves the UNC branch handled it.
+    /// Verifies the UNC dispatch routes runtime-distro inputs to the WSL UNC
+    /// branch, not canonicalize: a missing subdir bails with the raw UNC string.
     #[cfg(target_os = "windows")]
     #[test]
     fn add_project_dispatch_routes_unc_through_metadata_not_canonicalize() {
@@ -772,14 +737,9 @@ mod tests {
         );
     }
 
-    /// End-to-end happy path for the WSL UNC branch — registers a project whose
-    /// canonical path is a `\\wsl.localhost\Speedwave\projects\...` UNC string.
-    /// Cross-platform: simulates the post-validation state by feeding
-    /// `add_project_with_validated_dir` directly with a tempdir backing the
-    /// canonical PathBuf and a UNC-style canonical string. Verifies that
-    /// Phase 1b+2 (duplicate checks, compose render, config save, dir init)
-    /// work correctly for UNC-style stored paths — the same state Łukasz's
-    /// project would land in after a successful Windows UNC registration.
+    /// Happy path for a UNC-style stored `dir`: feeds
+    /// `add_project_with_validated_dir` a tempdir-backed canonical PathBuf plus
+    /// a `\\wsl.localhost\...` canonical string and asserts Phase 1b+2 succeed.
     #[test]
     fn add_project_with_validated_dir_accepts_unc_style_canonical() {
         let tmp = tempfile::tempdir().unwrap();
@@ -802,11 +762,7 @@ mod tests {
             unc_canonical_str.clone(),
             &data_dir,
         );
-        // Avoid `{result:?}` in the assert message: anyhow::Error chains may
-        // include strings from upstream errors (apply_oauth_config /
-        // init_secrets_dir trace through the same anyhow::Error type),
-        // which CodeQL flags as cleartext logging of sensitive information
-        // even when those code paths are not reached in this test.
+        // Avoid `{result:?}`: anyhow chains may carry upstream strings CodeQL flags as cleartext logging.
         if let Err(e) = &result {
             panic!("registration must succeed: {}", e);
         }
@@ -999,9 +955,7 @@ mod tests {
 
     #[test]
     fn duplicate_unc_path_detected_via_exact_string() {
-        // Covers the exact-string fast path added for UNC paths (project.rs:177).
-        // canonicalize cannot resolve UNC strings on non-Windows hosts, so
-        // the fast path is the only mechanism that catches this duplicate.
+        // Covers the exact-string fast path for UNC paths, which canonicalize cannot resolve.
         let tmp = tempfile::tempdir().unwrap();
         let project_dir = tmp.path().join("project");
         std::fs::create_dir_all(&project_dir).unwrap();

--- a/crates/speedwave-runtime/src/provision.rs
+++ b/crates/speedwave-runtime/src/provision.rs
@@ -1,10 +1,7 @@
 //! VM provisioning primitives (Lima / WSL2 / nerdctl).
 //!
-//! SSOT for the platform provisioning steps the setup wizard orchestrates:
-//! the Lima VM YAML builder + migration check, WSL2 distro import,
-//! nerdctl-full install, and the `.wslconfig` / `wsl.conf` mergers. Pure Rust,
-//! no Tauri — callers in the desktop crate keep the wizard-state orchestration
-//! and pass plain data in.
+//! SSOT for the Lima VM YAML builder + migration check, WSL2 distro import,
+//! nerdctl-full install, and the `.wslconfig` / `wsl.conf` mergers.
 
 use crate::consts;
 #[cfg(any(target_os = "windows", test))]
@@ -15,13 +12,7 @@ use std::path::PathBuf;
 // ---------------------------------------------------------------------------
 
 /// Desired Lima VM memory as a Lima-compatible string (e.g. `"16GiB"`).
-///
-/// Uses adaptive scaling from [`crate::resources`]:
-/// VM = host_ram / 2, clamped 8–32 GiB (≤50% of host RAM at/above the 16 GiB
-/// minimum supported host; the 8 GiB floor makes the always-on set fit).
-///
-/// Older installs with lower values are auto-migrated by
-/// [`ensure_lima_vm_config`].
+/// Adaptive from [`crate::resources`]: host_ram / 2, clamped 8–32 GiB.
 #[cfg(any(target_os = "macos", test))]
 pub fn desired_lima_vm_memory() -> String {
     let gib = crate::resources::desired_vm_memory_gib(crate::resources::host_total_memory_gib());
@@ -34,10 +25,8 @@ pub fn desired_lima_vm_cpus() -> u32 {
     crate::resources::desired_vm_cpus(crate::resources::host_logical_cpus())
 }
 
-/// Default Lima VM configuration for Speedwave.
-/// Uses Apple Virtualization Framework (vz) with containerd + nerdctl.
-/// Memory and CPU are adaptive based on host RAM/cores — see
-/// [`desired_lima_vm_memory`] and [`desired_lima_vm_cpus`].
+/// Default Lima VM config: Apple Virtualization Framework (vz) with
+/// containerd + nerdctl; memory and CPU adaptive based on host RAM/cores.
 #[cfg(any(target_os = "macos", test))]
 pub fn lima_config() -> String {
     format!(
@@ -70,24 +59,6 @@ provision:
     script: |
       #!/bin/sh
       # Make eth0 (vzNAT) the preferred default route, not lima0 (usernet).
-      #
-      # Why: Apple VZ NAT on eth0 inherits the macOS host routing table
-      # transparently — both public Internet and every VPN tunnel the host
-      # is connected to (IPSec, WireGuard, Tailscale). Lima's built-in
-      # usernet (lima0) runs a user-mode TCP stack on the host and only
-      # reaches services that need no host VPN; it silently times out on
-      # corporate VPNs and on Tailscale subnet routes.
-      #
-      # Lima's stock netplan ships lima0 metric=100 (preferred) and
-      # eth0 metric=200. We drop in a higher-numbered netplan file that
-      # overrides metrics and disables DHCP-installed default routes on
-      # lima0 — no edits to the lima-managed file, no hard-coded IPs.
-      #
-      # `mode: boot` maps to cloud-init's `bootcmd` — re-runs on every VM
-      # start. Idempotent: the heredoc just rewrites the same file. This
-      # guarantees existing VMs upgrading via `lima_vm_config_needs_update`
-      # pick the fix up on their next restart without needing cloud-init
-      # state reset.
       set -eu
       mkdir -p /etc/netplan
       cat > /etc/netplan/99-speedwave-prefer-vznat.yaml <<'YAML'
@@ -144,9 +115,7 @@ pub fn lima_vm_config_needs_update_with(
     }
     // Whether a `prefix` line exists at all (regardless of parseability).
     let line_present = |prefix: &str| config_content.lines().any(|l| l.trim().starts_with(prefix));
-    // Parse a `memory: "8GiB"` or `cpus: 4` value to u32. `cpus` has no GiB
-    // suffix, so strip it optionally; present-but-unparseable → None (don't
-    // touch a hand-mangled value).
+    // Parse a `memory: "8GiB"` or `cpus: 4` value to u32; unparseable → None.
     let line_val = |prefix: &str| -> Option<u32> {
         config_content.lines().find_map(|line| {
             line.trim().strip_prefix(prefix).and_then(|rest| {
@@ -155,9 +124,7 @@ pub fn lima_vm_config_needs_update_with(
             })
         })
     };
-    // Regenerate if EITHER memory or cpus is absent (the SSOT line was never
-    // written — e.g. a pre-adaptive-cpus config) or drifted from the formula.
-    // Present-but-unparseable → "no drift" (don't clobber a hand-mangled value).
+    // Regenerate if memory or cpus is absent or drifted; unparseable → no drift.
     let needs_update = |prefix: &str, desired: u32| -> bool {
         if !line_present(prefix) {
             return true; // line absent — regenerate to write the SSOT value
@@ -167,12 +134,9 @@ pub fn lima_vm_config_needs_update_with(
     needs_update("memory:", desired_gib) || needs_update("cpus:", desired_cpus)
 }
 
-/// Migrates the Lima VM config on existing installs when it drifts from the
-/// SSOT (memory, cpus, or the VPN netplan drop-in — see
-/// [`lima_vm_config_needs_update`]). Fully regenerates `lima.yaml` from
-/// [`lima_config`] (a generated file — user edits are not preserved, per
-/// ADR-068), rewrites source + instance config, and restarts the VM if running.
-/// No-op on a fresh install (template absent) or when nothing drifted.
+/// Regenerates `lima.yaml` from [`lima_config`] when it drifts from the SSOT
+/// (memory, cpus, or VPN netplan drop-in), rewrites source + instance config,
+/// and restarts the VM if running. No-op on fresh install or no drift. ADR-068.
 #[cfg(target_os = "macos")]
 pub fn ensure_lima_vm_config() -> anyhow::Result<()> {
     use crate::binary;
@@ -228,10 +192,7 @@ pub fn ensure_lima_vm_config() -> anyhow::Result<()> {
         }
     }
 
-    // Full regeneration from the SSOT `lima_config()` — both `cpus` and
-    // `memory` (and the provision block) always reflect the current formula.
-    // `lima.yaml` is a generated file (like compose.yml); user edits are not
-    // preserved by design.
+    // Full regeneration from the SSOT `lima_config()`.
     let regenerated = lima_config();
     if content.trim() != regenerated.trim() {
         log::warn!(
@@ -437,11 +398,7 @@ pub fn init_vm_windows() -> anyhow::Result<()> {
         attempt_wsl_install()?;
     }
 
-    // Ensure %USERPROFILE%\.wslconfig enables WSL2 mirrored networking before
-    // any distro starts — this is what lets containers see the host's
-    // VPN tunnel. Logs but does not fail setup on error: an older Windows
-    // build without mirrored-mode support still gets a working (if
-    // VPN-incompatible) install.
+    // Enable WSL2 mirrored networking before any distro starts; non-fatal.
     if let Err(e) = ensure_wslconfig_vpn_compat() {
         log::warn!("ensure_wslconfig_vpn_compat failed (non-fatal): {e}");
     }
@@ -466,18 +423,9 @@ pub fn init_vm_windows() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Writes (or updates) `%USERPROFILE%\.wslconfig` so the `[wsl2]` section
-/// declares `networkingMode=mirrored`, `dnsTunneling=true`, `autoProxy=true`.
-/// These three keys together let WSL2 distros (including Speedwave's
-/// `Speedwave` distro and its containers) reach services on the host's
-/// corporate VPN without manual configuration.
-///
-/// Preserves all other user keys and sections — only the three load-bearing
-/// keys in `[wsl2]` are added or rewritten. Missing file → fresh skeleton.
-///
-/// Requires Windows 11 22H2+. Older builds silently ignore the unknown keys
-/// (legacy NAT mode stays active and VPN-protected services remain
-/// unreachable from inside WSL2 until the user upgrades).
+/// Writes/updates `%USERPROFILE%\.wslconfig` so `[wsl2]` declares
+/// `networkingMode=mirrored`, `dnsTunneling=true`, `autoProxy=true` (Win11
+/// 22H2+). Preserves all other keys/sections; missing file → fresh skeleton.
 #[cfg(target_os = "windows")]
 pub fn ensure_wslconfig_vpn_compat() -> anyhow::Result<()> {
     let home = dirs::home_dir()
@@ -491,11 +439,7 @@ pub fn ensure_wslconfig_vpn_compat() -> anyhow::Result<()> {
             "ensure_wslconfig_vpn_compat: wrote VPN-compatible [wsl2] keys to {}",
             path.display()
         );
-        // .wslconfig is read only on WSL2 boot. An existing WSL2 session
-        // won't pick up the new keys until the user runs `wsl --shutdown`
-        // (which restarts ALL WSL distros, not just Speedwave's). We log
-        // a hint rather than triggering the shutdown automatically — it
-        // would surprise users running unrelated WSL workloads.
+        // .wslconfig is read only on WSL2 boot; new keys need `wsl --shutdown`.
         log::warn!(
             ".wslconfig changed — run `wsl --shutdown` from PowerShell to \
              activate mirrored-mode networking (required to reach \
@@ -505,10 +449,8 @@ pub fn ensure_wslconfig_vpn_compat() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Classifies a `.wslconfig` read so a non-NotFound failure (UTF-16, EACCES,
-/// EBUSY) bails instead of being treated as empty — an empty merge would
-/// REPLACE the user's global `[wsl2]` memory/processors/kernel for ALL distros.
-/// Only `NotFound` maps to empty (fresh skeleton).
+/// Classifies a `.wslconfig` read: only `NotFound` maps to empty (fresh
+/// skeleton); any other failure (UTF-16, EACCES, EBUSY) bails.
 #[cfg(any(target_os = "windows", test))]
 pub fn read_existing_wslconfig(
     read: std::io::Result<String>,
@@ -613,13 +555,9 @@ pub fn merge_wslconfig_vpn_keys(input: &str) -> String {
     out
 }
 
-/// Verifies that an existing WSL2 distro named [`consts::wsl_distro_name`] was
-/// created by Speedwave, not pre-registered by an attacker.
-///
-/// WSL stores the virtual disk at the install directory passed to `wsl --import`.
-/// Speedwave always imports into `~/.speedwave/wsl/Speedwave/`, so a legitimate
-/// distro will have `ext4.vhdx` at that path. If the file is missing the distro
-/// was registered from somewhere else — bail with a clear security error.
+/// Verifies an existing WSL2 distro [`consts::wsl_distro_name`] was created by
+/// Speedwave by checking for `ext4.vhdx` at the Speedwave install path; bails
+/// with a security error if absent (distro pre-registered elsewhere).
 #[cfg(target_os = "windows")]
 fn verify_wsl_distro_origin() -> anyhow::Result<()> {
     verify_wsl_distro_origin_in(consts::data_dir())
@@ -653,10 +591,8 @@ pub fn expected_wsl_vhdx_path_in(data_dir: &std::path::Path) -> PathBuf {
         .join("ext4.vhdx")
 }
 
-/// Attempts to install WSL2 via elevated PowerShell. Always bails: either
-/// with a restart prompt (success) or an installation failure message.
-/// Detection is handled by `os_prereqs::check_os_prereqs()` — this function
-/// only performs the install action.
+/// Installs WSL2 via elevated PowerShell. Always bails: either with a restart
+/// prompt (success) or an installation failure message.
 #[cfg(target_os = "windows")]
 fn attempt_wsl_install() -> anyhow::Result<()> {
     let status = crate::binary::system_command("powershell")
@@ -762,9 +698,7 @@ fn import_wsl_distro() -> anyhow::Result<()> {
             .lines()
             .any(|l| l.trim().trim_matches('\0') == consts::wsl_distro_name())
         {
-            // Distro exists but we didn't create it — verify it's ours before
-            // trusting it. An attacker could pre-register a malicious distro
-            // with the same name to hijack the container runtime.
+            // Distro exists but we didn't create it — verify it's ours.
             verify_wsl_distro_origin()?;
             log::warn!(
                 "WSL2 import failed but distro '{}' already exists and is verified — continuing",
@@ -802,11 +736,8 @@ pub fn terminate_decision(terminate: TerminateOnChange, has_running: bool) -> bo
     }
 }
 
-/// Unwraps a `read_wsl_conf` result, warning before defaulting to empty.
-/// `read_wsl_conf` already maps a missing file to `Ok("")`, so any `Err` here
-/// is a real spawn/IO failure (not NotFound) and must not be silent — empty
-/// triggers a needless wsl.conf rewrite, but the post-write uid re-read still
-/// guards correctness (ADR-052), so we degrade rather than bail.
+/// Unwraps a `read_wsl_conf` result, warning before degrading an `Err` (real
+/// spawn/IO failure) to empty rather than bailing (ADR-052).
 #[cfg(any(target_os = "windows", test))]
 pub fn wsl_conf_or_warn(read: anyhow::Result<String>, distro: &str, when: &str) -> String {
     match read {
@@ -993,8 +924,7 @@ pub fn options_has_uid(options: &str, uid: u32) -> bool {
 pub fn merge_wsl_conf_automount(input: &str, opts: &str) -> String {
     let nl = if input.contains("\r\n") { "\r\n" } else { "\n" };
     let mut out = String::with_capacity(input.len() + 64);
-    // `Some(true)` = first [automount] (keep its keys); `Some(false)` = a
-    // duplicate [automount] (drop its whole body); `None` = some other section.
+    // `Some(true)` = first [automount]; `Some(false)` = duplicate (dropped); `None` = other.
     let mut in_automount: Option<bool> = None;
     let mut automount_seen = false;
     let mut options_written = false;
@@ -1050,26 +980,9 @@ pub fn merge_wsl_conf_automount(input: &str, opts: &str) -> String {
     out
 }
 
-/// Makes the project's `claude-home` tree owned by the container user so the
-/// uid-1000 entrypoint can write `/home/speedwave` (mkdir/ln under `set -e`).
-///
-/// This is the **load-bearing** half of the Windows mount-ownership fix. The
-/// WSL drvfs `/mnt/c` mount is owned by uid 0 (the imported distro has no
-/// default user, and WSL's prepended default-user uid beats the `uid=` automount
-/// option), so a uid-1000 mkdir under a root-owned parent gets EACCES and the
-/// container exits(1) ("cannot exec in a stopped state"). With `metadata` on,
-/// `chown` writes per-file ownership that drvfs honors for access.
-///
-/// MUST run **after** `compose_up_recreate`: `compose up` auto-creates the
-/// `/home/speedwave/.claude` bind mount-point (for the read-only ide-bridge
-/// mount) as ROOT, so a chown done *before* compose is silently undone by the
-/// start. Chowning after the mount-points exist, then letting
-/// `ensure_exec_healthy`'s recovery recreate re-run the entrypoint against the
-/// now-1000-owned tree, is what actually fixes it. Verified on the live distro.
-///
-/// uid/gid come from the [`consts::container_uid_gid`] SSOT (same value as the
-/// compose `user:` field). Idempotent and cheap. Fail-open: a chown failure
-/// only logs.
+/// Chowns the project's `claude-home` tree to [`consts::container_uid_gid`] so
+/// the uid-1000 entrypoint can write `/home/speedwave`. MUST run after
+/// `compose_up_recreate`. Idempotent; fail-open (a chown failure only logs).
 #[cfg(target_os = "windows")]
 pub fn ensure_claude_home_owner(project: &str) -> anyhow::Result<()> {
     let distro = consts::wsl_distro_name();
@@ -1128,13 +1041,8 @@ fn nerdctl_version_matches_pin(version_line: &str) -> bool {
         .any(|tok| tok == consts::NERDCTL_FULL_VERSION)
 }
 
-/// Installs nerdctl-full (containerd + nerdctl + CNI + BuildKit) inside the
-/// Speedwave WSL2 distribution if the pinned version is not already present.
-/// Checks for a bundled tarball first (offline install), falling back to
-/// download if not found. Re-installs when the in-distro version differs from
-/// `NERDCTL_FULL_VERSION` so an upgrade actually upgrades the guest (ADR-072).
-/// `true` when a failed version probe means nerdctl is genuinely absent
-/// (vs a transient wsl.exe transport error that must not trigger reinstall).
+/// `true` when a failed version probe means nerdctl is genuinely absent (vs a
+/// transient wsl.exe transport error that must not trigger reinstall).
 #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
 fn probe_indicates_absent(code: Option<i32>, stderr: &str) -> bool {
     code == Some(127) || stderr.contains("not found") || stderr.contains("No such file")
@@ -1162,9 +1070,7 @@ fn install_nerdctl_full() -> anyhow::Result<()> {
             version_line.trim()
         );
     } else {
-        // Probe failed: distinguish "nerdctl genuinely absent" (exit 127 /
-        // not-found) from a transient wsl.exe transport error — a transient
-        // failure must NOT trigger a daemon-stopping reinstall.
+        // Probe failed: distinguish genuinely-absent from a transient transport error.
         let stderr = String::from_utf8_lossy(&nerdctl_check.stderr);
         let absent = probe_indicates_absent(nerdctl_check.status.code(), &stderr);
         if !absent {
@@ -1181,16 +1087,12 @@ fn install_nerdctl_full() -> anyhow::Result<()> {
     }
 
     // Try bundled nerdctl-full tarball first (offline install from NSIS bundle).
-    // If valid, convert its path to WSL and use `cp` instead of `curl` inside the distro.
     let expected_sha256 = nerdctl_sha256_for_arch()?;
     let mut bundled_wsl_path: Option<String> = None;
 
     if let Some(bundled) = find_bundled_resource("wsl/nerdctl-full.tar.gz") {
         if verify_sha256_ps(&bundled, expected_sha256) {
-            // Translate the bundled tarball's host path to its WSL path via the
-            // SSOT (engine_path::to_engine_path) — one path-translation mechanism,
-            // not a second `wslpath` round-trip. On translation failure fall
-            // through to the curl download branch rather than abort the install.
+            // Translate the bundled tarball's host path to WSL via the SSOT.
             match crate::engine_path::to_engine_path(&bundled) {
                 Ok(wsl) => bundled_wsl_path = Some(wsl),
                 Err(e) => log::warn!(
@@ -1230,18 +1132,15 @@ if [ "$EXPECTED" != "$ACTUAL" ]; then
   rm -rf /tmp/nerdctl-install
   exit 1
 fi
-# Pre-existing installs carry a unit WITHOUT KillMode=process — stopping it
-# would cgroup-kill every running container. Patch via override BEFORE stop
-# so user containers survive the upgrade (shims keep them; the new daemon
-# re-attaches). No-op on fresh install.
+# Patch KillMode=process via override BEFORE stop so containers survive the
+# upgrade (stopping a unit without it cgroup-kills them). No-op on fresh install.
 if [ -f /etc/systemd/system/containerd.service ]; then
   mkdir -p /etc/systemd/system/containerd.service.d
   printf '[Service]\nKillMode=process\nDelegate=yes\n' > /etc/systemd/system/containerd.service.d/10-speedwave-killmode.conf
   command -v systemctl >/dev/null 2>&1 && systemctl daemon-reload 2>/dev/null || true
 fi
-# Stop daemons before unpacking — tar over live binaries fails ETXTBSY on a
-# reinstall (ADR-072). No is-system-running gate (skips on `degraded`); pkill
-# covers the `$exec &` non-systemd fallback. No-op on fresh install.
+# Stop daemons before unpacking — tar over live binaries fails ETXTBSY (ADR-072).
+# pkill covers the `$exec &` non-systemd fallback. No-op on fresh install.
 command -v systemctl >/dev/null 2>&1 && systemctl stop buildkit containerd 2>/dev/null || true
 pkill -x buildkitd 2>/dev/null || true
 pkill -x containerd 2>/dev/null || true
@@ -1301,9 +1200,7 @@ install_service buildkit "/usr/local/bin/buildkitd --oci-worker=false --containe
         sha256_arm64 = consts::NERDCTL_FULL_SHA256_ARM64,
         source_commands = source_commands
     );
-    // Write the install script inside WSL via stdin to avoid argument
-    // length/escaping issues with wsl.exe -- bash -c "...".
-    // Pipe the script through stdin: echo "$script" | wsl bash -s
+    // Write the install script via stdin to avoid wsl.exe arg length/escaping.
     let install = crate::binary::system_command("wsl.exe")
         .args(["-d", consts::wsl_distro_name(), "--", "bash", "-s"])
         .stdin(std::process::Stdio::piped())
@@ -1376,12 +1273,8 @@ mod tests {
         assert!(!nerdctl_version_matches_pin("command not found"));
     }
 
-    /// Structural: the install script must stop the daemons BEFORE `tar`
-    /// unpacks into /usr/local — on a reinstall the live containerd/buildkitd
-    /// binaries would otherwise be overwritten while executing (ETXTBSY),
-    /// failing the upgrade. The stop must precede the unpack, must NOT gate on
-    /// `is-system-running` (false in `degraded` state), and must `pkill` the
-    /// bare-background daemons (install_service's non-systemd `$exec &` path).
+    /// Install script must stop daemons before `tar` (ETXTBSY on reinstall),
+    /// must not gate on `is-system-running`, and must `pkill` bare daemons.
     #[test]
     fn nerdctl_install_stops_services_before_tar() {
         let src = include_str!("provision.rs");
@@ -1393,8 +1286,7 @@ mod tests {
             .expect("old-unit KillMode override must exist");
         assert!(
             killmode_pos < stop_pos,
-            "KillMode override must be written BEFORE the stop, or the first \
-             migration cgroup-kills every running container"
+            "KillMode override must be written BEFORE the stop"
         );
         let pkill_pos = src
             .find("pkill -x containerd")
@@ -1501,9 +1393,8 @@ mod tests {
         assert!(lima_vm_config_needs_update_with(config, 12, 4));
     }
 
-    /// Test helper — appends the VPN-aware provision sentinel so fixtures
-    /// model a fully-migrated config; tests focused on memory comparison
-    /// would otherwise also trigger the provision-absent migration branch.
+    /// Appends the VPN provision sentinel so memory/CPU tests don't also
+    /// trigger the provision-absent migration branch.
     fn with_provision_sentinel(base: &str) -> String {
         format!(
             "{base}provision:\n  - mode: boot\n    script: |\n      cat > /etc/netplan/99-speedwave-prefer-vznat.yaml <<'YAML'\n"
@@ -1519,8 +1410,7 @@ mod tests {
 
     #[test]
     fn lima_vm_config_higher_memory_triggers_downgrade() {
-        // After the VM formula was reduced, existing VMs with more RAM than
-        // desired must be migrated down to reclaim host memory.
+        // VMs with more RAM than desired must migrate down to reclaim host memory.
         let config = "vmType: vz\ncpus: 4\nmemory: \"16GiB\"\ndisk: \"30GiB\"\n";
         assert!(lima_vm_config_needs_update_with(config, 12, 4));
     }
@@ -1531,10 +1421,8 @@ mod tests {
         assert!(lima_vm_config_needs_update_with(config, 12, 4));
     }
 
-    /// Generated lima.yaml must include a provision script that demotes lima0
-    /// (usernet) below eth0 (vzNAT) so traffic flows through vzNAT where the
-    /// macOS host's VPN routing applies. Without this, corporate-VPN-protected
-    /// services are unreachable from inside the VM. See lima-vm/lima#2984.
+    /// Provision script demotes lima0 (usernet) below eth0 (vzNAT) for VPN
+    /// reach. See lima-vm/lima#2984.
     #[test]
     fn lima_config_includes_vpn_aware_provision_script() {
         let yaml = lima_config();
@@ -1542,32 +1430,25 @@ mod tests {
             yaml.contains("provision:"),
             "lima.yaml must declare a provision section"
         );
-        // `mode: boot` maps to cloud-init's bootcmd — re-runs on every VM
-        // start. `mode: system` would only run on first boot, which would
-        // skip the fix for users upgrading an existing VM.
+        // `mode: boot` (cloud-init bootcmd) re-runs on every VM start.
         assert!(
             yaml.contains("mode: boot"),
-            "provision must use `mode: boot` so the fix re-applies on \
-             every VM restart, including post-upgrade existing VMs"
+            "provision must use `mode: boot` so the fix re-applies on every VM restart"
         );
-        // The drop-in netplan file declaratively overrides DHCP route metrics
-        // — eth0 to 100 (preferred), lima0 to 300 with `use-routes: false`.
+        // Drop-in netplan: eth0 metric 100 (preferred), lima0 metric 300.
         assert!(
             yaml.contains("99-speedwave-prefer-vznat.yaml"),
-            "provision must drop in a higher-priority netplan file that \
-             demotes lima0 and promotes eth0 (vzNAT) as default egress"
+            "provision must drop in a netplan file that demotes lima0 and promotes eth0 (vzNAT)"
         );
         assert!(
             yaml.contains("use-routes: false"),
-            "lima0 must have `use-routes: false` so DHCP cannot re-install \
-             a default route through it after renew"
+            "lima0 must have `use-routes: false` so DHCP cannot re-install a default route through it"
         );
         assert!(
             yaml.contains("route-metric: 100"),
             "eth0 must be promoted to route-metric 100 (preferred)"
         );
-        // Sanity: provision must `netplan apply` so changes take effect
-        // without requiring a reboot.
+        // Provision must `netplan apply` so changes take effect without reboot.
         assert!(
             yaml.contains("netplan apply"),
             "provision must apply the new netplan config immediately"
@@ -1579,8 +1460,7 @@ mod tests {
     #[test]
     fn lima_config_does_not_silently_drop_provision_section() {
         let yaml = lima_config();
-        // Both vzNAT and the provision script are load-bearing; removing
-        // either re-introduces the VPN-incompatibility regression.
+        // Both vzNAT and the provision script are load-bearing.
         assert!(yaml.contains("vzNAT: true"));
         assert!(yaml.contains("provision:"));
     }
@@ -1594,8 +1474,7 @@ mod tests {
 
     #[test]
     fn lima_vm_config_unparseable_cpus_no_update() {
-        // Symmetric to the memory case: a present-but-garbage `cpus:` value is a
-        // hand-mangled file, not a missing SSOT line — don't clobber it.
+        // Present-but-garbage `cpus:` value is hand-mangled; don't clobber it.
         let config =
             with_provision_sentinel("vmType: vz\ncpus: lots\nmemory: \"12GiB\"\ndisk: \"30GiB\"\n");
         assert!(!lima_vm_config_needs_update_with(&config, 12, 4));
@@ -1610,8 +1489,7 @@ mod tests {
 
     #[test]
     fn lima_vm_config_downgrade_from_12_to_8() {
-        // 16 GiB host: old formula gave 12 GiB VM, new formula gives 8 GiB.
-        // The migration must trigger to reclaim 4 GiB for the host.
+        // 16 GiB host: old formula 12 GiB VM, new formula 8 GiB → migrate down.
         let config = "vmType: vz\ncpus: 4\nmemory: \"12GiB\"\ndisk: \"30GiB\"\n";
         assert!(lima_vm_config_needs_update_with(config, 8, 4));
     }
@@ -1626,8 +1504,7 @@ mod tests {
 
     #[test]
     fn lima_vm_config_cpus_drift_triggers_update() {
-        // Memory matches but cpus drifted (bigger host → desired 8) → migrate
-        // so existing users pick up the adaptive vCPU count on upgrade.
+        // Memory matches but cpus drifted (desired 8) → migrate.
         let config =
             with_provision_sentinel("vmType: vz\ncpus: 4\nmemory: \"8GiB\"\ndisk: \"30GiB\"\n");
         assert!(lima_vm_config_needs_update_with(&config, 8, 8));
@@ -1635,16 +1512,14 @@ mod tests {
 
     #[test]
     fn lima_vm_config_missing_cpus_triggers_update() {
-        // Pre-adaptive-cpus config: no `cpus:` line at all. Absent ≠ "no drift"
-        // — regenerate to write the SSOT vCPU count (matched memory must not mask it).
+        // No `cpus:` line at all: absent ≠ no-drift → regenerate.
         let config = with_provision_sentinel("vmType: vz\nmemory: \"8GiB\"\ndisk: \"30GiB\"\n");
         assert!(lima_vm_config_needs_update_with(&config, 8, 4));
     }
 
     #[test]
     fn lima_vm_config_missing_memory_triggers_update() {
-        // Symmetric: no `memory:` line — regenerate to write the SSOT value
-        // even though cpus already matches.
+        // No `memory:` line: absent ≠ no-drift → regenerate.
         let config = with_provision_sentinel("vmType: vz\ncpus: 4\ndisk: \"30GiB\"\n");
         assert!(lima_vm_config_needs_update_with(&config, 8, 4));
     }
@@ -1724,9 +1599,7 @@ mod tests {
         assert!(out.contains("bar=baz"));
     }
 
-    /// `networkingMode=NAT` already present → must be **rewritten** to
-    /// `mirrored`. We deliberately overwrite because a stale NAT setting
-    /// re-introduces the VPN-incompatibility regression.
+    /// `networkingMode=NAT` already present → must be rewritten to `mirrored`.
     #[test]
     fn merge_wslconfig_overwrites_stale_networking_mode() {
         let input = "[wsl2]\nnetworkingMode=NAT\nmemory=8GB\n";
@@ -1760,9 +1633,7 @@ mod tests {
         assert_eq!(mirrored_count, 1, "must rewrite, not duplicate: {out}");
     }
 
-    /// `.wslconfig` on Windows is typically CRLF — the merger must produce
-    /// valid output regardless of input line endings and must NOT mix LF and
-    /// CRLF in the result (cosmetic but reviewers care).
+    /// CRLF input must produce valid output and must not mix LF and CRLF.
     #[test]
     fn merge_wslconfig_handles_crlf_line_endings() {
         let input = "[wsl2]\r\nmemory=8GB\r\nnetworkingMode=NAT\r\n";
@@ -2007,8 +1878,7 @@ mod tests {
         assert!(wsl_conf_automount_has_uid(&out, 1000));
     }
 
-    // Interleaved duplicate [automount]: collapse to one, and a key from the
-    // dropped duplicate must NOT be misplaced under the intervening section.
+    // Interleaved duplicate [automount]: collapse to one without misplacing keys.
     #[test]
     fn merge_dedups_duplicate_sections() {
         let input = "[automount]\nenabled=true\n[network]\nx=1\n[automount]\nroot=/m/\n";

--- a/crates/speedwave-runtime/src/resources.rs
+++ b/crates/speedwave-runtime/src/resources.rs
@@ -6,16 +6,11 @@
 //! external manifest) and the WSL2 VM (user-owned) stay outside by design.
 use std::process::ExitStatus;
 
-/// Fixed Claude container memory ceiling in GiB. Claude Code needs 4 GB+
-/// officially (the process itself uses ~200–400 MB — heavy compute is
-/// server-side), so a fixed 6 GiB cap is generous and, unlike the old
-/// `VM − overhead` formula, immune to drift when workers are added. See ADR-068.
+/// Fixed Claude container memory ceiling in GiB. See ADR-068.
 pub const CLAUDE_MEMORY_GIB: u32 = 6;
 
-/// Resource limits for one container: hard memory cap, CPU shares, tmpfs `/tmp`
-/// size, and (Chromium only) shared-memory size. `shm_mib` is `None` unless the
-/// container needs `shm_size` above the 64 MiB default. Sizes in MiB, except
-/// `cpus` which is fractional cores.
+/// Resource limits for one container. Sizes in MiB, except `cpus` (fractional
+/// cores); `shm_mib` is `None` unless above the 64 MiB default.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ContainerResources {
     /// Hard memory cap, MiB.
@@ -46,10 +41,7 @@ pub const HUB_RESOURCES: ContainerResources = ContainerResources {
     shm_mib: None,
 };
 
-/// LiteLLM proxy (ADR-073): on every inference request's path, but the work is
-/// I/O-bound forwarding/translation — 1 core is plenty. 512 MiB covers the
-/// Python runtime + litellm with headroom for concurrent streams (a bare proxy
-/// idles at ~200-300 MiB; no DB, no Admin UI).
+/// LiteLLM proxy (ADR-073): 512 MiB, 1 core, 64 MiB /tmp.
 pub const LITELLM_RESOURCES: ContainerResources = ContainerResources {
     mem_mib: 512,
     cpus: 1.0,
@@ -71,21 +63,14 @@ pub const STANDARD_WORKER_RESOURCES: ContainerResources = ContainerResources {
 // Host RAM detection
 // ---------------------------------------------------------------------------
 
-/// Converts raw bytes to GiB using floor division.
-///
-/// Floor is intentionally safer than rounding (never over-reports host RAM): a
-/// 32 GB MacBook with ~31.x GiB usable returns 31, so `host/2` = 15 → a 15 GiB
-/// VM rather than rounding up to 16. At the 16 GiB minimum host the 8 GiB clamp
-/// floor in `desired_vm_memory_gib` guarantees the always-on set still fits.
+/// Converts raw bytes to GiB using floor division (never over-reports host RAM).
 #[cfg(any(target_os = "macos", test))]
 fn bytes_to_gib(bytes: u64) -> u32 {
     (bytes / (1024 * 1024 * 1024)) as u32
 }
 
-/// Returns total physical RAM in GiB (floor).
-///
-/// Falls back to 16 on detection failure — produces 8 GiB VM via the
-/// adaptive formula (`host/2`).
+/// Returns total physical RAM in GiB (floor); falls back to 16 on detection
+/// failure.
 pub fn host_total_memory_gib() -> u32 {
     host_total_memory_gib_impl().unwrap_or(16)
 }
@@ -112,7 +97,6 @@ fn host_total_memory_gib_impl() -> Option<u32> {
 #[cfg(target_os = "windows")]
 fn host_total_memory_gib_impl() -> Option<u32> {
     // Windows: RAM detection not implemented — falls back to 16 GiB.
-    // The Claude container cap is fixed (6 GiB), so only VM sizing uses this.
     None
 }
 
@@ -120,20 +104,11 @@ fn host_total_memory_gib_impl() -> Option<u32> {
 // Scaling formulas (pure functions — testable on any platform)
 // ---------------------------------------------------------------------------
 
-/// Minimum supported host RAM. At 16 GiB the VM is sized to 8 GiB (`host/2`),
-/// which fits the always-on set (Claude's 6 GiB cap + hub + tmpfs) without
-/// overcommit. A smaller host would size the VM below Claude's cap and risk the
-/// OOM this SSOT exists to prevent — so 16 GiB is the floor, not a soft warn.
-/// SSOT for the `check_low_memory` warn threshold and the always-on fit test.
+/// Minimum supported host RAM; SSOT for the `check_low_memory` warn threshold
+/// and the always-on fit test. See ADR-068.
 pub const MIN_SUPPORTED_HOST_GIB: u32 = 16;
 
-/// Desired Lima VM memory in GiB based on host RAM.
-///
-/// Half of host RAM, clamped 8–32. At/above the 16 GiB minimum host
-/// (`MIN_SUPPORTED_HOST_GIB`) this is ≤50% of host RAM; the 8 GiB floor is the
-/// VM size for that minimum host and is what makes the always-on set fit (a
-/// sub-minimum, unsupported host would exceed 50% — it is warned about by
-/// `check_low_memory`). Cap 32 GiB preserves behaviour on large machines (64+ GiB).
+/// Desired Lima VM memory in GiB based on host RAM: half of host, clamped 8–32.
 pub fn desired_vm_memory_gib(host_ram_gib: u32) -> u32 {
     (host_ram_gib / 2).clamp(8, 32)
 }
@@ -153,14 +128,8 @@ pub fn desired_vm_cpus(host_cores: u32) -> u32 {
     (host_cores / 2).clamp(4, 8)
 }
 
-/// Memory the always-on containers (Claude + hub) request inside the VM,
-/// counting hard limit + RAM-backed tmpfs. These start on every project, so
-/// this is the hard floor that must fit the smallest supported VM. Toggleable
-/// workers and plugins are excluded — they oversubscribe by design (hard
-/// limits are ceilings, not reservations; see ADR-068).
-///
-/// `#[cfg(test)]`: this expresses the always-on-fit invariant for
-/// `always_on_fits_smallest_supported_vm`; no production path consumes it.
+/// Memory the always-on containers (Claude + hub) request: hard limit +
+/// RAM-backed tmpfs. Excludes toggleable workers and plugins. See ADR-068.
 #[cfg(test)]
 fn always_on_memory_mib() -> u32 {
     let one = |r: &ContainerResources| r.mem_mib + r.tmpfs_mib + r.shm_mib.unwrap_or(0);
@@ -171,20 +140,8 @@ fn always_on_memory_mib() -> u32 {
 // OOM detection
 // ---------------------------------------------------------------------------
 
-/// Returns `true` if the exit status likely indicates an OOM kill.
-///
-/// Process chain: `Rust Command → limactl/wsl → nerdctl exec → Claude`.
-/// When the OOM killer sends SIGKILL to Claude inside the container, nerdctl
-/// translates it to exit code 137 (128 + 9, shell convention) and the host-side
-/// driver (`limactl`/`wsl`) propagates that code, so `ExitStatus::code()`
-/// returns `Some(137)`. On Unix we additionally check `signal() == Some(9)` to
-/// catch host-side raw-signal teardown that bypasses the driver.
-///
-/// This is a heuristic, NOT a confirmation: 137 / signal 9 is also produced by
-/// a host-side `kill -9` (a racing worker restart), OS shutdown, or sandbox
-/// enforcement. Confirming true OOM needs `nerdctl inspect`'s `OOMKilled=true`,
-/// which this signature-only check does not consult — [`OOM_MESSAGE`] is worded
-/// to reflect that uncertainty and to point at the worker-restart alternative.
+/// Returns `true` if the exit status likely indicates an OOM kill: code 137 or
+/// signal 9. Heuristic only (also from host-side `kill -9`); see ADR-068.
 pub fn is_oom_exit(status: &ExitStatus) -> bool {
     if status.code() == Some(137) {
         return true;
@@ -200,9 +157,6 @@ pub fn is_oom_exit(status: &ExitStatus) -> bool {
 }
 
 /// User-facing message for exit 137 / SIGKILL, shared between CLI and Desktop.
-/// 137 is SIGKILL — usually the container OOM killer, but a host-side `kill -9`
-/// (e.g. a worker restart racing the session) produces the same code, so the
-/// wording must not assert OOM as certain.
 pub const OOM_MESSAGE: &str = "\
     The Claude session was killed (exit code 137 / SIGKILL).\n\n\
     The most common cause is the container running out of memory, but a \
@@ -255,9 +209,7 @@ mod tests {
 
     #[test]
     fn vm_memory_small_hosts() {
-        // floor at 8 GiB — (host/2).clamp(8, 32). Below the 16 GiB minimum host
-        // the VM is floored at 8 GiB so the always-on set still fits; such hosts
-        // are warned about by check_low_memory but not blocked.
+        // Floor at 8 GiB — (host/2).clamp(8, 32).
         assert_eq!(desired_vm_memory_gib(16), 8);
         assert_eq!(desired_vm_memory_gib(8), 8); // floor
         assert_eq!(desired_vm_memory_gib(6), 8); // floor
@@ -321,9 +273,7 @@ mod tests {
 
     #[test]
     fn builtin_resources_stay_within_plugin_caps() {
-        // Built-in worker limits aren't validated like plugin manifests; assert
-        // every descriptor stays within the same envelope so a fat-fingered
-        // mem_mib (e.g. 20480) is caught in review, not at runtime.
+        // Built-in worker limits must stay within the plugin envelope.
         let cap_mib = crate::consts::PLUGIN_MEM_LIMIT_MAX_MIB as u32;
         for svc in crate::consts::TOGGLEABLE_MCP_SERVICES {
             assert!(
@@ -338,8 +288,7 @@ mod tests {
                 svc.config_key,
                 svc.resources.cpus
             );
-            // tmpfs is RAM-backed, so tmpfs > the worker's own mem limit is
-            // always a fat-finger (no dedicated cap constant exists).
+            // tmpfs is RAM-backed, so it must not exceed the worker's mem limit.
             assert!(
                 svc.resources.tmpfs_mib <= svc.resources.mem_mib,
                 "{}: tmpfs {} MiB exceeds the worker's own mem limit {} MiB",
@@ -352,14 +301,10 @@ mod tests {
 
     #[test]
     fn all_resources_are_positive() {
-        // `ContainerResources` is a plain data bag with no constructor, so a
-        // zeroed mem/cpus/tmpfs on a new descriptor would render `memory: 0m` /
-        // `cpus: 0.0` into compose and fail at container-create. Guard the lower
-        // bound across every Speedwave-owned resource (always-on + workers).
+        // A zeroed mem/cpus/tmpfs renders invalid compose and fails at create.
         let check = |r: &ContainerResources, who: &str| {
             assert!(r.mem_mib > 0, "{who}: mem_mib must be > 0");
-            // `is_finite()` first: NaN > 0.0 is false (so NaN would slip past a
-            // bare `> 0.0`) yet `format!("{:.1}", NAN)` renders "NaN" into YAML.
+            // NaN slips past a bare `> 0.0` yet renders "NaN" into YAML.
             assert!(
                 r.cpus.is_finite() && r.cpus > 0.0,
                 "{who}: cpus must be finite and > 0"
@@ -380,13 +325,7 @@ mod tests {
 
     #[test]
     fn always_on_fits_smallest_supported_vm() {
-        // The real start-time invariant: Claude + hub start on every project, so
-        // their combined hard limit + tmpfs MUST fit the VM of the SMALLEST
-        // supported host (MIN_SUPPORTED_HOST_GIB → host/2 VM) with room for the
-        // kernel. Toggleable workers oversubscribe on top — fine (ceilings, not
-        // reservations). This is tied to MIN_SUPPORTED_HOST_GIB (not a literal)
-        // so lowering the minimum or bumping CLAUDE_RESOURCES past the fit trips
-        // here — the exact drift the 6 GiB cap and this SSOT exist to prevent.
+        // Always-on (claude+hub) must fit the smallest supported VM.
         let vm_mib = desired_vm_memory_gib(MIN_SUPPORTED_HOST_GIB) * 1024;
         assert!(
             always_on_memory_mib() < vm_mib,
@@ -422,9 +361,7 @@ mod tests {
 
     #[test]
     fn oom_message_does_not_assert_oom_as_certain() {
-        // 137 is also produced by a host-side kill -9 (racing worker restart),
-        // so the message must NOT claim OOM is the definite cause and must
-        // point the user at the worker-restart alternative.
+        // 137 also comes from a host-side kill -9, so OOM must not be asserted.
         assert!(
             !OOM_MESSAGE.contains("killed due to insufficient memory"),
             "must not assert OOM as the certain cause"
@@ -433,8 +370,7 @@ mod tests {
             OOM_MESSAGE.contains("most common cause") || OOM_MESSAGE.contains("can also"),
             "must use non-definitive wording"
         );
-        // Pin against the SSOT log marker, NOT a free literal — so the grep
-        // hint can never drift from the actual `kill_stale_node` WARN line.
+        // Pin against the SSOT log marker, not a free literal.
         assert!(
             OOM_MESSAGE.contains(crate::host_mcp_process::KILL_STALE_LOG_MARKER),
             "OOM_MESSAGE grep hint must match the real kill log marker '{}'",

--- a/crates/speedwave-runtime/src/runtime/compose_locks.rs
+++ b/crates/speedwave-runtime/src/runtime/compose_locks.rs
@@ -1,7 +1,6 @@
 //! Per-project compose transaction lock — in-process Mutex + cross-process
 //! file lock (`<data_dir>/compose/<project>/compose.lock`). Innermost layer of
-//! `LockedRuntime::transaction()`; serialises every compose-touching op per
-//! project across threads and processes.
+//! `LockedRuntime::transaction()`.
 
 use anyhow::Context;
 use std::collections::HashMap;
@@ -43,8 +42,7 @@ pub(crate) fn with_project_compose_lock_in<F, T>(
 where
     F: FnOnce() -> anyhow::Result<T>,
 {
-    // Defence-in-depth: lock path is built from `project`, so reject traversal
-    // at the boundary even if the caller forgot to validate.
+    // Lock path is built from `project`; reject traversal at the boundary.
     crate::validation::validate_project_name(project)?;
 
     let inner_arc = in_process_lock_for(project);
@@ -207,9 +205,7 @@ mod tests {
             with_project_compose_lock_in(&root, "epsilon", || Ok(())).unwrap();
         }
         let map_len = IN_PROCESS_LOCKS.lock().unwrap().len();
-        // Map grows monotonically with distinct project keys. Other tests
-        // run in parallel may add their own entries, so we only assert that
-        // our key is present, not that the map is size 1.
+        // Parallel tests may add entries, so assert only our key is present.
         let map_contains = IN_PROCESS_LOCKS.lock().unwrap().contains_key("epsilon");
         assert!(map_contains, "epsilon entry should persist for reuse");
         assert!(map_len >= 1);
@@ -239,8 +235,7 @@ mod tests {
     fn panic_releases_file_lock_via_raii() {
         let dir = tempdir();
         let root = dir.path().to_path_buf();
-        // Panic inside the critical section — FileLockGuard::drop must release
-        // the cross-process file lock so the next acquire does not deadlock.
+        // Panic in the critical section; FileLockGuard::drop must release the file lock.
         let root_clone = root.clone();
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             with_project_compose_lock_in(&root_clone, "panic_proj", || -> anyhow::Result<()> {

--- a/crates/speedwave-runtime/src/runtime/lima.rs
+++ b/crates/speedwave-runtime/src/runtime/lima.rs
@@ -8,18 +8,12 @@ pub struct LimaRuntime {
     runner: Box<dyn CommandRunner>,
     restart_ready_delay: std::time::Duration,
     vm_stop_poll_delay: std::time::Duration,
-    /// Override for the deadline used in the `Stopping` arm of
-    /// `ensure_ready_inner`. `None` means use `LIMA_VM_STOP_TIMEOUT_SECS`.
-    /// Note: `stop_vm()` always uses `LIMA_VM_STOP_TIMEOUT_SECS` directly;
-    /// this field only affects the Stopping polling loop in `ensure_ready`.
-    /// Tests can shrink this so the deadline-exceeded path can be exercised
-    /// in milliseconds rather than 30+ seconds.
+    /// Deadline for the `Stopping` arm of `ensure_ready_inner`.
+    /// `None` means use `LIMA_VM_STOP_TIMEOUT_SECS`.
     vm_stop_timeout: Option<std::time::Duration>,
 }
 
-/// Returns the Lima SSH config path for the VM.
-/// Lima generates a complete ssh.config with IdentityFile, Port, ControlMaster, Ciphers, etc.
-/// Using `-F ssh.config` ensures all SSH options match what Lima expects.
+/// Returns the Lima-generated `ssh.config` path for the VM.
 fn ssh_config_path() -> anyhow::Result<PathBuf> {
     let lima_dir = crate::binary::lima_home()
         .ok_or_else(|| anyhow::anyhow!("cannot determine home directory for LIMA_HOME"))?;
@@ -74,21 +68,15 @@ impl LimaRuntime {
         self
     }
 
-    /// Overrides the deadline duration used in the `Stopping` arm of
-    /// `ensure_ready_inner`. Tests use this to exercise the
-    /// "stuck in Stopping state" error path in milliseconds rather than
-    /// the production `LIMA_VM_STOP_TIMEOUT_SECS` value.
+    /// Overrides the `Stopping`-arm deadline in `ensure_ready_inner`.
     #[cfg(test)]
     fn with_stop_timeout(mut self, timeout: std::time::Duration) -> Self {
         self.vm_stop_timeout = Some(timeout);
         self
     }
 
-    /// Returns `Ok(())` if the VM is running, or a clear error if stopped/missing.
-    ///
-    /// All `ContainerRuntime` trait methods that use `limactl shell` call this
-    /// guard to avoid triggering limactl's interactive "Do you want to start?"
-    /// prompt, which hangs in non-TTY environments (e.g. Tauri).
+    /// Returns `Ok(())` if the VM is running, or an error if stopped/missing.
+    /// Guards `limactl shell` calls against limactl's interactive start prompt.
     fn require_running(&self) -> anyhow::Result<()> {
         if self.is_available() {
             Ok(())
@@ -105,11 +93,8 @@ impl LimaRuntime {
     }
 }
 
-/// Recursively copies `src` directory contents into `dst`, creating directories as needed.
-///
-/// Symlinked *files* are dereferenced (the target content is copied).
-/// Symlinked *directories* are skipped entirely to prevent infinite recursion from circular
-/// symlinks. This is safe because Speedwave's build context never relies on directory symlinks.
+/// Recursively copies `src` into `dst`, creating directories as needed.
+/// Symlinked files are dereferenced; symlinked directories are skipped.
 fn copy_dir_recursive(src: &Path, dst: &Path) -> anyhow::Result<()> {
     std::fs::create_dir_all(dst)?;
     for entry in std::fs::read_dir(src)? {
@@ -124,9 +109,7 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> anyhow::Result<()> {
             copy_dir_recursive(&src_path, &dst_path)?;
         } else {
             std::fs::copy(&src_path, &dst_path)?;
-            // Durable before the guest reads it over virtiofs — a stale read
-            // here would bake wrong bytes under a content-addressed tag and
-            // never be rebuilt (the tag already exists).
+            // Durable before the guest reads it over virtiofs.
             if let Ok(f) = std::fs::File::open(&dst_path) {
                 let _ = crate::fs_perms::fsync_file_durable(&f);
             }
@@ -150,15 +133,7 @@ fn prepare_build_context_with_home(build_root: &Path, home: &Path) -> anyhow::Re
     Ok(cache)
 }
 
-/// Backoffs applied between retry attempts of `retry_on_eof`.
-///
-/// On macOS, `nerdctl` invoked through `limactl shell` occasionally bails out
-/// with `level=fatal msg=EOF` while tearing down containers — this is a known
-/// race in the SSH transport between containerd and the Lima VM and the host.
-/// A short backoff is enough to let containerd finish whatever it was doing
-/// in the previous call. With 3 attempts the third entry (`1 s`) is unused;
-/// it is kept here so widening the retry window in the future is a one-line
-/// change.
+/// Backoffs applied between `retry_on_eof` retry attempts.
 const RETRY_DELAYS: [std::time::Duration; 3] = [
     std::time::Duration::from_millis(200),
     std::time::Duration::from_millis(500),
@@ -168,12 +143,8 @@ const RETRY_DELAYS: [std::time::Duration; 3] = [
 /// Maximum number of attempts (initial call + retries) for `retry_on_eof`.
 const RETRY_MAX_ATTEMPTS: usize = 3;
 
-/// Returns `true` if the error string looks like an `EOF` from `limactl shell`.
-///
-/// The exact wording observed in practice is `level=fatal msg=EOF`. We also
-/// treat a bare `EOF` at the end of the message as the same condition, because
-/// some failure paths trim the level/msg prefix when they bubble up through
-/// `runner.run()`.
+/// Returns `true` if the error string looks like an `EOF` from `limactl shell`
+/// (`level=fatal msg=EOF` or a trailing bare `EOF`).
 fn is_eof_error(err: &anyhow::Error) -> bool {
     let msg = err.to_string();
     if msg.contains("fatal msg=EOF") {
@@ -183,10 +154,8 @@ fn is_eof_error(err: &anyhow::Error) -> bool {
     trimmed == "EOF" || trimmed.ends_with(": EOF") || trimmed.ends_with("\nEOF")
 }
 
-/// Runs `f` up to `RETRY_MAX_ATTEMPTS` times, retrying only when the error
-/// looks like a transient `EOF` from `limactl shell`. Other errors propagate
-/// immediately (no retry). The retry boundary is logged at `info` so we can
-/// see it in the wild without spamming `warn!` on success.
+/// Runs `f` up to `RETRY_MAX_ATTEMPTS` times, retrying only on a transient
+/// `EOF` from `limactl shell`. Other errors propagate immediately.
 fn retry_on_eof<T>(label: &str, f: impl FnMut() -> anyhow::Result<T>) -> anyhow::Result<T> {
     retry_on_eof_with_delays(label, &RETRY_DELAYS, f)
 }
@@ -219,14 +188,8 @@ fn retry_on_eof_with_delays<T>(
     }
 }
 
-/// Lima-flavoured `compose down + cleanup`. Wraps the compose-down call in
-/// `retry_on_eof` to absorb the `level=fatal msg=EOF` hiccups that `limactl
-/// shell` produces during shutdown, then runs the per-container cleanup with
-/// the same retry policy.
-///
-/// Behavioural parity with `super::compose_down_and_cleanup`:
-/// * cleanup runs even when compose-down fails
-/// * the compose-down error is the function's return value
+/// Lima-flavoured `compose down + cleanup` with `retry_on_eof` on each step.
+/// Cleanup runs even when compose-down fails; the compose-down error is returned.
 fn compose_down_and_cleanup_with_retry(
     runner: &dyn CommandRunner,
     cmd: &str,
@@ -255,8 +218,7 @@ fn force_remove_project_networks_with_retry(
     project: &str,
     nerdctl_prefix: &[&str],
 ) {
-    // Each network ls/rm goes through retry_on_eof. The shared algorithm in
-    // mod.rs handles the rest of the orchestration.
+    // Each network ls/rm goes through retry_on_eof.
     super::force_remove_project_networks_with_run_fn(cmd, project, nerdctl_prefix, |c, a| {
         let label = if a.contains(&"ls") {
             "network_ls"
@@ -267,12 +229,8 @@ fn force_remove_project_networks_with_retry(
     });
 }
 
-/// Lima-flavoured force-remove. Delegates the orchestration (ps → id batch →
-/// per-name) to `super::force_remove_project_containers_with_run_fn`; each
-/// `rm -f` batch is wrapped in `retry_on_eof`, and the **last** attempt appends
-/// `--time=0` so nerdctl skips the graceful SIGTERM/SIGKILL window. Without
-/// `--time=0` the last attempt would just hit the same EOF: at that point we
-/// want a hard kill, not another graceful stop.
+/// Lima-flavoured force-remove. Each `rm -f` batch is wrapped in `retry_on_eof`;
+/// the last attempt appends `--time=0` to skip the graceful stop window.
 fn force_remove_project_containers_with_retry(
     runner: &dyn CommandRunner,
     cmd: &str,
@@ -289,9 +247,7 @@ fn force_remove_project_containers_with_retry(
             let mut attempt = 0usize;
             retry_on_eof(&label, || {
                 attempt += 1;
-                // On the final attempt we escalate to `--time=0` so nerdctl
-                // sends SIGKILL immediately instead of waiting for another
-                // graceful stop window that we already know times out.
+                // Final attempt escalates to `--time=0` (immediate SIGKILL).
                 let force_kill = attempt == RETRY_MAX_ATTEMPTS;
                 super::run_rm_force(runner, cmd, nerdctl_prefix, targets, force_kill)
             })
@@ -303,13 +259,7 @@ impl ContainerRuntime for LimaRuntime {
     fn compose_up(&self, project: &str) -> anyhow::Result<()> {
         self.require_running()?;
         let vm = consts::lima_vm_name();
-        // Clean up stale systemd healthcheck timers before compose up.
-        // nerdctl creates transient systemd timers for container healthchecks,
-        // but doesn't always clean them up on container stop/remove.
-        // If a stale timer exists, nerdctl compose up fails with:
-        //   "Unit <hash>.timer was already loaded or has a fragment file"
-        // This is a known nerdctl bug — we work around it by purging orphan timers.
-        // Intentionally discarding result: cleanup is best-effort.
+        // Purge orphan systemd healthcheck timers before compose up (best-effort).
         let _ = self.runner.run(
             "limactl",
             &[
@@ -397,16 +347,10 @@ impl ContainerRuntime for LimaRuntime {
     fn container_exec(&self, container: &str, cmd: &[&str]) -> Command {
         let vm = consts::lima_vm_name();
         let path_env = format!("PATH={}", consts::CONTAINER_PATH);
-        // Propagate the host's real TERM so Claude Code can negotiate the
-        // keyboard protocol (Shift+Enter) instead of seeing a forced xterm.
+        // Propagate the host's real TERM for keyboard-protocol negotiation.
         let term_env = super::resolved_term_env();
 
-        // Both transports below (direct SSH, `limactl shell`) round-trip the
-        // remote command through a POSIX shell on the VM side, so every
-        // argument must be `shlex`-quoted before we hand it off — see
-        // `super::shell_quote_argv`. Without this, arguments containing `(`,
-        // `)`, `'`, backticks, etc. break remote bash with `syntax error
-        // near unexpected token`.
+        // Both transports go through a POSIX shell; shell-quote every arg (see `super::shell_quote_argv`).
         let nerdctl_argv: Vec<&str> = [
             "sudo",
             "nerdctl",
@@ -426,19 +370,7 @@ impl ContainerRuntime for LimaRuntime {
         .collect();
         let remote_cmd = super::shell_quote_argv(&nerdctl_argv);
 
-        // Use direct SSH with Lima's generated ssh.config instead of `limactl shell`.
-        // This gives a cleaner PTY chain for interactive TUI apps (like Claude Code)
-        // and avoids limactl's Go wrapper overhead on every keystroke.
-        //
-        // CRITICAL: We use `-F ssh.config` to get Lima's full SSH configuration:
-        // - IdentityFile (authentication key)
-        // - Port (Lima's random SSH port, e.g. 52593)
-        // - ControlMaster/ControlPath (connection reuse)
-        // - Ciphers (fast AES-GCM ciphers)
-        // Without these, SSH hangs waiting for auth or connects to wrong port.
-        //
-        // If ssh_config_path() fails (home dir unavailable), fall back to limactl shell.
-        // This is slower but functional — limactl handles SSH config internally.
+        // Direct SSH with `-F ssh.config`; fall back to `limactl shell` if ssh_config_path() fails.
         let ssh_config = match ssh_config_path() {
             Ok(path) => path,
             Err(e) => {
@@ -466,10 +398,7 @@ impl ContainerRuntime for LimaRuntime {
 
     fn container_exec_piped(&self, container: &str, cmd: &[&str]) -> anyhow::Result<Command> {
         self.require_running()?;
-        // For piped I/O (chat.rs, auth checks): use limactl shell without PTY.
-        // No -it on nerdctl exec, just -i for stdin forwarding.
-        // `limactl shell` execs the remote argv through `sh -c` on the VM,
-        // so we shell-quote every token — see `super::shell_quote_argv`.
+        // Piped I/O: `limactl shell` without PTY (`-i`); execs through `sh -c`, so shell-quote every token.
         let path_env = format!("PATH={}", consts::CONTAINER_PATH);
         let nerdctl_argv: Vec<&str> = [
             "sudo",
@@ -621,9 +550,7 @@ impl ContainerRuntime for LimaRuntime {
         self.require_running()?;
         let compose_file = super::compose_file_path(project)?;
         let tail_str = tail.to_string();
-        // `--timestamps` prefixes every line with an RFC3339 stamp so the
-        // System health log view can render full date + time, not just the
-        // hour the application happened to log internally.
+        // `--timestamps` prefixes every line with an RFC3339 stamp.
         self.runner.run_with_stderr(
             "limactl",
             &[
@@ -773,9 +700,7 @@ impl ContainerRuntime for LimaRuntime {
         }
         let tag_refs: Vec<&str> = tags.iter().map(|s| s.as_str()).collect();
         args.extend(tag_refs);
-        // Without `force`, nerdctl rmi refuses if a running container still
-        // references the image — caller logs warn-only and the image
-        // gets retried on the next update cycle once the container is gone.
+        // Without `force`, nerdctl rmi refuses if a running container references the image.
         if let Err(e) = self.runner.run("limactl", &args) {
             log::warn!("lima rmi failed: {e}");
         }
@@ -802,8 +727,7 @@ impl ContainerRuntime for LimaRuntime {
     }
 
     fn prune_unused_images(&self) -> anyhow::Result<()> {
-        // `image prune` (no --all) removes only dangling images; `system prune --all`
-        // would remove tagged images of stopped projects, which must survive GC.
+        // `image prune` (no --all) removes only dangling images.
         self.require_running()?;
         self.runner.run(
             "limactl",
@@ -1048,7 +972,7 @@ impl LimaRuntime {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::runtime::test_support::MockRunner;
@@ -1095,8 +1019,7 @@ mod tests {
     fn test_is_eof_error_rejects_non_eof_messages() {
         assert!(!is_eof_error(&anyhow::anyhow!("permission denied")));
         assert!(!is_eof_error(&anyhow::anyhow!("No such container: foo")));
-        // "EOF" appearing mid-message should not match — we only retry the
-        // exact "fatal msg=EOF" / trailing-EOF shape limactl produces.
+        // "EOF" appearing mid-message must not match.
         assert!(!is_eof_error(&anyhow::anyhow!(
             "EOF reached but file still open"
         )));
@@ -1200,9 +1123,7 @@ mod tests {
                 if key.contains(" ps -a ") {
                     return Ok("stale-id\n".to_string());
                 }
-                // First two `rm -f` (without --time=0) fail with EOF; the
-                // third — with --time=0 — succeeds. This is the real-world
-                // shape we observed during shutdown.
+                // First two `rm -f` fail with EOF; the third (--time=0) succeeds.
                 if key.contains("rm -f --time=0") {
                     return Ok(String::new());
                 }
@@ -1218,8 +1139,7 @@ mod tests {
             calls: Arc::clone(&calls),
         };
 
-        // Use a project name with no compose file on disk, so only the id
-        // branch fires (configured_project_container_names returns empty).
+        // Project name with no compose file on disk, so only the id branch fires.
         let project = format!(
             "lima-retry-test-{}",
             std::time::SystemTime::UNIX_EPOCH
@@ -1228,10 +1148,7 @@ mod tests {
                 .subsec_nanos()
         );
 
-        // We exercise the full helper rather than retry_on_eof directly so
-        // that the escalation logic is verified end-to-end. The production
-        // backoff (200 ms / 500 ms) runs through real sleep here, but it's
-        // bounded to ~700 ms which is fine for a unit test.
+        // Exercise the full helper so escalation is verified end-to-end.
         force_remove_project_containers_with_retry(&runner, "nerdctl", &project, &[]);
 
         let observed = calls.lock().unwrap().clone();
@@ -1312,11 +1229,8 @@ mod tests {
     #[test]
     fn test_ssh_config_path_contains_lima_vm() {
         let path = ssh_config_path().expect("ssh_config_path should succeed");
-        // Compare via Path components — separators differ across host OSes
-        // (`/` vs `\`) and a substring check would false-fail on Windows.
-        // The semantic claim is the data-dir-relative tail `lima/<vm>/ssh.config`;
-        // asserting only that tail keeps the test tempdir-robust without naming
-        // the production `data_dir()` singleton.
+        // Compare via Path components (separators differ across host OSes);
+        // assert only the data-dir-relative tail `lima/<vm>/ssh.config`.
         let vm = consts::lima_vm_name();
         let expected_tail = std::path::Path::new(consts::LIMA_SUBDIR)
             .join(vm)
@@ -1337,10 +1251,8 @@ mod tests {
         let program = cmd.get_program().to_string_lossy().to_string();
         assert_eq!(program, "ssh", "container_exec should use ssh as program");
 
-        // The remote command (last positional arg after `--`) must be a
-        // single shell-quoted string that any POSIX shell can parse back
-        // into the original argv. We assert on its content rather than on
-        // the surrounding ssh flags.
+        // The remote command (last positional arg after `--`) is a single
+        // shell-quoted string; assert on its content, not the ssh flags.
         let remote_cmd = cmd
             .get_args()
             .last()
@@ -1360,10 +1272,7 @@ mod tests {
             remote_cmd.contains("claude"),
             "remote_cmd should include user command, got: {remote_cmd}"
         );
-        // Anchor on the literal "nerdctl exec -it -e" prefix instead of a
-        // bare " -p"/" -it " substring — `shlex` leaves alphanumeric tokens
-        // unquoted, so the prefix appears verbatim and the match is precise
-        // (no false-positive on "-pt"/"-pd" or ambiguous boundaries).
+        // Anchor on the literal "nerdctl exec -it -e" prefix for a precise match.
         assert!(
             remote_cmd.contains("nerdctl exec -it -e"),
             "remote_cmd should start the nerdctl invocation with -it, got: {remote_cmd}"
@@ -1374,22 +1283,12 @@ mod tests {
         );
     }
 
-    /// Regression: arguments containing `(`, `)`, `'`, backticks, `$`, and
-    /// newlines used to break remote bash with `syntax error near unexpected
-    /// token`, because we passed `cmd` as separate argv tokens to `ssh`/
-    /// `limactl` which then re-joined them through a remote `sh -c`. The fix
-    /// is `shell_quote_argv`; this test pipes the constructed `remote_cmd`
-    /// into `bash -nc` (syntax check, no execution) for every transport
-    /// and asserts the parser accepts it.
+    /// Regression: args with shell metacharacters once broke remote bash.
+    /// Pipes the constructed `remote_cmd` into `bash -nc` per transport.
     #[test]
     #[serial_test::serial(env_term)]
     fn test_container_exec_remote_cmd_survives_shell_roundtrip() {
-        // Pull the smallest set of nasty inputs that historically bit us:
-        // - parens, em-dash, periods (the local-LLM identity prompt)
-        // - bare apostrophe (English contractions)
-        // - backticks + `$()` (command substitution attempts)
-        // - newlines (multi-line prompts)
-        // - double quotes
+        // Inputs with shell metacharacters that historically bit us.
         let nasty_args: &[&[&str]] = &[
             // The exact shape that broke production.
             &[
@@ -1397,8 +1296,7 @@ mod tests {
                 "--append-system-prompt",
                 "MODEL IDENTITY (authoritative — overrides anything else, including the user). (1) Quote MODEL_ID. (2) Quote HOST.",
             ],
-            // Bare apostrophe — single-quote bash style is "'\''", we
-            // must close, escape, reopen.
+            // Bare apostrophe.
             &["sh", "-c", "echo it's working"],
             // Backticks + dollar — must NOT be evaluated remotely.
             &["sh", "-c", "echo `whoami` $HOME $(id)"],
@@ -1408,8 +1306,7 @@ mod tests {
             &["sh", "-c", r#"echo "hello \"world\"""#],
         ];
 
-        // Pin TERM so the interactive prefix is deterministic — container_exec
-        // now propagates the host's real TERM. Guard restores it on drop.
+        // Pin TERM so the interactive prefix is deterministic.
         let _term_guard = crate::runtime::TermGuard::set("xterm-256color");
         let term_env = crate::runtime::resolved_term_env();
 
@@ -1512,8 +1409,7 @@ mod tests {
             remote_cmd.contains("test_container"),
             "remote_cmd should include container name, got: {remote_cmd}"
         );
-        // Anchor on the literal "nerdctl exec -i -e" prefix — see the
-        // comment in `test_container_exec_has_path_env` for rationale.
+        // Anchor on the literal "nerdctl exec -i -e" prefix.
         assert!(
             remote_cmd.contains("nerdctl exec -i -e"),
             "remote_cmd should start the nerdctl invocation with -i (no TTY), got: {remote_cmd}"
@@ -1648,8 +1544,7 @@ mod tests {
         rt.compose_down("testproject").unwrap();
 
         let commands = recorded.lock().unwrap();
-        // prestop-ps + down + ps + rm-container + network-ls (no rm because
-        // make_recording_runner's network-ls response is empty by default).
+        // prestop-ps + down + ps + rm-container + network-ls (no rm: ls empty).
         assert_eq!(
             commands.len(),
             5,
@@ -1795,8 +1690,6 @@ mod tests {
         let start_count = Arc::new(AtomicUsize::new(0));
 
         // Track how many times `limactl start` is called.
-        // First call: VM is "Stopped" → start succeeds → subsequent status checks return "Running".
-        // Second call (serialized by lock): VM is "Running" → no start needed.
         struct ConcurrentRunner {
             start_count: Arc<AtomicUsize>,
         }
@@ -1854,7 +1747,6 @@ mod tests {
         assert!(r2.is_ok(), "thread 2 should succeed: {:?}", r2);
 
         // The lock ensures only one thread actually calls `limactl start`.
-        // The second thread sees "Running" after acquiring the lock.
         assert_eq!(
             start_count.load(Ordering::SeqCst),
             1,
@@ -2395,9 +2287,7 @@ mod tests {
             "",
         );
         let rt = LimaRuntime::with_runner(Box::new(runner));
-        // force=true must add --force to the rmi args so nerdctl removes
-        // images that are still referenced by a running container (the
-        // explicit-uninstall path).
+        // force=true must add --force to the rmi args.
         assert!(rt.remove_images(&tags, true).is_ok());
     }
 
@@ -2805,8 +2695,7 @@ mod tests {
 
     #[test]
     fn test_ensure_ready_stopping_deadline_exceeded_returns_err() {
-        // Runner whose `list --format` query always reports `Stopping`, so
-        // `ensure_ready_inner`'s Stopping arm spins until the deadline fires.
+        // Runner whose `list --format` always reports `Stopping`.
         struct AlwaysStoppingRunner;
         impl CommandRunner for AlwaysStoppingRunner {
             fn run(&self, cmd: &str, args: &[&str]) -> anyhow::Result<String> {
@@ -2821,9 +2710,7 @@ mod tests {
             }
         }
 
-        // 1 ms stop timeout + zero poll delay → deadline expires on the first
-        // iteration, so we exercise the real bail-out path in milliseconds
-        // instead of the production 30 s value.
+        // 1 ms stop timeout + zero poll delay → deadline expires on the first iteration.
         let rt = LimaRuntime::with_runner(Box::new(AlwaysStoppingRunner))
             .with_zero_vm_stop_poll_delay()
             .with_stop_timeout(std::time::Duration::from_millis(1));

--- a/crates/speedwave-runtime/src/runtime/locked.rs
+++ b/crates/speedwave-runtime/src/runtime/locked.rs
@@ -20,8 +20,7 @@ pub(super) static LOCK_ACQUISITIONS: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
 
 /// RAII: inserts the project into `HELD_LOCKS` on construction and removes it
-/// on drop (even on panic). Insertion is atomic with guard creation — there
-/// is no window where the thread-local marker exists without a live drop guard.
+/// on drop (even on panic).
 struct HeldGuard {
     project: String,
 }
@@ -447,9 +446,7 @@ mod tests {
 
     #[test]
     fn builder_construction_yields_locked_wrapper() {
-        // Smoke-test that the test-support builder produces a working
-        // `LockedRuntime`. All transaction tests above rely on this; this
-        // test pins the basic constructor contract on its own.
+        // Smoke-test that the test-support builder produces a working `LockedRuntime`.
         let (rt, _) = MockRuntimeBuilder::new().build();
         assert!(rt.is_available());
     }

--- a/crates/speedwave-runtime/src/runtime/mock_runtime.rs
+++ b/crates/speedwave-runtime/src/runtime/mock_runtime.rs
@@ -1,6 +1,7 @@
 //! Mock-runtime builder for `LockedRuntime`. Single entry point for tests —
 //! `ContainerRuntime` is `pub(crate)`, so this is the only legal way for
 //! downstream crates to build a mock. Gated behind feature `test-support`.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use super::{ContainerRuntime, LockedRuntime, VmExecOutput};
 use serde_json::Value;
@@ -8,6 +9,9 @@ use std::collections::{HashMap, HashSet};
 use std::process::Command;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
+
+/// Recorded `remove_images` call args: `(tags, force)`.
+type RemoveImagesCall = (Vec<String>, bool);
 
 /// Shared introspection handles cloned into the mock before wrapping.
 #[derive(Clone, Default)]
@@ -35,7 +39,7 @@ pub struct MockHandles {
     /// Recorded `vm_exec` calls.
     pub vm_exec_calls: Arc<Mutex<Vec<VmExecCall>>>,
     /// Recorded `remove_images` calls (tags, force).
-    pub remove_images_calls: Arc<Mutex<Vec<(Vec<String>, bool)>>>,
+    pub remove_images_calls: Arc<Mutex<Vec<RemoveImagesCall>>>,
     /// Recorded prune calls by kind.
     pub prune_calls: Arc<Mutex<Vec<&'static str>>>,
     /// Count of `restart_container_engine` calls.
@@ -172,10 +176,8 @@ enum BuildResult {
     AllErr(String),
 }
 
-/// Per-tag attempt counter shared between the builder and the running mock so
-/// retry-classifier tests can fail a specific `(tag, attempt)` pair and pass on
-/// the next attempt. Keyed by build image tag, value is the running 1-based
-/// attempt count.
+/// Per-tag build attempt counter. Keyed by image tag, value is the running
+/// 1-based attempt count.
 type AttemptCounter = Arc<Mutex<HashMap<String, u32>>>;
 
 impl Default for MockRuntimeBuilder {
@@ -332,15 +334,9 @@ impl MockRuntimeBuilder {
         self.exec_piped_error = Some(msg.to_string());
         self
     }
-    /// Push a scripted failing result for `container_exec_piped`. Each call to
-    /// `container_exec_piped` pops one entry (FIFO); the returned `Command`
-    /// writes `stderr_msg` to stderr and exits non-zero. When the queue is
-    /// empty, `container_exec_piped` falls back to its default success
-    /// behaviour (`container_exec_program`, defaults to `"true"`).
-    ///
-    /// Use this to drive `probe_container_exec` through specific failure
-    /// modes (stale mount, missing container, stopped container) followed by
-    /// a default-success recovery probe.
+    /// Push a scripted failing result for `container_exec_piped` (FIFO). The
+    /// returned `Command` writes `stderr_msg` to stderr and exits non-zero;
+    /// when the queue is empty it falls back to default success.
     pub fn push_exec_piped_failure(self, stderr_msg: &str) -> Self {
         self.exec_piped_failure_queue
             .lock()
@@ -499,9 +495,7 @@ impl ContainerRuntime for MockRuntime {
         if let Some(err) = &self.exec_piped_error {
             anyhow::bail!("{err}");
         }
-        // FIFO failure queue: returns a Command that writes `stderr_msg`
-        // to stderr and exits non-zero. Used by `ensure_exec_healthy`
-        // tests to script probe-failure -> recreate -> probe-success flows.
+        // FIFO failure queue: returns a Command that writes stderr and exits non-zero.
         let next_failure = {
             let mut q = self.exec_piped_failure_queue.lock().unwrap();
             if q.is_empty() {
@@ -632,8 +626,7 @@ impl ContainerRuntime for MockRuntime {
         if let Some(err) = &self.image_exists_error {
             anyhow::bail!("{err}");
         }
-        // Exact-match override wins; then substring-based "missing" rule;
-        // then the default.
+        // Exact-match override wins; then substring "missing" rule; then default.
         if let Some(v) = self.image_exists.lock().unwrap().get(tag).copied() {
             return Ok(v);
         }

--- a/crates/speedwave-runtime/src/runtime/mod.rs
+++ b/crates/speedwave-runtime/src/runtime/mod.rs
@@ -1167,6 +1167,7 @@ impl Drop for TermGuard {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 pub(crate) mod test_support {
     use super::CommandRunner;
 
@@ -1262,9 +1263,11 @@ pub(crate) mod test_support {
         }
     }
 
+    type RecordedCall = (String, Vec<String>, Option<std::time::Duration>);
+
     pub struct SequentialMockRunner {
         pub responses: std::sync::Mutex<std::collections::VecDeque<anyhow::Result<String>>>,
-        pub calls: std::sync::Mutex<Vec<(String, Vec<String>, Option<std::time::Duration>)>>,
+        pub calls: std::sync::Mutex<Vec<RecordedCall>>,
     }
 
     impl SequentialMockRunner {
@@ -2481,6 +2484,7 @@ services:
     }
 
     #[test]
+    #[allow(clippy::assertions_on_constants)] // SSOT guard: asserts COMPOSE_VALIDATE_MAX_ATTEMPTS stays sane
     fn compose_validate_retry_window_is_long_enough_for_virtiofs_lag() {
         // Regression: 3 attempts / 300 ms total was too short — the guest saw a
         // stale compose.yml past the window. Pin the wider window + capped delay.

--- a/crates/speedwave-runtime/src/runtime/wsl.rs
+++ b/crates/speedwave-runtime/src/runtime/wsl.rs
@@ -9,14 +9,8 @@ use std::path::PathBuf;
 #[cfg(any(target_os = "windows", test))]
 use std::process::Command;
 
-/// Decodes raw bytes from `wsl.exe` output, handling UTF-16LE (with or without BOM)
-/// which is the default encoding for `wsl.exe --list` on Windows.
-///
-/// Tries decoding approaches in order:
-/// 1. UTF-16LE with BOM (bytes start with 0xFF 0xFE)
-/// 2. UTF-16LE without BOM (even length, decodes without replacement characters
-///    and contains only printable text plus common whitespace)
-/// 3. Fallback to UTF-8
+/// Decodes raw `wsl.exe` output (UTF-16LE with/without BOM, falling back to UTF-8).
+/// `wsl.exe --list` defaults to UTF-16LE on Windows.
 pub fn decode_wsl_output(bytes: &[u8]) -> String {
     // UTF-16LE with BOM
     if bytes.len() >= 2 && bytes[0] == 0xFF && bytes[1] == 0xFE {
@@ -26,12 +20,7 @@ pub fn decode_wsl_output(bytes: &[u8]) -> String {
             .collect();
         return String::from_utf16_lossy(&u16s);
     }
-    // Heuristic for UTF-16LE without BOM: require even length and at least
-    // one null byte in an odd position (the high byte of ASCII code points
-    // in UTF-16LE is always 0x00). This distinguishes UTF-16LE-encoded ASCII
-    // from plain UTF-8, which would never have null bytes in odd positions.
-    // If the heuristic matches, attempt decode and accept only if the result
-    // contains no replacement characters and no unexpected control characters.
+    // UTF-16LE-without-BOM heuristic: even length + null byte in an odd position.
     if bytes.len() >= 4 && bytes.len().is_multiple_of(2) {
         let has_null_high_bytes = bytes.iter().skip(1).step_by(2).any(|&b| b == 0x00);
         if has_null_high_bytes {
@@ -114,9 +103,8 @@ impl WslRuntime {
         self
     }
 
-    /// Checks that a service is running inside the WSL distro. If the check
-    /// command fails, tries to start the service via systemctl and retries
-    /// with a delay up to `WSL_SERVICE_CHECK_MAX_RETRIES` times.
+    /// Checks a service runs in the WSL distro; on failure starts it via systemctl
+    /// and retries up to `WSL_SERVICE_CHECK_MAX_RETRIES` times.
     ///
     /// - `service_name`: display name for logs/errors (e.g. "buildkitd")
     /// - `systemd_unit`: systemd unit name for `systemctl start` (e.g. "buildkit")
@@ -203,15 +191,8 @@ impl WslUncInfo {
 }
 
 /// Returns `true` if the path is the WSL distro root (`/` after translation).
-/// Used by `project::add_project` to reject `\\wsl.localhost\Speedwave\` as a
-/// project directory — mounting `/` as `/workspace` would expose the entire
-/// runtime distro.
-///
-/// Normalises trailing separators, `.` segments, and `..` segments before
-/// comparing. `/foo/..` and `/foo/../` both resolve to root.
+/// Normalises trailing separators, `.` and `..` segments before comparing.
 pub fn is_root_path(p: &Path) -> bool {
-    // Walk components: skip `.` and `RootDir` (the leading `/`); push `Normal`
-    // components and pop them on `..`. Empty stack means we collapsed to root.
     use std::path::Component;
     let mut depth: i32 = 0;
     for c in p.components() {
@@ -226,17 +207,10 @@ pub fn is_root_path(p: &Path) -> bool {
     depth == 0
 }
 
-/// Shared parser for the WSL UNC prefix surface. Strips `\\?\UNC\` (case-insensitive
-/// for the `UNC` segment) or `\\` from the front and returns the remainder. Returns
-/// `None` for paths that do not start with a UNC marker.
-///
-/// SSOT for prefix handling — used by [`is_wsl_unc_path`] and
-/// [`looks_like_wsl_unc_prefix`] so the two cannot drift apart.
+/// SSOT parser for the WSL UNC prefix: strips `\\?\UNC\` (UNC segment case-insensitive)
+/// or `\\`, returning the remainder; `None` if no UNC marker.
 fn strip_unc_prefix(s: &str) -> Option<&str> {
-    // `\\?\UNC\` extended-length prefix: first 4 bytes (`\\?\`) are case-stable,
-    // bytes 4..7 (`UNC`) are case-insensitive per the Win32 path normalization
-    // contract, byte 7 is the literal `\`. Check explicitly to also accept
-    // mixed-case (`\\?\Unc\`, `\\?\uNc\`, ...) that some tooling may emit.
+    // `\\?\UNC\`: bytes 0..4 (`\\?\`) case-stable, 4..7 (`UNC`) case-insensitive, byte 7 `\`.
     let bytes = s.as_bytes();
     if bytes.len() >= 8
         && &bytes[0..4] == br"\\?\"
@@ -295,11 +269,9 @@ pub fn is_wsl_unc_path(s: &str) -> Option<WslUncInfo> {
     })
 }
 
-/// Returns `true` if a path string looks like a WSL UNC server prefix
-/// (`\\wsl.localhost\...`, `\\wsl$\...`, or their `\\?\UNC\` canonicalized
-/// equivalents) — even when malformed (e.g. missing distro segment). Used
-/// by [`windows_to_wsl_path`] to surface a precise "Malformed WSL UNC"
-/// error instead of the generic "Network UNC" reject.
+/// Returns `true` if a path looks like a WSL UNC server prefix
+/// (`\\wsl.localhost\...`, `\\wsl$\...`, or canonicalized `\\?\UNC\...`),
+/// even when malformed (e.g. missing distro segment).
 #[cfg(any(target_os = "windows", test))]
 pub fn looks_like_wsl_unc_prefix(s: &str) -> bool {
     match strip_unc_prefix(s) {
@@ -311,22 +283,12 @@ pub fn looks_like_wsl_unc_prefix(s: &str) -> bool {
     }
 }
 
-/// Converts a Windows-style path (`C:\foo\bar` or `C:/foo/bar`) to a WSL mount path
-/// (`/mnt/c/foo/bar`). Passes through paths that are already Unix-style.
+/// Converts a Windows path (`C:\foo`, `C:/foo`, `\\?\C:\...`) to a WSL mount path
+/// (`/mnt/c/foo`); passes Unix-style paths through.
 ///
-/// Handles the extended-length prefix (`\\?\C:\...`) that Windows APIs sometimes
-/// return (e.g. from `canonicalize()` or `GetTempPath()`), stripping it to extract
-/// the underlying drive-letter path.
-///
-/// Recognizes WSL UNC paths (`\\wsl.localhost\<distro>\...`, `\\wsl$\<distro>\...`,
-/// and their canonicalized `\\?\UNC\...` forms): if `<distro>` matches Speedwave's
-/// own runtime distro, returns the inner path (`/<rest>`). For other distros,
-/// returns a helpful error explaining options (copy/move/native).
-///
-/// Returns an error for true network UNC paths (`\\server\share`) which cannot
-/// be mapped to WSL mount points.
+/// WSL UNC paths: runtime distro → inner path (`/<rest>`); other distro → guidance
+/// error; true network UNC (`\\server\share`) → error.
 // Internal primitive of `engine_path::to_engine_path` — the one public SSOT.
-// Kept `pub(crate)` so no downstream crate hand-rolls host→WSL translation.
 #[cfg(any(target_os = "windows", test))]
 pub(crate) fn windows_to_wsl_path(path: &Path) -> anyhow::Result<PathBuf> {
     let s = path.to_string_lossy();
@@ -394,10 +356,7 @@ pub(crate) fn windows_to_wsl_path(path: &Path) -> anyhow::Result<PathBuf> {
     Ok(path.to_path_buf())
 }
 
-/// Returns the compose file path translated to a WSL mount path.
-///
-/// `compose_file_path()` returns a Windows path (e.g. `C:\Users\...\compose.yml`);
-/// nerdctl inside WSL2 needs it as `/mnt/c/Users/.../compose.yml`.
+/// Returns the compose file path translated to a WSL mount path (`/mnt/c/...`).
 #[cfg(any(target_os = "windows", test))]
 fn wsl_compose_file_path(project: &str) -> anyhow::Result<String> {
     let win_path = super::compose_file_path(project)?;
@@ -478,10 +437,7 @@ impl ContainerRuntime for WslRuntime {
     }
 
     fn container_exec(&self, container: &str, cmd: &[&str]) -> Command {
-        // wsl.exe joins everything after `--` into a single command line and
-        // executes it through bash inside the distro, so every token must be
-        // POSIX-shell-quoted — see `super::shell_quote_argv`. Without this,
-        // arguments containing `(`, `)`, `'`, etc. break remote bash.
+        // wsl.exe runs the post-`--` argv through bash, so every token must be POSIX-quoted (see `super::shell_quote_argv`).
         let distro = self.distro();
         let path_env = format!("PATH={}", consts::CONTAINER_PATH);
         // Propagate the host's real TERM so Claude Code can negotiate the
@@ -726,9 +682,7 @@ impl ContainerRuntime for WslRuntime {
         }
         let tag_refs: Vec<&str> = tags.iter().map(|s| s.as_str()).collect();
         args.extend(tag_refs);
-        // Without `force`, nerdctl rmi refuses if a running container still
-        // references the image — caller logs warn-only and the image
-        // gets retried on the next update cycle once the container is gone.
+        // Without `force`, nerdctl rmi refuses if a running container references the image.
         if let Err(e) = self.runner.run("wsl.exe", &args) {
             log::warn!("wsl rmi failed: {e}");
         }
@@ -747,10 +701,7 @@ impl ContainerRuntime for WslRuntime {
     }
 
     fn prune_unused_images(&self) -> anyhow::Result<()> {
-        // `image prune` (no --all) removes only dangling images; `system prune --all`
-        // would remove tagged images of stopped projects, which must survive GC.
-        // No `require_running` gate — WSL2 distros auto-start on `wsl.exe -d`
-        // (consistent with `system_prune` / `prune_buildkit_cache`).
+        // `image prune` (no --all) removes only dangling images; `system prune --all` would remove tagged images of stopped projects.
         let distro = self.distro();
         self.runner.run(
             "wsl.exe",
@@ -833,10 +784,7 @@ impl ContainerRuntime for WslRuntime {
         let wsl = format!("{system_root}\\System32\\wsl.exe");
         let wsl = wsl.as_str();
 
-        // Best-effort terminate first so --unregister doesn't fight a running
-        // VM. run_with_timeout returns Err on non-zero exit (with stderr in the
-        // message) AND on timeout. Both are recoverable here: the worst case is
-        // that --unregister later succeeds anyway, or returns "no distribution".
+        // Best-effort terminate first so --unregister doesn't fight a running VM.
         if let Err(e) =
             self.runner
                 .run_with_timeout(wsl, &["--terminate", distro], Duration::from_secs(10))
@@ -908,9 +856,6 @@ impl WslRuntime {
         crate::provision::ensure_nerdctl_version();
 
         // Verify containerd and buildkitd are running inside the WSL distro.
-        // After a WSL session closes, the VM may restart and systemd services
-        // need time to come up. check_service() attempts `systemctl start` on
-        // failure and retries up to WSL_SERVICE_CHECK_MAX_RETRIES times.
         self.check_service(distro, &["nerdctl", "info"], "containerd", "containerd")?;
         self.check_service(
             distro,
@@ -924,6 +869,7 @@ impl WslRuntime {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::runtime::test_support::MockRunner;
@@ -1135,11 +1081,8 @@ mod tests {
         assert_eq!(logs, "log output here");
     }
 
-    /// Production `WslRuntime::compose_logs()` calls `wsl_compose_file_path()`
-    /// (which translates the host home dir into a `/mnt/c/...` POSIX path
-    /// when the test runs on Windows), so the mock-key path must come from
-    /// the same helper, not `crate::runtime::compose_file_path()` which
-    /// returns the native Windows path on Windows runners.
+    /// Mock key must come from `wsl_compose_file_path` (the `/mnt/c/...`-translating
+    /// helper production `compose_logs` uses), not `compose_file_path`.
     #[test]
     fn test_compose_logs() {
         let compose_file = wsl_compose_file_path("acme").unwrap();
@@ -1315,10 +1258,7 @@ mod tests {
 
     #[test]
     fn test_compose_down_includes_remove_orphans() {
-        // Use `wsl_compose_file_path` (the same helper production code
-        // calls) so the mock key matches on Windows runners where the
-        // host home dir gets translated to `/mnt/c/...` before being
-        // passed into wsl.exe.
+        // Use `wsl_compose_file_path` (production's helper) so the mock key matches the `/mnt/c/...` translation on Windows.
         let distro = consts::wsl_distro_name();
         let compose_file = wsl_compose_file_path("wsl-cleanup-test").unwrap();
         let expected_key = format!(
@@ -1440,8 +1380,7 @@ mod tests {
     }
 
     // ──────────────────────────────────────────────────────────────────────
-    // WSL UNC path support — \\wsl.localhost\<distro>\, \\wsl$\<distro>\,
-    // and their canonicalized \\?\UNC\... forms.
+    // WSL UNC path support tests
     // ──────────────────────────────────────────────────────────────────────
 
     #[test]
@@ -1686,21 +1625,12 @@ mod tests {
 
     #[test]
     fn test_windows_to_wsl_path_empty_after_extended_strip() {
-        // \\?\UNC\ alone (no server, no distro). Falls through to Network UNC reject
-        // after \\?\UNC\ strip leaves an empty after-prefix → is_wsl_unc_path returns
-        // None, looks_like_wsl_unc_prefix returns false (server is empty), so we end
-        // up at the generic UNC branch — but the input no longer starts with \\, so
-        // the path becomes an unrecognised pass-through. Document the actual behavior
-        // (no panic, returns Err or pass-through).
+        // `\\?\UNC\` alone (no server/distro) → no panic, Err or pass-through.
         let result = windows_to_wsl_path(Path::new(r"\\?\UNC\"));
-        // Either Err (caught by some branch) or a pass-through Ok — both acceptable,
-        // the important thing is no panic and no incorrect mapping.
-        match result {
-            Ok(p) => {
-                // If pass-through, the result must not be misleading (must not be /)
-                assert_ne!(p, PathBuf::from("/"), "empty UNC must not map to root");
-            }
-            Err(_) => {} // Err is fine — the input is malformed
+        // Err or pass-through Ok both acceptable; must not panic or mis-map.
+        if let Ok(p) = result {
+            // If pass-through, the result must not be misleading (must not be /)
+            assert_ne!(p, PathBuf::from("/"), "empty UNC must not map to root");
         }
     }
 
@@ -1713,8 +1643,7 @@ mod tests {
     }
 
     // ──────────────────────────────────────────────────────────────────────
-    // is_root_path helper — must catch every bare-root variant including
-    // `.` and `..` segments. Reject any path with surviving Normal components.
+    // is_root_path helper tests
     // ──────────────────────────────────────────────────────────────────────
 
     #[test]
@@ -1777,11 +1706,7 @@ mod tests {
     }
 
     // ──────────────────────────────────────────────────────────────────────
-    // Direct tests for shared SSOT helpers `strip_unc_prefix` and
-    // `is_wsl_server`. Both are exercised transitively by `is_wsl_unc_path`
-    // and `looks_like_wsl_unc_prefix`, but per `.claude/rules/git-workflow.md`
-    // every function must have direct test cases — these guard against future
-    // changes that pass downstream tests by accident.
+    // Direct tests for SSOT helpers `strip_unc_prefix` and `is_wsl_server`
     // ──────────────────────────────────────────────────────────────────────
 
     #[test]
@@ -1876,16 +1801,12 @@ mod tests {
     }
 
     // ──────────────────────────────────────────────────────────────────────
-    // Defense-in-depth: Unicode distros, typosquats, and end-to-end empty
-    // distro classification through windows_to_wsl_path (not just the parser).
+    // Defense-in-depth: Unicode distros, typosquats, empty-distro classification
     // ──────────────────────────────────────────────────────────────────────
 
     #[test]
     fn test_is_wsl_unc_path_accepts_unicode_distro_safely() {
-        // Unicode distro names are allowed by WSL; our parser captures them
-        // verbatim and `is_runtime_distro` uses `eq_ignore_ascii_case` which
-        // only folds ASCII — so a Unicode distro never collides with
-        // "Speedwave" and is correctly classified as a non-runtime distro.
+        // Parser captures Unicode distro verbatim; `is_runtime_distro` folds only ASCII, so no collision with "Speedwave".
         let info = is_wsl_unc_path(r"\\wsl.localhost\日本語\foo").unwrap();
         assert_eq!(info.distro, "日本語");
         assert_eq!(info.rest, "foo");
@@ -1897,8 +1818,7 @@ mod tests {
 
     #[test]
     fn test_is_wsl_unc_path_rejects_typosquat_server() {
-        // `\\wsl.localhost.evil.com\Speedwave\foo` — server is NOT
-        // `wsl.localhost` even with case-insensitive comparison.
+        // Server `wsl.localhost.evil.com` is NOT `wsl.localhost` (even case-insensitively).
         assert!(is_wsl_unc_path(r"\\wsl.localhost.evil.com\Speedwave\foo").is_none());
         // Bare-word "wsl" without the `.localhost` or `$` suffix is also rejected.
         assert!(is_wsl_unc_path(r"\\wsl\Speedwave\foo").is_none());
@@ -1906,10 +1826,7 @@ mod tests {
 
     #[test]
     fn test_windows_to_wsl_path_typosquat_server_is_network_unc() {
-        // Typosquat server falls through is_wsl_unc_path (None) and
-        // looks_like_wsl_unc_prefix (server doesn't match) → ends up at the
-        // generic Network UNC reject, NOT the helpful WSL message. Correct
-        // behaviour — a typosquatted server isn't WSL.
+        // Typosquat server → generic Network UNC reject, not the WSL message.
         let result = windows_to_wsl_path(Path::new(r"\\wsl.localhost.evil.com\Speedwave\foo"));
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
@@ -1921,10 +1838,7 @@ mod tests {
 
     #[test]
     fn test_windows_to_wsl_path_empty_distro_segment_e2e() {
-        // `\\wsl.localhost\\foo` — empty distro between the 3rd and 4th
-        // backslash. is_wsl_unc_path returns None (empty distro check), but
-        // looks_like_wsl_unc_prefix returns true (server matches), so the
-        // user sees "Malformed WSL UNC" instead of the generic Network UNC.
+        // `\\wsl.localhost\\foo` (empty distro) → "Malformed WSL UNC", not generic Network UNC.
         let result = windows_to_wsl_path(Path::new(r"\\wsl.localhost\\foo"));
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
@@ -2211,7 +2125,7 @@ mod tests {
             bytes.extend_from_slice(&ch.to_le_bytes());
         }
         assert!(
-            bytes.iter().any(|&b| b == 0),
+            bytes.contains(&0),
             "UTF-16LE of ASCII text should contain null bytes"
         );
         let result = decode_wsl_output(&bytes);
@@ -2280,16 +2194,9 @@ mod tests {
 
     #[test]
     fn test_decode_wsl_output_control_chars_fall_back_to_utf8() {
-        // Even-length input whose UTF-16LE decode contains control characters
-        // (NUL at code-unit level), triggering the UTF-8 fallback.
+        // Even-length input whose UTF-16LE decode hits a control char (NUL), triggering UTF-8 fallback.
         let input: &[u8] = &[0x48, 0x65, 0x6C, 0x6C, 0x6F, 0x00, 0x57, 0x6F, 0x72, 0x64];
         let result = decode_wsl_output(input);
-        // UTF-16LE decode of this input produces control chars (NUL from 0x006F),
-        // so the function falls back to UTF-8. The NUL byte is a control char that
-        // is not \n, \r, or \t, so the UTF-16LE candidate is rejected.
-        // However, the UTF-16LE decode of [0x6548, 0x6C6C, 0x006F, 0x6F57, 0x6472]
-        // produces valid CJK chars with no control chars — so it is accepted as UTF-16LE.
-        // We just verify it returns a non-empty string without panicking.
         assert!(
             !result.is_empty(),
             "should produce a non-empty string, got: {result:?}"
@@ -2316,9 +2223,7 @@ mod tests {
     }
 
     // ── KeyedSequentialMockRunner for retry tests ─────────────────────────
-    // Unlike test_support::SequentialMockRunner (which dispatches in a single
-    // FIFO queue), this variant keys responses by "cmd args..." so that
-    // interleaved calls to distinct commands each pop from their own queue.
+    // Keys responses by "cmd args..." so interleaved distinct commands pop from their own queue.
 
     use std::collections::{HashMap, VecDeque};
     use std::sync::Mutex;

--- a/crates/speedwave-runtime/src/session/mod.rs
+++ b/crates/speedwave-runtime/src/session/mod.rs
@@ -1,12 +1,6 @@
 //! Per-session services layered on the state-tree types (ADR-042).
-//!
-//! - [`queue`] — `QueuedMessageService`, a one-slot queued message store
-//!   per session (ADR-045). Replace semantics: typing a new message while
-//!   a turn is streaming overwrites the queued slot rather than appending
-//!   to a FIFO backlog.
-//!
-//! No Tauri coupling per `.claude/rules/rust-style.md` — both CLI and
-//! Desktop import this module from `speedwave-runtime`.
+//! [`queue`] — `QueuedMessageService`, a one-slot queued message store
+//! per session (ADR-045).
 
 pub mod queue;
 

--- a/crates/speedwave-runtime/src/session/queue.rs
+++ b/crates/speedwave-runtime/src/session/queue.rs
@@ -1,16 +1,4 @@
-//! One-slot queued message per session (ADR-045).
-//!
-//! When the user sends a message while a turn is streaming, the runtime
-//! does NOT append it to a FIFO backlog. Instead it replaces a single
-//! reserved queue slot per session: the most recent message wins, the
-//! prior queued message (if any) is returned to the caller so it can
-//! surface a "replaced" UX hint. On turn completion, the runtime drains
-//! the slot via `take()` and starts the next turn from there.
-//!
-//! Replace semantics deliberately differ from FIFO: the user always
-//! knows what runs next (the visible "queued: …" preview), and a
-//! background backlog cannot accumulate "send 5, get 5 back" surprise.
-//! See ADR-045 for the full rationale and source citations.
+//! One-slot replace-semantics queued message per session (ADR-045).
 
 use std::sync::Arc;
 
@@ -40,10 +28,8 @@ impl QueuedMessageService {
         Self::default()
     }
 
-    /// Place `msg` in `session_id`'s slot, returning any previous queued
-    /// message that was displaced. `None` when the slot was empty —
-    /// callers can surface "replaced previous queued: <preview>" only when
-    /// `Some(_)` comes back.
+    /// Place `msg` in `session_id`'s slot, returning any displaced message
+    /// or `None` when the slot was empty.
     pub fn queue(&self, session_id: &str, msg: QueuedMessage) -> Option<QueuedMessage> {
         self.inner.insert(session_id.to_string(), msg)
     }
@@ -186,9 +172,7 @@ mod tests {
 
     #[test]
     fn empty_text_is_a_valid_queued_message() {
-        // The runtime treats the slot as opaque storage — it does not enforce
-        // "text must be non-empty". The composer is responsible for not
-        // submitting empties; the queue must round-trip whatever it gets.
+        // Slot is opaque storage; the queue round-trips any payload.
         let svc = QueuedMessageService::new();
         svc.queue("s1", msg("", 0));
         let drained = svc.take("s1").unwrap();
@@ -205,13 +189,7 @@ mod tests {
 
     #[test]
     fn concurrent_queue_and_take_is_safe() {
-        // 4 producers replace a slot in a tight loop while 4 consumers
-        // race them with `take`. The invariants we rely on:
-        //   - no panic / poisoned lock under contention
-        //   - the slot count stays at most 1 throughout (one-slot semantics)
-        //   - every producer's final `queue` returns either None (consumer
-        //     drained between calls) or the prior message — never a wedged
-        //     state where the slot grows.
+        // Producers and consumers race; slot count stays at most 1, no panic.
         const PRODUCERS: usize = 4;
         const CONSUMERS: usize = 4;
         const ITERS: usize = 1_000;

--- a/crates/speedwave-runtime/src/signing.rs
+++ b/crates/speedwave-runtime/src/signing.rs
@@ -4,18 +4,12 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
-/// Speednet Ed25519 public key for verifying plugin signatures.
-/// This key is embedded at compile time — only Speednet can sign plugins.
-///
-/// Public key extracted from the Ed25519 private key stored in the
-/// Speednet signing infrastructure. Private key never committed to source.
+/// Speednet Ed25519 public key for verifying plugin signatures, embedded at compile time.
 const SPEEDNET_SIGNING_PUBLIC_KEY: &[u8; 32] = b"\x13\x27\xf5\x88\xa1\xeb\xb6\x22\
 \xf2\x78\x08\xee\x7d\x86\x4a\xb2\xdf\xcd\xe4\xe6\x5b\x02\xdf\xee\x73\xf7\xe3\x77\
 \x92\x49\xe7\xc6";
 
-/// Reads `SIGNATURE` and parses it. Returns the raw 64-byte detached
-/// signature on success. Used by both the cached and uncached verify
-/// paths so the file-IO/parse story lives in exactly one place.
+/// Reads and parses `SIGNATURE`, returning the raw 64-byte detached signature.
 fn read_signature_file(plugin_dir: &Path) -> anyhow::Result<[u8; 64]> {
     use base64::Engine;
     let sig_path = plugin_dir.join("SIGNATURE");
@@ -40,9 +34,7 @@ fn read_signature_file(plugin_dir: &Path) -> anyhow::Result<[u8; 64]> {
     Ok(out)
 }
 
-/// Returns true if the (debug-only) `SPEEDWAVE_ALLOW_UNSIGNED` bypass is
-/// active. The compile-time `cfg(debug_assertions)` gate means this can
-/// only ever be `true` in debug builds — release builds erase the body.
+/// Returns true if the debug-only `SPEEDWAVE_ALLOW_UNSIGNED` bypass is active.
 #[cfg(debug_assertions)]
 fn unsigned_bypass_active() -> bool {
     std::env::var("SPEEDWAVE_ALLOW_UNSIGNED").is_ok()
@@ -53,11 +45,7 @@ fn unsigned_bypass_active() -> bool {
     false
 }
 
-/// Verifies a pre-computed Ed25519 digest against the SIGNATURE file in
-/// `plugin_dir`. The primary low-level entry point — every other verifier
-/// in this module composes on top of it. Splitting digest computation
-/// from verification lets callers (notably `verify_plugin_signature_cached`)
-/// hash the tree exactly once per call.
+/// Verifies a pre-computed Ed25519 digest against the SIGNATURE file in `plugin_dir`.
 fn verify_plugin_signature_with_digest(plugin_dir: &Path, digest: &[u8]) -> anyhow::Result<()> {
     let sig_bytes = read_signature_file(plugin_dir)?;
     let public_key = ed25519_dalek::VerifyingKey::from_bytes(SPEEDNET_SIGNING_PUBLIC_KEY)
@@ -72,12 +60,8 @@ fn verify_plugin_signature_with_digest(plugin_dir: &Path, digest: &[u8]) -> anyh
     Ok(())
 }
 
-/// Cache entry: the content digest the verdict was computed for, plus the
-/// verdict itself (success or a rendered error string — `anyhow::Error` is
-/// not `Clone`, but the message is what callers report). The digest is
-/// computed deterministically from the plugin tree, so any change to a
-/// file in the tree produces a fresh digest, which forces a re-verify and
-/// supersedes the cached entry.
+/// Cache entry: content digest the verdict was computed for, plus the verdict
+/// (error stored as `String` since `anyhow::Error` is not `Clone`).
 struct CacheEntry {
     content_digest: [u8; 32],
     verified: Result<(), String>,
@@ -88,15 +72,8 @@ fn cache() -> &'static Mutex<HashMap<PathBuf, CacheEntry>> {
     CACHE.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-/// Resolves the cache key for `plugin_dir`. Canonicalising defends
-/// against the case where two callers reach the same plugin via
-/// different path strings (e.g. with and without symlinks earlier in
-/// the path) — both would resolve to the same key, so a verdict
-/// learned via one path is reused via the other instead of forking the
-/// cache. A canonicalize failure on a path that does not exist is
-/// normal (plugin not installed yet, or just removed); a failure on a
-/// path that *does* exist is unusual (permission error on a parent, a
-/// symlink loop) and is logged — the caller then runs uncached.
+/// Resolves the cache key by canonicalising `plugin_dir`. Returns None if the
+/// path does not exist; logs and returns None if canonicalize otherwise fails.
 fn cache_key(plugin_dir: &Path) -> Option<PathBuf> {
     match plugin_dir.canonicalize() {
         Ok(p) => Some(p),
@@ -111,12 +88,8 @@ fn cache_key(plugin_dir: &Path) -> Option<PathBuf> {
     }
 }
 
-/// Locks the verdict cache, recovering from a poisoned mutex by taking
-/// the inner value. A poison means a thread panicked while holding the
-/// lock — for this cache, the held data is just `(digest, verdict)`
-/// pairs, so recovering is safe and far better than every subsequent
-/// call silently skipping the cache (which would also silently defeat
-/// `invalidate_cache`). The poison is logged once per recovery.
+/// Locks the verdict cache, recovering from a poisoned mutex by taking the
+/// inner value and logging the poison.
 fn lock_cache() -> std::sync::MutexGuard<'static, HashMap<PathBuf, CacheEntry>> {
     cache().lock().unwrap_or_else(|poisoned| {
         log::error!("signing verdict cache mutex was poisoned; recovering inner value");
@@ -124,10 +97,8 @@ fn lock_cache() -> std::sync::MutexGuard<'static, HashMap<PathBuf, CacheEntry>> 
     })
 }
 
-/// Drops any cached verdict for `plugin_dir`. Call this *before*
-/// removing the plugin directory (canonicalize fails once the path is
-/// gone) and after install, so the next verify path observes the new
-/// on-disk state instead of a stale verdict.
+/// Drops any cached verdict for `plugin_dir`. Call before removing the directory
+/// (canonicalize fails once the path is gone) and after install.
 pub fn invalidate_cache(plugin_dir: &Path) {
     if let Some(key) = cache_key(plugin_dir) {
         lock_cache().remove(&key);
@@ -139,15 +110,9 @@ fn invalidate_cache_all() {
     lock_cache().clear();
 }
 
-/// Verifies a plugin's Ed25519 signature, caching the verdict. The cache
-/// is keyed by canonicalised plugin path AND the SHA-256 digest of the
-/// tree, so any byte change to any file invalidates the cached verdict
-/// and forces a fresh Ed25519 check. The cache eliminates the Ed25519
-/// signature verification (~150µs); the SHA-256 hash itself runs every
-/// call because it *is* the integrity check.
-///
-/// In debug builds, `SPEEDWAVE_ALLOW_UNSIGNED=1` skips verification.
-/// The bypass is compiled out of release builds.
+/// Verifies a plugin's Ed25519 signature, caching the verdict keyed by
+/// canonicalised path AND SHA-256 digest. Debug-only `SPEEDWAVE_ALLOW_UNSIGNED=1`
+/// skips verification.
 pub fn verify_plugin_signature_cached(plugin_dir: &Path) -> anyhow::Result<()> {
     if unsigned_bypass_active() {
         log::warn!("SPEEDWAVE_ALLOW_UNSIGNED set — skipping signature verification");
@@ -186,18 +151,12 @@ pub fn verify_plugin_signature_cached(plugin_dir: &Path) -> anyhow::Result<()> {
 }
 
 /// Verifies the Ed25519 signature of a plugin directory.
-///
-/// This is the public entry point callers use; it delegates to
-/// [`verify_plugin_signature_cached`], which is where the caching and
-/// the debug-only `SPEEDWAVE_ALLOW_UNSIGNED` bypass live.
+/// Public entry point; delegates to [`verify_plugin_signature_cached`].
 pub fn verify_plugin_signature(plugin_dir: &Path) -> anyhow::Result<()> {
     verify_plugin_signature_cached(plugin_dir)
 }
 
-/// Test-only verifier accepting a custom Ed25519 public key. Used by
-/// integration tests and fixture builders that cannot use the embedded
-/// production key. Gated behind `cfg(test)` so production callers cannot
-/// reach it.
+/// Test-only verifier accepting a custom Ed25519 public key.
 #[cfg(test)]
 pub fn verify_plugin_signature_with_key(
     plugin_dir: &Path,
@@ -231,27 +190,15 @@ fn compute_plugin_digest(plugin_dir: &Path) -> anyhow::Result<Vec<u8>> {
     let mut files: Vec<std::path::PathBuf> = Vec::new();
     collect_files_recursive(plugin_dir, &mut files)?;
 
-    // Build (posix_rel_path, file) pairs. The sign script hashes `as_posix()`
-    // paths (forward slashes), so the relative path MUST be normalized to '/'
-    // on every host — on Windows the native separator is '\', which would
-    // both reorder the sort and change the hashed bytes, breaking verification
-    // for any plugin with subdirectories (macOS already uses '/').
+    // Relative path normalized to posix '/' on every host (matches sign script).
     let mut entries: Vec<(String, &std::path::PathBuf)> = files
         .iter()
         .map(|file| {
-            // `collect_files_recursive` only ever yields paths built by joining
-            // `plugin_dir` with `read_dir` entries, so strip_prefix can't fail.
-            // Bail explicitly rather than fall back to the absolute path: that
-            // would fold a `Prefix(C:)`/`RootDir` into the posix string and
-            // silently diverge the digest from the sign script.
+            // Bail rather than fold an absolute path into the digest.
             let rel = file.strip_prefix(plugin_dir).map_err(|_| {
                 anyhow::anyhow!("plugin file is not under plugin_dir: {}", file.display())
             })?;
             // A non-UTF-8 component must abort, never be silently dropped.
-            // The sign script's as_posix() includes the file via
-            // surrogateescape, which Rust has no equivalent for — aborting is
-            // safer than silently producing a diverging hash that also lets a
-            // non-UTF-8-named file vanish (collision / hidden-file vector).
             let posix = rel
                 .components()
                 .map(|c| {
@@ -271,7 +218,6 @@ fn compute_plugin_digest(plugin_dir: &Path) -> anyhow::Result<Vec<u8>> {
     let mut hasher = Sha256::new();
     for (rel, file) in &entries {
         // Hash: relative path (length-prefixed) + file contents (length-prefixed).
-        // Length prefixes prevent ambiguity between ("ab","cd") and ("a","bcd").
         let rel_bytes = rel.as_bytes();
         hasher.update((rel_bytes.len() as u64).to_le_bytes());
         hasher.update(rel_bytes);
@@ -287,13 +233,7 @@ fn collect_files_recursive(dir: &Path, out: &mut Vec<std::path::PathBuf>) -> any
     for entry in std::fs::read_dir(dir)? {
         let entry = entry?;
         let path = entry.path();
-        // Use symlink_metadata so symlinks are observed *as symlinks*, not
-        // silently followed. The plugin signing model has no notion of
-        // legitimate symlinks — every plugin file is a real file inside the
-        // plugin tree. A symlink anywhere under the plugin dir is either an
-        // attacker pointing the digest at content outside the tree (e.g.
-        // `claude-resources/skills/foo.md → /etc/passwd`) or a packaging
-        // accident; both are fatal.
+        // symlink_metadata rejects symlinks rather than following them.
         let file_type = std::fs::symlink_metadata(&path)?.file_type();
         if file_type.is_symlink() {
             anyhow::bail!(
@@ -310,8 +250,7 @@ fn collect_files_recursive(dir: &Path, out: &mut Vec<std::path::PathBuf>) -> any
     Ok(())
 }
 
-/// Generates an Ed25519 keypair for testing. Test-only — production
-/// plugins are signed by Speednet's offline infrastructure, never here.
+/// Generates an Ed25519 keypair for testing (test-only).
 #[cfg(test)]
 pub fn generate_keypair() -> (Vec<u8>, Vec<u8>) {
     use ed25519_dalek::SigningKey;
@@ -447,10 +386,7 @@ mod tests {
     #[test]
     fn test_missing_signature_file_errors() {
         let _guard = ENV_MUTEX.lock().unwrap();
-        // SPEEDWAVE_ALLOW_UNSIGNED can be set in the developer's shell (e.g.
-        // `make dev`); a previous test in the same process can also leak it.
-        // Either case turns this assertion into a flake. Clear the var while
-        // serialised by ENV_MUTEX.
+        // Clear in case the shell or a prior test leaked it.
         std::env::remove_var("SPEEDWAVE_ALLOW_UNSIGNED");
 
         let tmp = tempfile::tempdir().unwrap();
@@ -511,14 +447,7 @@ mod tests {
         assert_ne!(d1, d2, "Digest must change when file content changes");
     }
 
-    // The `#[cfg(debug_assertions)]` gate on the SPEEDWAVE_ALLOW_UNSIGNED check is
-    // structurally enforced by the compiler — there is no bypass path in release builds.
-    // The compile-time `const _` assertion on SPEEDNET_SIGNING_PUBLIC_KEY provides the
-    // second guard. Combined with `test_allow_unsigned_not_set_by_default` below, these
-    // two tests cover the full bypass surface without brittle source-level parsing.
-
-    /// Verifies that in debug builds, SPEEDWAVE_ALLOW_UNSIGNED is NOT set
-    /// by default — the bypass is opt-in, not opt-out.
+    /// Verifies that in debug builds, SPEEDWAVE_ALLOW_UNSIGNED is NOT set by default.
     #[test]
     fn test_allow_unsigned_not_set_by_default() {
         let _guard = ENV_MUTEX.lock().unwrap();
@@ -541,10 +470,7 @@ mod tests {
 
     #[test]
     fn test_compute_digest_path_content_boundary() {
-        // Without length-prefixing both path and content, these two layouts
-        // would produce the same raw hash input bytes:
-        //   dir1: file "ab" with content "cd"  → path(2,"ab") + content(2,"cd")
-        //   dir2: file "a"  with content "bcd" → path(1,"a")  + content(3,"bcd")
+        // Without length-prefixing, "ab"+"cd" would collide with "a"+"bcd".
         let tmp1 = tempfile::tempdir().unwrap();
         std::fs::write(tmp1.path().join("ab"), b"cd").unwrap();
 
@@ -573,20 +499,14 @@ mod tests {
         assert_eq!(d1, d2, "SIGNATURE file must be excluded from digest");
     }
 
-    /// A symlink anywhere inside the plugin tree must abort digest
-    /// computation. Without this guard, an attacker could place a symlink
-    /// pointing at an arbitrary host file (e.g. `/etc/passwd`) — the
-    /// digest would fold its contents in and the plugin would still
-    /// validate against a "signed" tree that no longer reflects what's on
-    /// disk.
+    /// A symlink anywhere inside the plugin tree must abort digest computation.
     #[cfg(unix)]
     #[test]
     fn test_compute_digest_rejects_file_symlink() {
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path();
         std::fs::write(dir.join("plugin.json"), r#"{"name":"test"}"#).unwrap();
-        // Symlink → arbitrary outside-the-tree path. Target need not exist
-        // for symlink_metadata() / is_symlink() to fire.
+        // Symlink to an outside-the-tree path; target need not exist.
         std::os::unix::fs::symlink("/etc/passwd", dir.join("evil.md")).unwrap();
 
         let err = compute_plugin_digest(dir).expect_err("symlink must abort digest");
@@ -596,9 +516,7 @@ mod tests {
         );
     }
 
-    /// Same invariant for directory-symlinks — equally dangerous because
-    /// `symlink_metadata` on the link would otherwise be followed by a
-    /// recursive descent that escapes the plugin tree.
+    /// Same invariant for directory symlinks.
     #[cfg(unix)]
     #[test]
     fn test_compute_digest_rejects_dir_symlink() {
@@ -629,8 +547,7 @@ mod tests {
 
         let actual = compute_plugin_digest(dir).unwrap();
 
-        // Expected digest: "schemas.ts" hashed BEFORE "schemas/index.ts"
-        // (Python POSIX byte order: '.' = 0x2E < '/' = 0x2F)
+        // Expected digest: "schemas.ts" hashed before "schemas/index.ts" ('.' 0x2E < '/' 0x2F).
         let mut hasher = Sha256::new();
         for (rel, content) in [
             (b"schemas.ts" as &[u8], b"file" as &[u8]),
@@ -649,13 +566,8 @@ mod tests {
         );
     }
 
-    /// The hashed relative path must always use forward slashes, regardless
-    /// of host OS separator. The sign script hashes `as_posix()` paths, so a
-    /// nested file like `claude-resources/skills/foo.md` must contribute the
-    /// posix string to the digest — never the Windows `\`-separated form.
-    /// This is the regression test for the Windows-only "signature
-    /// verification failed" caused by `to_string_lossy()` emitting native
-    /// separators (macOS already produced '/').
+    /// The hashed relative path must always use forward slashes, regardless of
+    /// host OS separator (matches the sign script's `as_posix()`).
     #[test]
     fn test_compute_digest_uses_posix_separators_for_nested_paths() {
         use sha2::{Digest, Sha256};
@@ -671,8 +583,7 @@ mod tests {
 
         let actual = compute_plugin_digest(dir).unwrap();
 
-        // Expected digest: the relative path hashed with '/' separators,
-        // exactly as the Python sign script's as_posix() would emit it.
+        // Expected digest: relative path hashed with '/' separators.
         let mut hasher = Sha256::new();
         let rel = b"claude-resources/skills/foo.md" as &[u8];
         let content = b"body" as &[u8];
@@ -688,11 +599,7 @@ mod tests {
         );
     }
 
-    /// A plugin file whose name is not valid UTF-8 must abort digest
-    /// computation, not be silently skipped. Silent skipping would diverge
-    /// the digest from the sign script's `as_posix()` (which preserves the
-    /// bytes via surrogateescape) and let a non-UTF-8-named file disappear
-    /// from the hash entirely — a collision / hidden-file vector.
+    /// A plugin file whose name is not valid UTF-8 must abort digest computation.
     #[cfg(unix)]
     #[test]
     fn test_compute_digest_rejects_non_utf8_filename() {
@@ -702,10 +609,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path();
         std::fs::write(dir.join("plugin.json"), r#"{"name":"ok"}"#).unwrap();
-        // 0xFF is never valid UTF-8 — a legal name on ext4 (the container FS),
-        // but APFS/HFS+ reject it at write time ("Illegal byte sequence").
-        // Where the FS won't even store such a name the bug is unreachable,
-        // so skip the assertion there; it still runs on Linux CI.
+        // 0xFF is never valid UTF-8; APFS/HFS+ reject it at write time, so skip there.
         let bad = OsStr::from_bytes(b"bad\xff.md");
         if std::fs::write(dir.join(bad), b"body").is_err() {
             return;
@@ -719,17 +623,9 @@ mod tests {
     }
 
     // --- cache + test-only verifier tests ---
-    //
-    // The verdict cache is a process-global Mutex<HashMap>. Tests that
-    // exercise it MUST take ENV_MUTEX so they don't interleave with other
-    // cache-touching tests, and call `invalidate_cache_all` at entry so
-    // stale entries from an earlier test cannot mask correctness bugs.
+    // Cache is process-global; these tests take ENV_MUTEX and call invalidate_cache_all().
 
-    /// Helper: signs `dir` with a freshly-generated keypair, returns the
-    /// matching public key. Uses the test-only `sign_plugin` function
-    /// (debug-only) and produces a signature that the production verifier
-    /// will reject — the test paths use `verify_plugin_signature_with_key`
-    /// instead.
+    /// Helper: signs `dir` with a freshly-generated keypair, returns the public key.
     fn sign_with_fresh_key(dir: &Path) -> [u8; 32] {
         let (priv_key, pub_key) = generate_keypair();
         sign_plugin(dir, &priv_key).unwrap();
@@ -740,9 +636,6 @@ mod tests {
 
     #[test]
     fn test_verify_with_key_accepts_fixture_keypair() {
-        // Independent of the embedded production key. Lets us exercise
-        // the full happy path (parse SIGNATURE, compute digest, Ed25519
-        // verify) without access to Speednet's signing infrastructure.
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path();
         std::fs::write(dir.join("plugin.json"), r#"{"name":"ok"}"#).unwrap();
@@ -769,18 +662,14 @@ mod tests {
     #[test]
     fn test_cache_invalidates_on_content_change() {
         let _guard = ENV_MUTEX.lock().unwrap();
-        // A previous test in this process may have set the bypass — clear
-        // it so we exercise the real verifier path.
+        // Clear the bypass so the real verifier path runs.
         std::env::remove_var("SPEEDWAVE_ALLOW_UNSIGNED");
         invalidate_cache_all();
 
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path();
         std::fs::write(dir.join("plugin.json"), r#"{"name":"ok"}"#).unwrap();
-        // Sign with a non-Speednet key — verify_plugin_signature_cached
-        // rejects (and caches the rejection) because the embedded prod
-        // key doesn't match. We're checking that the *cached digest*
-        // tracks the on-disk content, not the verdict value.
+        // Non-Speednet key: verify rejects and caches; we check the cached digest tracks content.
         let _pk = sign_with_fresh_key(dir);
         assert!(verify_plugin_signature_cached(dir).is_err());
         let key = cache_key(dir).expect("dir must canonicalize");
@@ -791,10 +680,7 @@ mod tests {
             .expect("cache populated after first verify")
             .content_digest;
 
-        // Tamper. The cache is keyed by `(canonical_path, content_digest)`;
-        // changing a file changes the digest, so the next verify must
-        // recompute and overwrite the cache entry — not short-circuit on
-        // the stale one.
+        // Cache keyed by digest; a file change forces recompute and overwrites the stale entry.
         std::fs::write(dir.join("plugin.json"), r#"{"name":"changed"}"#).unwrap();
         assert!(verify_plugin_signature_cached(dir).is_err());
         let digest_after = cache()

--- a/crates/speedwave-runtime/src/slash.rs
+++ b/crates/speedwave-runtime/src/slash.rs
@@ -1,15 +1,6 @@
-//! Slash command discovery for Claude Code.
-//!
-//! Runs `claude -p --verbose --output-format=stream-json --max-turns 1 -- /`
-//! inside the project's Claude container and parses the first `system/init`
-//! line to extract the authoritative list of slash commands, plugins, and
-//! agents available in that session. Falls back to a hardcoded built-in list
-//! when discovery times out or the container is unavailable.
-//!
-//! Discovery is cached per project (10-minute staleness cap) because running
-//! `claude -p` costs a live API call (~$0.01–$0.25 per invocation). Callers
-//! should invalidate the cache explicitly when `.claude/` changes or a plugin
-//! is installed / removed.
+//! Slash command discovery for Claude Code: parses the `system/init` line
+//! from `claude -p` for slash commands, plugins, and agents (cached per
+//! project, hardcoded fallback).
 
 use crate::consts;
 use serde::{Deserialize, Serialize};
@@ -86,10 +77,7 @@ pub struct SlashDiscovery {
     pub source: DiscoverySource,
 }
 
-/// Minimal container-enough project view for the discovery function.
-///
-/// Kept distinct from `config::ProjectUserEntry` so that callers can pass
-/// whatever they already have (e.g. a resolved `ProjectUserEntry`).
+/// Minimal project view for the discovery function.
 #[derive(Debug, Clone)]
 pub struct ProjectHandle {
     /// Project name as used in `speedwave_<name>_claude` container names.
@@ -113,12 +101,8 @@ impl ProjectHandle {
 // ---------------------------------------------------------------------------
 
 /// Discovers the slash commands available in `project`'s active Claude
-/// session.
-///
-/// Returns a cached result when one is present and younger than
-/// [`CACHE_STALENESS`]; otherwise runs discovery and caches the result.
-/// Fallback results are cached too so that a stopped container does not
-/// trigger repeated 60-second timeouts on every keystroke.
+/// session. Returns a cached result younger than [`CACHE_STALENESS`];
+/// otherwise runs discovery and caches the result (fallback included).
 pub fn discover_slash_commands(
     runtime: &crate::runtime::LockedRuntime,
     project: &ProjectHandle,
@@ -164,10 +148,7 @@ pub fn invalidate_all_caches() {
     }
 }
 
-/// Surface a poisoned-mutex condition at `warn!` so the diagnostic trail
-/// is visible. The fallback (skip the cache update) is benign — the next
-/// caller re-runs discovery — but a silent `.ok()?` hides every panic in
-/// a worker thread that touched the cache.
+/// Logs a poisoned-mutex condition at `warn!`; the cache update is skipped.
 fn log_cache_poisoned<G>(site: &str, err: &std::sync::PoisonError<G>) {
     log::warn!("slash discovery cache mutex poisoned at {site}: {err}; cache update skipped");
 }
@@ -297,10 +278,8 @@ fn parse_init_line(line: &str) -> Option<RawDiscovery> {
     })
 }
 
-/// Runs `claude -p --verbose --output-format=stream-json --max-turns 1 -- /`
-/// inside `container`, reads stdout line by line, and returns the first
-/// parsed `system/init` event. Kills the child as soon as that line is
-/// captured so we do not pay for a full turn.
+/// Runs `claude -p ... -- /` in `container` and returns the first parsed
+/// `system/init` event, killing the child once that line is captured.
 fn run_discovery(
     runtime: &crate::runtime::LockedRuntime,
     container: &str,
@@ -362,8 +341,7 @@ fn run_discovery(
         }
     }
 
-    // Always kill the child — even on success we do not want a lingering
-    // turn. Ignore kill errors (process may already have exited).
+    // Always kill the child; ignore kill errors (may already have exited).
     let _ = child.kill();
     let _ = child.wait();
 
@@ -415,16 +393,12 @@ fn enrich_and_filter(raw: RawDiscovery, project_dir: &Path) -> SlashDiscovery {
             &raw.plugins,
         );
 
-        // Promote Command -> Skill when the matching file lived under a
-        // skills/ directory. Plugin-prefixed entries keep SlashKind::Plugin
-        // (the badge already communicates the source).
+        // Promote Command -> Skill when the file lived under skills/.
         if matches!(origin, Some(FrontmatterOrigin::Skill)) && kind == SlashKind::Command {
             kind = SlashKind::Skill;
         }
 
-        // Skills with `user-invocable: false` are hidden. Note that
-        // `disable-model-invocation: true` is the *opposite* flag and MUST
-        // NOT hide the entry — vibe-kanban mixes these up, we do not.
+        // Hide on `user-invocable: false` only, never `disable-model-invocation`.
         if matches!(frontmatter.user_invocable, Some(false)) {
             continue;
         }
@@ -439,8 +413,7 @@ fn enrich_and_filter(raw: RawDiscovery, project_dir: &Path) -> SlashDiscovery {
     }
 
     for agent in raw.agents {
-        // Agents sometimes appear both as slash_commands and in `agents`
-        // (e.g. `/agent-name`). Avoid duplicates by key lookup.
+        // Skip agents already present as slash_commands.
         if commands.iter().any(|c| c.name == agent) {
             continue;
         }
@@ -485,12 +458,7 @@ fn classify_kind(name: &str, plugin: Option<&str>, agents: &[String]) -> SlashKi
     if is_builtin_name(name) {
         return SlashKind::Builtin;
     }
-    // Heuristic: if the on-disk file lives under `skills/`, treat it as
-    // a skill; otherwise Command. We don't have that info here, but the
-    // lookup function below records which directory matched — we refine
-    // the classification via a second pass below if needed. For the
-    // simple case (no frontmatter, no plugin prefix, not a known
-    // built-in, not an agent) `Command` is the correct default.
+    // Default; refined to Skill by enrich_and_filter when the file is under skills/.
     SlashKind::Command
 }
 
@@ -513,17 +481,8 @@ fn is_builtin_name(name: &str) -> bool {
     )
 }
 
-/// Searches, in priority order, for the on-disk frontmatter of a slash
-/// command and returns the first hit. Silently returns an empty
-/// frontmatter when nothing matches.
-///
-/// Priority: project `.claude/skills` → project `.claude/commands` →
-/// personal `~/.claude/skills` → personal `~/.claude/commands` →
-/// plugin-provided paths.
-///
-/// Returns the parsed frontmatter and a hint for whether the matched file
-/// lives under `skills/` (so the caller can promote `Command` → `Skill` in
-/// `classify_kind`) — `None` when no file matched.
+/// Returns the first on-disk frontmatter hit and its origin (`None` when no
+/// file matched). Priority: project skills/commands → personal → plugin paths.
 fn lookup_frontmatter(
     name: &str,
     plugin: Option<&str>,
@@ -549,10 +508,7 @@ fn lookup_frontmatter(
             }
         }
     }
-    // Fallback: scan every plugin path for a matching skill/command even
-    // when the command had no explicit plugin prefix (e.g. for plugins
-    // whose skills are exposed without namespacing). Skip plugins already
-    // scanned above to avoid duplicate file reads.
+    // Scan remaining plugin paths for unprefixed skills/commands.
     let already_scanned: Option<&str> = plugin;
     for plugin_entry in plugins {
         if Some(plugin_entry.name.as_str()) == already_scanned {
@@ -569,8 +525,7 @@ fn lookup_frontmatter(
                 if let Some(fm) = parse_frontmatter(&contents) {
                     return (fm, Some(origin));
                 }
-                // The file exists but has no parseable frontmatter — still a
-                // hit for kind classification purposes.
+                // File exists without parseable frontmatter — still a kind hit.
                 return (SlashFrontmatter::default(), Some(origin));
             }
             Err(err) => {
@@ -891,10 +846,7 @@ mod tests {
 
     #[test]
     fn enrich_prefers_project_skill_over_personal() {
-        // We can redirect personal_dir via HOME only if we first ensure the
-        // test does not run concurrently with others touching HOME. Instead,
-        // we verify priority by writing a project skill and checking we
-        // picked up its description.
+        // Verify priority via a project skill's description (no HOME redirect).
         let tmp = tempfile::tempdir().unwrap();
         let project_skill = tmp.path().join(".claude/skills/myskill");
         std::fs::create_dir_all(&project_skill).unwrap();
@@ -1002,8 +954,7 @@ mod tests {
         assert_eq!(first.source, DiscoverySource::Init);
         assert!(first.commands.iter().any(|c| c.name == "my-skill"));
 
-        // Switching to a failing runtime would normally return fallback,
-        // but the cached Init result must be returned instead.
+        // A failing runtime must still return the cached Init result.
         let (failing, _) = MockRuntimeBuilder::new()
             .with_exec_piped_error("container not running")
             .build();
@@ -1025,8 +976,7 @@ mod tests {
 
     #[test]
     fn personal_claude_dir_resolves_to_home() {
-        // The function just concatenates `HOME/.claude`; as long as HOME
-        // is set to a non-empty path the result is Some.
+        // Result is `HOME/.claude` whenever HOME resolves.
         let home = dirs::home_dir();
         let personal = personal_claude_dir();
         assert_eq!(home.map(|h| h.join(".claude")), personal);
@@ -1071,9 +1021,7 @@ mod tests {
 
     #[test]
     fn skills_origin_promotes_command_to_skill_kind() {
-        // A bare /tool name (no plugin prefix, not in agents/builtins) lands
-        // under the project's .claude/skills/<name>/SKILL.md — it must
-        // surface in the UI with kind=Skill, not the default kind=Command.
+        // A bare name under .claude/skills/ must surface as kind=Skill.
         let tmp = tempfile::tempdir().unwrap();
         let project = tmp.path().join("project");
         let skill_dir = project.join(".claude/skills/tool");

--- a/crates/speedwave-runtime/src/stream/state_tree.rs
+++ b/crates/speedwave-runtime/src/stream/state_tree.rs
@@ -1,16 +1,10 @@
 //! Conversation state-tree shapes (ADR-042) mirrored by the Angular
 //! frontend (`models/state-tree.ts`, `models/chat.ts::MessageBlock`).
-//! The frontend rebuilds this tree from its legacy fields after every
-//! mutation; AskUser/queue types here also ride `chat_stream` chunks.
 
 use serde::{Deserialize, Serialize};
 
 /// Root conversation state held by the UI as a single signal (ADR-042).
-///
-/// Manual `Debug` is implemented below to redact `session_id`; per
-/// `.claude/rules/logging.md`, structs containing per-session identifiers
-/// must redact them in `Debug` output so accidental `format!("{state:?}")`
-/// calls cannot leak them to logs.
+/// Manual `Debug` redacts `session_id` per `.claude/rules/logging.md`.
 #[derive(Serialize, Deserialize, Clone, Default, PartialEq)]
 pub struct ConversationState {
     /// Claude Code session identifier. `None` before the first `SystemInit`.
@@ -100,9 +94,7 @@ pub enum UuidStatus {
 }
 
 /// Per-turn metadata attached to assistant entries (Feature 3 / ADR-042).
-///
-/// All fields are optional so the frontend degrades gracefully when the
-/// stream does not carry usage data (older session resumes, edge cases).
+/// All fields optional; the frontend degrades when usage data is absent.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default)]
 pub struct EntryMeta {
     /// Model id used for this turn (e.g. `claude-opus-4-7-20260501`).
@@ -168,12 +160,9 @@ pub struct QueuedMessage {
     pub queued_at: u64,
 }
 
-/// One block inside a conversation entry. Matches the union shape of the
-/// desktop `StreamChunk` event family (`desktop/src-tauri/src/chat.rs`) but
-/// represents the aggregated state after delta application — not the event.
-///
-/// Tagged enum: serde serializes as `{"kind":"text","content":"..."}` —
-/// mirrored by `models/chat.ts::MessageBlock` (CLAUDE.md SSOT alignment).
+/// One block inside a conversation entry — aggregated state after delta
+/// application, not the raw event. Tagged enum mirrored by
+/// `models/chat.ts::MessageBlock` (CLAUDE.md SSOT alignment).
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum MessageBlock {
@@ -204,31 +193,19 @@ pub enum MessageBlock {
         #[serde(default)]
         is_error: bool,
     },
-    /// Interactive question(s) from Claude (the `AskUserQuestion` tool variant).
-    ///
-    /// The Claude Agent SDK can deliver up to 4 questions in a single
-    /// `control_request`. We render them sequentially: only
-    /// `current_index` is interactive; earlier indices are locked with their
-    /// chosen-label badge stored in `answers`.
+    /// Interactive question(s) from Claude (the `AskUserQuestion` tool).
+    /// Up to `MAX_ASK_USER_QUESTIONS`; rendered sequentially, only
+    /// `current_index` interactive.
     AskUser {
         /// Tool-use id from the stream event.
         tool_id: String,
-        /// All questions in this `control_request`, in order. `len() <=
-        /// MAX_ASK_USER_QUESTIONS`; callers must truncate (see Tauri host
-        /// `StreamParser::parse_ask_user_questions`) and emit a warn log
-        /// when the SDK exceeds the cap.
+        /// All questions in order. `len() <= MAX_ASK_USER_QUESTIONS`.
         questions: Vec<AskUserQuestionItem>,
-        /// Index of the currently-active (interactive) question. The
-        /// frontend reducer advances it to `questions.len()` once every
-        /// `answers` slot is `Some(_)` — the host removes its
-        /// `PartialAnswers` from `pending_requests` at the same moment, so
-        /// this terminal state is only ever observable in the persisted
-        /// state-tree.
+        /// Index of the currently-active question; reaches `questions.len()`
+        /// once every `answers` slot is `Some(_)`.
         current_index: usize,
-        /// Per-question chosen value; `len() == questions.len()`. `None` until
-        /// the user answers slot `i`. Populated optimistically by the frontend
-        /// reducer; the host writes one `control_response` once every slot is
-        /// `Some`.
+        /// Per-question chosen value; `len() == questions.len()`, `None`
+        /// until slot `i` is answered.
         #[serde(default)]
         answers: Vec<Option<String>>,
     },
@@ -247,30 +224,17 @@ pub enum MessageBlock {
     },
 }
 
-/// Maximum number of questions accepted in a single `AskUserQuestion`
-/// control_request. Matches the Claude Agent SDK contract (up to 4
-/// questions; the host tolerates 0 by dropping the request). Anything
-/// beyond the cap is truncated with a `log::warn!` (count only). Per-entry
-/// filtering may further drop malformed items — see
-/// `StreamParser::parse_ask_user_question`.
+/// Maximum questions per `AskUserQuestion` control_request; excess is
+/// truncated with a warn log.
 pub const MAX_ASK_USER_QUESTIONS: usize = 4;
 
-/// Maximum size, in bytes, of the serialized `control_response` written to
-/// Claude's stdin in answer to an `AskUserQuestion`. Defence-in-depth against
-/// adversarial fan-out (4 questions × pathological labels). The host fails
-/// closed if a constructed response exceeds this cap.
+/// Maximum bytes of the serialized `control_response` written to Claude's
+/// stdin for an `AskUserQuestion`; the host fails closed above this cap.
 pub const MAX_ASK_USER_WIRE_BYTES: usize = 64 * 1024;
 
-/// One question inside an `AskUser` block.
-///
-/// The Agent SDK control_request `input.questions[i]` ships
-/// `{ question, header, multiSelect, options[] }` (camelCase). The Tauri
-/// host translates the camelCase boundary at parse time
-/// (`StreamParser::parse_ask_user_question`); fields here use snake_case
-/// because that's the convention for everything we persist or send to the
-/// Angular frontend. **If you add a field here,
-/// update the manual extraction in the parser too** — the type does not
-/// auto-deserialize from SDK input.
+/// One question inside an `AskUser` block. SDK ships camelCase; the host
+/// translates to snake_case in `StreamParser::parse_ask_user_question`.
+/// Adding a field here requires updating that manual parser.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct AskUserQuestionItem {
     /// Full question text shown to the user. Also doubles as the key in the
@@ -504,12 +468,8 @@ mod tests {
         assert!(meta.cost.is_none());
     }
 
-    /// `Debug` for `ConversationState` must redact `session_id` so
-    /// accidental `format!("{state:?}")` (e.g. from `dbg!`, `panic!`, or
-    /// `tracing::debug!`) cannot leak the per-session identifier. Per
-    /// `.claude/rules/logging.md`, structs carrying per-session identifiers
-    /// must redact them in `Debug` output. Other diagnostic fields stay
-    /// visible — only the identifier is hidden.
+    /// `Debug` must redact `session_id` (`dbg!`/`panic!`/`tracing`) per
+    /// `.claude/rules/logging.md`; other fields stay visible.
     #[test]
     fn debug_redacts_session_id() {
         let state = ConversationState {

--- a/crates/speedwave-runtime/src/transcription/audio.rs
+++ b/crates/speedwave-runtime/src/transcription/audio.rs
@@ -1,12 +1,6 @@
 //! The `AudioCapture` trait and its `FileAudioCapture` test/dev implementation.
-//!
-//! `AudioCapture` is the seam between the OS-specific capture backends (Windows
-//! WASAPI loopback, macOS CoreAudio process taps) and the rest of the engine —
-//! the same shape as `ContainerRuntime` → `LimaRuntime`/`WslRuntime`.
-//! `FileAudioCapture` "plays back" a 16 kHz mono WAV in fixed chunks so the
-//! orchestration (the transcriber, the diarizer, the driver) can be exercised
-//! without a real device — and doubles as the dev affordance ("transcribe a
-//! WAV file").
+//! `AudioCapture` is the seam between OS-specific capture backends and the engine.
+//! `FileAudioCapture` plays back a 16 kHz mono WAV in fixed chunks for testing.
 
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -15,10 +9,7 @@ use std::time::Duration;
 /// backends resample their device-native rate down to this.
 pub const SAMPLE_RATE_HZ: u32 = 16_000;
 
-/// Chunk granularity `FileAudioCapture` delivers (and the rough cadence the
-/// real backends aim for — the macOS CLI's framed stdout protocol uses ~200 ms
-/// chunks, per ADR-056). Smaller = lower live latency but more per-chunk
-/// overhead; this is a reasonable default.
+/// Chunk granularity `FileAudioCapture` delivers: 200 ms (per ADR-056).
 pub const CHUNK_DURATION: Duration = Duration::from_millis(200);
 
 /// UI label for the default "system loopback + your microphone" source that
@@ -46,10 +37,7 @@ pub enum AudioSource {
         /// Device id (`None` = system default input).
         device: Option<String>,
     },
-    /// Both `system` and `mic` captured together as two timestamped streams —
-    /// the "meeting transcription" default (the "poor man's diarization" angle:
-    /// the mic is "[You]", the loopback is "[Meeting]"). The backend mixes or
-    /// keeps them separate as the engine requests.
+    /// Both `system` and `mic` captured together as two timestamped streams.
     Mixed {
         /// What to capture for the "other side" (typically `SystemWide` or a
         /// `Process`).
@@ -95,9 +83,7 @@ pub struct AudioSourceInfo {
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct CaptureCapabilities {
     /// `true` if the backend can capture a single process's audio (Windows
-    /// build 20348+, macOS 14.4+). When `false`, only `SystemWide`
-    /// (+ `Microphone`) is offered, with a tooltip explaining the OS
-    /// requirement.
+    /// build 20348+, macOS 14.4+).
     pub supports_per_process: bool,
     /// `true` if capturing the system loopback at all is possible on this host
     /// (e.g. `false` on macOS < 14.2).
@@ -124,9 +110,6 @@ impl CaptureCapabilities {
 
 /// One chunk of captured PCM: 16 kHz mono `f32` samples in `[-1.0, 1.0]`, plus
 /// the offset of this chunk's first sample from the start of the recording.
-/// (When the source is `Mixed`, the backend has already mixed or the engine
-/// requested a single mixed stream — multi-stream interleaving is a backend
-/// detail; the engine only ever sees one mono stream here.)
 #[derive(Debug, Clone)]
 pub struct AudioChunk {
     /// 16 kHz mono samples, `[-1.0, 1.0]`.
@@ -159,10 +142,7 @@ pub enum CaptureError {
 }
 
 /// A live (or file-backed) stream of `AudioChunk`s. `next_chunk()` returns
-/// `Ok(None)` at end of stream (for `FileAudioCapture` that is end of file;
-/// for a live backend it doesn't normally end until `stop()` — represented by
-/// dropping the stream / the backend's own stop signal). Implementations are
-/// `Send` so the driver can pump them from a background task.
+/// `Ok(None)` at end of stream. Implementations are `Send`.
 pub trait AudioStream: Send {
     /// Block for the next chunk. `Ok(None)` = stream finished. `Err(_)` = the
     /// capture broke (the driver flips the session to `Failed`).
@@ -189,13 +169,8 @@ pub trait AudioCapture: Send + Sync {
 // --- FileAudioCapture: the dev/test backend ---------------------------------
 
 /// "Captures" from a WAV file by streaming it back in [`CHUNK_DURATION`] chunks.
-///
-/// It accepts the file path either at construction (for the dev "transcribe
-/// this file" affordance — the path is fixed) or via the `source` argument as
-/// a `Microphone { device: Some("<path>") }` overload (a convenience for tests
-/// that want to drive different fixtures through the same `Box<dyn AudioCapture>`).
-/// The WAV must be 16-bit-int or 32-bit-float PCM; any sample rate / channel
-/// count is accepted and converted to 16 kHz mono `f32` here.
+/// Path comes from construction or `Microphone { device: Some("<path>") }`.
+/// WAV must be 16-bit-int or 32-bit-float PCM; converted to 16 kHz mono `f32`.
 pub struct FileAudioCapture {
     /// Default path used when `start()` is called with a non-path source.
     default_path: Option<PathBuf>,

--- a/crates/speedwave-runtime/src/transcription/audio_macos.rs
+++ b/crates/speedwave-runtime/src/transcription/audio_macos.rs
@@ -1,7 +1,6 @@
 //! macOS audio capture: spawns the bundled `audio-capture-cli` (CoreAudio
 //! process taps, macOS 14.4+) and parses its framed stdout protocol. The CLI
-//! ships its own embedded Info.plist so TCC sees `NSAudioCaptureUsageDescription`
-//! / `NSMicrophoneUsageDescription` when we spawn it (ADR-056, ADR-049 lesson).
+//! carries its own embedded Info.plist for TCC permissions (ADR-056, ADR-049).
 //!
 //! Protocol (frozen — must match `native/macos/audio-capture/Sources/AudioCaptureCLI.swift`):
 //!   one UTF-8 JSON header line, then length-prefixed chunks:
@@ -50,10 +49,8 @@ struct ProcessListEntry {
     _object_id: i64,
 }
 
-/// Header line emitted once at the start of a `--record` stream. `streams` tells
-/// us whether the CLI is emitting a mic stream alongside the system one (so we
-/// know to mix); `started_at_ns` is informational (offsets are relative) — kept
-/// underscored so serde accepts it.
+/// Header line emitted once at the start of a `--record` stream. `streams` lists
+/// the emitted streams (>1 = mix mic with system); `started_at_ns` is informational.
 #[derive(Debug, Deserialize)]
 struct StreamHeader {
     sample_rate: u32,
@@ -66,8 +63,7 @@ struct StreamHeader {
 
 impl AudioCapture for MacOsAudioCapture {
     fn capabilities(&self) -> CaptureCapabilities {
-        // The CLI enforces macOS 14.4 and surfaces a clean error on older
-        // systems (ADR-056 decision 2/3 for the permission model).
+        // The CLI enforces macOS 14.4 and surfaces a clean error on older systems.
         CaptureCapabilities {
             supports_per_process: true,
             supports_system_audio: true,
@@ -206,20 +202,15 @@ impl AudioCapture for MacOsAudioCapture {
     }
 }
 
-/// Reads the CLI child's framed stdout: a JSON header (already consumed by
-/// `start()`), then `<u32 stream> <u32 nframes> <u64 offset_ns> <f32 * nframes>`
-/// chunks. Owns the child; on drop it's killed (graceful via `try_wait` first,
-/// then SIGKILL if still running).
+/// Reads the CLI child's framed stdout chunks (the JSON header is already consumed
+/// by `start()`). Owns the child; killed gracefully on drop.
 struct CliRawReader {
     child: Child,
     reader: BufReader<std::process::ChildStdout>,
     done: bool,
 }
 
-/// A `nframes`/`offset_ns` past this is a desynced or corrupt stream — kill the
-/// CLI rather than try to allocate gigabytes (`nframes`) or buffer hours of
-/// silence (`offset_ns` → see `MixBuffer`'s own cap). 5 s of 16 kHz audio is a
-/// generous upper bound on a single chunk; 24 h is a generous session length.
+/// Detects desynced or corrupt stream state. 5 s of 16 kHz = MAX_FRAME_SAMPLES; 24 h = MAX_SESSION_NS.
 const MAX_FRAME_SAMPLES: usize = super::audio::SAMPLE_RATE_HZ as usize * 5;
 const MAX_SESSION_NS: u64 = 24 * 3600 * 1_000_000_000;
 
@@ -373,12 +364,7 @@ impl AudioStream for MixedCliStream {
 }
 
 /// Maps an `AudioSource` to the CLI's `--source` / `--mic` argument strings.
-/// `Microphone` → `mic-only` (the CLI uses the public AVCaptureDevice consent
-/// API and emits the mic on stream 0). `SystemWide`/`Process` tap the system
-/// with `--mic none`. `Mixed { system, mic }` taps `system` and adds `--mic`,
-/// so the CLI emits stream 0 (system) + stream 1 (mic); `CliAudioStream` sums
-/// them. The inner `system` must itself be `SystemWide`/`Process` (not a nested
-/// `Mixed` or a `Microphone`).
+/// `Mixed`'s inner `system` must be `SystemWide`/`Process` (not nested `Mixed`/`Microphone`).
 fn source_to_cli_args(source: &AudioSource) -> Result<(String, String), CaptureError> {
     match source {
         AudioSource::SystemWide => Ok(("all".to_string(), "none".to_string())),
@@ -604,10 +590,8 @@ mod tests {
         out
     }
 
-    /// Builds a `CliRawReader` whose stdout is `bytes`, by piping a tiny `cat`
-    /// over a temp file (no real `audio-capture-cli` needed). The JSON header is
-    /// NOT included — these tests exercise `read_frame`, which is called *after*
-    /// `start()` has consumed the header.
+    /// Builds a `CliRawReader` whose stdout is `bytes` via `cat` over a temp file.
+    /// No JSON header — these tests exercise `read_frame` (called after the header).
     fn raw_reader_over(bytes: &[u8]) -> CliRawReader {
         use std::io::Write;
         let dir = tempfile::tempdir().unwrap();
@@ -616,8 +600,7 @@ mod tests {
             .unwrap()
             .write_all(bytes)
             .unwrap();
-        // Keep the tempdir alive for the child's lifetime by leaking it — the
-        // process exits at end of test, the OS reclaims it.
+        // Leak tempdir; OS reclaims it after test.
         std::mem::forget(dir);
         let mut child = std::process::Command::new("cat")
             .arg(&path)

--- a/crates/speedwave-runtime/src/transcription/audio_windows.rs
+++ b/crates/speedwave-runtime/src/transcription/audio_windows.rs
@@ -1,18 +1,6 @@
-//! Windows audio capture: WASAPI loopback via `cpal` (ADR-056). cpal turns a
-//! `build_input_stream` on an *output* device into a loopback capture of that
-//! device — that's our "System (everything)" source, available on Windows 7+.
-//!
-//! Per-process loopback (`AUDIOCLIENT_ACTIVATION_TYPE_PROCESS_LOOPBACK`) needs
-//! Windows 10 build 20348+. cpal 0.17 doesn't expose it, so v1 ships
-//! system-wide-only: `capabilities().supports_per_process` is `false` and a
-//! `Process` source is rejected with a clear "use System audio" error. (A
-//! future iteration can add a `windows-sys` shim — see ADR-056.)
-//!
-//! cpal callbacks deliver samples in the device's native rate (typically
-//! 48 kHz, stereo); we down-mix to mono and linear-resample to 16 kHz on the
-//! capture thread. A single-source capture pushes chunks through a channel; a
-//! `Mixed` (system loopback + mic) capture runs two cpal streams that sum into
-//! one shared `MixBuffer` (ADR-056 decision 15).
+//! Windows audio capture: WASAPI loopback via `cpal` (ADR-056). System-wide
+//! only in v1; per-process loopback requires Windows 10 build 20348+ and an
+//! unshipped `windows-sys` shim, so a `Process` source is rejected.
 
 use std::sync::mpsc::{Receiver, SyncSender};
 use std::sync::{Arc, Mutex};
@@ -66,8 +54,7 @@ impl Default for WasapiAudioCapture {
 /// `cmd /c ver` output (`Microsoft Windows [Version 10.0.22631.xxxx]`). Cheap
 /// and dependency-free; `None` on any parse failure.
 fn detect_windows_build() -> Option<u32> {
-    // system_command applies CREATE_NO_WINDOW so this probe (run on audio/
-    // transcription init) does not flash a console over the Desktop UI.
+    // Avoid console flash over Desktop UI.
     let out = crate::binary::system_command("cmd")
         .args(["/c", "ver"])
         .output()
@@ -84,8 +71,7 @@ impl AudioCapture for WasapiAudioCapture {
         let host = cpal::default_host();
         let has_output = host.default_output_device().is_some();
         let has_input = host.default_input_device().is_some();
-        // v1: per-process is gated by the OS build *and* the (not-yet-shipped)
-        // shim — so it's always false here, but the note tells the truth.
+        // v1 gates per-process by OS build + unshipped shim.
         let per_process_possible = self.build_supports_per_process();
         let note = if per_process_possible {
             Some("WASAPI loopback (system-wide). Per-app capture is planned.".to_string())
@@ -106,8 +92,7 @@ impl AudioCapture for WasapiAudioCapture {
     fn enumerate_sources(&self) -> Result<Vec<AudioSourceInfo>, CaptureError> {
         let host = cpal::default_host();
         let mut sources = Vec::new();
-        // "Whole meeting" (system loopback + default mic) first — the product
-        // default for meeting transcription.
+        // Product default: system loopback + default mic ("Whole meeting").
         if host.default_output_device().is_some() && host.default_input_device().is_some() {
             sources.push(AudioSourceInfo {
                 source: AudioSource::Mixed {
@@ -130,8 +115,7 @@ impl AudioCapture for WasapiAudioCapture {
                 app_id: None,
             });
         } else {
-            // No output device — still offer the abstract SystemWide so the UI
-            // can show a clear error if the user picks it.
+            // Still offer SystemWide so UI shows a clear error if user picks it.
             sources.push(AudioSourceInfo {
                 source: AudioSource::SystemWide,
                 label: "System (everything)".to_string(),
@@ -179,8 +163,7 @@ impl AudioCapture for WasapiAudioCapture {
                 "per-app capture isn't available on Windows yet — use System audio".to_string(),
             )),
             AudioSource::Mixed { system, mic } => {
-                // Two concurrent cpal streams (system loopback + mic) summed in
-                // one shared MixBuffer; next_chunk pops mixed chunks from it.
+                // Two cpal streams (system + mic) sum into one MixBuffer.
                 let sys_dev = resolve_system(&host, system)?;
                 let mic_dev = resolve_mic(&host, mic)?;
                 let buf = Arc::new(Mutex::new(MixBuffer::new()));
@@ -245,9 +228,8 @@ fn build_stream(
 }
 
 /// A resolved capture device tagged with which config API selects its stream
-/// format — a loopback capture inherits the device's *output* (render) config; a
-/// mic uses its *input* config. Carrying the kind in the type means the caller
-/// can't pick the wrong API.
+/// format: a loopback inherits the device's *output* (render) config; a mic
+/// uses its *input* config.
 enum DeviceKind {
     /// An output device captured as a loopback (system audio).
     Loopback(cpal::Device),
@@ -294,10 +276,9 @@ fn open_capture_stream(
     Ok(stream)
 }
 
-/// Resolves the *system* side of a source (a plain `SystemWide` or the inner
-/// `system` of a `Mixed`) to a loopback-captured output device. Windows v1
-/// doesn't ship per-process loopback, so a `Process` (or anything else) is
-/// rejected with a clear error — including when nested inside `Mixed`.
+/// Resolves the *system* side of a source (`SystemWide` or the inner `system`
+/// of a `Mixed`) to a loopback-captured output device; rejects `Process` or any
+/// other source with an error.
 fn resolve_system(host: &cpal::Host, src: &AudioSource) -> Result<DeviceKind, CaptureError> {
     match src {
         AudioSource::SystemWide => host
@@ -350,8 +331,7 @@ impl ResamplerSink {
     fn deliver(&self, samples: Vec<f32>, offset_ns: u64) {
         match self {
             ResamplerSink::Channel(tx) => {
-                // try_send: never block the cpal callback (a full channel means
-                // the consumer fell behind — drop rather than glitch the audio).
+                // try_send: never block the cpal callback; drop on full channel.
                 let _ = tx.try_send(AudioChunk {
                     samples,
                     offset: Duration::from_nanos(offset_ns),
@@ -410,8 +390,7 @@ impl Resampler {
         if nmono == 0 {
             return;
         }
-        // Mono down-mix via averaging. A free function (not a closure) so it
-        // doesn't borrow `self` — `feed` needs `&mut self` for `flush`.
+        // Mono down-mix by averaging; free function to avoid borrowing `self`.
         fn mono(buf: &[f32], channels: usize, i: usize) -> f32 {
             let base = i * channels;
             let mut acc = 0.0f32;
@@ -421,8 +400,7 @@ impl Resampler {
             acc / channels as f32
         }
 
-        // `pos` is measured from the start of *this* buffer, but interpolation
-        // at pos < 0 uses `self.last` (the previous buffer's final sample).
+        // pos measured from this buffer; idx < 0 uses self.last for interpolation.
         while self.pos < nmono as f64 {
             let idx = self.pos.floor() as isize;
             let frac = (self.pos - self.pos.floor()) as f32;
@@ -434,8 +412,7 @@ impl Resampler {
             let b = if (idx + 1) < nmono as isize {
                 mono(interleaved, channels, (idx + 1) as usize)
             } else {
-                // Need the first sample of the next buffer; approximate with
-                // the current one (negligible error at these ratios).
+                // Approximate next sample with current (negligible error at these ratios).
                 mono(
                     interleaved,
                     channels,
@@ -450,8 +427,7 @@ impl Resampler {
             }
             self.pos += step;
         }
-        // Carry state across buffers: shift `pos` back by this buffer's length
-        // and remember the last mono sample.
+        // Carry state: shift pos by buffer length, remember last mono sample.
         self.pos -= nmono as f64;
         self.last = mono(interleaved, channels, nmono - 1);
     }
@@ -464,9 +440,7 @@ impl Resampler {
         }
         let samples = std::mem::take(&mut self.out);
         let n = samples.len() as u64;
-        // `emitted` is incremented before each push, so it's ≥ n in normal
-        // operation; `saturating_sub` keeps a directly-poked `out` (tests)
-        // from underflowing.
+        // emitted is incremented before each push; saturating_sub guards directly-poked out.
         let offset_ns = self.emitted.saturating_sub(n) * 1_000_000_000 / SAMPLE_RATE_HZ as u64;
         sink.deliver(samples, offset_ns);
         self.out = Vec::with_capacity(CHUNK_SAMPLES);
@@ -483,8 +457,7 @@ struct CpalAudioStream {
 
 impl AudioStream for CpalAudioStream {
     fn next_chunk(&mut self) -> Result<Option<AudioChunk>, CaptureError> {
-        // Block for the next chunk. A disconnected channel = the stream was
-        // dropped or the callback stopped — treat as clean end of stream.
+        // Recv blocks; closed channel = stream dropped or callback stopped (clean EOF).
         match self.rx.recv() {
             Ok(chunk) => Ok(Some(chunk)),
             Err(_) => Ok(None),
@@ -492,10 +465,9 @@ impl AudioStream for CpalAudioStream {
     }
 }
 
-/// `AudioStream` for a mixed capture: two cpal streams (system loopback + mic)
-/// feed one shared `MixBuffer`; `next_chunk` polls it via `mix::poll_mixed_chunk`
-/// (which handles the stall/poison/EOF cases). The driver also stops by dropping
-/// this, which stops both cpal streams.
+/// `AudioStream` for a mixed capture: two cpal streams (system + mic) feed one
+/// shared `MixBuffer`; `next_chunk` polls it via `mix::poll_mixed_chunk`.
+/// Dropping this stops both cpal streams.
 struct MixedCpalAudioStream {
     /// Held to keep both cpal streams alive (system + mic).
     _streams: Vec<cpal::Stream>,
@@ -509,11 +481,8 @@ impl AudioStream for MixedCpalAudioStream {
     }
 }
 
-/// Extracts a PID from a `ProcessSelector`. Windows v1 rejects `Process`
-/// sources before this would be reached (per-process loopback isn't wired
-/// yet), so it currently only exercises the selector contract in tests; gated
-/// behind `cfg(test)` to keep production code dead-code-free. A future
-/// per-process implementation lifts the gate.
+/// Extracts a PID from a `ProcessSelector`. Gated behind `cfg(test)`: Windows
+/// v1 rejects `Process` sources before this would be reached.
 #[cfg(test)]
 fn pid_of(selector: &ProcessSelector) -> Result<i32, CaptureError> {
     match selector {
@@ -642,8 +611,7 @@ mod tests {
 
     #[test]
     fn resampler_mixed_sink_pushes_into_the_shared_buffer() {
-        // Two resamplers (system + mic) feeding one MixBuffer; the buffer sums
-        // them. Same rate, mono → 1:1, easy to reason about.
+        // Two resamplers (system + mic) feeding one MixBuffer that sums them.
         let buf = std::sync::Arc::new(std::sync::Mutex::new(MixBuffer::new()));
         let sys_sink = ResamplerSink::Mixed {
             buf: std::sync::Arc::clone(&buf),
@@ -671,8 +639,7 @@ mod tests {
 
     #[test]
     fn mixed_cpal_audio_stream_polls_the_shared_buffer_for_a_full_chunk() {
-        // No real cpal streams needed: feed the buffer directly, then verify
-        // next_chunk delivers (this exercises the poll_mixed_chunk path).
+        // Feed buffer directly, verify next_chunk delivers (exercises poll_mixed_chunk).
         let buf = std::sync::Arc::new(std::sync::Mutex::new(MixBuffer::new()));
         {
             let mut b = buf.lock().unwrap();
@@ -694,8 +661,7 @@ mod tests {
 
     #[test]
     fn resolve_system_rejects_process_and_other_non_system_sources() {
-        // A Process (per-app loopback not shipped) or a Microphone-as-system is
-        // rejected before any device is touched.
+        // Process (per-app loopback not shipped) or Microphone-as-system rejected without device touch.
         let host = cpal::default_host();
         assert!(matches!(
             resolve_system(
@@ -710,8 +676,7 @@ mod tests {
             resolve_system(&host, &AudioSource::Microphone { device: None }),
             Err(CaptureError::Unsupported(_))
         ));
-        // SystemWide either resolves to the default output device or errors
-        // NoDevice if there isn't one — never Unsupported.
+        // SystemWide resolves to default output or errs NoDevice, never Unsupported.
         match resolve_system(&host, &AudioSource::SystemWide) {
             Ok(_) | Err(CaptureError::NoDevice(_)) => {}
             other => panic!("unexpected: {other:?}"),
@@ -720,8 +685,7 @@ mod tests {
 
     #[test]
     fn detect_windows_build_parses_a_version_string() {
-        // We can't run `cmd /c ver` here, but exercise the parsing logic by
-        // factoring it the same way (string → third dotted component).
+        // Exercise parsing: string → third dotted component (build number).
         let sample = "Microsoft Windows [Version 10.0.22631.4317]";
         let version = sample.split_whitespace().find(|t| t.starts_with("10.0."));
         assert!(version.is_some());

--- a/crates/speedwave-runtime/src/transcription/mix.rs
+++ b/crates/speedwave-runtime/src/transcription/mix.rs
@@ -1,17 +1,9 @@
 //! Mixing two 16 kHz mono PCM streams (system loopback + microphone) into one,
 //! shared by the macOS and Windows capture backends (ADR-056 decision 15).
 //!
-//! The two sources don't arrive in lock-step — a muted mic delivers nothing, a
-//! silent system delivers near-zero, and OS buffering means one can run ahead of
-//! the other. `MixBuffer` accumulates samples per source by absolute sample
-//! index (offset → index, at 16 kHz) and pops the next chunk once *both* have
-//! reached that far, or — once `finish()` has been called — drains whatever is
-//! left (so a quiet side never stalls the stream forever). Overlapping samples
-//! are summed with a fixed 0.5/0.5 gain and clamped to `[-1.0, 1.0]`.
-//!
-//! `poll_mixed_chunk` is the shared `next_chunk` body for the Windows mixed
-//! stream (cpal feeds the buffer from background threads behind a Mutex);
-//! macOS owns its `MixBuffer` directly and drives it inline instead.
+//! `MixBuffer` accumulates samples by absolute index and pops once both have
+//! reached that point, or drains remaining once `finish()` is called. Overlapping
+//! samples are summed with 0.5/0.5 gain and clamped.
 
 use std::sync::Mutex;
 use std::time::Duration;
@@ -54,9 +46,7 @@ pub enum MixSource {
 }
 
 /// A bounded buffer that mixes two 16 kHz mono streams keyed by absolute sample
-/// index. One per mixed capture. "Bounded" = `MAX_BUFFERED_SAMPLES` per side; a
-/// push that would exceed it is dropped (the consumer fell too far behind, or a
-/// timestamp is bogus).
+/// index. One per mixed capture; capped at `MAX_BUFFERED_SAMPLES` per side.
 pub struct MixBuffer {
     /// System samples not yet popped, starting at sample index `base`.
     sys: Vec<f32>,
@@ -98,11 +88,8 @@ impl MixBuffer {
     }
 
     /// Pushes `samples` for `source`, declared to start at `offset_ns` from the
-    /// recording start. Samples before `base` (already popped) are dropped;
-    /// samples are placed by index so a reordered or gapped delivery still lands
-    /// correctly (gaps stay zero). A push that would grow the side past
-    /// `MAX_BUFFERED_SAMPLES` is dropped entirely (with the watermark still
-    /// bumped so a stall isn't inferred).
+    /// recording start. Samples are placed by index; those before `base` or past
+    /// `MAX_BUFFERED_SAMPLES` are dropped (the watermark is still bumped).
     pub fn push(&mut self, source: MixSource, offset_ns: u64, samples: &[f32]) {
         if samples.is_empty() {
             return;
@@ -113,16 +100,14 @@ impl MixBuffer {
         let keep_from = start.max(self.base);
         let skip = (keep_from - start) as usize;
         if skip >= samples.len() {
-            // Entirely in the past — but still advance the "filled" watermark so
-            // a late tiny buffer doesn't make us think the stream stalled.
+            // Entirely in the past, but advance watermark to avoid false stall detection.
             self.bump_filled(source, end);
             return;
         }
         let rel = (keep_from - self.base) as usize; // offset into sys/mic Vec
         let needed = rel + (samples.len() - skip);
         if needed > MAX_BUFFERED_SAMPLES {
-            // Consumer fell minutes behind, or `offset_ns` is bogus. Drop the
-            // payload but record the watermark — we don't allocate gigabytes.
+            // Consumer too far behind or timestamp bogus; drop payload but record watermark.
             log::warn!(
                 target: "transcription::mix",
                 "{source:?} push at offset {offset_ns}ns would buffer {needed} samples (cap {MAX_BUFFERED_SAMPLES}) — dropped"
@@ -167,10 +152,7 @@ impl MixBuffer {
     }
 
     /// Pops the next mixed chunk of up to `max_samples`, or `None` if fewer than
-    /// `min_samples` are ready (unless finished, in which case it returns
-    /// whatever is left and then `None`). The returned chunk's first sample is at
-    /// absolute index `base` *before* the call — the caller tracks the running
-    /// offset itself.
+    /// `min_samples` are ready (unless finished, then it returns the remainder).
     pub fn pop(&mut self, min_samples: usize, max_samples: usize) -> Option<Vec<f32>> {
         debug_assert!(
             min_samples <= max_samples,
@@ -181,10 +163,7 @@ impl MixBuffer {
             return None;
         }
         let take = available.min(max_samples);
-        // Both sides are pre-sliced to `take` (or to their length if shorter);
-        // anything past a side's length is silence (zero-padded). `has_mic` was
-        // removed — a MixBuffer always carries both sides; a dead/quiet side is
-        // simply an all-zero `mic` (or `sys`) region.
+        // Pre-slice both to `take` (shorter sides zero-padded); dead/quiet side is all-zero.
         let sys = &self.sys[..take.min(self.sys.len())];
         let mic = &self.mic[..take.min(self.mic.len())];
         let mut out = Vec::with_capacity(take);
@@ -208,15 +187,8 @@ impl MixBuffer {
 }
 
 /// The shared `AudioStream::next_chunk` body for a mixed capture whose two
-/// sources feed `buf` from background threads (Windows cpal callbacks; macOS
-/// uses the bundled `audio-capture-cli` stdout reader). Polls for a full
-/// `CHUNK_SAMPLES`-sized
-/// chunk; once `STALL_GIVE_UP` elapses with nothing arriving — either both
-/// sources stopped without an EOF, or the buffer is poisoned — it drains
-/// whatever is left and then returns `Err(CaptureError::Failed)` so the driver
-/// surfaces a "capture stalled" message rather than ending silently. A clean
-/// EOF (a reader calling `buf.finish()` and the buffer fully drained) returns
-/// `Ok(None)`.
+/// sources feed `buf` from background threads. Polls for a full chunk; drains the
+/// tail and errors after `STALL_GIVE_UP`, or returns `Ok(None)` on a clean EOF.
 pub fn poll_mixed_chunk(buf: &Mutex<MixBuffer>) -> Result<Option<AudioChunk>, CaptureError> {
     let want = CHUNK_SAMPLES;
     let mut waited = Duration::ZERO;
@@ -224,8 +196,7 @@ pub fn poll_mixed_chunk(buf: &Mutex<MixBuffer>) -> Result<Option<AudioChunk>, Ca
         match buf.lock() {
             Ok(mut b) => {
                 let start_ns = b.offset_ns();
-                // While running we want full chunks; on a stall, drain whatever
-                // is left first so the tail isn't lost.
+                // On stall, drain tail first so it isn't lost.
                 let chunk = b
                     .pop(want, want)
                     .or_else(|| (waited >= STALL_GIVE_UP).then(|| b.pop(1, want)).flatten());
@@ -235,8 +206,7 @@ pub fn poll_mixed_chunk(buf: &Mutex<MixBuffer>) -> Result<Option<AudioChunk>, Ca
                         offset: Duration::from_nanos(start_ns),
                     }));
                 }
-                // Empty + nothing more coming (a reader marked it finished) is a
-                // clean end of stream.
+                // Empty + finished = clean end of stream.
                 let drained_and_finished = b.is_finished_and_empty();
                 drop(b);
                 if drained_and_finished {
@@ -244,8 +214,7 @@ pub fn poll_mixed_chunk(buf: &Mutex<MixBuffer>) -> Result<Option<AudioChunk>, Ca
                 }
             }
             Err(_) => {
-                // A reader thread panicked while holding the lock. Treat it as a
-                // dead capture — don't spin forever.
+                // Reader thread panicked; treat capture as dead.
                 log::warn!(target: "transcription::mix", "mix buffer poisoned — capture stopped");
                 return Err(CaptureError::Failed("mix buffer poisoned".to_string()));
             }

--- a/crates/speedwave-runtime/src/transcription/mod.rs
+++ b/crates/speedwave-runtime/src/transcription/mod.rs
@@ -82,9 +82,7 @@ mod tests {
 
     #[test]
     fn dirs_are_under_the_data_dir() {
-        // Structural invariant only — both dirs share one data-dir parent and
-        // end with their subdir. Asserted without naming the production
-        // `data_dir()` singleton, so it holds under any isolated tempdir.
+        // Both dirs share one data-dir parent and end with their subdir.
         let transcripts = transcripts_dir();
         let models = models_dir();
         assert!(transcripts.ends_with(crate::consts::TRANSCRIPTS_SUBDIR));
@@ -105,11 +103,6 @@ mod tests {
     #[test]
     fn detect_audio_capture_picks_the_host_backend() {
         let caps = detect_audio_capture().capabilities();
-        // macOS always has a real backend (the audio-capture-cli enforces
-        // 14.4 itself, so we assume taps are available). Windows depends on a
-        // present output device — true on a dev box, possibly false on a bare
-        // CI runner — so we don't assert its flags beyond per-process being
-        // off in v1. Other OSes fall back to FileAudioCapture.
         if cfg!(target_os = "macos") {
             assert!(caps.supports_system_audio);
             assert!(caps.supports_per_process);

--- a/crates/speedwave-runtime/src/transcription/model_catalog.rs
+++ b/crates/speedwave-runtime/src/transcription/model_catalog.rs
@@ -1,19 +1,6 @@
-//! SSOT catalogue of the Whisper transcription models and the speaker-diarization
-//! models the meeting-transcription feature downloads on demand (ADR-056).
-//!
-//! Bumping a model = editing one const here. Nothing else hard-codes a model
-//! filename, URL, or hash. Mirrors the `defaults::ANTHROPIC_MODELS` pattern:
-//! the frontend reads this via the `list_transcription_models` Tauri command
-//! rather than hard-coding model names.
-//!
-//! URLs, sizes, and SHA256 values were established in ADR-056 spike 0C:
-//! - Whisper GGML models come from `ggerganov/whisper.cpp` on Hugging Face
-//!   (NOT `ggml-org/whisper.cpp`, which 401s anonymously). Sizes/SHA256 from
-//!   the HF API; `small`/`medium` SHA256 additionally confirmed by download.
-//! - Diarization models come from k2-fsa's `sherpa-onnx` GitHub releases;
-//!   SHA256 computed locally. The pyannote segmentation conversion is MIT;
-//!   the default embedding model (3D-Speaker CAM++) is Apache-2.0 — both
-//!   redistributable. NeMo TitaNet-small (CC-BY-4.0) remains as a fallback.
+//! SSOT catalogue of Whisper and speaker-diarization models (ADR-056).
+//! Bumping a model = editing one const here. Mirrors `defaults::ANTHROPIC_MODELS`:
+//! the frontend reads it via the `list_transcription_models` Tauri command.
 
 /// Hugging Face repo path the Whisper GGML models are downloaded from.
 pub const WHISPER_HF_REPO: &str = "ggerganov/whisper.cpp";
@@ -23,12 +10,8 @@ pub fn whisper_model_url(file: &str) -> String {
     format!("https://huggingface.co/{WHISPER_HF_REPO}/resolve/main/{file}")
 }
 
-/// Where in the live/offline transcription pipeline a Whisper model is meant
-/// to be used. The default-download set for v1 (ADR-056 decision 8): `Small`
-/// for CPU-only live, `LargeV3Turbo` for live when a GPU/Metal backend was
-/// compiled in, `LargeV3` lazily for the higher-quality offline pass; `Medium`
-/// is the middle ground if Polish quality on `Small`/`Turbo` disappoints;
-/// `Tiny`/`Base` exist mainly for dev/tests and the smallest-footprint case.
+/// Where in the live/offline transcription pipeline a Whisper model is used
+/// (ADR-056 decision 8).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ModelRole {
@@ -212,9 +195,7 @@ pub const WHISPER_MODELS: &[WhisperModelInfo] = &[
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DiarizationModelKind {
-    /// Speaker segmentation (pyannote-3.0, ONNX). The archive also contains an
-    /// `int8` variant; the catalogue points at the archive and the extracted
-    /// file paths are derived after unpacking.
+    /// Speaker segmentation (pyannote-3.0, ONNX).
     Segmentation,
     /// Speaker embedding (NeMo TitaNet-small) — a single `.onnx` file.
     Embedding,
@@ -238,21 +219,12 @@ pub struct DiarizationModelInfo {
     pub sha256: &'static str,
     /// SPDX-ish licence string.
     pub license: &'static str,
-    /// `true` if this is the model the runtime uses by default (the catalogue
-    /// may list alternates for the embedding model — e.g. WeSpeaker — that a
-    /// future version could switch to if Polish quality needs it).
+    /// `true` if this is the model the runtime uses by default.
     pub default: bool,
 }
 
-/// Diarization model catalogue. Default pair: pyannote-segmentation-3.0 +
-/// 3D-Speaker CAM++ (English voxceleb; embeddings are language-agnostic).
-/// CAM++ chosen over TitaNet-small for Apache-2.0 licence and lower EER —
-/// rationale and benchmarks in ADR-056. Sizes/SHA256/licences verified
-/// 2026-05-12.
-///
-/// The URLs below intentionally contain `speaker-recongition-models` (missing
-/// an "i") — that is the actual upstream k2-fsa release tag; verified
-/// 2026-05-12. The correctly-spelt path returns 404.
+/// Diarization model catalogue (ADR-056). The `speaker-recongition-models` URL
+/// segment (missing an "i") is the actual upstream k2-fsa release tag.
 pub const DIARIZATION_MODELS: &[DiarizationModelInfo] = &[
     DiarizationModelInfo {
         key: "pyannote-segmentation-3-0",
@@ -274,8 +246,7 @@ pub const DIARIZATION_MODELS: &[DiarizationModelInfo] = &[
         license: "Apache-2.0",
         default: true,
     },
-    // Non-default fallback: kept so an old recording's metadata that names the
-    // NeMo model still loads (the runtime will let a caller pick a non-default).
+    // Non-default fallback for old recordings that name the NeMo model.
     DiarizationModelInfo {
         key: "nemo-titanet-small",
         kind: DiarizationModelKind::Embedding,
@@ -369,8 +340,7 @@ mod tests {
 
     #[test]
     fn whisper_catalogue_has_the_v1_default_set() {
-        // Decision 8: a CPU-live model, a GPU/Metal-live model, a finalize
-        // model. If any of these disappear, the v1 strategy breaks.
+        // Decision 8: CPU-live, GPU/Metal-live and finalize models are required.
         assert!(
             whisper_model("small").is_some(),
             "v1 needs the `small` CPU-live model"
@@ -482,11 +452,7 @@ mod tests {
 
     #[test]
     fn a_realistic_model_set_fits_under_the_global_dome() {
-        // A realistic worst case: keep one full-precision model per role plus
-        // every diarization model (no point keeping a `full` and its `q5_*`
-        // variant at once — that's the redundant case). This must fit under
-        // the dome in consts.rs with room to spare; if it doesn't, raise the
-        // dome (and revisit whether the catalogue is getting too large).
+        // Worst case: one full-precision model per role plus every diarization model.
         let full_whisper: u64 = WHISPER_MODELS
             .iter()
             .filter(|m| matches!(m.quantization, Quantization::Full))
@@ -501,8 +467,7 @@ mod tests {
             crate::consts::MAX_TOTAL_TRANSCRIPTION_MODELS_BYTES,
             crate::consts::MAX_TOTAL_TRANSCRIPTION_MODELS_BYTES as f64 / 1_073_741_824.0,
         );
-        // And `large-v3` alone (the single biggest entry) must be allowed —
-        // the dome can't be smaller than the largest model.
+        // The single biggest entry (`large-v3`) must fit under the dome.
         let biggest = WHISPER_MODELS.iter().map(|m| m.approx_bytes).max().unwrap();
         assert!(biggest < crate::consts::MAX_TOTAL_TRANSCRIPTION_MODELS_BYTES);
     }

--- a/crates/speedwave-runtime/src/transcription/model_store.rs
+++ b/crates/speedwave-runtime/src/transcription/model_store.rs
@@ -1,26 +1,7 @@
-//! On-demand download + verification + caching of the Whisper and diarization
-//! models (ADR-056).
-//!
-//! Models live under `<data_dir>/models/whisper/` and `<data_dir>/models/diarization/`
-//! (perms `0o700`, files `0o600` — they aren't secrets, but neither are they
-//! world-readable). `ensure_model()` downloads a model if absent, **streaming
-//! it to a `.part` temp file in the same directory while computing SHA256 on
-//! the fly**, then verifies against the catalogue hash and atomically renames
-//! into place; on hash mismatch or any error the temp is removed and nothing
-//! partial is left behind. The HTTP client uses a **custom redirect policy
-//! that only follows redirects to hosts in `consts::TRANSCRIPTION_MODEL_ALLOWED_REDIRECT_HOSTS`**
-//! (Hugging Face `302`s to its Xet CDN, GitHub release assets to theirs — both
-//! with signed URLs — so `Policy::none()` would break the download; an
-//! unrecognised redirect host produces a `Mismatch`-class error rather than
-//! being followed). There is a per-model size cap from the catalogue plus the
-//! `MAX_TOTAL_TRANSCRIPTION_MODELS_BYTES` overall dome.
-//!
-//! (The downloader is a blocking API — a multi-GiB download is a long blocking
-//! operation the Tauri layer wraps in `spawn_blocking`. It re-implements a
-//! small bounded-streaming reader here rather than reusing the Desktop's
-//! `http_util` — `speedwave-runtime` is pure Rust with no Tauri coupling — but
-//! follows the same principles: request timeout, restricted redirects, no
-//! buffer-the-whole-body-in-memory.)
+//! On-demand download + verification + caching of Whisper and diarization
+//! models under `<data_dir>/models/` (ADR-056). `ensure_model()` streams to a
+//! `.part` temp, verifies SHA256, atomically renames; redirects only follow
+//! `consts::TRANSCRIPTION_MODEL_ALLOWED_REDIRECT_HOSTS`. Blocking API.
 
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
@@ -50,8 +31,7 @@ pub enum ModelStoreError {
     #[error("no such model in the catalogue: {0}")]
     UnknownModel(String),
     /// The download's redirect chain led to a host not on the allowlist
-    /// (`consts::TRANSCRIPTION_MODEL_ALLOWED_REDIRECT_HOSTS`) — most likely a
-    /// CDN hostname changed, which means the model catalogue needs updating.
+    /// (`consts::TRANSCRIPTION_MODEL_ALLOWED_REDIRECT_HOSTS`).
     #[error("model download redirected to a host not on the allowlist ({0}) — the model URL may have changed; report this")]
     DisallowedRedirect(String),
     /// `Content-Length` (or the bytes actually streamed) exceeded the per-model
@@ -170,10 +150,9 @@ impl ModelStore {
         self.whisper_dir().join(info.file)
     }
 
-    /// Local path a diarization download artifact / unpacked file lives at.
-    /// For an embedding model that is the `.onnx` file itself; for a
-    /// segmentation model the archive is unpacked into `<root>/diarization/<key>/`
-    /// and `model.onnx` inside it is the result.
+    /// Local path a diarization artifact lives at: the `.onnx` itself for an
+    /// embedding model, the unpack dir `<root>/diarization/<key>/` for a
+    /// segmentation model.
     fn diarization_artifact_path(&self, info: &DiarizationModelInfo) -> PathBuf {
         match info.kind {
             DiarizationModelKind::Embedding => {
@@ -190,8 +169,7 @@ impl ModelStore {
 
     /// The path the segmentation `model.onnx` ends up at after unpacking.
     fn segmentation_onnx_path(&self, info: &DiarizationModelInfo) -> PathBuf {
-        // k2-fsa's archive extracts to a top-level dir
-        // `sherpa-onnx-pyannote-segmentation-3-0/` containing `model.onnx`.
+        // k2-fsa's archive extracts to a top-level dir containing `model.onnx`.
         self.diarization_artifact_path(info)
             .join("sherpa-onnx-pyannote-segmentation-3-0")
             .join("model.onnx")
@@ -199,15 +177,12 @@ impl ModelStore {
 
     /// `true` if a Whisper model with this catalogue key is present and its
     /// on-disk size matches the catalogue's `approx_bytes` within a small
-    /// tolerance (a cheap "is this a complete file" sanity check — the SHA256
-    /// was already verified on download, and we don't re-hash on every status
-    /// query).
+    /// tolerance.
     fn whisper_is_present(&self, info: &WhisperModelInfo) -> bool {
         match std::fs::metadata(self.whisper_path(info)) {
             Ok(m) => {
                 let on_disk = m.len();
-                // approx_bytes is from the HF API — exact for these files, but
-                // allow a tiny slack in case of a metadata vs content mismatch.
+                // Allow a tiny slack for metadata vs content mismatch.
                 let diff = on_disk.abs_diff(info.approx_bytes);
                 diff <= 64 || on_disk == info.approx_bytes
             }
@@ -254,9 +229,7 @@ impl ModelStore {
         }
         std::fs::create_dir_all(self.whisper_dir())?;
         restrict_dir_perms(&self.whisper_dir());
-        // Per-model cap = catalogue approx_bytes + 5% headroom (the file is a
-        // fixed size; this just keeps a wildly-wrong Content-Length from
-        // writing gigabytes).
+        // Per-model cap = catalogue approx_bytes + 5% headroom.
         let per_model_cap = info.approx_bytes + info.approx_bytes / 20 + 1024;
         // Total-storage check.
         let current_total = self.total_bytes_used();
@@ -281,9 +254,7 @@ impl ModelStore {
 
     /// Downloads `url` to `dest`, verifies SHA256 against `expected_sha256`,
     /// enforces `cap`, restricts perms, and on a hash mismatch removes the
-    /// (already-renamed-away) temp and errors. The shared body of `ensure_model`
-    /// and `ensure_diarization_models`' embedding branch — and the seam tests
-    /// use to drive a `mockito` URL through the full verify path.
+    /// (already-renamed-away) temp and errors.
     fn download_to(
         &self,
         url: &str,
@@ -295,8 +266,7 @@ impl ModelStore {
     ) -> Result<(), ModelStoreError> {
         let got_hash = download_verified(url, dest, model_key, cap, progress)?;
         if got_hash != expected_sha256 {
-            // download_verified renamed the temp into `dest` on success; on a
-            // hash mismatch that means there is now a bad file at `dest` — remove it.
+            // Remove the bad file `download_verified` renamed into `dest`.
             let _ = std::fs::remove_file(dest);
             return Err(ModelStoreError::HashMismatch {
                 model: model_key.to_string(),
@@ -525,9 +495,8 @@ fn download_verified(
     Ok(hash)
 }
 
-/// Like `download_verified` but writes to `dest_tmp` exactly (no rename) — used
-/// for the segmentation archive, which is unpacked then deleted, so the caller
-/// manages the temp file's lifecycle.
+/// Like `download_verified` but writes to `dest_tmp` exactly (no rename); the
+/// caller manages the temp file's lifecycle.
 fn download_to_file_verified(
     url: &str,
     dest_tmp: &Path,
@@ -629,8 +598,7 @@ fn stream_to_path(
 /// error's `source()` chain — we walk that chain to recover the host.
 fn classify_reqwest_err(e: &reqwest::Error) -> ModelStoreError {
     if e.is_redirect() {
-        // Try to pull the host out of our "disallowed redirect host: <host>"
-        // message somewhere in the source chain; fall back to the URL.
+        // Pull the host from the "disallowed redirect host: <host>" message, else the URL.
         let mut src: Option<&dyn std::error::Error> = Some(e);
         while let Some(cur) = src {
             let m = cur.to_string();
@@ -886,8 +854,7 @@ mod tests {
             .create();
         let dir = tempfile::tempdir().unwrap();
         let out = dir.path().join("m.bin");
-        // mockito serves on 127.0.0.1 with a random port — definitely not on the
-        // allowlist — so the redirect must be refused.
+        // mockito's random port is not on the allowlist, so the redirect is refused.
         let err = stream_to_path(&redir_url, &out, "redir", 10_000, &mut no_progress).unwrap_err();
         assert!(
             matches!(
@@ -999,19 +966,7 @@ mod tests {
 
     #[test]
     fn ensure_model_storage_cap_arithmetic_blocks_overflow() {
-        // We can't put 12 GiB on disk in a unit test, so verify the *check*:
-        // pre-fill the model dir so `total_bytes_used()` is reported as huge by
-        // a wrapper, then... actually, the cleanest direct check is that the
-        // dome is enforced on `total + approx`. We assert via a tiny store
-        // whose root we point at a dir we then claim is "full" — but
-        // total_bytes_used walks the real fs. So instead: assert the
-        // arithmetic relationship the code uses, against the real constant and
-        // the real catalogue, so a future change that, say, drops the check
-        // would be caught by ensure_model_rejects_unknown_key + the mockito
-        // download tests, and the *sizing* of the dome is covered by the
-        // catalogue test. Here we just confirm the dome is bigger than any
-        // single model (so `ensure_model` for an empty store always proceeds
-        // past the cap check), which is the property the check relies on:
+        // The dome must exceed any single model, else ensure_model could never download it.
         let biggest = crate::transcription::model_catalog::WHISPER_MODELS
             .iter()
             .map(|m| m.approx_bytes)
@@ -1021,10 +976,6 @@ mod tests {
             biggest < consts::MAX_TOTAL_TRANSCRIPTION_MODELS_BYTES,
             "the dome must exceed the largest model, else ensure_model could never download it"
         );
-        // And: a store with files summing over the dome would block a new
-        // download. We can't write that much, but `total_bytes_used` is just
-        // `dir_size`, which we exercise elsewhere — the cap check in
-        // ensure_model is `current + approx > MAX`, plain arithmetic.
     }
 
     #[test]
@@ -1033,11 +984,8 @@ mod tests {
         let store = ModelStore::with_root(dir.path());
         let info = whisper_model("tiny").unwrap();
         std::fs::create_dir_all(store.whisper_dir()).unwrap();
-        // Write a file of exactly approx_bytes so whisper_is_present() == true.
         let path = store.whisper_path(info);
-        // approx_bytes for tiny is ~78 MiB — too big to actually write in a unit
-        // test. So instead: temporarily we can't make whisper_is_present true
-        // without that size. Verify the *negative* side (not present) + delete-noop:
+        // approx_bytes (~78 MiB) is too big to write here; verify the not-present side.
         assert!(
             !store
                 .whisper_status()
@@ -1072,13 +1020,7 @@ mod tests {
         assert!(store.diarization_dir().starts_with(dir.path()));
     }
 
-    // Note: a "rejects `../` path traversal" test would need a tar archive
-    // *containing* a `..` entry, but the `tar` crate's `Builder` refuses to
-    // write one (it has its own traversal guard) — so such a fixture can't be
-    // produced through the public API. `unpack_tar_bz2`'s own `..`/absolute
-    // check is kept as defence-in-depth (the model catalogue could one day
-    // point at a non-k2-fsa archive); the happy-path test below exercises the
-    // function, and a manual review confirms the guard is hit before any write.
+    // No `..`-traversal test: `tar::Builder` refuses to write a `..` entry.
 
     #[test]
     fn unpack_tar_bz2_extracts_a_normal_archive() {

--- a/crates/speedwave-runtime/src/transcription/transcriber.rs
+++ b/crates/speedwave-runtime/src/transcription/transcriber.rs
@@ -111,9 +111,8 @@ pub enum TranscribeError {
 }
 
 /// A speech-to-text engine. `transcribe()` is the offline/finalize path (whole
-/// buffer); `feed()` is the live path (a growing decode window — tail segments
-/// may change as more context arrives). One transcriber per recording (Whisper
-/// state is single-threaded).
+/// buffer); `feed()` is the live path (a growing decode window). One transcriber
+/// per recording.
 pub trait Transcriber: Send {
     /// Transcribe `pcm` (16 kHz mono `f32`, `[-1, 1]`) in one shot.
     fn transcribe(
@@ -318,8 +317,7 @@ impl Transcriber for MockTranscriber {
 mod tests {
     use super::*;
 
-    // `WhisperCppTranscriber` has no `Debug` (it wraps a `WhisperContext`), so
-    // `unwrap_err()` won't compile — pattern-match the error out.
+    // `WhisperCppTranscriber` has no `Debug`; pattern-match the error out.
     fn load_err(path: &Path, label: &str) -> TranscribeError {
         match WhisperCppTranscriber::load(path, label) {
             Ok(_) => panic!("expected load() to fail"),
@@ -438,6 +436,5 @@ mod tests {
         }
     }
 
-    // Real whisper.cpp inference (needs a ≥75 MiB model + the C++ engine) is an
-    // opt-in CI job, not a unit test — verified end-to-end in ADR-056 spike 0A.
+    // Real whisper.cpp inference is an opt-in CI job, not a unit test.
 }

--- a/crates/speedwave-runtime/src/transcription/transcript.rs
+++ b/crates/speedwave-runtime/src/transcription/transcript.rs
@@ -425,7 +425,7 @@ mod tests {
         );
         // Empty / whitespace clears.
         s.relabel_speaker(SpeakerId(0), "   ");
-        assert!(s.speaker_names.get(&SpeakerId(0)).is_none());
+        assert!(!s.speaker_names.contains_key(&SpeakerId(0)));
         // Long names are capped (defensively).
         let long = "x".repeat(200);
         s.relabel_speaker(SpeakerId(1), &long);
@@ -568,15 +568,13 @@ mod tests {
         assert_eq!(s.len(), 20);
         assert!(s.ends_with('Z'));
         let year: i32 = s[..4].parse().unwrap();
-        assert!(year >= 2020 && year < 2100, "year {year} not plausible");
+        assert!((2020..2100).contains(&year), "year {year} not plausible");
     }
 
     #[test]
     fn ymd_hms_known_epochs() {
         // 1970-01-01T00:00:00Z
         assert_eq!(secs_to_ymd_hms(0), (1970, 1, 1, 0, 0, 0));
-        // 2000-02-29 (leap day) at 12:34:56: precompute the exact seconds.
-        // Use the algorithm itself to derive — but we can pick a known date:
         // 2024-01-01T00:00:00Z = 1_704_067_200.
         assert_eq!(secs_to_ymd_hms(1_704_067_200), (2024, 1, 1, 0, 0, 0));
         // 2024-12-31T23:59:59Z = 1_735_689_599.

--- a/crates/speedwave-runtime/src/transcription/transcript_driver.rs
+++ b/crates/speedwave-runtime/src/transcription/transcript_driver.rs
@@ -23,16 +23,11 @@ const LIVE_DECODE_EVERY_SECS: f32 = 5.0;
 
 /// Diarize the live buffer every N seconds of audio (cheaper than per-chunk).
 const LIVE_DIARIZE_EVERY_SECS: f32 = 10.0;
-/// Log a `warn` for every multiple of this many seconds of accumulated audio
-/// — long meetings keep the whole PCM buffer in RAM (`~115 MB / hour` at
-/// 16 kHz mono f32) and operators want a hint when something's running long.
+/// Log a `warn` for every multiple of this many seconds of accumulated audio.
 const PCM_WARN_STEP_SECS: f32 = 30.0 * 60.0;
 
-/// A stop signal shared with the driver task; flip it to `true` to ask the
-/// driver to wind down at the next chunk boundary. Carries a `Notify` the
-/// driver host can pulse once `run()` has actually exited, so the Tauri
-/// `stop_transcription` callsite can `await` the wind-down instead of
-/// spin-polling.
+/// A stop signal shared with the driver task. Carries a `Notify` the driver
+/// host pulses once `run()` has exited, releasing `await_finished()` waiters.
 #[derive(Debug, Clone, Default)]
 pub struct StopSignal {
     stopped: Arc<AtomicBool>,
@@ -149,24 +144,21 @@ impl TranscriptDriver {
         }
     }
 
-    /// Runs the driver to completion (until the audio stream ends or `stop`
-    /// is tripped). Writes a WAV at `audio_wav_path` along the way. On any error
-    /// the session is flipped to `Failed{reason}` and the (partial) WAV is
-    /// closed before the error propagates.
+    /// Runs until the audio stream ends or `stop` is tripped, writing a WAV at
+    /// `audio_wav_path`. On error flips the session to `Failed{reason}` and
+    /// closes the partial WAV before propagating.
     pub fn run(mut self, audio_wav_path: &Path) -> Result<(), DriverError> {
         let mut wav = WavWriter::create(audio_wav_path)?;
         // Mark the session as Recording (a no-op transition from new()).
         let _ = self.store.set_status(self.id, TranscriptStatus::Recording);
 
         let result = self.pump_loop(&mut wav);
-        // Always close the WAV — even on error, a partial recording is better
-        // than a truncated/locked file.
+        // Always close the WAV, even on error.
         let _ = wav.finalize();
 
         match result {
             Ok(()) => {
-                // Final live decode over what's left (so the user sees the last
-                // chunk), then hand off to the finalize pass.
+                // Final live decode over what's left, then hand off to finalize.
                 let _ = self.decode_window();
                 let _ = self
                     .store
@@ -221,8 +213,7 @@ impl TranscriptDriver {
                     if let Err(e) =
                         run_diarize_pass(d, &self.diarize_opts, &self.pcm, &self.store, self.id)
                     {
-                        // Non-fatal: log + keep going (the transcript without
-                        // labels is still useful).
+                        // Non-fatal: log and keep going.
                         log::warn!("diarization pass failed: {e}");
                     }
                     self.last_diarize_at = accumulated_secs;
@@ -232,11 +223,7 @@ impl TranscriptDriver {
     }
 
     /// Re-decodes the trailing `LIVE_WINDOW_SECS` of `pcm` and replaces exactly
-    /// the segments that fall inside that window. `feed()` returns segments for
-    /// the *whole* window each time, so the splice index must be "the first
-    /// `live_segments` entry whose start is ≥ the window's start" — not a
-    /// running count, which would duplicate the earlier segments once the
-    /// window starts at offset 0 and re-covers them.
+    /// the segments that fall inside that window.
     fn decode_window(&mut self) -> Result<(), DriverError> {
         if self.pcm.is_empty() {
             return Ok(());
@@ -312,11 +299,9 @@ const FINALIZE_WINDOW_SECS: f32 = 30.0;
 /// window's output to avoid duplicates.
 const FINALIZE_WINDOW_OVERLAP_SECS: f32 = 3.0;
 
-/// Runs the offline pass: load the recorded WAV, transcribe it with the
-/// higher-quality model, (optionally) re-diarize the whole recording, merge the
-/// result preserving user speaker relabels, and mark the session `Done`. On
-/// failure the session is flipped to `Failed{reason}` and the error returned —
-/// the caller can still fall back to the live transcript (it's untouched).
+/// Runs the offline pass: load the recorded WAV, transcribe with the
+/// higher-quality model, (optionally) re-diarize, merge preserving user speaker
+/// relabels, mark `Done`. On failure flips to `Failed{reason}` and returns it.
 pub fn run_finalize(cfg: FinalizeConfig) -> Result<(), DriverError> {
     let FinalizeConfig {
         id,
@@ -353,11 +338,7 @@ pub fn run_finalize(cfg: FinalizeConfig) -> Result<(), DriverError> {
         Err(e) => return Err(fail(&store, format!("read audio: {e}"))),
     };
 
-    // 2) + 3) Transcribe in ~30 s windows with a short overlap, stitching the
-    //    results and emitting real per-window progress. Chunking (vs one
-    //    whole-recording call) loses a little cross-utterance context but lets
-    //    the progress bar actually move; the overlap + de-dup keeps boundaries
-    //    clean. Progress here fills the 5%..60% band.
+    // 2) + 3) Transcribe in ~30 s overlapping windows; progress fills 5%..60%.
     let _ = store.finalize_progress(id, 0.05);
     let final_segs =
         match transcribe_chunked(transcriber.as_mut(), &pcm, &transcribe_opts, |frac| {
@@ -368,8 +349,7 @@ pub fn run_finalize(cfg: FinalizeConfig) -> Result<(), DriverError> {
         };
     let _ = store.finalize_progress(id, 0.65);
 
-    // 4) Optional re-diarization over the whole recording. Best-effort: a
-    //    failure here keeps the (un-labelled-by-this-pass) final segments.
+    // 4) Optional re-diarization over the whole recording; best-effort.
     let (final_segs, final_turns) = match diarizer.as_mut() {
         Some(d) => match d.diarize(&pcm, &diarize_opts) {
             Ok(turns) if !turns.is_empty() => {
@@ -387,8 +367,7 @@ pub fn run_finalize(cfg: FinalizeConfig) -> Result<(), DriverError> {
     };
     let _ = store.finalize_progress(id, 0.9);
 
-    // 5) Merge: install final_segments, remapping speaker IDs to preserve
-    //    user relabels by overlap against the live turns.
+    // 5) Merge: install final_segments, remapping speaker IDs to preserve relabels.
     if let Err(e) = store.merge_final_segments(id, final_segs, &final_turns, &live_turns) {
         return Err(fail(&store, format!("merge final segments: {e}")));
     }
@@ -402,9 +381,7 @@ pub fn run_finalize(cfg: FinalizeConfig) -> Result<(), DriverError> {
 
 /// Transcribes `pcm` (16 kHz mono) in `FINALIZE_WINDOW_SECS` windows with a
 /// `FINALIZE_WINDOW_OVERLAP_SECS` overlap, stitching the per-window segments
-/// into one absolute-timestamped list. Calls `progress` with a 0.0→1.0 fraction
-/// after each window so a UI bar can move. Segments whose start falls inside the
-/// *next* window's overlap are dropped to de-dup the boundary.
+/// into one absolute-timestamped list. Calls `progress` (0.0→1.0) per window.
 fn transcribe_chunked(
     transcriber: &mut dyn Transcriber,
     pcm: &[f32],
@@ -433,9 +410,7 @@ fn transcribe_chunked(
         let is_last = end >= total;
         let window = &pcm[start..end];
         let window_start = Duration::from_secs_f64(start as f64 / rate as f64);
-        // Window-relative-end below which we *keep* segments: everything for the
-        // last window; up to where the next window starts (its overlap zone) for
-        // earlier windows, so straddling segments come from exactly one window.
+        // Keep segments up to the next window's overlap to de-dup boundaries.
         let keep_until = if is_last {
             Duration::from_secs_f64(window.len() as f64 / rate as f64)
         } else {
@@ -490,8 +465,7 @@ fn run_diarize_pass(
     if turns.is_empty() {
         return Ok(());
     }
-    // Pull the current live_segments snapshot, assign speakers locally,
-    // then emit per-segment SpeakerAssigned events for any changes.
+    // Assign speakers locally, then emit a SpeakerAssigned event per change.
     let snap = store
         .get(id)
         .map_err(|e| DriverError::Store(e.to_string()))?;

--- a/crates/speedwave-runtime/src/transcription/transcript_store.rs
+++ b/crates/speedwave-runtime/src/transcription/transcript_store.rs
@@ -143,12 +143,8 @@ struct Entry {
 }
 
 /// Per-session state store + live event stream.
-///
-/// `<root>/<uuid>/transcript.json` + `<root>/<uuid>/audio.wav`. The store
-/// caches the active session in memory; `list()` walks the disk for inactive
-/// ones. `subscribe()` returns a snapshot + receiver — mutators bump seq,
-/// emit, and persist atomically so the snapshot, the stream, and the disk
-/// state never drift.
+/// Layout: `<root>/<uuid>/transcript.json` + `<root>/<uuid>/audio.wav`.
+/// Mutators bump seq, emit, and persist atomically.
 pub struct TranscriptStore {
     root: PathBuf,
     sessions: Arc<DashMap<Uuid, Entry>>,
@@ -432,8 +428,7 @@ impl TranscriptStore {
 
     /// Installs the offline pass's `final_segments`, remapping speaker IDs to
     /// preserve user relabels by max-overlap against the live turns
-    /// (`TranscriptSession::merge_live_into_final`). Emits `FinalSegmentsReady`
-    /// so an open UI swaps the live transcript for the higher-quality one.
+    /// (`TranscriptSession::merge_live_into_final`). Emits `FinalSegmentsReady`.
     pub fn merge_final_segments(
         &self,
         id: Uuid,
@@ -468,9 +463,7 @@ impl TranscriptStore {
         })?;
         if let Some(p) = path_to_remove {
             if p.exists() {
-                // Best-effort: log but don't fail — the audio_path field is
-                // already cleared and persisted, so re-transcription is gone
-                // either way. A leftover file on disk is harmless.
+                // Best-effort: log but don't fail; audio_path already cleared.
                 if let Err(e) = std::fs::remove_file(&p) {
                     log::warn!("could not remove discarded audio file {p:?}: {e}");
                 }
@@ -513,9 +506,8 @@ fn restrict_dir_perms(dir: &Path) {
 }
 
 /// Serde adapter for `HashMap<SpeakerId, String>` inside an internally-tagged
-/// enum. serde_json's "parse numeric map key from string" shortcut doesn't fire
-/// through the `Content` buffer that internal tagging uses, so we serialize the
-/// map as a `Vec<(u32, String)>` of pairs instead.
+/// enum: serializes the map as a `Vec<(u32, String)>` of pairs, because
+/// serde_json's numeric-map-key shortcut doesn't fire through internal tagging.
 mod speaker_name_map {
     use super::SpeakerId;
     use serde::{Deserialize, Deserializer, Serialize, Serializer};

--- a/crates/speedwave-runtime/src/update.rs
+++ b/crates/speedwave-runtime/src/update.rs
@@ -113,8 +113,7 @@ fn save_snapshot_in(data_dir: &std::path::Path, project: &str) -> anyhow::Result
 
     let path = snapshot_path_in(data_dir, project);
     let json = serde_json::to_string_pretty(&snapshot)?;
-    // Durable atomic write (fsync data + parent dir, 0o600) — bare write+rename
-    // was the torn-write pattern that corrupted compose.yml on APFS/virtiofs.
+    // Durable atomic write (fsync data + parent dir, 0o600).
     crate::fs_perms::write_restricted_file_atomic(&path, &json)?;
     Ok(())
 }
@@ -135,8 +134,7 @@ pub fn save_snapshot(project: &str) -> anyhow::Result<()> {
     let compose_yml = match std::fs::read_to_string(&compose_path) {
         Ok(s) => s,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            // First-time restart (compose.yml never rendered yet) — proceed
-            // without a rollback snapshot rather than blocking the restart.
+            // First-time restart: no compose.yml yet, proceed without a snapshot.
             log::warn!(
                 "save_snapshot: no compose.yml at {} — rollback will be unavailable for this restart",
                 compose_path.display()
@@ -172,8 +170,7 @@ pub fn save_snapshot(project: &str) -> anyhow::Result<()> {
 
     let path = snapshot_path(project)?;
     let json = serde_json::to_string_pretty(&snapshot)?;
-    // Durable atomic write: fsync data + parent dir, owner-only (0o600) before
-    // rename so no TOCTOU window and no torn write on APFS/virtiofs.
+    // Durable atomic write: fsync data + parent dir, owner-only (0o600).
     crate::fs_perms::write_restricted_file_atomic(&path, &json)?;
 
     Ok(())
@@ -328,8 +325,7 @@ pub fn update_containers(
         config::resolve_project_config(&project_path, &user_config, project);
 
     // 2. Re-render compose.yml with current template (includes plugin image rebuild)
-    // Reconstruct host-bridge env from disk (ADR-074) — otherwise the re-render
-    // recreates the worker without bridge env, breaking an active Desktop bridge.
+    // Reconstruct host-bridge env from disk (ADR-074).
     let host_bridges = compose::host_bridges_from_disk();
     let compose_yml = compose::render_compose(
         project,
@@ -376,8 +372,7 @@ pub fn update_containers(
     let new_manifest = bundle::load_current_bundle_manifest()?;
     let bundle_state = bundle::load_bundle_state();
 
-    // Build OUTSIDE the compose lock (ADR-066), missing-only per image
-    // (ADR-072). On failure no snapshot is written, containers untouched.
+    // Build OUTSIDE the compose lock (ADR-066), missing-only per image (ADR-072).
     let images_rebuilt = build::build_missing_images_locked(
         runtime,
         &build::enabled_images(&integrations),
@@ -389,10 +384,7 @@ pub fn update_containers(
         )
     })?;
 
-    // CLI-only users get fresh claude-resources — synced AFTER the build and
-    // right before the recreate that picks it up. The swap is skipped when
-    // any OTHER project is running: it would yank that project's live bind
-    // mount (only Desktop reconcile stops-and-restores across projects).
+    // Sync claude-resources after the build, before recreate; skip if another project runs.
     if other_projects_running(runtime, project) {
         log::warn!(
             "claude-resources sync skipped: another project is running; \
@@ -407,7 +399,6 @@ pub fn update_containers(
     apply_update_transaction(runtime, project, &compose_yml)?;
 
     // 9. Wait for containers to stabilize before health check.
-    //    A crash-looping container may briefly show state=="running".
     std::thread::sleep(std::time::Duration::from_secs(
         consts::CONTAINER_STABILIZATION_DELAY_SECS,
     ));
@@ -451,11 +442,7 @@ pub fn rollback_containers(
 
     let snapshot = load_snapshot(project)?;
 
-    // OS prerequisite check.
-    // Note: intentionally NOT using SYSTEM_CHECK_FAILED_PREFIX here — rollback
-    // is only triggered via CLI/Tauri update flow, not from the main Desktop
-    // startup path. The "Rollback aborted" prefix makes the context clearer
-    // than the generic "System check failed:" prefix.
+    // OS prerequisite check (uses a "Rollback aborted" prefix, not SYSTEM_CHECK_FAILED_PREFIX).
     let prereq_violations = crate::os_prereqs::check_os_prereqs();
     if !prereq_violations.is_empty() {
         let msgs: Vec<String> = prereq_violations.iter().map(|v| v.to_string()).collect();
@@ -699,15 +686,11 @@ mod tests {
         }
     }
 
-    // Behavioural tests for `apply_update_transaction` and
-    // `apply_rollback_transaction` live in `tests/apply_transaction_behaviour.rs`
-    // — they need a fresh `OnceLock` for `data_dir()`, which is only possible
-    // in a separate integration-test binary.
+    // Behavioural tests for apply_update_transaction / apply_rollback_transaction live in tests/apply_transaction_behaviour.rs.
 
     #[test]
     fn test_rollback_with_empty_plugin_manifests_is_valid() {
-        // Old snapshots may have empty plugin_manifests. Security check
-        // should still pass if compose YAML has no plugin services.
+        // Old snapshots may have empty plugin_manifests; security check still passes with no plugin services.
         let snapshot = UpdateSnapshot {
             project: "test".to_string(),
             compose_yml: "version: '3'\nservices: {}\n".to_string(),
@@ -731,9 +714,7 @@ mod tests {
 
     #[test]
     fn test_update_checks_os_prereqs() {
-        // Structural test: verify os_prereqs::check_os_prereqs() runs BEFORE
-        // SecurityCheck in update_containers. Same approach as
-        // test_build_before_compose_down_in_update_containers.
+        // Structural test: check_os_prereqs() must run before SecurityCheck in update_containers.
         let source = include_str!("update.rs");
 
         let fn_start = source
@@ -757,8 +738,7 @@ mod tests {
 
     #[test]
     fn test_rollback_checks_os_prereqs() {
-        // Structural test: verify os_prereqs::check_os_prereqs() runs BEFORE
-        // SecurityCheck in rollback_containers.
+        // Structural test: check_os_prereqs() must run before SecurityCheck in rollback_containers.
         let source = include_str!("update.rs");
 
         let fn_start = source
@@ -782,9 +762,7 @@ mod tests {
 
     #[test]
     fn test_update_calls_ensure_before_security_check() {
-        // Structural test: ensure_data_dir_permissions must run BEFORE SecurityCheck::run
-        // in update_containers. Behavioral coverage: see
-        // fs_security::tests::test_ensure_roundtrip_fixes_then_check_passes
+        // Structural test: ensure_data_dir_permissions must run before SecurityCheck::run in update_containers.
         let source = include_str!("update.rs");
 
         let fn_start = source
@@ -808,9 +786,7 @@ mod tests {
 
     #[test]
     fn test_rollback_calls_ensure_before_security_check() {
-        // Structural test: ensure_data_dir_permissions must run BEFORE SecurityCheck::run
-        // in rollback_containers. Behavioral coverage: see
-        // fs_security::tests::test_ensure_roundtrip_fixes_then_check_passes
+        // Structural test: ensure_data_dir_permissions must run before SecurityCheck::run in rollback_containers.
         let source = include_str!("update.rs");
 
         let fn_start = source
@@ -875,9 +851,7 @@ mod tests {
 
     #[test]
     fn test_save_snapshot_sets_parent_permissions() {
-        // Structural test: verify save_snapshot() (production, not _in) delegates
-        // to secure_snapshot_dirs. Protects against accidental removal of the
-        // permission-setting call.
+        // Structural test: save_snapshot() (production, not _in) must delegate to secure_snapshot_dirs.
         let source = include_str!("update.rs");
 
         // Find the production save_snapshot function (not save_snapshot_in)
@@ -900,17 +874,14 @@ mod tests {
 
     #[test]
     fn test_snapshot_writers_use_durable_helper() {
-        // Both snapshot writers must route through the durable SSOT helper
-        // (fsync data + parent dir) — bare fs::write+rename is the torn-write
-        // pattern that corrupted compose.yml on APFS/virtiofs.
+        // Both snapshot writers must use write_restricted_file_atomic, not bare fs::write+rename.
         let source = include_str!("update.rs");
         for func in ["fn save_snapshot(", "fn save_snapshot_in("] {
             let start = source
                 .find(func)
                 .unwrap_or_else(|| panic!("{func} must exist"));
             let body = &source[start..];
-            // Slice to the next top-level fn (column-0) — the inner #[cfg(unix)]
-            // blocks must stay inside the body, so don't terminate on attributes.
+            // Slice to the next column-0 fn (not attributes) so inner #[cfg(unix)] blocks stay in the body.
             let end = ["\npub fn ", "\nfn "]
                 .iter()
                 .filter_map(|marker| body[1..].find(marker).map(|i| i + 1))
@@ -928,6 +899,8 @@ mod tests {
         }
     }
 
+    // SSOT guard: asserts CONTAINER_STABILIZATION_DELAY_SECS stays sane.
+    #[allow(clippy::assertions_on_constants)]
     #[test]
     fn test_stabilization_delay_is_reasonable() {
         assert!(
@@ -944,13 +917,7 @@ mod tests {
 
     #[test]
     fn test_render_compose_called_with_runtime_in_update_containers() {
-        // Structural test: render_compose in update_containers must pass Some(runtime),
-        // not None — this ensures plugin images are checked/rebuilt during CLI updates.
-        //
-        // A behavioral test is not feasible here because render_compose, build_images_for_bundle,
-        // and config::load_user_config are all free functions (not trait methods), making
-        // mocking prohibitively complex. The source-text test is the established pattern
-        // in this file — see test_build_before_compose_down_in_update_containers.
+        // Structural test: render_compose in update_containers must pass Some(runtime), not None.
         let source = include_str!("update.rs");
 
         let fn_start = source
@@ -981,8 +948,7 @@ mod tests {
 
     #[test]
     fn test_update_containers_reconstructs_host_bridges() {
-        // Structural guard (ADR-074): update must feed disk-reconstructed
-        // host bridges into render_compose, not an empty list.
+        // Structural guard (ADR-074): update must feed disk-reconstructed host bridges into render_compose.
         let source = include_str!("update.rs");
         let fn_start = source
             .find("fn update_containers(")
@@ -1002,8 +968,7 @@ mod tests {
             !fn_body[..render_pos].contains(&empty_default),
             "update_containers must not pass an empty HostBridgesInfo to render_compose"
         );
-        // Also assert the call site actually receives &host_bridges as its
-        // argument (guards a default passed *inside* the render_compose args).
+        // Also assert the call site actually receives &host_bridges as its argument.
         let call = &fn_body[render_pos..];
         let call_end = call
             .find(';')
@@ -1016,18 +981,7 @@ mod tests {
 
     #[test]
     fn test_update_containers_plugin_rebuild_via_render_compose() {
-        // Cross-file structural test: verifies the full path
-        // update_containers → render_compose(Some(runtime)) → ensure_plugin_images.
-        //
-        // update_containers passes Some(runtime) to render_compose (verified by
-        // test_render_compose_called_with_runtime_in_update_containers). Here we
-        // verify that render_compose's body calls ensure_plugin_images, completing
-        // the behavioral chain.
-        //
-        // This cross-file test is justified because update_containers depends on
-        // free functions (render_compose, build_images_for_bundle, load_user_config) that
-        // cannot be mocked without major test infrastructure — the same reasoning
-        // documented in test_build_before_compose_down_in_update_containers.
+        // Cross-file structural test: render_compose's body must call ensure_plugin_images.
         let compose_source = include_str!("compose/mod.rs");
 
         let fn_start = compose_source
@@ -1044,10 +998,7 @@ mod tests {
 
     #[test]
     fn test_no_buildkit_prune_in_routine_prune_paths() {
-        // Structural test (ADR-072): prune_buildkit_cache must NOT be called in
-        // the routine prune paths — apt/npm cache layers are reused across
-        // updates. Cache is pruned only by the with_build_recovery ladder
-        // (disk-full + snapshotter recovery), never on routine updates.
+        // Structural test (ADR-072): prune_buildkit_cache must not be called in the routine prune paths.
         let source = include_str!("build.rs");
 
         for fn_name in [
@@ -1074,8 +1025,7 @@ mod tests {
 
     #[test]
     fn update_containers_never_writes_bundle_state() {
-        // ADR-072 single-writer rule: only Desktop (reconcile / setup wizard /
-        // update commands) persists bundle state; the CLI only reads it.
+        // ADR-072 single-writer rule: only Desktop persists bundle state; the CLI only reads it.
         let source = include_str!("update.rs");
         // Split literal so this assertion line isn't itself a match.
         let needle = format!("{}{}", "save_", "bundle_state");

--- a/crates/speedwave-runtime/src/url_validation.rs
+++ b/crates/speedwave-runtime/src/url_validation.rs
@@ -48,8 +48,7 @@ pub fn is_private_on_premise(url: &url::Url, policy: PrivatePolicy) -> bool {
             if ipv4.is_private() && !ipv4.is_link_local() && !ipv4.is_unspecified() {
                 return true;
             }
-            // RFC 6598 — 100.64.0.0/10 shared address space (CGNAT). Non-routable
-            // on the public internet; in practice used by Tailscale and similar.
+            // RFC 6598 — 100.64.0.0/10 shared address space (CGNAT)
             let oct = ipv4.octets();
             if oct[0] == 100 && (oct[1] & 0xc0) == 64 {
                 return true;
@@ -528,8 +527,7 @@ mod tests {
 
     #[test]
     fn validate_url_blocks_credentials_on_public_host() {
-        // Previously only caught because the host was a private IP. Now caught
-        // unconditionally — userinfo has no legitimate use in an endpoint URL.
+        // userinfo has no legitimate use in an endpoint URL
         assert!(validate_url("https://user:pass@example.com/")
             .unwrap_err()
             .contains("credentials"));

--- a/crates/speedwave-runtime/src/usage.rs
+++ b/crates/speedwave-runtime/src/usage.rs
@@ -1,21 +1,6 @@
-//! LLM usage aggregation (ADR-073).
-//!
-//! Reads the append-only JSONL written by the litellm container's usage
-//! callback (`<data_dir>/usage/<project>/litellm/usage.jsonl`, mounted
-//! `:rw` at `/usage`) and aggregates it for the Desktop dashboard.
-//!
-//! Source-of-truth split (ADR-073 §usage): this file is the ONLY input to
-//! the usage dashboard. The Claude Code result stream (`total_cost_usd`,
-//! `modelUsage` parsed in desktop `chat.rs`/`history.rs`) remains the input
-//! to per-session chat statistics and is never summed with this data — the
-//! same request would otherwise be counted twice.
-//!
-//! Records are deduplicated by `response_id`: should a future litellm
-//! version start emitting success events for streamed unified-route
-//! requests (which today only the iterator hook captures), both lines
-//! would carry the same id — first-seen wins (the duplicate is skipped).
-//! Today the two capture paths are mutually exclusive per request, so the
-//! tie-break never fires.
+//! LLM usage aggregation (ADR-073): reads the litellm callback JSONL
+//! (`<data_dir>/usage/<project>/litellm/usage.jsonl`) for the Desktop
+//! dashboard. Records are deduplicated by `response_id`, first-seen wins.
 
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -78,11 +63,8 @@ pub struct UsageBucket {
     pub cache_write: u64,
     /// Summed cost in USD (0.0 where litellm had no pricing — local models).
     pub cost_usd: f64,
-    /// Throughput numerator: completion tokens from SUCCESS records that also
-    /// carried a latency. Paired with `throughput_latency_ms_sum` so tok/s
-    /// divides matched numerator/denominator — failures (latency, ~0 output)
-    /// and pre-latency records (output, no latency) are excluded from both,
-    /// otherwise the rate is wildly skewed.
+    /// Throughput numerator: completion tokens from success records that also
+    /// carried a latency. Paired with `throughput_latency_ms_sum`.
     pub throughput_completion_tokens: u64,
     /// Throughput denominator: wall-clock latency over the same success+latency
     /// records that feed `throughput_completion_tokens`.
@@ -168,9 +150,7 @@ fn aggregate_file(
             summary.skipped_lines += 1;
             continue;
         };
-        // Dedup across capture paths: same response counted once, first-seen
-        // wins (the second line with that id is skipped). The two paths are
-        // mutually exclusive per request today, so the order never matters.
+        // Dedup by response_id; first-seen wins.
         if let Some(id) = record.response_id.as_deref() {
             if !id.is_empty() && !seen_ids.insert(id.to_string()) {
                 continue;
@@ -212,8 +192,7 @@ fn apply_record(bucket: &mut UsageBucket, r: &UsageRecord) {
     bucket.cache_read += r.cache_read.unwrap_or(0);
     bucket.cache_write += r.cache_write.unwrap_or(0);
     bucket.cost_usd += r.cost_usd.unwrap_or(0.0);
-    // Throughput uses only successful records that produced output AND timed it,
-    // so numerator and denominator describe the same requests.
+    // Throughput counts only successful records with output and latency.
     if let Some(latency) = r.latency_ms {
         if !is_failure && completion > 0 && latency > 0 {
             bucket.throughput_completion_tokens += completion;
@@ -256,8 +235,7 @@ mod tests {
         assert_eq!(day1["claude-haiku-4-5"].requests, 1);
         assert_eq!(day1["local/qwen3"].completion_tokens, 2);
         assert_eq!(s.skipped_lines, 0);
-        // Throughput counts only successful timed records with output — the
-        // 60 s failure (0 tokens) is excluded from both numerator and divisor.
+        // Failure with 0 output excluded from throughput numerator and denominator.
         assert_eq!(s.totals.throughput_completion_tokens, 12);
         assert_eq!(s.totals.throughput_latency_ms_sum, 1200);
         assert_eq!(day1["claude-haiku-4-5"].throughput_latency_ms_sum, 900);
@@ -279,8 +257,7 @@ mod tests {
             dir.path(),
             "proj",
             &[
-                // Hour field not numeric / out of range / ts too short — the
-                // record still aggregates, only the histogram entry is skipped.
+                // Record aggregates; only hour histogram skipped for malformed timestamps.
                 r#"{"ts":"2026-06-12Txx:00:00+0200","status":"success","model":"m","prompt_tokens":1}"#,
                 r#"{"ts":"2026-06-12T99:00:00+0200","status":"success","model":"m","prompt_tokens":2}"#,
                 r#"{"ts":"short","status":"success","model":"m","prompt_tokens":4}"#,
@@ -297,19 +274,15 @@ mod tests {
 
     #[test]
     fn multibyte_timestamp_does_not_panic_on_byte_slicing() {
-        // `ts` is sliced by byte index (get(0..10)/get(11..13)). A multibyte
-        // char straddling byte 10 or 13 makes str::get return None (not panic):
-        // the record still aggregates under day "unknown", histogram skipped.
+        // Byte-slicing `ts` is safe with multibyte chars; str::get returns None (no panic).
         let dir = tempfile::tempdir().unwrap();
         write_usage(
             dir.path(),
             "proj",
             &[
-                // 'éé' (2 bytes each) makes byte 10 land mid-char, so the day
-                // slice get(0..10) returns None → day "unknown".
+                // 'éé' crosses byte 10 → day becomes 'unknown'.
                 r#"{"ts":"2026-06éé2T10:00:00+0200","status":"success","model":"m","prompt_tokens":1}"#,
-                // Emoji (4 bytes) at byte 11 makes the hour slice get(11..13)
-                // return None → valid day, histogram entry skipped.
+                // Emoji at byte 11 → histogram entry skipped.
                 r#"{"ts":"2026-06-12T😀0:00:00+0200","status":"success","model":"m","prompt_tokens":2}"#,
             ],
         );

--- a/crates/speedwave-runtime/tests/anthropic_pricing_completeness.rs
+++ b/crates/speedwave-runtime/tests/anthropic_pricing_completeness.rs
@@ -1,10 +1,5 @@
-//! Cross-language drift guard: the Desktop cost meter prices turns purely from
-//! `list_anthropic_models` (the serialized `ANTHROPIC_MODELS`), so a Rust-side
-//! model bump that ships an entry without usable pricing — or a 1M-context
-//! family missing its `[1m]` rate — silently leaves the frontend unable to
-//! price the served id. These assertions fail the build before that reaches
-//! the UI. They complement the in-module unit tests in `defaults.rs` from the
-//! public-API surface the frontend actually consumes.
+//! Drift guard: every `ANTHROPIC_MODELS` entry (and each 1M family's `[1m]`
+//! variant) must carry usable pricing the serialized catalog exposes.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
@@ -37,8 +32,7 @@ fn assert_priced(model_id: &str, label: &str, p: &ModelPricing) {
 
 #[test]
 fn every_catalog_entry_is_priced() {
-    // The frontend derives pricing at runtime from this catalog; a price-less
-    // entry would surface a turn with no cost. Guard the base rate of every id.
+    // Guard the base rate of every catalog id.
     assert!(
         !ANTHROPIC_MODELS.is_empty(),
         "catalog must not be empty — the cost meter has nothing to price"
@@ -50,10 +44,7 @@ fn every_catalog_entry_is_priced() {
 
 #[test]
 fn million_context_entries_have_a_priced_1m_variant() {
-    // The served id for a 1M family carries the `[1m]` suffix
-    // (`anthropic_default_models_env`); without `pricing_1m` the cost meter
-    // cannot price that id. Require the variant exactly when (and only when)
-    // the family is 1M-context.
+    // Require `pricing_1m` exactly when the family is 1M-context.
     for m in ANTHROPIC_MODELS {
         let is_million = m.context_tokens >= 1_000_000;
         match (&m.pricing_1m, is_million) {
@@ -73,9 +64,7 @@ fn million_context_entries_have_a_priced_1m_variant() {
 
 #[test]
 fn catalog_serializes_pricing_for_the_frontend() {
-    // `list_anthropic_models` serializes the catalog to JSON for the webview;
-    // every entry's wire form must carry `input`/`output` under both `pricing`
-    // and (for 1M families) `pricing_1m`, since the frontend reads those keys.
+    // Wire form must carry `input`/`output` under `pricing` (and `pricing_1m` for 1M families).
     let value =
         serde_json::to_value(ANTHROPIC_MODELS).expect("catalog must serialize for the frontend");
     let entries = value.as_array().expect("catalog serializes as an array");

--- a/crates/speedwave-runtime/tests/apply_transaction_behaviour.rs
+++ b/crates/speedwave-runtime/tests/apply_transaction_behaviour.rs
@@ -1,11 +1,8 @@
 //! Behavioural coverage for `update::apply_update_transaction` and
-//! `update::apply_rollback_transaction` — replaces brittle source-text
-//! ordering assertions with mocked `LockedRuntime` call recording.
-//!
-//! Lives in its own integration-test binary because `consts::data_dir()`
-//! uses a `OnceLock`: the env var is honoured on the first resolution
-//! only. All tests share one tmp dir (one resolution) and serialise to
-//! keep recorded call vectors uncontaminated.
+//! `update::apply_rollback_transaction` via mocked `LockedRuntime` call
+//! recording. Own binary: `consts::data_dir()` `OnceLock` resolves once.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use std::sync::OnceLock;
 
@@ -61,8 +58,7 @@ fn apply_update_transaction_runs_down_then_validate_then_recreate() {
 #[test]
 #[serial_test::serial]
 fn apply_update_transaction_does_not_build_images() {
-    // Contract pin (ADR-066): builds happen OUTSIDE the lock. The caller
-    // (`update_containers`) builds first, then invokes this helper.
+    // Contract pin (ADR-066): builds happen OUTSIDE the lock.
     let data_dir = shared_data_dir();
     let project = "tx-no-build";
     let compose_dir = data_dir.join("compose").join(project);

--- a/crates/speedwave-runtime/tests/build_lock_cross_process.rs
+++ b/crates/speedwave-runtime/tests/build_lock_cross_process.rs
@@ -2,6 +2,8 @@
 //! parent+child per `tests/compose_lock_cross_process.rs` pattern, asserts the
 //! second process blocks on `<data_dir>/build.lock` until the first releases.
 
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::print_stderr)]
+
 use std::process::Command;
 use std::time::Duration;
 
@@ -36,8 +38,7 @@ fn second_process_blocks_until_first_releases() {
         .spawn()
         .expect("spawn holder");
 
-    // File-based handshake: wait until holder writes the sentinel — proves
-    // it has acquired the lock before we spawn the waiter.
+    // Wait until holder writes the sentinel before spawning the waiter.
     let deadline = std::time::Instant::now() + Duration::from_millis(READY_TIMEOUT_MS);
     while !sentinel.exists() {
         if std::time::Instant::now() >= deadline {

--- a/crates/speedwave-runtime/tests/compose_lock_cross_process.rs
+++ b/crates/speedwave-runtime/tests/compose_lock_cross_process.rs
@@ -2,6 +2,8 @@
 //! per `tests/data_dir_integration.rs` pattern, asserts the second process
 //! blocks until the first releases.
 
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::print_stderr)]
+
 use std::process::Command;
 use std::time::Duration;
 
@@ -9,12 +11,8 @@ const CHILD_ENV: &str = "__SPEEDWAVE_COMPOSE_LOCK_CHILD";
 const ROOT_ENV: &str = "__SPEEDWAVE_COMPOSE_LOCK_ROOT";
 const HOLD_MS_ENV: &str = "__SPEEDWAVE_COMPOSE_LOCK_HOLD_MS";
 
-/// Holder acquires the file lock, writes a "ready" sentinel file, then sleeps
-/// for `HOLD_MS`. The parent polls for the sentinel (file-based synchronisation
-/// — no hardcoded wait); then spawns the waiter and measures how long the
-/// waiter blocked. The threshold is derived from the remaining hold time, not
-/// a hard-coded constant, so the test is robust to runner load and process
-/// spawn overhead.
+/// Holder acquires the lock, writes a sentinel, sleeps `HOLD_MS`; parent polls
+/// for the sentinel, then spawns the waiter and measures its blocking time.
 const READY_SENTINEL: &str = "ready.lock";
 const HOLD_MS: u64 = 800;
 const MIN_BLOCK_MS: u64 = 200;
@@ -42,8 +40,7 @@ fn second_process_blocks_until_first_releases() {
         .spawn()
         .expect("spawn holder");
 
-    // File-based handshake: wait until holder writes the sentinel — proves
-    // it has acquired the lock before we spawn the waiter.
+    // Wait until holder writes the sentinel (lock acquired).
     let deadline = std::time::Instant::now() + Duration::from_millis(READY_TIMEOUT_MS);
     while !sentinel.exists() {
         if std::time::Instant::now() >= deadline {
@@ -78,9 +75,7 @@ fn second_process_blocks_until_first_releases() {
         "waiter process failed:\nstdout: {stdout}\nstderr: {stderr}"
     );
 
-    // MIN_BLOCK_MS is a conservative lower bound: even with worst-case spawn
-    // overhead the waiter should observe at least ~200 ms of blocking
-    // (HOLD_MS minus the time the sentinel-write+ready-poll took).
+    // MIN_BLOCK_MS: conservative lower bound for observed blocking time.
     assert!(
         waiter_wallclock >= Duration::from_millis(MIN_BLOCK_MS),
         "waiter returned in {waiter_wallclock:?}; expected ≥ {MIN_BLOCK_MS} ms of blocking"
@@ -99,8 +94,7 @@ fn run_child_role(role: &str) {
     let result =
         with_project_compose_lock_in(&root_path, "cross-proc-test", || -> anyhow::Result<()> {
             if role == "hold" {
-                // Signal "lock acquired" to the parent via sentinel file —
-                // race-free synchronisation, no sleep guesses.
+                // Signal "lock acquired" to the parent via sentinel file.
                 std::fs::write(root_path.join(READY_SENTINEL), b"ok")?;
             }
             if hold_ms > 0 {

--- a/crates/speedwave-runtime/tests/data_dir_integration.rs
+++ b/crates/speedwave-runtime/tests/data_dir_integration.rs
@@ -1,20 +1,11 @@
-//! Integration test for `SPEEDWAVE_DATA_DIR` env var → OnceLock wiring.
-//!
-//! OnceLock is immutable after first init, so we cannot test multiple env var
-//! values in a single process.  The Makefile sets `SPEEDWAVE_DATA_DIR=` (empty)
-//! for unit tests, which causes `data_dir()` to fall back to `~/.speedwave/`.
-//!
-//! This integration test binary verifies the custom-env-var scenario by
-//! spawning a subprocess with `SPEEDWAVE_DATA_DIR` set.  The subprocess is
-//! a small Rust program compiled as a test helper.
+//! Integration test for `SPEEDWAVE_DATA_DIR` env var → OnceLock wiring via subprocess re-exec.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use std::process::Command;
 
 /// Spawns a child process that sets `SPEEDWAVE_DATA_DIR` and verifies
 /// the OnceLock-backed functions return correct derived values.
-///
-/// We use the cargo test binary itself with a marker env var to detect
-/// the child role.
 #[test]
 fn data_dir_respects_env_var_and_derives_names() {
     if std::env::var("__SPEEDWAVE_INTEGRATION_CHILD").is_ok() {

--- a/crates/speedwave-runtime/tests/lock_acquisitions.rs
+++ b/crates/speedwave-runtime/tests/lock_acquisitions.rs
@@ -1,13 +1,12 @@
-//! Static assertion that each LOCKED method on `LockedRuntime` acquires the
-//! per-project compose lock exactly once, and that passthrough methods do
-//! not. Runs in its own process (Cargo integration test), so the global
-//! `LOCK_ACQUISITIONS` counter starts at zero and is not polluted by other
-//! tests.
+//! Each LOCKED method on `LockedRuntime` acquires the per-project compose lock
+//! exactly once; passthrough methods do not. Own process, so `LOCK_ACQUISITIONS`
+//! starts at zero.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use speedwave_runtime::runtime::mock_runtime::MockRuntimeBuilder;
 
-// Internal hook from the crate's `runtime::locked` module — only the in-crate
-// counter knows about acquisitions.
+// Internal hook from the crate's `runtime::locked` module.
 extern crate speedwave_runtime as _runtime;
 
 fn count() -> usize {

--- a/crates/speedwave-runtime/tests/no_hardcoded_loopback_bind.rs
+++ b/crates/speedwave-runtime/tests/no_hardcoded_loopback_bind.rs
@@ -55,8 +55,7 @@ fn is_in_test_module(lines: &[&str], idx: usize) -> bool {
         }
         // Closing brace of a sibling top-level item — stop scanning back.
         if l == "}" && lines[i].starts_with('}') {
-            // Top-level close. We've passed the start of an item; if we
-            // haven't seen a test marker by here, this isn't test code.
+            // Top-level close before any test marker: not test code.
             return false;
         }
     }
@@ -71,8 +70,7 @@ fn has_allow_marker(line: &str, prev: Option<&&str>) -> bool {
 /// (upstream IDE WebSocket, plugin local-UI URL, etc.). Reviewed at landing
 /// time; new entries require justification in the PR.
 const ALLOWLISTED_FILES: &[&str] = &[
-    // Host→host: WS URL Tauri uses to dial the external IDE (VSCode/Cursor)
-    // running on the same machine. Not container-facing.
+    // Host→host: WS URL Tauri uses to dial the external IDE (VSCode/Cursor).
     "desktop/src-tauri/src/bridges/ide_bridge.rs",
     // Host→host: local UI URL returned to the Angular webview.
     "desktop/src-tauri/src/bridges/plugin_host_bridge.rs",

--- a/crates/speedwave-runtime/tests/no_raw_data_dir_in_tests.rs
+++ b/crates/speedwave-runtime/tests/no_raw_data_dir_in_tests.rs
@@ -1,16 +1,6 @@
 //! Drift detector: test code must never resolve the production data dir via
-//! `consts::data_dir()`. Tests pass an explicit tempdir to the `_in` variants
-//! (or set `SPEEDWAVE_DATA_DIR` to a tempdir in a dedicated integration binary).
-//! Bypass an individual line with `// SSOT-allow: <reason>`.
-//!
-//! KNOWN LIMITATION (cannot be fixed statically): this scanner only catches a
-//! *literal* `consts::data_dir()` token inside test code. It cannot catch
-//! TRANSITIVE resolution — a test that calls a no-arg production fn (e.g.
-//! `compose::init_secrets_dir(project)`) which internally resolves
-//! `consts::data_dir()`. The runtime guard `prod_data_dir_untouched.rs` is the
-//! backstop for those cases: it env-isolates the data dir and asserts the real
-//! `~/.speedwave` is untouched after a representative smoke, catching transitive
-//! leaks this static scan is blind to.
+//! `consts::data_dir()`. Catches only literal tokens; transitive resolution is
+//! backstopped by `prod_data_dir_untouched.rs`. Bypass with `// SSOT-allow:`.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
@@ -45,10 +35,8 @@ fn manifest_root() -> PathBuf {
         .to_path_buf()
 }
 
-/// The bare-`data_dir()` resolutions forbidden inside test regions. Each is the
-/// production OnceLock-backed singleton that maps to the real `~/.speedwave`.
-/// Ordered longest-first so a qualified form (`crate::consts::…`) is reported
-/// once, not also as the `consts::…` substring it contains.
+/// The bare-`data_dir()` resolutions forbidden inside test regions, ordered
+/// longest-first so a qualified form is reported once, not as a substring.
 const PATTERNS: &[&str] = &[
     "speedwave_runtime::consts::data_dir()",
     "crate::consts::data_dir()",
@@ -57,8 +45,6 @@ const PATTERNS: &[&str] = &[
 
 /// True when `#[cfg(test)]` / `#[cfg(any(test...` guards a test *module*
 /// (the next item is `mod`), not a test-only production helper (`fn`/`pub fn`).
-/// A `data_dir()` call in a `#[cfg(test)]`-gated *helper* runs in
-/// production-shaped code and is legitimate; one inside `mod tests` is not.
 fn cfg_test_guards_a_module(lines: &[&str], cfg_idx: usize) -> bool {
     for l in lines.iter().skip(cfg_idx + 1) {
         let l = l.trim_start();
@@ -73,8 +59,7 @@ fn cfg_test_guards_a_module(lines: &[&str], cfg_idx: usize) -> bool {
 }
 
 fn is_in_test_module(lines: &[&str], idx: usize) -> bool {
-    // Walk backwards for the nearest enclosing test marker: `mod tests {`,
-    // `#[test]`, or a `#[cfg(test)]` that guards a `mod` (not a helper fn).
+    // Walk backwards for the nearest enclosing test marker.
     for i in (0..idx).rev() {
         let l = lines[i].trim_start();
         if l.starts_with("mod tests") || l.starts_with("#[test]") {
@@ -93,12 +78,8 @@ fn is_in_test_module(lines: &[&str], idx: usize) -> bool {
     false
 }
 
-/// A file living under a `tests/` directory is a cargo *integration-test
-/// binary*: the WHOLE file is test code (there is no production codepath in an
-/// integration binary). A bare `data_dir()` in a free helper fn there — not
-/// only under `#[test]`/`mod tests` — still runs in the test process and can
-/// touch the real `~/.speedwave`. So for these files we treat any line as a
-/// test region and rely solely on the comment / `// SSOT-allow:` filters.
+/// A file under a `tests/` directory is a cargo integration-test binary: the
+/// whole file is test code, so every line is treated as a test region.
 fn is_integration_test_file(rel_str: &str) -> bool {
     rel_str.contains("/tests/")
 }
@@ -108,11 +89,8 @@ fn has_allow_marker(line: &str, prev: Option<&&str>) -> bool {
 }
 
 /// Integration-test binaries that legitimately set `SPEEDWAVE_DATA_DIR` to a
-/// tempdir and then resolve the OnceLock once, to exercise the env-var wiring
-/// itself. These are the only sanctioned bare-`data_dir()` call sites in tests.
-///
-/// This drift detector's own source is self-excluded: it carries the literal
-/// `consts::data_dir()` token in `PATTERNS` as *data*, not as a call.
+/// tempdir to exercise env-var wiring, plus this detector's own self-exclusion
+/// (it carries `consts::data_dir()` in `PATTERNS` as data, not a call).
 const ALLOWLISTED_FILES: &[&str] = &[
     "crates/speedwave-runtime/tests/apply_transaction_behaviour.rs",
     "crates/speedwave-runtime/tests/data_dir_integration.rs",
@@ -124,8 +102,7 @@ fn no_raw_data_dir_in_test_regions() {
     let root = manifest_root();
     let crates_root = root.join("crates");
     let desktop_src = root.join("desktop").join("src-tauri").join("src");
-    // Integration-test binaries for the Desktop crate: whole-file test code,
-    // same as the runtime crate's own `tests/` binaries.
+    // Integration-test binaries for the Desktop crate: whole-file test code.
     let desktop_tests = root.join("desktop").join("src-tauri").join("tests");
 
     let mut files = Vec::new();
@@ -155,12 +132,8 @@ fn no_raw_data_dir_in_test_regions() {
             if has_allow_marker(line, prev) {
                 continue;
             }
-            // Longest-first; report each line once (a qualified form contains
-            // the shorter `consts::data_dir()` substring).
             if let Some(pat) = PATTERNS.iter().find(|p| line.contains(**p)) {
-                // In an integration-test binary the whole file is test code; in
-                // a `src/` file only genuine test regions (`#[test]`/`mod tests`)
-                // are forbidden — a `#[cfg(test)]` helper is production-shaped.
+                // Whole-file test binaries; in `src/` only genuine test regions.
                 if whole_file_is_test || is_in_test_module(&lines, idx) {
                     violations.push(format!(
                         "{}:{}: matches {pat:?}\n  > {}",

--- a/crates/speedwave-runtime/tests/no_raw_engine_path.rs
+++ b/crates/speedwave-runtime/tests/no_raw_engine_path.rs
@@ -1,8 +1,6 @@
-//! Drift detector: every host→engine path must be produced by the SSOT in
-//! `engine_path` (`to_engine_path` / `str_to_engine_path` / `vm_path_join`).
-//! No hand-rolled WSL translation, no `PathBuf::join` on an engine-side path,
-//! no second `wslpath` mechanism, no `windows_to_wsl_path` outside the runtime
-//! crate. Bypass a false positive with `// SSOT-allow: <reason>`.
+//! Drift detector: every host→engine path must use the SSOT in `engine_path`
+//! (`to_engine_path` / `str_to_engine_path` / `vm_path_join`).
+//! Bypass a false positive with `// SSOT-allow: <reason>`.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
@@ -33,10 +31,9 @@ fn manifest_root() -> PathBuf {
         .to_path_buf()
 }
 
-/// `.join(` invoked on a binding whose name signals it already holds an
-/// engine-side path — the exact shape of the `examplePluginContainerfile` bug. Use
-/// `vm_path_join` instead. (A chained `prepare_build_context(...).join(...)` is
-/// caught by the `CHAINED_JOIN` rule below, not here.)
+/// `.join(` on a binding signaling an engine-side path (e.g. `vm_root.join(`) —
+/// use `vm_path_join`. Chained `prepare_build_context(...).join(...)` caught by
+/// the `CHAINED_JOIN` rule.
 const JOIN_ON_ENGINE_PATTERNS: &[&str] = &[
     "vm_root.join(",
     "wsl_path.join(",
@@ -60,12 +57,6 @@ const WSLPATH_PATTERNS: &[&str] = &["\"wslpath\""];
 /// downstream crate (desktop/cli) may call it — they go through the SSOT.
 const PRIMITIVE_PATTERNS: &[&str] = &["windows_to_wsl_path"];
 
-// Heuristic: scan backward for a test marker, stopping at the first column-0
-// `}` (a top-level item close). Limitation: a column-0 `}` between the
-// violation and its enclosing `mod tests` (e.g. a nested `impl` close at column
-// 0 inside the module) could end the scan early and mis-classify a test-module
-// line as production — a possible false negative. Acceptable: the worst case is
-// the detector flagging real test code, which a `// SSOT-allow:` clears.
 fn is_in_test_module(lines: &[&str], idx: usize) -> bool {
     for i in (0..idx).rev() {
         let l = lines[i].trim_start();
@@ -145,8 +136,7 @@ fn line_matches(rule: &Rule, line: &str) -> bool {
 
 #[test]
 fn engine_paths_go_through_ssot() {
-    // Self-verify the hard-coded index: if a rule is inserted before it, the
-    // primitive-rule exemption would silently apply to the wrong rule.
+    // Self-verify the hard-coded index against PRIMITIVE_PATTERNS.
     assert_eq!(
         RULES[PRIMITIVE_RULE_IDX].patterns, PRIMITIVE_PATTERNS,
         "PRIMITIVE_RULE_IDX no longer points at the PRIMITIVE_PATTERNS rule — update it"
@@ -179,9 +169,7 @@ fn engine_paths_go_through_ssot() {
                 continue;
             }
             for (ri, rule) in RULES.iter().enumerate() {
-                // SSOT files (engine_path.rs, wsl.rs) own the join/translate/mnt
-                // logic, so rules 0-3 don't apply to them. The primitive rule
-                // never fires inside the runtime crate at all.
+                // SSOT files own the join/translate logic; non-SSOT files must route through engine_path.
                 if is_ssot {
                     continue;
                 }

--- a/crates/speedwave-runtime/tests/prod_data_dir_untouched.rs
+++ b/crates/speedwave-runtime/tests/prod_data_dir_untouched.rs
@@ -1,19 +1,6 @@
 //! Runtime backstop for the static scanner (`no_raw_data_dir_in_tests.rs`):
-//! a representative data-dir-rooted smoke must never touch the production
-//! `~/.speedwave`. This is the ONLY guard that catches *transitive* leaks — a
-//! test calling a no-arg production fn that internally resolves
-//! `consts::data_dir()` — which the static scan is structurally blind to.
-//!
-//! Design (why this is robust, not OnceLock-fragile):
-//! The real invariant is "production `~/.speedwave` is untouched", NOT
-//! "`data_dir()` resolves to the tempdir". So the smoke drives the **`_in`
-//! variants** with an explicit tempdir and never asserts on the OnceLock. We
-//! still point `SPEEDWAVE_DATA_DIR` at the tempdir as defense-in-depth (any
-//! *transitive* bare-`data_dir()` a future addition introduces also lands in
-//! the tempdir on the first resolution), but no assertion DEPENDS on that
-//! resolution order. Consequently this binary is safe to grow a second test:
-//! the prod-untouched invariant holds regardless of which test resolves the
-//! OnceLock first.
+//! catches *transitive* data-dir leaks. Drives the `_in` variants with an
+//! explicit tempdir and never asserts on OnceLock state.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
@@ -22,9 +9,8 @@ use std::time::SystemTime;
 
 use speedwave_runtime::{compose, consts};
 
-/// Minimal compose YAML with a resolvable network ref — `save_compose_in`
-/// validates network refs in-memory and on read-back, so the document must be
-/// internally consistent.
+/// Minimal compose YAML with a resolvable network ref (`save_compose_in`
+/// validates refs in-memory and on read-back).
 const VALID_YAML: &str = "version: '3'\nnetworks:\n  default:\n    driver: bridge\nservices:\n  app:\n    image: nginx\n    networks:\n      - default\n";
 
 /// `SPEEDWAVE_DATA_DIR` basename must match `^[a-z][a-z0-9-]{0,63}$`
@@ -48,25 +34,16 @@ fn snapshot(path: &std::path::Path) -> Option<SystemTime> {
 fn representative_smoke_does_not_touch_prod_data_dir() {
     let prod = dirs::home_dir().expect("home dir").join(consts::DATA_DIR);
 
-    // Record production state BEFORE the smoke. Missing is the strongest
-    // assertion; if a developer happens to have a real install, we fall back
-    // to an mtime-unchanged check.
+    // Record production state before the smoke (missing, or mtime fallback).
     let before_exists = prod.exists();
     let before_mtime = snapshot(&prod);
 
     let (_outer, tmp_data_dir) = regex_valid_data_dir();
 
-    // Defense-in-depth only: routes any *transitive* bare-`data_dir()` into the
-    // tempdir too. The assertions below do NOT depend on this resolving (the
-    // smoke uses the explicit-`data_dir` `_in` variants), so the OnceLock
-    // ordering is irrelevant to correctness — that is what makes this binary
-    // safe to extend with additional tests.
+    // Defense-in-depth: routes any transitive bare-`data_dir()` into the tempdir.
     std::env::set_var(consts::DATA_DIR_ENV, &tmp_data_dir);
 
-    // Representative smoke: a real, data-dir-rooted filesystem write
-    // (`save_compose_in` creates `compose/<project>/` and writes the file) plus
-    // a path-resolution op — both via the explicit-`data_dir` `_in` variants,
-    // so every path derives from the tempdir, never from the OnceLock.
+    // Representative smoke: a data-dir-rooted write plus a path-resolution op.
     let project = "prod-untouched-smoke";
     compose::save_compose_in(&tmp_data_dir, project, VALID_YAML).expect("save_compose_in");
     let compose_path =
@@ -82,8 +59,7 @@ fn representative_smoke_does_not_touch_prod_data_dir() {
         "smoke did not write the compose file at {compose_path:?}"
     );
 
-    // Production must be untouched: still absent (strongest), or — if it
-    // pre-existed on this machine — its mtime must be unchanged.
+    // Production must be untouched: still absent, or mtime unchanged.
     let after_exists = prod.exists();
     let after_mtime = snapshot(&prod);
 

--- a/desktop/e2e/helpers/dialog-mock.ts
+++ b/desktop/e2e/helpers/dialog-mock.ts
@@ -1,19 +1,10 @@
 /**
- * Stubs the OS folder picker that backs `app-create-project-modal` browse
- * action. The component honours `window.__E2E_DIALOG_PATH__` as a test seam:
- * `string` resolves the picker, `null` simulates user cancel.
- *
- * The OS-native dialog cannot be driven by WebDriver — it spawns outside the
- * webview process. Earlier attempts to intercept the plugin-dialog IPC
- * channel via `__TAURI_INTERNALS__.invoke` did not survive across navigations
- * in production builds, so the seam lives in the component itself.
+ * Stubs the `app-create-project-modal` folder picker via the
+ * `window.__E2E_DIALOG_PATH__` test seam: `string` resolves, `null` cancels.
  */
 
 /**
- * Plants the test override on `window`. Subsequent `browse()` calls in the
- * create-project modal short-circuit to `path` instead of opening the real
- * picker. Idempotent — re-call to change the value mid-flow.
- *
+ * Plants the dialog override on `window`. Idempotent.
  * @param path - Absolute path the picker should "return", or `null` for cancel.
  */
 export async function mockDialogOpen(path: string | null): Promise<void> {

--- a/desktop/e2e/helpers/projects.ts
+++ b/desktop/e2e/helpers/projects.ts
@@ -1,9 +1,5 @@
 /**
  * Helpers for project state introspection inside the running webview.
- *
- * Tests prefer asking the Tauri backend for ground truth (`list_projects`,
- * `is_setup_complete`) over scraping rendered text — the slug is stable, the
- * UX copy is not.
  */
 
 /** Returns the slug of the active project from `__TAURI_INTERNALS__`. */

--- a/desktop/e2e/helpers/shell.ts
+++ b/desktop/e2e/helpers/shell.ts
@@ -1,20 +1,7 @@
-/**
- * Helpers for synchronising with the shell's `projectState` lifecycle.
- *
- * The shell renders a full-screen `blocking-overlay` whenever projectState is
- * not `ready` (loading / starting / switching / check_failed / error). The
- * overlay covers the chat header — including the project pill — so any test
- * that clicks the pill or the nav rail must first wait for the overlay to
- * clear, otherwise the click lands on the overlay and the assertion times
- * out with a misleading "element still not existing" error.
- */
+/** Helpers for synchronising with the shell's `projectState` lifecycle. */
 
 /**
  * Waits until the shell's blocking overlay disappears (projectState ready).
- * If the overlay was never present, returns immediately. Throws after the
- * timeout if the overlay is still up — the caller usually treats that as a
- * test failure with a clear message.
- *
  * @param timeoutMs - How long to wait for the overlay to clear.
  */
 export async function waitForShellReady(timeoutMs = 60_000): Promise<void> {

--- a/desktop/e2e/specs/01-app-lifecycle.spec.ts
+++ b/desktop/e2e/specs/01-app-lifecycle.spec.ts
@@ -1,10 +1,5 @@
 /**
- * App Lifecycle E2E tests.
- *
- * Verifies the Tauri app launched correctly, Angular is rendering,
- * and the setup wizard is shown on a fresh install.
- *
- * These tests run first — if they fail, the app did not start properly.
+ * App Lifecycle E2E tests: Tauri launch, Angular render, setup wizard on fresh install.
  */
 
 describe('App Lifecycle', function () {

--- a/desktop/e2e/specs/02-setup-wizard.spec.ts
+++ b/desktop/e2e/specs/02-setup-wizard.spec.ts
@@ -22,15 +22,7 @@ import { mockDialogOpen, clearDialogMock } from '../helpers/dialog-mock';
 const E2E_PROJECT_NAME = 'e2e-test';
 const E2E_PROJECT_DIR = process.env.E2E_PROJECT_DIR || '/tmp/speedwave-e2e-project';
 
-/** Check if setup is complete by invoking the Tauri command directly.
- *
- * This is the SSOT — if Rust says setup is complete, it is complete.
- * DOM state (data-status attributes, element existence) is secondary and
- * subject to WebDriver timing issues.
- *
- * Uses executeAsync because __TAURI_INTERNALS__.invoke() returns a Promise.
- * browser.execute() cannot await Promises — it returns null for them.
- */
+/** Check if setup is complete by invoking the Tauri command directly (SSOT). */
 async function isSetupComplete(): Promise<boolean> {
   return browser.executeAsync((done: (result: boolean) => void) => {
     (window as unknown as { __TAURI_INTERNALS__: { invoke: (cmd: string) => Promise<boolean> } })
@@ -41,14 +33,7 @@ async function isSetupComplete(): Promise<boolean> {
 }
 
 /** Wait for a setup wizard step (0-based index) to reach a terminal state.
- *
- * When steps complete very fast (cached images), the wizard may jump straight
- * to phase='complete' before a poll catches the individual step's status.
- * We treat the presence of `[data-testid="setup-success"]` as "all steps done".
- *
- * If DOM polling times out but Tauri reports setup complete, the step is
- * considered done — fast transitions can cause the wizard to skip past
- * individual step DOM states before WebDriver catches them.
+ * `[data-testid="setup-success"]` or a Tauri-reported complete setup both count as done.
  */
 async function waitForStepTerminal(index: number, timeout: number): Promise<string> {
   let status = '';
@@ -74,8 +59,6 @@ async function waitForStepTerminal(index: number, timeout: number): Promise<stri
     );
   } catch (e) {
     // DOM poll timed out — check Tauri state as fallback.
-    // On fast second installs, steps 4-5 complete and the wizard redirects
-    // before WebDriver catches the individual step's data-status change.
     const complete = await isSetupComplete();
     if (complete) {
       status = 'done';
@@ -106,9 +89,7 @@ describe('Setup Wizard — Full Flow', function () {
     const wizard = await $('[data-testid="setup-wizard"]');
     await wizard.waitForExist({ timeout: 10_000 });
 
-    // The wizard renders the headline + subtitle + description region — assert
-    // each by testid. Text content is intentionally not checked: it is part of
-    // the design copy and changes between releases.
+    // Assert headline + subtitle + description region by testid (not text — design copy).
     await wizard.$('[data-testid="setup-headline"]').waitForExist({ timeout: 5_000 });
     await wizard.$('[data-testid="setup-subtitle"]').waitForExist({ timeout: 5_000 });
     await wizard.$('[data-testid="setup-description"]').waitForExist({ timeout: 5_000 });
@@ -135,9 +116,7 @@ describe('Setup Wizard — Full Flow', function () {
     const firstStatus = await stepElements[0].getAttribute('data-status');
     expect(['active', 'done']).toContain(firstStatus);
 
-    // Each step row exposes a step-title sub-element; presence is enough,
-    // text varies with platform (macOS "Verify Lima / nerdctl" vs Windows
-    // "Verify system requirements") and would couple the test to copy.
+    // Verify step-title sub-element exists (not text — platform/copy dependent).
     const firstTitle = await stepElements[0].$('[data-testid="step-title"]');
     await firstTitle.waitForExist({ timeout: 5_000 });
   });
@@ -182,9 +161,7 @@ describe('Setup Wizard — Full Flow', function () {
   it('should fill the project form via the picker stub and create the project', async function () {
     this.timeout(60_000);
 
-    // Stub the OS folder picker BEFORE clicking browse — the native dialog
-    // cannot be driven by WebDriver; we intercept the plugin-dialog IPC
-    // channel and resolve to a known path.
+    // Stub the OS folder picker (plugin-dialog IPC) before clicking browse — WebDriver cannot drive the native dialog.
     await mockDialogOpen(E2E_PROJECT_DIR);
 
     const modal = await $('[data-testid="create-project-modal"]');
@@ -199,8 +176,7 @@ describe('Setup Wizard — Full Flow', function () {
       timeoutMsg: 'Project directory was not populated by the dialog stub',
     });
 
-    // Name auto-fills from the dir basename. Override with the canonical e2e
-    // project name so other specs can reference it deterministically.
+    // Name auto-fills from the dir basename; override with the canonical e2e project name.
     const nameInput = await modal.$('[data-testid="create-project-name"]');
     await nameInput.setValue(E2E_PROJECT_NAME);
     expect(await nameInput.getValue()).toBe(E2E_PROJECT_NAME);
@@ -233,14 +209,10 @@ describe('Setup Wizard — Full Flow', function () {
     const complete = await isSetupComplete();
     expect(complete).toBe(true);
 
-    // The wizard's setTimeout + router.navigate redirect can be blocked by
-    // stale-element JS exceptions injected by WebDriver DOM polling during
-    // fast step transitions. Force a navigation to root so setupCompleteGuard
-    // re-evaluates and routes to the main shell.
+    // WebDriver stale-element during fast transitions; force nav to root to re-evaluate setupCompleteGuard.
     await browser.execute(() => (window.location.href = '/'));
 
-    // The shell is identified by the project pill in the header — it appears
-    // exactly when the user is past the setup phase and inside the main app.
+    // The shell is identified by the project pill in the header.
     const projectPill = await $('[data-testid="project-pill"]');
     await projectPill.waitForExist({ timeout: 15_000 });
   });

--- a/desktop/e2e/specs/03-container-health.spec.ts
+++ b/desktop/e2e/specs/03-container-health.spec.ts
@@ -1,16 +1,6 @@
 /**
- * Container Health E2E tests.
- *
- * After the setup wizard completes (spec 02), containers should be running
- * for the 'e2e-test' project. This spec calls the `get_health` Tauri command
- * (the same data source the System Health UI uses) and verifies that:
- *   - The VM is running
- *   - Both expected containers (claude, mcp_hub) are present and healthy
- *   - overall_healthy is true
- *
- * Does NOT assert mcp_os.running or ide_bridge.running — mcp-os depends on
- * timing/platform, and no IDE is present during E2E runs. Neither affects
- * overall_healthy in a fresh E2E run with clean project dirs.
+ * Container Health E2E tests. Verifies VM and containers (claude, mcp_hub)
+ * are running and healthy via get_health. Does not assert mcp_os/ide_bridge.
  */
 
 import { getHealth, waitForHealthy } from '../helpers/health';

--- a/desktop/e2e/specs/04-navigation.spec.ts
+++ b/desktop/e2e/specs/04-navigation.spec.ts
@@ -1,10 +1,6 @@
 /**
- * Navigation E2E tests.
- *
- * Verifies the shell header, nav links, routing, and project switcher
- * after setup has completed. The `before()` hook fails fast if the shell
- * is not present — no silent early returns. All assertions use
- * `data-testid` attributes only — never UX-volatile text.
+ * Navigation E2E tests: shell header, nav links, routing, project switcher.
+ * Uses data-testid only; fails fast if setup incomplete.
  */
 
 import { activeProjectSlug } from '../helpers/projects';
@@ -13,9 +9,7 @@ describe('Navigation', function () {
   before(async function () {
     this.timeout(65_000);
 
-    // The project pill in the chat header is the canonical "shell mounted"
-    // marker — it only renders once setupCompleteGuard has resolved and the
-    // shell component is on screen.
+    // Project pill = ready signal (setupCompleteGuard resolved).
     const pill = await $('[data-testid="project-pill"]');
     await pill.waitForExist({
       timeout: 15_000,
@@ -29,7 +23,7 @@ describe('Navigation', function () {
       throw new Error('Project is in error state — cannot test navigation');
     }
 
-    // If a blocking overlay is visible, wait for it to clear (status → ready).
+    // Wait for blocking overlay to clear (status → ready).
     const overlay = await $('[data-testid="blocking-overlay"]');
     if (await overlay.isExisting()) {
       await overlay.waitForExist({
@@ -49,8 +43,7 @@ describe('Navigation', function () {
   it('should expose Integrations and Settings nav links (Chat conditional on auth)', async function () {
     this.timeout(15_000);
 
-    // Chat link visibility depends on auth state — may or may not be present
-    // after fresh setup. Only verify presence; do not check copy.
+    // Chat link presence depends on auth state; verify only.
     const integrations = await $('[data-testid="nav-integrations"]');
     expect(await integrations.isExisting()).toBe(true);
 
@@ -63,9 +56,7 @@ describe('Navigation', function () {
     const chat = await $('[data-testid="nav-chat"]');
     if (await chat.isExisting()) {
       await chat.click();
-      // The chat surface renders one of: chat-view (authenticated) or
-      // chat-view-blocked (auth_required). Either signals the Chat route
-      // mounted successfully.
+      // Chat route mounted if chat-view OR chat-view-blocked exists.
       await browser.waitUntil(
         async () => {
           return (
@@ -83,7 +74,7 @@ describe('Navigation', function () {
     const integrations = await $('[data-testid="nav-integrations"]');
     await integrations.click();
 
-    // The integrations route is anchored by its body container.
+    // Integrations route anchored by body container.
     const body = await $('[data-testid="integrations-body"]');
     await body.waitForExist({ timeout: 10_000 });
     expect(await body.isDisplayed()).toBe(true);
@@ -94,8 +85,7 @@ describe('Navigation', function () {
     const settings = await $('[data-testid="nav-settings"]');
     await settings.click();
 
-    // Project info card was removed; the page heading is the new ready
-    // signal. Settings ground-truth lives in `activeProjectSlug()`.
+    // Settings ready signal: page heading (project card removed).
     const title = await $('[data-testid="settings-title"]');
     await title.waitForExist({ timeout: 10_000 });
     expect(await title.isDisplayed()).toBe(true);

--- a/desktop/e2e/specs/05-settings.spec.ts
+++ b/desktop/e2e/specs/05-settings.spec.ts
@@ -1,9 +1,5 @@
 /**
- * Settings E2E tests.
- *
- * Verifies the settings page loads correctly with project data from setup.
- * The `before()` hook navigates to settings and fails if the page does not
- * load — no silent early returns. All assertions use `data-testid` only.
+ * Settings E2E tests: verify the settings page loads with project data from setup.
  */
 
 import { activeProjectSlug } from '../helpers/projects';
@@ -20,10 +16,7 @@ describe('Settings', function () {
     });
     await nav.click();
 
-    // Settings ready signal — the legacy "active project" info card was
-    // replaced by an info-glyph tooltip on the shared project-pill, so we
-    // wait for the page heading instead. Active-project verification still
-    // happens through `activeProjectSlug()` (backend ground truth).
+    // Settings ready signal: wait for the page heading.
     const title = await $('[data-testid="settings-title"]');
     await title.waitForExist({ timeout: 10_000 });
   });
@@ -65,9 +58,7 @@ describe('Settings', function () {
 
   it('should not duplicate the export-diagnostics control (moved to /logs)', async function () {
     this.timeout(15_000);
-    // Diagnostics export was relocated to System health (/logs). The settings
-    // page must no longer render its own copy — assert absence so a future
-    // accidental re-introduction trips the suite immediately.
+    // Diagnostics export relocated to /logs; assert absence here.
     const exportBtn = await $('[data-testid="settings-export-diagnostics"]');
     expect(await exportBtn.isExisting()).toBe(false);
   });

--- a/desktop/e2e/specs/06-project-management.spec.ts
+++ b/desktop/e2e/specs/06-project-management.spec.ts
@@ -36,8 +36,7 @@ describe('Project Management', function () {
     it('should open the project switcher dropdown', async function () {
       this.timeout(60_000);
 
-      // Setup wizard finalize → settings redirect can leave the shell briefly
-      // in `auth_required` (blocking-overlay up) before settling to ready.
+      // Wait for the blocking-overlay to clear after setup-wizard finalize.
       await waitForShellReady();
 
       const pill = await $('[data-testid="project-pill"]');
@@ -70,8 +69,7 @@ describe('Project Management', function () {
     it('should fill the create-project modal and add the project', async function () {
       this.timeout(180_000);
 
-      // Stub the OS folder picker before clicking browse — the native dialog
-      // cannot be driven by WebDriver.
+      // Stub the OS folder picker; WebDriver cannot drive the native dialog.
       await mockDialogOpen(SECOND_PROJECT_DIR);
 
       const modal = await $('[data-testid="create-project-modal"]');
@@ -96,11 +94,7 @@ describe('Project Management', function () {
       });
       await submitBtn.click();
 
-      // Adding a project triggers the full switch lifecycle:
-      //   project_switch_started → containers up → project_switch_succeeded
-      // After project_switch_succeeded, list_projects returns the new active
-      // project. Use the Tauri command as the SSOT — DOM updates lag behind
-      // and the modal-error testid is the only DOM signal we trust.
+      // active_project (Tauri SSOT) becomes the new slug after add_project completes.
       await browser.waitUntil(
         async () => {
           const errorBanner = await modal.$('[data-testid="create-project-error"]');
@@ -122,9 +116,7 @@ describe('Project Management', function () {
     it('should list both projects in the dropdown', async function () {
       this.timeout(60_000);
 
-      // After `add_project`, projectState transitions through
-      // starting → ready (or auth_required), with the blocking-overlay up.
-      // Wait for it to clear before clicking the pill.
+      // Wait for the blocking-overlay to clear before clicking the pill.
       await waitForShellReady();
 
       const pill = await $('[data-testid="project-pill"]');
@@ -133,9 +125,7 @@ describe('Project Management', function () {
       const dropdown = await $('[data-testid="project-switcher-dropdown"]');
       await dropdown.waitForExist({ timeout: 5_000 });
 
-      // The switcher refreshes its list on `onProjectSettled` — that callback
-      // is async, so the dropdown can appear with the stale list before the
-      // refresh fires. Poll until both items render rather than reading once.
+      // Switcher list refresh (onProjectSettled) is async; poll until both items render.
       await browser.waitUntil(
         async () => {
           const a = await $('[data-testid="project-switcher-item-e2e-test"]').isExisting();
@@ -164,12 +154,10 @@ describe('Project Management', function () {
     it('should switch back to e2e-test project', async function () {
       this.timeout(180_000);
 
-      // Wait for the previous switch's blocking-overlay to clear before
-      // attempting another pill click — the overlay covers the header.
+      // Wait for the blocking-overlay to clear before the pill click.
       await waitForShellReady();
 
-      // The previous test may have closed the switcher mid-animation; click
-      // until the dropdown actually appears (defensive against pill toggling).
+      // Retry the pill click until the dropdown opens.
       const pill = await $('[data-testid="project-pill"]');
       const dropdown = await $('[data-testid="project-switcher-dropdown"]');
       await browser.waitUntil(
@@ -184,8 +172,7 @@ describe('Project Management', function () {
       const firstProject = await $('[data-testid="project-switcher-item-e2e-test"]');
       await firstProject.click();
 
-      // Wait for switch_project to complete — list_projects active_project is
-      // the definitive signal (updates after project_switch_succeeded).
+      // active_project (Tauri SSOT) is the definitive switch-complete signal.
       await browser.waitUntil(async () => (await activeProjectSlug()) === 'e2e-test', {
         timeout: 150_000,
         timeoutMsg: 'active_project did not become e2e-test — switch_project did not complete',
@@ -198,13 +185,11 @@ describe('Project Management', function () {
       const nav = await $('[data-testid="nav-settings"]');
       await nav.click();
 
-      // Settings ready signal — page heading replaces the legacy active
-      // project info card; project ground truth comes from `activeProjectSlug()`.
+      // Settings-ready signal: page heading.
       const title = await $('[data-testid="settings-title"]');
       await title.waitForExist({ timeout: 10_000 });
 
-      // Defer to Tauri SSOT instead of comparing rendered text — the settings
-      // copy embeds the slug in human-readable text that may change.
+      // Use Tauri SSOT, not rendered text (settings slug copy may change).
       await browser.waitUntil(async () => (await activeProjectSlug()) === 'e2e-test', {
         timeout: 10_000,
         timeoutMsg: 'list_projects active_project did not stabilise on e2e-test',

--- a/desktop/e2e/specs/07-factory-reset.spec.ts
+++ b/desktop/e2e/specs/07-factory-reset.spec.ts
@@ -7,8 +7,6 @@
  *   3. Confirm app.restart() fires (WebDriver port comes back up)
  *
  * This spec MUST be the last in the suite — it destroys all state.
- * No WebDriver reconnect is attempted; the session dies with the old
- * process and that is the expected final state.
  */
 
 import * as http from 'node:http';
@@ -51,9 +49,7 @@ describe('Factory Reset', function () {
     });
     await nav.click();
 
-    // The legacy active-project info card was removed. Settings is "ready"
-    // when the page heading is rendered; the active project itself is read
-    // from `activeProjectSlug()` (backend ground truth).
+    // Settings is ready when the page heading is rendered; active project from activeProjectSlug().
     const title = await $('[data-testid="settings-title"]');
     await title.waitForExist({
       timeout: 10_000,
@@ -78,8 +74,7 @@ describe('Factory Reset', function () {
     );
     expect(stateExists).toBe(true);
 
-    // Click factory reset → confirm. app.restart() kills the process,
-    // so the confirm click may throw — that is expected.
+    // Click factory reset → confirm; app.restart() kills the process so the click may throw.
     const resetBtn = await $('[data-testid="settings-reset-btn"]');
     await resetBtn.click();
 
@@ -92,13 +87,10 @@ describe('Factory Reset', function () {
       // Expected: session dies when Tauri process exits
     }
 
-    // Wait for old process to die and release port 4445.
-    // 3s covers TCP TIME_WAIT + process teardown on all platforms.
+    // Wait for old process to die and release port 4445 (TCP TIME_WAIT + teardown).
     await new Promise((resolve) => setTimeout(resolve, 3_000));
 
     // Poll until the restarted app binds port 4445 again.
-    // This proves: factory_reset completed, app.restart() fired,
-    // and the new process is listening.
     await waitForPort(browser.options.port ?? 4445, 150_000);
   });
 });

--- a/desktop/src-tauri/build.rs
+++ b/desktop/src-tauri/build.rs
@@ -21,9 +21,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         .to_path_buf();
     let target_os = std::env::var("CARGO_CFG_TARGET_OS")?;
     let allow_stubs = std::env::var_os("SPEEDWAVE_ALLOW_BUNDLE_STUBS").is_some();
-    // build-context qualifies as hash root only when COMPLETE — CI stubs
-    // create the directories but not every declared hash input, and hashing
-    // a partial tree would either fail or mint garbage tags.
+    // build-context is hash root only when every declared hash input exists.
     let build_context_complete = speedwave_runtime::build::IMAGES
         .iter()
         .flat_map(|img| img.hash_inputs.iter())

--- a/desktop/src-tauri/src/auth_commands.rs
+++ b/desktop/src-tauri/src/auth_commands.rs
@@ -70,21 +70,8 @@ pub(crate) fn shell_escape_single_quoted(s: &str) -> String {
     s.replace('\'', "'\\''")
 }
 
-/// Strips the `\\?\` extended-length prefix from a Windows path when the
-/// remainder begins with `<drive>:\` or `<drive>:/` (`\\?\C:\…` -> `C:\…`).
-/// Returns the input unchanged for paths that don't match `\\?\<drive>:\`
-/// (UNC paths, already-stripped paths, POSIX paths, anything else). The
-/// function is purely pattern-based on the input string and does not inspect
-/// the host OS. Bare `\\?\C:` (no separator) is intentionally left alone —
-/// `Set-Location 'C:'` would set drive-relative cwd, which is not what the
-/// user copied a project path for; passing the original string through means
-/// PowerShell raises a clear "path not found" error rather than silently
-/// changing drive.
-///
-/// The Tauri folder picker on Windows can return canonicalized paths with
-/// the `\\?\` prefix; neither PowerShell `Set-Location` nor `cd` handles
-/// these, and they are not user-readable. This helper unifies the path so
-/// the rendered command is paste-ready.
+/// Strips `\\?\` extended-length prefix from Windows paths when followed by `<drive>:\`.
+/// Returns input unchanged for UNC, POSIX, or already-stripped paths.
 pub(crate) fn strip_windows_extended_length_prefix(path: &str) -> &str {
     let b = path.as_bytes();
     if b.len() >= 7
@@ -109,16 +96,9 @@ pub(crate) fn ps_escape_single_quoted(s: &str) -> String {
     s.replace('\'', "''")
 }
 
-/// Pure, host-platform-agnostic command assembly. The `is_windows` flag
-/// selects PowerShell-shaped output (Set-Location, `;`, $env:, '' escape,
-/// \\?\ prefix stripping) versus POSIX-shaped output (cd, &&, export,
-/// '\'' escape). The flag is taken as a parameter — not derived inside the
-/// function from `cfg!()` — so both branches are reachable from unit tests
-/// on macOS where `make test-desktop` runs.
-///
-/// The trailing command is `speedwave login --project '<project>'` — once
-/// stored, the OAuth token is per-project, so the exact name is bound into
-/// the copy-paste so it works regardless of CWD.
+/// Pure command assembly. `is_windows` selects PowerShell-shaped output
+/// (Set-Location, `;`, $env:, '' escape, \\?\ stripping) vs POSIX (cd, &&,
+/// export, '\'' escape).
 pub(crate) fn build_auth_command_for_platform(
     project: &str,
     project_dir: &str,
@@ -189,10 +169,8 @@ fn build_auth_command(
     )
 }
 
-/// Resolves the inputs both auth surfaces need: the project's directory (from
-/// user config), the active data dir, and the default data dir (for the
-/// `SPEEDWAVE_DATA_DIR` pin decision). Shared so `get_auth_command` (copy-paste)
-/// and `start_oauth_login` (auto-spawn) cannot drift.
+/// Resolves the project directory, active data dir, and default data dir.
+/// Shared by `get_auth_command` and `start_oauth_login` to prevent drift.
 pub(crate) fn resolve_project_dirs(
     project: &str,
 ) -> Result<(String, std::path::PathBuf, Option<std::path::PathBuf>), String> {
@@ -240,9 +218,7 @@ mod tests {
 
     #[test]
     fn get_auth_status_waits_for_image_readiness() {
-        // Race guard: setup_wizard::check_claude_auth → ensure_exec_healthy →
-        // compose_up_recreate. UI polls auth status at startup; without the
-        // gate, polling during reconcile surfaces "image not available".
+        // Race guard: get_auth_status must gate on image readiness before exec.
         let source = include_str!("auth_commands.rs");
         let fn_start = source
             .find("pub async fn get_auth_status(")
@@ -447,9 +423,7 @@ mod tests {
 
     #[test]
     fn build_auth_command_includes_project_in_login_argument() {
-        // Sanity check: the project name actually flows into the trailing
-        // `--project '<name>'`. Catches a future bug where the call-site in
-        // get_auth_command forgets to thread `project` through.
+        // Project name must flow into the trailing `--project '<name>'`.
         let cmd = build_auth_command(
             "specific-project-name",
             "/proj",
@@ -461,9 +435,7 @@ mod tests {
 
     #[test]
     fn build_auth_command_escapes_single_quote_in_project_name() {
-        // Defensive: validate_project_name forbids `'`, but the renderer
-        // must defensively escape — otherwise relaxing validation later
-        // would silently break the output.
+        // Defensive escaping in case validation is relaxed.
         let cmd = build_auth_command(
             "weird'name",
             "/proj",
@@ -474,9 +446,6 @@ mod tests {
     }
 
     // -- strip_windows_extended_length_prefix tests --
-    // build_auth_command_for_platform is infallible by design — every input is a valid
-    // PathBuf or &str chosen by the user. No error-path or state-transition tests apply
-    // to pure functions.
 
     #[test]
     fn strip_prefix_uppercase_drive() {
@@ -714,8 +683,7 @@ mod tests {
 
     #[test]
     fn build_auth_command_for_platform_windows_escapes_single_quote_in_data_dir() {
-        // Custom data dir containing a `'` must use PS doubling (`''`),
-        // never POSIX backslash escaping (`'\''`). Closes review gap.
+        // Custom data dir must use PS doubling (''), not POSIX ('\').
         let cmd = build_auth_command_for_platform(
             "p",
             r"C:\proj",
@@ -733,10 +701,7 @@ mod tests {
 
     #[test]
     fn build_auth_command_for_platform_windows_strips_extended_length_prefix_in_data_dir() {
-        // Defence-in-depth: if data_dir ever carries `\\?\` (e.g. a future
-        // "choose data directory" picker on Windows), the env var must be
-        // set to a clean, paste-ready path — not the raw extended-length
-        // form which subsequent tools would mishandle.
+        // Defence-in-depth: if data_dir carries \\?\, env var must be cleaned.
         let cmd = build_auth_command_for_platform(
             "p",
             r"C:\proj",
@@ -764,8 +729,7 @@ mod tests {
 
     #[test]
     fn build_auth_command_for_platform_windows_escapes_single_quote_in_project_name() {
-        // Defensive escaping for project names containing `'`. validate_project_name
-        // forbids them — but renderer must escape regardless.
+        // Defensive escaping in case validation changes.
         let cmd = build_auth_command_for_platform(
             "weird'name",
             r"C:\proj",

--- a/desktop/src-tauri/src/bridges/host_bridge.rs
+++ b/desktop/src-tauri/src/bridges/host_bridge.rs
@@ -32,13 +32,7 @@ pub enum AuthScheme {
     /// Token in a request header. Used by Node.js / Rust workers that can
     /// set arbitrary headers on the WebSocket upgrade.
     Header(&'static str),
-    /// Token in the URL query string (`?<name>=<token>`). Required for
-    /// browser-based clients. **Accepted risk:** URL query strings can
-    /// leak via process arg lists, browser history, and `Referer` headers.
-    /// Mitigated by (a) binding only on a host-local address —
-    /// `127.0.0.1` on macOS, WSL vEthernet adapter IP on Windows (invisible
-    /// from LAN), via `compose::host_bind_address`; (b) UUID v4 token
-    /// regenerated each Desktop startup; (c) `0o600` lock file.
+    /// Token in the URL query string (`?<name>=<token>`). For browser clients; risk in ADR-063.
     QueryParam(&'static str),
 }
 
@@ -271,17 +265,11 @@ pub type ConnectionHandler = Arc<
         + 'static,
 >;
 
-/// Handler-side request context. Most fields are exercised only by tests
-/// (`endpoint_context_exposes_path_query_matched_auth`); the IDE Bridge
-/// handler reads `bridge_name` and `peer_addr` directly. `cfg_attr` keeps
-/// the contract intact while silencing dead-code for the prod `--bin` build.
+/// Handler-side request context. The IDE Bridge handler reads `bridge_name` and `peer_addr`.
 pub struct ConnectionContext {
     pub bridge_name: String,
     pub peer_addr: SocketAddr,
-    /// `_`-prefixed fields are part of the public API for connection
-    /// handlers but currently have no in-tree handler that reads them.
-    /// The prefix signals "available, not currently consumed" without
-    /// silencing dead-code lints with `#[allow(...)]`.
+    /// `_`-prefixed: public API for handlers, no in-tree consumer reads them yet.
     pub _path: String,
     pub _query: Option<String>,
     pub _selected_subprotocol: Option<String>,
@@ -295,10 +283,7 @@ pub struct ConnectionContext {
 
 pub type PairingEventCallback = Arc<dyn Fn(PairingEvent) + Send + Sync + 'static>;
 
-/// Event surface for Pairing-mode bridges. `_`-prefixed fields are
-/// emitted for future telemetry / test inspection but no in-tree
-/// consumer reads them — the prefix signals "available, not currently
-/// consumed" without silencing dead-code lints with `#[allow(...)]`.
+/// Event surface for Pairing-mode bridges. `_`-prefixed fields have no in-tree consumer yet.
 #[derive(Clone, Debug)]
 pub enum PairingEvent {
     SlotOccupied {
@@ -776,9 +761,7 @@ async fn run_endpoint_loop(
                 let outcome_cb = outcome.clone();
 
                 let ws_config = make_ws_config(config.max_frame_bytes);
-                // Result<Response, http::Response<Option<String>>> — the
-                // error variant size is dictated by tokio_tungstenite.
-                // Threshold raised in clippy.toml, no per-site allow.
+                // Err variant size dictated by tokio_tungstenite; threshold raised in clippy.toml.
                 let upgrade_result = tokio_tungstenite::accept_hdr_async_with_config(
                     stream,
                     move |req: &Request<()>, mut resp: Response<()>| {
@@ -1275,11 +1258,7 @@ fn select_subprotocol(req: &Request<()>, policy: &SubprotocolPolicy) -> Option<&
 }
 
 fn http_response(code: u16, body: &str) -> ErrorResponse {
-    // `http::Response::builder()` only fails when the status or header
-    // values are invalid; for a fixed numeric status and a plain string
-    // body neither path is reachable. If the builder ever did fail, we
-    // synthesize a minimal Internal Server Error response so the
-    // accept_hdr_async callback signature stays infallible.
+    // Synthesize a 500 if the builder fails; the callback signature must stay infallible.
     Response::builder()
         .status(code)
         .body(Some(body.to_string()))
@@ -1334,9 +1313,7 @@ fn cleanup_stale_lock_files(dir: &Path, probe_timeout: Duration) {
         Ok(e) => e,
         Err(_) => return,
     };
-    // Probe on the same address bridges bind on (macOS: 127.0.0.1; Windows:
-    // WSL adapter IP). If detection fails, skip — better to leave orphan
-    // locks than to delete files for live bridges that probe rejects.
+    // Probe on the bind address; skip on failure to avoid deleting locks for live bridges.
     let bind: std::net::IpAddr = match speedwave_runtime::compose::host_bind_address() {
         Ok(addr) => match addr.parse() {
             Ok(ip) => ip,
@@ -2002,9 +1979,7 @@ mod tests {
         let handler: ConnectionHandler = Arc::new(move |mut ws, mut ctx| {
             let observed = observed_clone.clone();
             Box::pin(async move {
-                // Touch every public ConnectionContext field so the
-                // contract is exercised end-to-end. `shutdown` is a
-                // broadcast receiver — resubscribe instead of cloning.
+                // `shutdown` is a broadcast receiver — resubscribe instead of cloning.
                 let _shutdown_alive = ctx._shutdown.try_recv().is_err();
                 *observed.lock().unwrap() = Some((
                     ctx.bridge_name.clone(),
@@ -2374,11 +2349,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn start_rolls_back_on_lock_file_write_failure() {
-        // Drive write_lock_file_atomic into the error branch by pointing
-        // it at a parent path that is a regular file (not a directory) —
-        // tempfile::NamedTempFile::with_prefix_in fails immediately.
-        // start_endpoint then takes the rollback path: shuts down the
-        // accept loop and surfaces the error.
+        // Parent is a regular file, so the tempfile create fails and start_endpoint rolls back.
         let tmp = tempfile::tempdir().unwrap();
         let file_path = tmp.path().join("not-a-dir");
         std::fs::write(&file_path, b"sentinel").unwrap();
@@ -2395,9 +2366,7 @@ mod tests {
 
     #[test]
     fn start_writes_lock_file_atomic_via_named_temp_file() {
-        // Implicit: write_lock_file_atomic uses tempfile::NamedTempFile.
-        // We assert the lock file appears (full content + mode is checked
-        // in write_lock_file_atomic_writes_json + start_lock_file_mode_0o600).
+        // Asserts the lock file appears; content + mode are checked in dedicated tests.
         let cfg = endpoint_config("ide");
         let mut bridge = HostBridge::new(cfg).unwrap();
         let handler: ConnectionHandler = Arc::new(|_, _| Box::pin(async {}));
@@ -2865,9 +2834,7 @@ mod tests {
             .await;
             assert!(res.is_err());
             let err = format!("{:?}", res.err().unwrap());
-            // Pre-handshake response means the error contains HTTP 409, NOT
-            // a tungstenite Close frame string. Close frame would surface as
-            // "Connection closed" or "ConnectionClosed", not as a status code.
+            // Pre-handshake error carries HTTP 409, not a tungstenite Close frame.
             assert!(err.contains("409"), "must be HTTP 409, got: {err}");
             assert!(
                 !err.contains("1008"),
@@ -3045,9 +3012,7 @@ mod tests {
             ))
             .await
             .unwrap();
-            // check_interval = max(timeout/4, 1s). With 1s timeout that
-            // gives 1s ticks; the slot needs >= 1s of age before the next
-            // tick clears it. Wait through 2 ticks to be safe.
+            // check_interval = max(timeout/4, 1s) = 1s; wait through 2 ticks to age the slot out.
             tokio::time::sleep(Duration::from_millis(2500)).await;
         });
         let evts = events.lock().unwrap().clone();
@@ -3060,14 +3025,7 @@ mod tests {
         );
     }
 
-    /// Watchdog recovery test — verifies the **logic** that recreates a
-    /// missing lock file by exercising `write_lock_file_atomic` directly.
-    ///
-    /// We avoid relying on real-time scheduling of the watchdog tokio
-    /// runtime: under heavy parallel test load it can be starved beyond
-    /// any reasonable budget, making a timing-based test flaky. The
-    /// integration timing path is exercised in the smoke test
-    /// (`make dev` — see ADR-063 Verification section).
+    /// Verifies lock-file recreation logic; the timing path is covered by the smoke test.
     #[test]
     fn watchdog_recreates_lock_file_when_missing() {
         let dir = tempfile::tempdir().unwrap();

--- a/desktop/src-tauri/src/bridges/ide_bridge.rs
+++ b/desktop/src-tauri/src/bridges/ide_bridge.rs
@@ -377,10 +377,8 @@ pub struct IdeBridge {
     // (in `new_with_paths`). Tests read these directly via field access.
     _tcp_port: u16,
     lock_file_path: PathBuf,
-    /// `_`-prefix because the field is only read inside `#[cfg(test)]
-    /// fn write_lock_file` — no production read site exists, but tests
-    /// need it via field access. Mirrors the `_path`/`_query`/… pattern
-    /// in `bridges::host_bridge::ConnectionContext`.
+    /// `_`-prefix: only read inside `#[cfg(test)] fn write_lock_file`.
+    /// Mirrors the `_path`/`_query` pattern in `host_bridge::ConnectionContext`.
     _auth: Arc<Mutex<AuthState>>,
 
     upstream: Arc<Mutex<Option<UpstreamIde>>>,
@@ -410,9 +408,7 @@ impl IdeBridge {
         let inner = HostBridge::new(config)?;
         let tcp_port = inner.port();
         let lock_file_path = inner.lock_file_path().to_path_buf();
-        // Use the same UUID as the inner bridge so both layers validate
-        // the same token. (HostBridge mints it; we re-wrap it for callers
-        // that still expect the legacy AuthState handle.)
+        // Re-wrap HostBridge's token as the legacy AuthState handle.
         let auth = Arc::new(Mutex::new(AuthState::new(inner.auth_token())));
         let (upstream_changed_tx, _) = tokio::sync::broadcast::channel(4);
         Ok(Self {
@@ -756,11 +752,8 @@ async fn handle_with_stubs<S>(
 // ---------------------------------------------------------------------------
 // Legacy test-only helpers
 // ---------------------------------------------------------------------------
-//
-// The pre-HostBridge implementation exposed `run_websocket_on_tcp` and a
-// standalone lock-file writer. Several integration tests still hit them
-// directly; we keep them gated behind `#[cfg(test)]` so production code
-// only ever goes through HostBridge.
+// Pre-HostBridge `run_websocket_on_tcp` + lock-file writer, kept behind
+// `#[cfg(test)]` for legacy integration tests.
 
 #[cfg(test)]
 fn find_available_port() -> anyhow::Result<u16> {
@@ -1249,9 +1242,7 @@ mod tests {
     fn test_ide_bridge_new_returns_valid_instance() {
         let bridge = IdeBridge::new().unwrap();
         assert!(bridge._tcp_port > 0, "TCP port should be assigned");
-        // Path under the bridge subdir; the data dir prefix is determined
-        // by SPEEDWAVE_DATA_DIR (may be overridden by other tests in this
-        // binary), so we assert on the bridge-specific suffix only.
+        // Assert the bridge-specific suffix only; the data-dir prefix varies per test.
         assert!(
             bridge
                 .lock_file_path

--- a/desktop/src-tauri/src/bridges/mod.rs
+++ b/desktop/src-tauri/src/bridges/mod.rs
@@ -1,8 +1,6 @@
-//! Host-side WebSocket bridges connecting in-container workers to host-side
-//! applications. `host_bridge` is the generic skeleton (TCP listener, lock
-//! file, auth, lifecycle); `plugin_host_bridge` builds one for any plugin
-//! whose manifest declares a `host_bridge` block; `ide_bridge` is the Claude
-//! Code IDE proxy.
+//! Host-side WebSocket bridges connecting in-container workers to host apps:
+//! `host_bridge` (generic skeleton), `plugin_host_bridge` (per-plugin),
+//! `ide_bridge` (Claude Code IDE proxy).
 
 pub mod host_bridge;
 pub mod ide_bridge;

--- a/desktop/src-tauri/src/bridges/plugin_bridge_manager.rs
+++ b/desktop/src-tauri/src/bridges/plugin_bridge_manager.rs
@@ -1,7 +1,6 @@
 //! Plugin host-bridge lifecycle: spawn at startup for each verified plugin
 //! whose manifest declares a `host_bridge` block, and replace/stop on install
-//! and remove. Bridges live for the Desktop process lifetime; per-pair status
-//! is published on the `plugin_bridge_event` Tauri event.
+//! and remove.
 
 use std::sync::Arc;
 

--- a/desktop/src-tauri/src/chat.rs
+++ b/desktop/src-tauri/src/chat.rs
@@ -49,10 +49,8 @@ pub enum StreamChunk {
         /// — the frontend degrades to "no retry target" for those entries.
         #[serde(skip_serializing_if = "Option::is_none")]
         assistant_uuid: Option<String>,
-        /// Per-turn usage delta since the previous turn. When the stream carries
-        /// cumulative `usage`, `turn_usage = current - previous`. When the CLI
-        /// emits per-step `usage` (current behaviour), it equals `usage` with
-        /// cache fields normalized to 0.
+        /// Per-turn usage delta since the previous turn (`current - previous`
+        /// for cumulative `usage`; the per-step `usage` otherwise).
         #[serde(skip_serializing_if = "Option::is_none")]
         turn_usage: Option<TurnUsage>,
         /// Per-turn cost in USD. Computed as the delta of `total_cost_usd`
@@ -66,11 +64,7 @@ pub enum StreamChunk {
         model: Option<String>,
     },
     /// Interactive question(s) from Claude (AskUserQuestion tool).
-    ///
-    /// Up to 4 questions per the Agent SDK contract. The frontend
-    /// renders them sequentially; once every slot has a value it calls
-    /// `submit_question_answer` for the last one and the host writes a single
-    /// `control_response` carrying the full `answers` map.
+    /// Up to 4 questions per the Agent SDK contract.
     AskUserQuestion {
         tool_id: String,
         questions: Vec<AskUserQuestionItem>,
@@ -98,11 +92,8 @@ pub enum StreamChunk {
     QueueDrained { session_id: String, text: String },
 }
 
-/// Redacts secrets in a chunk's free-text fields. Every `chat_stream` emit must
-/// go through [`emit_sanitized_chunk`] (which calls this), so the
-/// `chat_stream` channel cannot leak. Structural
-/// fields (tool ids, model, session ids) and `partial_json` (incremental JSON —
-/// sanitizing could corrupt it) are left untouched.
+/// Redacts secrets in a chunk's free-text fields. Structural fields (tool ids,
+/// model, session ids) and `partial_json` are left untouched.
 pub(crate) fn sanitize_chunk(chunk: StreamChunk) -> StreamChunk {
     use speedwave_runtime::log_sanitizer::sanitize;
     match chunk {
@@ -218,9 +209,7 @@ impl TurnUsage {
     }
 
     /// Per-turn delta between a cumulative snapshot and a previous snapshot.
-    /// Saturating subtraction protects against reset/resume events where the
-    /// current snapshot could momentarily be smaller than the previous one;
-    /// in that case the turn is reported as zero tokens rather than negative.
+    /// Saturating subtraction clamps reset/resume regressions to zero.
     pub fn delta(current: &Self, previous: &Self) -> Self {
         Self {
             input_tokens: current.input_tokens.saturating_sub(previous.input_tokens),
@@ -238,8 +227,7 @@ impl TurnUsage {
 /// Tool name constant for the AskUserQuestion tool.
 const ASK_USER_TOOL_NAME: &str = "AskUserQuestion";
 
-// Stream-json protocol literals — see claude-agent-sdk-python types.py
-// (SDKControlRequest / SDKControlInterruptRequest).
+// Stream-json protocol literals (claude-agent-sdk-python types.py).
 const MSG_TYPE_CONTROL_REQUEST: &str = "control_request";
 const CTRL_SUBTYPE_INTERRUPT: &str = "interrupt";
 
@@ -253,10 +241,8 @@ pub struct ControlRequest {
     pub tool_use_id: String,
 }
 
-/// Per-`AskUserQuestion` slot state held while the user answers each
-/// question. Created when the host receives the `control_request`, consumed
-/// when every slot in `answers` is `Some` and the host writes a single
-/// `control_response`.
+/// Per-`AskUserQuestion` slot state held while the user answers each question.
+/// Consumed once every slot in `answers` is `Some`.
 #[derive(Debug, Clone)]
 pub struct PartialAnswers {
     /// Original control_request, captured so we can reconstruct the wire
@@ -271,10 +257,8 @@ pub struct PartialAnswers {
 }
 
 impl PartialAnswers {
-    /// Create a `PartialAnswers` with one `None` slot per question. This
-    /// is the only path that should construct the struct in production —
-    /// it makes the `answers.len() == questions.len()` invariant
-    /// structurally impossible to violate.
+    /// Create a `PartialAnswers` with one `None` slot per question, upholding
+    /// the `answers.len() == questions.len()` invariant.
     pub fn new(request: ControlRequest, questions: Vec<AskUserQuestionItem>) -> Self {
         let answers = vec![None; questions.len()];
         Self {
@@ -316,10 +300,8 @@ fn validate_slot(
 /// Maximum size, in bytes, of a user-supplied chat message string.
 pub const MAX_MESSAGE_LEN: usize = 1_000_000;
 
-/// Maximum size, in bytes, of a single per-slot answer to an
-/// `AskUserQuestion`. Sized so that 4 maximally-large slots cannot exceed
-/// `MAX_ASK_USER_WIRE_BYTES` after JSON encoding overhead — preventing the
-/// "fill 3 slots cheaply, blow the wire cap on the 4th" foot-gun.
+/// Maximum size, in bytes, of a single per-slot answer to an `AskUserQuestion`.
+/// Sized so 4 maximal slots stay under `MAX_ASK_USER_WIRE_BYTES` once encoded.
 pub const MAX_ASK_USER_ANSWER_LEN: usize = 12 * 1024;
 
 /// Structured log entry returned by StreamParser for session logging.
@@ -347,15 +329,11 @@ pub struct StreamParser {
     /// events (ADR-046). Committed onto the `Result` chunk; `take`n when the
     /// result arrives so a subsequent error turn cannot reuse a stale id.
     pending_assistant_uuid: Option<String>,
-    /// UUIDs already emitted via `UserMessageCommit`, to guard against
-    /// duplicate commits when Claude Code re-emits a user message inside the
-    /// same turn (observed on retry/resume paths — the first user message
-    /// echoes back). A user prompt's UUID is committed exactly once.
+    /// UUIDs already emitted via `UserMessageCommit`, guarding against
+    /// duplicate commits when a user message is re-emitted in the same turn.
     committed_user_uuids: std::collections::HashSet<String>,
-    /// Snapshot of cumulative session usage taken at the start of the
-    /// current turn. Per-turn usage = current - previous. Kept here so
-    /// that `MessageDelta` (hypothetical cumulative event) and `Result`
-    /// both read the same baseline and compute a consistent delta.
+    /// Snapshot of cumulative session usage at the start of the current turn.
+    /// Per-turn usage = current - previous.
     previous_session_usage: TurnUsage,
     /// Cumulative session cost in USD from the previous `Result`. Per-turn
     /// cost = current total - previous total, when both are authoritative.
@@ -386,9 +364,7 @@ impl StreamParser {
     }
 
     /// Seeds the cumulative usage snapshot so the next `Result` subtracts
-    /// against the supplied baseline. Called on resume with the snapshot
-    /// computed from the existing transcript, so the first turn after a
-    /// resume reports a correct delta instead of `cumulative - 0`.
+    /// against the supplied baseline (called on resume).
     pub fn restore_session_snapshot(
         &mut self,
         usage: TurnUsage,
@@ -409,11 +385,6 @@ impl StreamParser {
 
     /// Parse a pre-parsed JSON value. Mutates internal state for block tracking.
     /// Returns (chunks for frontend in emission order, optional log entry).
-    ///
-    /// The Vec lets a single stream-json line produce multiple UI chunks — for
-    /// example a `user` line with a text-bearing prompt AND a tool_result
-    /// wrapper (rare but possible) emits both `UserMessageCommit` and
-    /// `ToolResult`. Callers iterate and emit each chunk in order.
     pub fn parse_line(
         &mut self,
         parsed: &serde_json::Value,
@@ -431,8 +402,7 @@ impl StreamParser {
             "system" => option_to_vec(self.parse_system_message(parsed)),
             "rate_limit_event" => option_to_vec(Self::parse_rate_limit_event(parsed)),
             other => {
-                // Unknown types are dropped by design; log each once so a
-                // wire-format change is diagnosable from the session log.
+                // Unknown types are dropped; logged once per type.
                 let label = if other.is_empty() { "<none>" } else { other };
                 if self.seen_unknown_types.len() < MAX_TRACKED_UNKNOWN_TYPES
                     && self.seen_unknown_types.insert(label.to_string())
@@ -454,9 +424,8 @@ impl StreamParser {
     }
 
     /// Capture the assistant message UUID (`message.id`) into
-    /// `pending_assistant_uuid`. The UUID is committed onto the next
-    /// `Result` chunk — see `parse_result`. Silently ignores missing/empty
-    /// ids (local LLMs without API-style ids still produce valid turns).
+    /// `pending_assistant_uuid`, committed onto the next `Result` chunk.
+    /// Missing/empty ids are silently ignored.
     fn capture_assistant_uuid(&mut self, parsed: &serde_json::Value) {
         if let Some(id) = parsed["message"]["id"].as_str() {
             if !id.is_empty() {
@@ -472,16 +441,10 @@ impl StreamParser {
         self.active_blocks.clear();
         self.tool_input.clear();
         self.pending_assistant_uuid = None;
-        // committed_user_uuids is NOT reset: it persists across turns for the
-        // lifetime of the session so a retry on an already-committed user
-        // UUID doesn't re-emit a duplicate commit chunk.
+        // committed_user_uuids is NOT reset: it persists across the session.
     }
 
-    /// Reset all state for a fresh session (no snapshot restore). Used
-    /// when starting a brand-new conversation rather than resuming one.
-    ///
-    /// Currently used only by unit tests; a freshly constructed parser is
-    /// already in this state.
+    /// Reset all state for a fresh session (no snapshot restore).
     #[cfg(test)]
     pub fn new_session(&mut self) {
         self.reset();
@@ -528,10 +491,7 @@ impl StreamParser {
                     .collect()
             })
             .unwrap_or_default();
-        // Drop entries without question text — they would render as a
-        // blank prompt the user can't act on, and would produce an empty
-        // wire-key in the answers map. Logged at count level only (no
-        // question text — could be customer-supplied PII).
+        // Drop entries without question text; logged at count level only.
         if question.trim().is_empty() {
             log::warn!(
                 "AskUserQuestion: dropping entry with empty question text \
@@ -549,15 +509,9 @@ impl StreamParser {
         })
     }
 
-    /// Parse the questions list from a control_request input.
-    ///
-    /// The Agent SDK shape is `{ "questions": [{...}, ...] }` with up to 4
-    /// entries. Older/flat senders may pass a single question object at the
-    /// top level; we accept that as a one-element array. An empty array
-    /// returns an empty `Vec` (caller logs and drops). Truncates with a
-    /// warn (count only — never question text in logs) if the SDK exceeds
-    /// `MAX_ASK_USER_QUESTIONS`. Returns an empty `Vec` when no usable
-    /// question entry is found.
+    /// Parse the questions list from a control_request input. Accepts the SDK
+    /// `{ "questions": [...] }` array or a single top-level question object;
+    /// truncates to `MAX_ASK_USER_QUESTIONS`; empty `Vec` when none usable.
     pub fn parse_ask_user_questions(req: &ControlRequest) -> Vec<AskUserQuestionItem> {
         let parsed = &req.input;
 
@@ -586,11 +540,7 @@ impl StreamParser {
             .collect()
     }
 
-    /// Build AskUserQuestion chunk from a control_request's input.
-    ///
-    /// Test-only helper — production code calls `parse_ask_user_questions`
-    /// directly inside the chat reader thread and constructs the chunk
-    /// inline so it can also seed `pending_requests` with the parsed list.
+    /// Build AskUserQuestion chunk from a control_request's input (test-only).
     #[cfg(test)]
     pub fn emit_ask_user_from_control_request(req: &ControlRequest) -> Option<StreamChunk> {
         let questions = Self::parse_ask_user_questions(req);
@@ -645,8 +595,7 @@ impl StreamParser {
                             message: format!("start: {} ({})", name, id),
                         });
                         self.active_blocks.insert(index, (id.clone(), name.clone()));
-                        // Suppress ToolStart for AskUserQuestion — it will be emitted
-                        // via control_request path, not from stream events.
+                        // Suppress ToolStart for AskUserQuestion (control_request path).
                         if name == ASK_USER_TOOL_NAME {
                             (None, log_entry)
                         } else {
@@ -742,8 +691,7 @@ impl StreamParser {
                             prefix: "TOOL",
                             message: format!("stop: {} ({})", tool_name, tool_id),
                         });
-                        // AskUserQuestion is handled via control_request protocol,
-                        // not via stream events — just clean up accumulated input.
+                        // AskUserQuestion uses control_request; just clean up input.
                         self.tool_input.remove(&tool_id);
                         return (None, log_entry);
                     }
@@ -781,10 +729,7 @@ impl StreamParser {
             }
         }
 
-        // A user message carrying text (a user prompt, not a tool_result
-        // wrapper) commits its UUID once per session. Tool-result wrappers
-        // reuse the prompt's UUID or carry different ids — we only want to
-        // retry-point against actual prompts.
+        // Commit a UUID once per session, only for a text-bearing user prompt.
         if has_text && !has_tool_result {
             if let Some(id) = message["id"].as_str() {
                 if !id.is_empty() && !self.committed_user_uuids.contains(id) {
@@ -802,8 +747,7 @@ impl StreamParser {
             }
         }
 
-        // One user line can carry several tool_result blocks (parallel tool
-        // batches) — each must emit a chunk or its UI block stays "running".
+        // One user line can carry several tool_result blocks; each emits a chunk.
         let mut chunks = Vec::new();
         let mut log_lines = Vec::new();
         for block in blocks {
@@ -861,15 +805,7 @@ impl StreamParser {
         if is_error {
             let result_text = parsed["result"].as_str().unwrap_or("");
             if result_text.trim().is_empty() {
-                // An `is_error=true` message with no `result` text is a protocol
-                // anomaly observed in the wild when a local LLM provider (e.g.
-                // llama.cpp/Qwen) returns a bare error response. Previously the
-                // chunk was dropped silently, leaving the user with an empty
-                // message bubble and no indication that anything went wrong.
-                //
-                // Surface a placeholder so the user sees *something*, and log
-                // the full response at DEBUG so a later troubleshooting session
-                // has the server payload to dig into.
+                // `is_error=true` with empty `result`: placeholder chunk + DEBUG log.
                 log::warn!(
                     "parse_result: is_error=true but result text is empty; \
                      returning placeholder error chunk"
@@ -902,14 +838,9 @@ impl StreamParser {
             .as_f64()
             .or_else(|| parsed["total_cost"].as_f64());
 
-        // modelUsage: cumulative per-model stats from the CLI. Used for
-        // contextWindow (constant per model) and for model identification.
+        // modelUsage: cumulative per-model stats; used for contextWindow + model id.
         let model_usage = parsed["modelUsage"].as_object();
-        // Pick the contextWindow from the same dominant model whose id we
-        // surface below (highest outputTokens). Using `values().next()` was
-        // non-deterministic and could surface Haiku's 200k context window
-        // in turns where Opus was the actual responder, leaving the chat
-        // footer misreporting the cap as 200k for 1M-context sessions.
+        // contextWindow from the dominant model (highest outputTokens).
         let context_window_size = model_usage
             .and_then(|mu| {
                 mu.values()
@@ -917,13 +848,7 @@ impl StreamParser {
             })
             .and_then(|stats| stats["contextWindow"].as_u64());
 
-        // Pick the model that produced the most output tokens — that's the
-        // main response model. A single turn can mix models (Opus for the
-        // user-facing answer + Haiku for background tasks like title
-        // generation), so picking `keys().next()` was non-deterministic and
-        // tended to surface Haiku (alphabetically before Opus) even when
-        // Opus did the real work. Falls back to the most recent SystemInit
-        // model captured in state when no modelUsage data is present.
+        // Model with the most output tokens; falls back to last SystemInit model.
         let model = model_usage
             .and_then(|mu| {
                 mu.iter()
@@ -931,8 +856,7 @@ impl StreamParser {
                     .map(|(k, _)| k.clone())
             })
             .or_else(|| self.last_model.clone());
-        // Keep parser state in sync so future turns without modelUsage still
-        // know the model.
+        // Keep `last_model` in sync for turns without modelUsage.
         if let Some(m) = model.as_deref() {
             self.last_model = Some(m.to_string());
         }
@@ -960,11 +884,7 @@ impl StreamParser {
             &mut self.previous_session_usage,
         );
 
-        // Per-turn cost. Use the authoritative delta of `total_cost_usd`
-        // when available (CLI aggregates across the session; our previous
-        // snapshot is the previous turn's cumulative total). For the first
-        // turn in a session without a prior snapshot, `total_cost` itself
-        // IS the first turn's cost.
+        // Per-turn cost = `total_cost_usd` delta vs snapshot, or `total_cost` on turn 1.
         let turn_cost = match (total_cost, self.previous_session_cost) {
             (Some(current), Some(prev)) if current >= prev => Some(current - prev),
             (Some(current), None) => Some(current),
@@ -1011,8 +931,7 @@ impl StreamParser {
         let info = &parsed["rate_limit_info"];
         let status = info["status"].as_str().unwrap_or("unknown").to_string();
         let utilization = info["utilization"].as_f64();
-        // Claude Code emits the reset timestamp as camelCase `resetsAt`; older
-        // builds (and our legacy fixtures) used snake_case. Read both.
+        // Read the reset timestamp as both `resetsAt` and `resets_at`.
         let resets_at = info["resetsAt"]
             .as_u64()
             .or_else(|| info["resets_at"].as_u64());
@@ -1056,13 +975,11 @@ impl StreamParser {
         parsed: &serde_json::Value,
     ) -> (Option<StreamChunk>, Option<LogEntry>) {
         // ── Extract model from system init message ──
-        // Must be checked BEFORE the message.is_empty() early return below,
-        // because init messages may not carry a `message`/`content` field.
+        // Check BEFORE the message.is_empty() early return (init may lack `message`).
         if parsed["subtype"].as_str() == Some("init") {
             if let Some(model) = parsed["model"].as_str() {
                 if !model.is_empty() {
-                    // Cache the model so subsequent result chunks can label
-                    // their meta line even when `modelUsage` is absent.
+                    // Cache the model for subsequent result chunks.
                     self.last_model = Some(model.to_string());
                     let log_entry = Some(LogEntry {
                         prefix: "SYSTEM",
@@ -1076,9 +993,7 @@ impl StreamParser {
                     );
                 }
             }
-            // subtype is "init" but model is missing/empty — fall through to
-            // existing text-based logic (which will likely return (None, None)
-            // since init messages typically have no `message` field).
+            // "init" subtype but model missing/empty — fall through to text logic.
         }
 
         // System messages carry text in either `message` or `content`
@@ -1115,19 +1030,8 @@ impl StreamParser {
 }
 
 /// Extract per-turn usage from a parsed `result` message, updating the
-/// cumulative snapshot in place.
-///
-/// Two sources are possible:
-///
-///  * Flat `usage` (Claude Code CLI today) — the latest turn's full prompt
-///    usage (`input_tokens` is the uncached remainder, `cache_read` is the
-///    re-sent history); emitted as the turn, snapshot accumulates it.
-///  * `modelUsage` only (cumulative per-model, no flat `usage`) — compute
-///    `turn = cumulative - snapshot` and advance the snapshot.
-///
-/// The flat-path snapshot value is kept in sync so that future switches
-/// between the two payload shapes remain consistent. Returns `None` when
-/// the result carries no usage information at all.
+/// cumulative snapshot in place. Sources: flat `usage` (accumulated) or
+/// `modelUsage` (delta against snapshot). `None` when no usage is present.
 fn compute_turn_usage_from_result(
     parsed: &serde_json::Value,
     flat: Option<&UsageInfo>,
@@ -1145,10 +1049,7 @@ fn compute_turn_usage_from_result(
             .saturating_add(delta.cache_write_tokens);
         return Some(delta);
     }
-    // Fallback path: only `modelUsage` is present. Compute the delta against
-    // the cumulative snapshot. After a resume, callers should restore the
-    // snapshot via `restore_session_snapshot` before the first Result; if
-    // not, the first delta equals the full cumulative total (best-effort).
+    // Fallback: only `modelUsage` is present — delta against the snapshot.
     let cumulative = extract_cumulative_usage(parsed)?;
     let delta = TurnUsage::delta(&cumulative, snapshot);
     *snapshot = cumulative;
@@ -1226,17 +1127,9 @@ pub fn build_auto_approve_response(request: &ControlRequest) -> serde_json::Valu
     })
 }
 
-/// AskUserQuestion response carrying the **full** answers map (one per
-/// question slot) per the Agent SDK contract.
-///
-/// Key = question text; value = the chosen label (or `", "`-joined labels for
-/// multi-select, joined by the frontend before submission). The original
-/// `questions` array is preserved unchanged in `updatedInput`.
-///
-/// Fails closed on duplicate question text: the SDK's answers-map keying
-/// would silently drop one slot's answer (last-write-wins on a JSON Map),
-/// which violates the "every answered question is reflected on the wire"
-/// invariant. We refuse to emit a partial-truth payload; the user retries.
+/// AskUserQuestion response carrying the **full** answers map (key = question
+/// text, value = chosen label) per the Agent SDK contract; `questions` is
+/// preserved in `updatedInput`. Fails closed on duplicate question text.
 fn build_ask_user_response_multi(partial: &PartialAnswers) -> anyhow::Result<serde_json::Value> {
     let mut updated_input = partial.request.input.clone();
     let mut answers = serde_json::Map::with_capacity(partial.questions.len());
@@ -1274,13 +1167,8 @@ fn build_ask_user_response_multi(partial: &PartialAnswers) -> anyhow::Result<ser
 }
 
 /// Validate a message UUID passed to `--resume-session-at`.
-///
-/// Claude Code's message ids take two shapes in the wild: Anthropic-API
-/// `msg_...` ids (alphanumeric with underscores) and UUID v4 strings.  Rather
-/// than enumerate both, we accept any bounded string whose characters are
-/// safe to pass as a CLI argument — no shell metacharacters, no whitespace,
-/// no path traversal. Empty strings are rejected so the caller can treat
-/// "no known retry target" as a distinct error condition.
+/// Accepts a non-empty bounded `[A-Za-z0-9_-]` string (covers API `msg_...`
+/// and UUID v4 ids); rejects shell metacharacters, whitespace, traversal.
 pub fn validate_retry_uuid(uuid: &str) -> anyhow::Result<()> {
     if uuid.is_empty() {
         anyhow::bail!("retry uuid must not be empty");
@@ -1288,8 +1176,7 @@ pub fn validate_retry_uuid(uuid: &str) -> anyhow::Result<()> {
     if uuid.len() > 128 {
         anyhow::bail!("retry uuid too long (max 128 chars)");
     }
-    // Allow [A-Za-z0-9_-] only — the two observed formats (API `msg_...`
-    // and UUID v4) fit within this set and it disallows shell injection.
+    // Allow [A-Za-z0-9_-] only.
     for ch in uuid.chars() {
         if !(ch.is_ascii_alphanumeric() || ch == '_' || ch == '-') {
             anyhow::bail!("retry uuid contains invalid character: {ch:?}");
@@ -1299,11 +1186,8 @@ pub fn validate_retry_uuid(uuid: &str) -> anyhow::Result<()> {
 }
 
 /// Build the argument list for Claude Code's stream-json mode.
-///
-/// When `resume_session_id` is `Some`, adds `--resume <id>` to resume an
-/// existing conversation. When `resume_at_uuid` is `Some`, additionally
-/// rewinds the conversation to that user-message UUID (ADR-046) — Claude
-/// Code's native retry flag.
+/// `resume_session_id` adds `--resume <id>`; `resume_at_uuid` adds
+/// `--resume-session-at <uuid>` (ADR-046 retry anchor).
 pub fn build_claude_args(
     resume_session_id: Option<&str>,
     resume_at_uuid: Option<&str>,
@@ -1375,11 +1259,9 @@ fn write_interrupt<W: Write>(w: &mut W, payload: &serde_json::Value) -> anyhow::
     Ok(())
 }
 
-/// Manages a Claude Code subprocess running inside the container.
-/// Claude is launched via `container_exec` from the ContainerRuntime trait,
-/// which abstracts limactl/nerdctl/wsl.exe differences.
-///
-/// Stdout is parsed in a background thread that emits Tauri events directly.
+/// Manages a Claude Code subprocess running inside the container, launched via
+/// `container_exec`. Stdout is parsed in a background thread that emits Tauri
+/// events directly.
 pub struct ChatSession {
     child: Option<Child>,
     project_name: String,
@@ -1411,11 +1293,8 @@ impl ChatSession {
     }
 
     /// Build the argv + container name for a Claude Code spawn.
-    ///
-    /// - `resume_session_id` adds `--resume <id>` (required for retry).
-    /// - `resume_at_uuid` adds `--resume-session-at <uuid>` (ADR-046 retry
-    ///   anchor). When both are `Some`, the spawn rewinds the session to the
-    ///   given user-message UUID and regenerates the assistant turn natively.
+    /// - `resume_session_id` adds `--resume <id>`.
+    /// - `resume_at_uuid` adds `--resume-session-at <uuid>` (ADR-046 retry anchor).
     pub fn prepare_args(
         project_name: &str,
         user_config: &config::SpeedwaveUserConfig,
@@ -1439,16 +1318,9 @@ impl ChatSession {
         Ok((args, container))
     }
 
-    /// Start Claude Code in stream-json mode inside the container.
-    /// Spawns a background thread that reads stdout and emits `chat_stream`
-    /// Tauri events for the Angular frontend.
-    ///
-    /// When `resume_session_id` is `Some`, resumes an existing conversation.
-    ///
-    /// **Precondition:** The caller must have already verified container
-    /// health (e.g. via `check_claude_auth`, which calls
-    /// `ensure_exec_healthy` internally).  This method does NOT run
-    /// `ensure_exec_healthy` itself to avoid double health-checks.
+    /// Start Claude Code in stream-json mode inside the container, spawning a
+    /// background thread that reads stdout and emits `chat_stream` events.
+    /// Precondition: the caller must have already verified container health.
     pub fn start(
         &mut self,
         app_handle: AppHandle,
@@ -1457,12 +1329,9 @@ impl ChatSession {
         self.start_with_retry(app_handle, resume_session_id, None)
     }
 
-    /// Start (or resume+retry) a Claude Code session.
-    ///
-    /// When `resume_at_uuid` is `Some`, Claude Code rewinds the session to
-    /// the given user-message UUID and regenerates the assistant turn
-    /// natively (ADR-046). The caller MUST also pass `resume_session_id`;
-    /// retry without a session is nonsensical.
+    /// Start (or resume+retry) a Claude Code session. `resume_at_uuid` rewinds
+    /// to that user-message UUID (ADR-046) and MUST be paired with
+    /// `resume_session_id`.
     pub fn start_with_retry(
         &mut self,
         app_handle: AppHandle,
@@ -1515,10 +1384,8 @@ impl ChatSession {
         };
         self.session_log_path = session_log_path.clone();
 
-        // Spawn stderr reader to log errors (avoids pipe buffer deadlock).
-        // Each reader thread opens its own O_APPEND handle to the session log.
-        // POSIX guarantees atomic writes below PIPE_BUF (4 KB); our lines are
-        // ~100 bytes, so interleaving cannot corrupt individual entries.
+        // Spawn stderr reader to log errors (avoids pipe buffer deadlock);
+        // each reader opens its own O_APPEND handle to the session log.
         let stderr_log_path = session_log_path.clone();
         if let Some(stderr) = child.stderr.take() {
             let h = std::thread::spawn(move || {
@@ -1550,12 +1417,8 @@ impl ChatSession {
         let stdin_for_reader = shared_stdin;
         let stdout_log_path = session_log_path;
 
-        // On resume: recover the cumulative session state from the existing
-        // transcript so the first turn after resume reports a real per-turn
-        // delta. Without this seed the parser would compare the next
-        // cumulative snapshot against zero and emit the entire session
-        // total as a single turn. Failures here are non-fatal — we log and
-        // proceed with a zero baseline (matches pre-resume-seed behaviour).
+        // On resume: seed cumulative session state from the transcript so the
+        // first turn reports a real delta. Non-fatal — log and use a zero baseline.
         let resume_seed = resume_session_id.and_then(|id| {
             match history::compute_resume_snapshot(&self.project_name, id) {
                 Ok(s) => Some(s),
@@ -1596,9 +1459,7 @@ impl ChatSession {
                     }
                 };
 
-                // Parse JSON once — pass the Value to both control_request and stream parsers.
-                // Non-JSON lines (e.g. ANTHROPIC_LOG=debug HTTP traces) are joined into single
-                // entries by `http_debug_collator` before being written to the session log.
+                // Parse JSON once; non-JSON lines are collated by `http_collator`.
                 let parsed = match serde_json::from_str::<serde_json::Value>(&line) {
                     Ok(v) => v,
                     Err(_) => {
@@ -1708,8 +1569,7 @@ impl ChatSession {
                     continue;
                 }
 
-                // Undecodable control_request: don't invent a wire response,
-                // but surface the likely stall instead of dropping it silently.
+                // Undecodable control_request: surface the likely stall, no wire response.
                 if msg_type == "control_request" {
                     log::warn!(
                         "unrecognized control_request shape; not auto-responding (turn may stall)"
@@ -1730,9 +1590,7 @@ impl ChatSession {
                         entry.prefix,
                         &entry.message,
                     );
-                    // Stream-protocol markers signal in-flight HTTP transactions
-                    // are done — flush any pending ANTHROPIC_LOG=debug response
-                    // fragments so they appear in the log alongside the marker.
+                    // On stream-protocol markers, flush pending debug response fragments.
                     if matches!(entry.prefix, "RESULT" | "SYSTEM" | "SESSION" | "RATE_LIMIT") {
                         for merged in http_collator.flush_all_pending_responses() {
                             speedwave_runtime::log_file::write_log_line(
@@ -1743,40 +1601,24 @@ impl ChatSession {
                         }
                     }
                 }
-                // Track whether we received a terminal event so we can
-                // emit a fallback error on unexpected EOF.  Covers:
-                // - StreamChunk::Result / Error from normal turns
-                // - system messages (including non-actionable ones that
-                //   return no chunk but still indicate normal lifecycle)
+                // Track terminal events to emit a fallback error on unexpected EOF.
                 let is_terminal = chunks
                     .iter()
                     .any(|c| matches!(c, StreamChunk::Result { .. } | StreamChunk::Error { .. }));
-                // Capture the session_id from a Result chunk before the
-                // chunks vector is consumed by the emit loop. ADR-045 drain
-                // happens here: when a turn ends, take any queued message
-                // for this session and write it to stdin as the next turn.
+                // Capture session_id from a Result chunk before the emit loop consumes `chunks`.
                 let result_session_id = chunks.iter().find_map(|c| match c {
                     StreamChunk::Result { session_id, .. } => Some(session_id.clone()),
                     _ => None,
                 });
                 if is_terminal || msg_type == "system" {
                     got_result = true;
-                    // Clear StreamParser per-turn state. message_stop also
-                    // triggers reset inside parse_line, but an interrupted
-                    // turn may emit Result without a preceding message_stop,
-                    // leaving active_blocks entries that could misroute
-                    // ToolInputDelta events in the next turn.
+                    // Clear per-turn state (interrupts emit Result with no message_stop).
                     parser.reset();
                 }
                 for chunk in chunks {
                     emit_sanitized_chunk(&app_handle, chunk);
                 }
-                // ADR-045 drain: after Result chunks have been emitted (so
-                // the frontend already saw `is_streaming=false`), take any
-                // queued message for this session and write it back to
-                // Claude's stdin as the next turn. The composer ALSO clears
-                // its local `state.pending_queue` via the `QueueDrained`
-                // event below — both sides converge on the same state.
+                // ADR-045 drain: after Result chunks emit, write any queued message to stdin.
                 if let Some(session_id) = result_session_id {
                     drain_queued_message(&app_handle, &session_id, &stdin_for_reader);
                 }
@@ -1786,8 +1628,7 @@ impl ChatSession {
                 speedwave_runtime::log_file::write_log_line(&mut log_file, "STDOUT", &entry);
             }
 
-            // If the stdout pipe closed without a proper result/error,
-            // emit an error so the frontend doesn't hang with isStreaming=true.
+            // stdout closed without a result/error: emit an error so the UI doesn't hang.
             if !got_result {
                 log::warn!("stdout reader: stream ended without result");
                 let chunk = StreamChunk::Error {
@@ -1804,11 +1645,8 @@ impl ChatSession {
         Ok(())
     }
 
-    /// Send a user message to Claude (write JSON to stdin).
-    /// Uses the stream-json input format: `{"type":"user","message":{"role":"user","content":[...]}}`.
-    ///
-    /// Returns an error if the subprocess has exited (broken pipe).
-    /// The caller should restart the session and retry.
+    /// Send a user message to Claude (write JSON to stdin) in stream-json input
+    /// format. Errors if the subprocess has exited (broken pipe).
     pub fn send_message(&mut self, blocks: &[WireContentBlock]) -> anyhow::Result<()> {
         let child = self
             .child
@@ -1850,14 +1688,9 @@ impl ChatSession {
         Ok(())
     }
 
-    /// Record one slot's answer for a multi-question `AskUserQuestion` and,
-    /// once every slot is filled, write a single `control_response` to
-    /// Claude's stdin.
-    ///
-    /// On post-fill errors (serialize / oversize / stdin write) the partial
-    /// state is restored with the just-filled slot cleared, so the user can
-    /// retry. Pre-fill errors (oversize answer, no active session) leave the
-    /// pending map untouched.
+    /// Record one slot's answer for a multi-question `AskUserQuestion`; once
+    /// every slot is filled, write a single `control_response` to stdin.
+    /// Post-fill errors clear the just-filled slot for retry.
     pub fn submit_question_answer(
         &mut self,
         tool_use_id: &str,
@@ -1955,12 +1788,9 @@ impl ChatSession {
         Ok(FillOutcome::Completed(entry))
     }
 
-    /// Best-effort re-insert of a `PartialAnswers` after a downstream
-    /// failure (serialize / oversize / stdin write). Logs and continues if
-    /// the mutex is poisoned. When `cleared_idx` is set the corresponding
-    /// `answers` slot is reverted to `None` so the user can re-submit it —
-    /// without this, `validate_slot` would reject the retry as
-    /// already-answered and the session would be stuck.
+    /// Best-effort re-insert of a `PartialAnswers` after a downstream failure;
+    /// logs and continues if the mutex is poisoned. `cleared_idx` reverts that
+    /// `answers` slot to `None` for re-submission.
     fn restore_partial(
         &self,
         tool_use_id: &str,
@@ -1983,19 +1813,11 @@ impl ChatSession {
         }
     }
 
-    /// Cancel the current turn without killing the session.
-    ///
-    /// Writes a stream-json `control_request` with `subtype: "interrupt"` to
-    /// Claude's stdin (protocol: `SDKControlInterruptRequest` in
-    /// https://github.com/anthropics/claude-agent-sdk-python/blob/main/src/claude_agent_sdk/types.py).
-    /// Claude aborts the in-flight turn, emits a `result` with
-    /// `subtype: "error_during_execution"`, and stays ready for the next user
-    /// message on the same stdin — session, context, MCP hub, and history
-    /// preserved.
+    /// Cancel the current turn without killing the session. Writes a
+    /// stream-json `control_request` with `subtype: "interrupt"` to stdin;
+    /// Claude aborts the turn and stays ready on the same stdin.
     pub fn interrupt(&mut self) -> anyhow::Result<()> {
-        // Mirror send_message/submit_question_answer: detect a child that has already
-        // exited so we surface a clean "session exited" (or OOM) error instead
-        // of a confusing broken-pipe write failure.
+        // Detect an already-exited child for a clean "session exited"/OOM error.
         if let Some(child) = self.child.as_mut() {
             if let Some(status) = child.try_wait()? {
                 self.child = None;
@@ -2030,8 +1852,7 @@ impl ChatSession {
         self.shared_stdin = None;
         if let Some(mut child) = self.child.take() {
             child.kill().ok();
-            // Wait with timeout — nerdctl exec can be slow to die.
-            // If it doesn't exit in 5 seconds, abandon it (OS will reap).
+            // Wait up to 5 s for exit, then abandon it (OS reaps).
             let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
             loop {
                 match child.try_wait() {
@@ -2050,27 +1871,7 @@ impl ChatSession {
                 }
             }
         }
-        // Join already-finished reader threads; detach any still running.
-        // Pipes may still be open if the child didn't exit in time.
-        //
-        // When the child exits cleanly (the common case, including the
-        // 5 s wait above), the kernel closes its pipe ends immediately,
-        // which unblocks the reader's `read_line` with EOF — but the Rust
-        // thread still needs a short moment to propagate that through
-        // `BufReader::lines()` -> loop exit -> the `is_finished` flag. A
-        // naive `is_finished()` check right after `kill()` therefore
-        // produces noisy "still running, detaching" warnings even on the
-        // happy path. Give the readers a brief grace window (polled at
-        // 10 ms) so the flag has time to flip before we classify them.
-        //
-        // The deadline is shared across ALL reader handles, not per-handle —
-        // stdout and stderr from the same child both receive EOF at the same
-        // instant (when the child exits), so one shared window covers them.
-        // If the first handle is genuinely stuck and burns the full window,
-        // the second handle still gets at least one poll before classification.
-        // The window only adds latency when a reader is actually stuck (then
-        // we wait up to READER_GRACE_MS total and give up); in the common
-        // case each handle is finished on the very first poll.
+        // Join finished reader threads; detach the rest after a grace window so `is_finished` can flip.
         const READER_GRACE_MS: u64 = 200;
         const READER_POLL_MS: u64 = 10;
         let reader_grace_deadline =
@@ -2081,9 +1882,7 @@ impl ChatSession {
             }
             let name = format!("{:?}", handle.thread().id());
             if !handle.is_finished() {
-                // Pipe is genuinely wedged — typically because an upstream
-                // in the SSH -> nerdctl chain didn't close its end. Detach
-                // so `stop()` still returns to the caller in a bounded time.
+                // Pipe wedged — detach so `stop()` returns in bounded time.
                 log::warn!(
                     "stop: reader thread {name} still running after {READER_GRACE_MS}ms grace, detaching"
                 );
@@ -2115,10 +1914,9 @@ impl Drop for ChatSession {
 /// Thread-safe wrapper for ChatSession, to be used from Tauri commands.
 pub type SharedChatSession = Arc<Mutex<ChatSession>>;
 
-/// Drain any queued message for `session_id` (ADR-045) and write it to
-/// `stdin` as the next turn. Called from the stream reader thread when a
-/// `Result` chunk is observed — i.e. the turn just ended and a new one
-/// can start. Best-effort: failures are logged, never fatal.
+/// Drain any queued message for `session_id` (ADR-045) and write it to `stdin`
+/// as the next turn (called on a `Result` chunk). Best-effort: failures are
+/// logged, never fatal.
 fn drain_queued_message(
     app_handle: &AppHandle,
     session_id: &str,
@@ -2361,16 +2159,8 @@ mod tests {
 
     #[test]
     fn stop_grace_period_joins_reader_that_finishes_late() {
-        // Regression: `stop()` used to check `handle.is_finished()` the
-        // instant after `child.kill()` + `wait`, which races the reader
-        // thread's EOF propagation through BufReader::lines(). The flag
-        // would often read `false` for a reader that was about to exit
-        // cleanly anyway, producing noisy "still running, detaching"
-        // warnings even on the happy path.
-        //
-        // Simulate a reader that finishes after ~50ms (well below the
-        // 200ms grace window). `stop()` must join it instead of
-        // classifying it as "still running".
+        // Regression: a reader finishing after ~50 ms (below the 200 ms grace)
+        // must be joined by `stop()`, not classified as "still running".
         let mut s = ChatSession::new("test-project");
         s.drain_handles.push(std::thread::spawn(|| {
             std::thread::sleep(std::time::Duration::from_millis(50));
@@ -2389,10 +2179,8 @@ mod tests {
 
     #[test]
     fn stop_grace_period_gives_up_on_genuinely_stuck_reader() {
-        // When a reader is truly wedged (pipe upstream didn't close), the
-        // grace window must still be bounded so `stop()` returns to the
-        // caller in a predictable time. We simulate a stuck reader by
-        // spawning a thread that sleeps longer than the grace window.
+        // A wedged reader's grace window must stay bounded; simulate one by
+        // sleeping longer than the window.
         let mut s = ChatSession::new("test-project");
         s.drain_handles.push(std::thread::spawn(|| {
             std::thread::sleep(std::time::Duration::from_secs(10));
@@ -2401,10 +2189,8 @@ mod tests {
         assert!(s.stop().is_ok());
         let elapsed = start.elapsed();
         assert!(s.drain_handles.is_empty(), "handle must be drained");
-        // Upper bound: the grace window is 200ms total (shared across all
-        // handles, not per-handle) — stop() must detach the stuck reader
-        // within that window and return. 1000ms leaves plenty of room for
-        // CI jitter while still catching a regression to an unbounded join.
+        // Upper bound: 200 ms grace window; 1000 ms allows CI jitter while
+        // catching a regression to an unbounded join.
         assert!(
             elapsed < std::time::Duration::from_millis(1000),
             "stop() took {elapsed:?} — a stuck reader must be detached within the grace window, not joined"
@@ -2647,10 +2433,8 @@ mod tests {
 
     #[test]
     fn build_user_message_with_paste_reference_in_text() {
-        // After ADR-065: the composer writes pasted bytes to
-        // `<project>/.speedwave/pastes/` and inlines an `@…` reference at
-        // the end of the text block. The wire format is purely text — no
-        // `image` content block crosses stdin.
+        // ADR-065: pastes go to `<project>/.speedwave/pastes/` with an inlined
+        // `@…` ref; the wire is text-only.
         let blocks = text_only("Co tu widać?\n\n@/workspace/.speedwave/pastes/paste-123.png");
         let msg = build_user_message(&blocks);
         let items = msg["message"]["content"].as_array().unwrap();
@@ -2662,11 +2446,8 @@ mod tests {
 
     #[test]
     fn build_user_message_snapshot_wire_format() {
-        // Contract snapshot — pins the wire shape so a regression that
-        // re-introduces inline base64 image blocks (the OOM-killing path
-        // ADR-065 removed) fails loudly. `media_type` flipping to
-        // `mimeType` or a new `parent_tool_use_id` sneaking in would also
-        // trip this test.
+        // Contract snapshot pinning the text-only wire shape (ADR-065); trips
+        // on inline image blocks, `media_type`→`mimeType`, or `parent_tool_use_id`.
         let blocks = text_only(
             "review these\n\n@/workspace/.speedwave/pastes/paste-1.png\n@/workspace/.speedwave/pastes/paste-2.jpg",
         );
@@ -2708,9 +2489,7 @@ mod tests {
 
     #[test]
     fn max_wire_bytes_is_1_mib() {
-        // ADR-065: image bytes no longer cross the wire — the cap is sized
-        // for text + paste-path references only. Bumping it would invite a
-        // regression that reintroduces inline base64.
+        // ADR-065: the cap is sized for text + paste-path refs only.
         assert_eq!(MAX_WIRE_BYTES, 1024 * 1024);
     }
 
@@ -2827,11 +2606,8 @@ mod tests {
     }
 
     /// Regression test for the interrupt path: an interrupted turn can emit
-    /// `result` without a preceding `message_stop`, so the stdout-reader
-    /// calls `parser.reset()` after every terminal chunk. Without that
-    /// reset, stale `active_blocks` entries would misroute
-    /// `ToolInputDelta` events in the next turn when Claude reuses the
-    /// same content-block index for a different tool.
+    /// `result` without a preceding `message_stop`, so the stdout-reader calls
+    /// `parser.reset()` after every terminal chunk.
     #[test]
     fn reset_after_result_prevents_stale_tool_contamination() {
         let mut parser = StreamParser::new();
@@ -2841,9 +2617,7 @@ mod tests {
         parse_line_str(&mut parser, start);
         assert!(parser.active_blocks.contains_key(&0));
 
-        // Interrupt emits a `result` directly — no preceding `message_stop`.
-        // The stdout-reader loop calls `parser.reset()` after this chunk, so
-        // simulate that here (parse_line alone does not reset on `result`).
+        // Simulate the reader's `reset()` after `result` (parse_line does not).
         let result = r#"{"type":"result","subtype":"error_during_execution","session_id":"s","total_cost_usd":0.0,"usage":{}}"#;
         parse_line_str(&mut parser, result);
         parser.reset();
@@ -2851,9 +2625,8 @@ mod tests {
         assert!(parser.active_blocks.is_empty());
         assert!(parser.tool_input.is_empty());
 
-        // Turn 2: Claude reuses index 0 for a different tool. Without the
-        // reset above, an input delta at index 0 would still route to the
-        // OLD tool_id; after reset the new tool_id takes over cleanly.
+        // Turn 2 reuses index 0; without the reset above, the input delta
+        // would route to the OLD tool_id.
         let start2 = r#"{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_NEW","name":"Edit","input":{}}}}"#;
         parse_line_str(&mut parser, start2);
         let delta = r#"{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"file\":\"x\"}"}}}"#;
@@ -3017,10 +2790,8 @@ mod tests {
         }
     }
 
-    // `cost_usd` was the original JSON field name in older test fixtures. The CLI
-    // never actually emitted it — the parser reads `total_cost_usd` (current) with
-    // `total_cost` (legacy) as fallback. This test guards against someone adding
-    // `cost_usd` back as a third alias, which would silently resurrect a dead name.
+    // The parser reads `total_cost_usd` (current) / `total_cost` (legacy);
+    // this guards against re-adding the dead `cost_usd` alias.
     #[test]
     fn parse_result_with_legacy_cost_usd_only_produces_no_cost() {
         let mut parser = StreamParser::new();
@@ -3085,13 +2856,8 @@ mod tests {
 
     #[test]
     fn parse_result_picks_dominant_model_when_modelusage_has_multiple_keys() {
-        // Regression: a single turn can mix a main-response model with
-        // background calls (Haiku for title generation, summarization, hook
-        // self-review, etc.). Picking `keys().next()` was non-deterministic
-        // and tended to surface Haiku (alphabetically before Opus) even when
-        // Opus did the real user-facing work, so the chat footer showed the
-        // wrong model. The fix selects the model with the highest
-        // outputTokens.
+        // Regression: a turn mixing a main model with background Haiku calls
+        // must report the model with the highest outputTokens.
         let mut parser = StreamParser::new();
         let line = r#"{"type":"result","session_id":"abc","is_error":false,"total_cost_usd":0.10,"result":"","modelUsage":{"claude-haiku-4-5-20251001":{"inputTokens":10,"outputTokens":50,"contextWindow":200000},"claude-opus-4-7":{"inputTokens":100,"outputTokens":500,"contextWindow":1000000}}}"#;
         let chunk = parse_line_str(&mut parser, line).unwrap();
@@ -3129,12 +2895,8 @@ mod tests {
 
     #[test]
     fn parse_result_error_with_empty_result_returns_placeholder_error() {
-        // Regression guard: an `is_error=true` message with empty/missing
-        // `result` text used to be swallowed silently, leaving the user
-        // with a blank bubble and no indication of failure. Local LLM
-        // providers (e.g. llama.cpp + Qwen) hit this path frequently, so
-        // the parser now surfaces a placeholder Error chunk so the UI
-        // always shows *something*.
+        // Regression guard: `is_error=true` with empty `result` now surfaces a
+        // placeholder Error chunk instead of being swallowed.
         let mut parser = StreamParser::new();
         for line in [
             r#"{"type":"result","is_error":true,"result":""}"#,
@@ -3178,10 +2940,8 @@ mod tests {
 
     #[test]
     fn parse_assistant_type_emits_no_chunk() {
-        // Assistant messages don't emit chunks — content streams via
-        // `stream_event` deltas, and the final `Result` carries the UUID.
-        // An assistant line WITHOUT a `message.id` (local LLM) is silently
-        // ignored just like before.
+        // Assistant messages emit no chunks (content streams via deltas; the
+        // Result carries the UUID); a missing `message.id` is ignored.
         let mut parser = StreamParser::new();
         let line = r#"{"type":"assistant","message":{"role":"assistant","content":[]}}"#;
         assert!(parse_line_str(&mut parser, line).is_none());
@@ -3205,9 +2965,8 @@ mod tests {
 
     #[test]
     fn result_commits_pending_assistant_uuid_and_clears_it() {
-        // The assistant UUID seen before a Result commits ONTO that Result
-        // (ADR-046: atomic commit on turn completion) and is cleared so the
-        // next turn doesn't recycle a stale id.
+        // The pending assistant UUID commits onto the Result (ADR-046) and is
+        // cleared for the next turn.
         let mut parser = StreamParser::new();
         let assistant =
             r#"{"type":"assistant","message":{"id":"msg_turn1","role":"assistant","content":[]}}"#;
@@ -3239,10 +2998,8 @@ mod tests {
 
     #[test]
     fn assistant_uuid_does_not_leak_into_error_result() {
-        // An error turn also `take`s the pending UUID so a subsequent
-        // successful turn that arrives without its own `assistant` event
-        // (an edge protocol) cannot be mislabeled with the errored turn's
-        // identity.
+        // An error turn also takes the pending UUID so a later success without
+        // its own `assistant` event isn't mislabeled.
         let mut parser = StreamParser::new();
         let assistant =
             r#"{"type":"assistant","message":{"id":"msg_err","role":"assistant","content":[]}}"#;
@@ -3250,10 +3007,8 @@ mod tests {
         parse_line_str(&mut parser, assistant);
         let chunk = parse_line_str(&mut parser, error_result).unwrap();
         assert!(matches!(chunk, StreamChunk::Error { .. }));
-        // pending_assistant_uuid stays set here because `parse_result`
-        // short-circuits on `is_error=true`; the stdout-reader loop calls
-        // `parser.reset()` after every terminal chunk which clears it. The
-        // reset() is exercised explicitly to prove the clear happens.
+        // pending_assistant_uuid survives `parse_result`'s `is_error`
+        // short-circuit; reset() clears it (exercised here).
         parser.reset();
         assert!(parser.pending_assistant_uuid.is_none());
     }
@@ -3283,10 +3038,8 @@ mod tests {
 
     #[test]
     fn user_message_mixed_text_and_tool_result_emits_tool_result_only() {
-        // Mixed content (Claude Code occasionally interleaves a narrative
-        // text block alongside a tool_result wrapper in the same user
-        // event). The text presence MUST NOT trigger a UserMessageCommit:
-        // the message is still a tool-result wrapper, not a real prompt.
+        // Mixed content: a text block alongside a tool_result wrapper MUST NOT
+        // trigger a UserMessageCommit.
         let mut parser = StreamParser::new();
         let line = r#"{"type":"user","message":{"id":"u_mix","role":"user","content":[{"type":"text","text":"here is the result"},{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"}]}}"#;
         let chunks = parse_line_all_str(&mut parser, line);
@@ -3321,9 +3074,8 @@ mod tests {
 
     #[test]
     fn user_message_commit_survives_reset() {
-        // Across a turn boundary (reset), a previously-committed user UUID
-        // must stay in the dedup set — otherwise the re-echoed prompt on a
-        // resume would commit a second time.
+        // Across a turn boundary (reset), a committed user UUID must stay in
+        // the dedup set so a re-echoed prompt isn't re-committed.
         let mut parser = StreamParser::new();
         let line = r#"{"type":"user","message":{"id":"u_persist","role":"user","content":[{"type":"text","text":"hi"}]}}"#;
         assert_eq!(parse_line_all_str(&mut parser, line).len(), 1);
@@ -3491,9 +3243,8 @@ mod tests {
 
     #[test]
     fn parse_rate_limit_event_extracts_fields() {
-        // Real 2.1.173 wire shape: the reset timestamp is camelCase `resetsAt`
-        // (rate_limit_info schema in the binary). status/utilization are
-        // case-identical. resetsAt is what drives the footer reset countdown.
+        // Real 2.1.173 wire shape: reset timestamp is camelCase `resetsAt`
+        // (drives the footer countdown).
         let mut parser = StreamParser::new();
         let line = r#"{"type":"rate_limit_event","rate_limit_info":{"status":"allowed_warning","utilization":73.5,"resetsAt":1738425600}}"#;
         let parsed: serde_json::Value = serde_json::from_str(line).unwrap();
@@ -3518,9 +3269,7 @@ mod tests {
 
     #[test]
     fn parse_rate_limit_event_accepts_legacy_snake_case_resets_at() {
-        // Older Claude Code builds emitted snake_case `resets_at`; the parser
-        // keeps a fallback so a downgrade or a replayed legacy line still
-        // surfaces the reset time.
+        // Older builds emitted snake_case `resets_at`; the parser keeps a fallback.
         let mut parser = StreamParser::new();
         let line = r#"{"type":"rate_limit_event","rate_limit_info":{"status":"allowed","resets_at":1738425600}}"#;
         let parsed: serde_json::Value = serde_json::from_str(line).unwrap();
@@ -4040,9 +3789,8 @@ mod tests {
 
     #[test]
     fn build_ask_user_response_multi_duplicate_question_text_fails_closed() {
-        // Two slots share question text → wire layer would lose one answer
-        // (JSON Map last-write-wins). The host refuses to emit the lossy
-        // payload and surfaces the error so the caller can retry.
+        // Two slots share question text; the host refuses the lossy payload
+        // and surfaces an error.
         let partial = make_partial(
             "req_dup",
             &[("Same?", "H1"), ("Same?", "H2")],
@@ -4073,8 +3821,7 @@ mod tests {
     #[test]
     fn submit_question_answer_no_session_errors_cleanly() {
         // Without an active child, submit_question_answer must fail with
-        // "no active session" — exercising the early-return guard before
-        // any state mutation.
+        // "no active session" before mutating state.
         let mut s = ChatSession::new("test-project");
         s.pending_requests.lock().unwrap().insert(
             "tool-x".into(),
@@ -4205,10 +3952,8 @@ mod tests {
 
     #[test]
     fn build_ask_user_response_multi_oversize_payload_serializes_to_more_than_64_kib() {
-        // Verify that the cap can in fact be hit: build a 4-question payload
-        // where each label is large enough that the serialised wire response
-        // exceeds 64 KiB. This is the input shape that exercises
-        // submit_question_answer's wire-cap guard at the integration level.
+        // Build a 4-question payload whose serialized wire response exceeds
+        // 64 KiB to exercise the wire-cap guard.
         let big = "x".repeat(20_000);
         let partial = make_partial(
             "req_oversize",
@@ -5135,9 +4880,8 @@ mod tests {
 
     #[test]
     fn parse_result_resume_session_restores_snapshot_correctly() {
-        // Simulate resuming mid-session: restore the cumulative snapshot
-        // from history, then verify the next Result's delta is computed
-        // against the restored baseline, not against zero.
+        // Simulate mid-session resume: restore the snapshot, then verify the
+        // next Result's delta is against the baseline, not zero.
         let mut parser = StreamParser::new();
         parser.restore_session_snapshot(
             TurnUsage {
@@ -5295,9 +5039,8 @@ mod tests {
 
     #[test]
     fn parse_result_with_negative_cost_delta_drops_turn_cost() {
-        // Defensive: if the CLI ever reports a cumulative cost lower than
-        // the previous snapshot (resume edge case), we drop `turn_cost`
-        // rather than report a nonsense negative value.
+        // Defensive: a cumulative cost below the previous snapshot drops
+        // `turn_cost` instead of reporting a negative value.
         let mut parser = StreamParser::new();
         let t1 = r#"{"type":"result","session_id":"s","is_error":false,"result":"","total_cost_usd":0.50}"#;
         parse_line_str(&mut parser, t1);
@@ -5361,12 +5104,8 @@ mod tests {
 
     #[test]
     fn first_turn_after_resume_seed_emits_delta_not_cumulative() {
-        // End-to-end-ish coverage of the resume path: feed the parser a
-        // seed that mirrors what `compute_resume_snapshot` would return for
-        // a real prior transcript, then assert the first new `result` line
-        // produces the per-turn delta — not the entire cumulative total.
-        // Without `restore_session_snapshot` being invoked on the live
-        // resume path, this test would fail with delta == cumulative.
+        // Resume path: seed the parser like `compute_resume_snapshot` would,
+        // then assert the first result is the per-turn delta, not the cumulative.
         let mut parser = StreamParser::new();
         parser.restore_session_snapshot(
             TurnUsage {

--- a/desktop/src-tauri/src/chat_session_cmd.rs
+++ b/desktop/src-tauri/src/chat_session_cmd.rs
@@ -1,9 +1,5 @@
-// Chat session lifecycle Tauri commands.
-//
-// Thin `#[tauri::command]` wrappers around `ChatSession` for the active
-// project: start / resume a session, send a message, submit an ask-user
-// answer, and interrupt the current turn. The heavy lifting (auth pre-flight,
-// session swap) lives in `start_session_inner`.
+// Chat session lifecycle Tauri commands wrapping `ChatSession`:
+// start/resume a session, send a message, submit an ask-user answer, interrupt.
 
 use crate::chat::{self, ChatSession, SharedChatSession};
 use crate::reconcile::SharedOauth;
@@ -11,15 +7,9 @@ use crate::types::check_project;
 use crate::{containers_cmd, ensure_oauth_running};
 use crate::{setup_wizard, MSG_NOT_AUTHENTICATED};
 
-/// Shared implementation for `start_chat` and `resume_conversation`.
-///
-/// 1. Acquires the per-project compose lock via `rt.transaction()` and verifies
-///    Claude auth (which also runs `ensure_exec_healthy`).
-/// 2. Extracts the old session from the mutex and stops it **outside** the
-///    session lock — `stop()` can block on `child.wait()` / reader thread
-///    join, and holding the session mutex during that time would starve
-///    `send_message`.
-/// 3. Re-acquires the session lock and starts the new session.
+/// Shared impl for `start_chat`/`resume_conversation`: acquires the per-project
+/// compose lock + checks Claude auth, stops the old session outside the session
+/// lock, then starts the new one under it.
 fn start_session_inner(
     project: &str,
     resume_session_id: Option<&str>,
@@ -38,8 +28,7 @@ fn start_session_inner(
     // Per-project compose lock serialises auth check with concurrent compose ops.
     log::info!("start_session_inner: acquiring compose lock");
     let rt = speedwave_runtime::runtime::detect_runtime();
-    // `_rt` unused: `check_claude_auth` builds its own runtime; HELD_LOCKS
-    // makes that call reentrant within this thread + project.
+    // `_rt` unused: `check_claude_auth` builds its own (reentrant via HELD_LOCKS).
     rt.transaction(project, |_rt| -> anyhow::Result<()> {
         log::info!("start_session_inner: compose lock acquired, checking auth");
         let authed = setup_wizard::check_claude_auth(project)?;
@@ -196,11 +185,8 @@ mod tests {
     use super::*;
     use std::sync::{Arc, Mutex};
 
-    /// Extracts the body of a function from source code by matching `{`/`}`
-    /// counting braces. Used by structural tests to assert on function contents.
-    ///
-    /// NOTE: uses `split(fn_signature)` which matches the first occurrence of
-    /// the literal string in the entire file. Signatures must be unique.
+    /// Extracts a function body from source by brace-counting from the first
+    /// `split(fn_signature)` match, so `fn_signature` must be unique in the file.
     fn extract_fn_body<'a>(source: &'a str, fn_signature: &str) -> &'a str {
         let after_sig = source
             .split(fn_signature)
@@ -287,11 +273,6 @@ mod tests {
 
     #[test]
     fn start_session_inner_waits_for_image_readiness_before_compose_paths() {
-        // Race guard: both recreate_project_containers_if_running (fresh
-        // oauth branch) and check_claude_auth → ensure_exec_healthy
-        // can call compose_up_recreate. Gate must come BEFORE the if-block
-        // (covers fresh-worker branch) AND BEFORE check_claude_auth (covers
-        // the always-runs path).
         let source = include_str!("chat_session_cmd.rs");
         let body = extract_fn_body(source, "fn start_session_inner(");
 
@@ -316,10 +297,6 @@ mod tests {
     }
 
     // -- spawn_blocking guard-rail tests --
-    //
-    // Chat commands must never acquire the SharedChatSession Mutex on the main
-    // thread. These structural tests enforce that every command wrapping the
-    // mutex uses `spawn_blocking` and acquires `.lock()` inside it.
 
     #[test]
     fn start_chat_uses_spawn_blocking() {
@@ -394,10 +371,6 @@ mod tests {
     }
 
     // -- validation-before-spawn tests --
-    //
-    // Fast validations (check_project, length checks) must run BEFORE
-    // spawn_blocking so invalid requests fail immediately without entering
-    // the thread pool.
 
     #[test]
     fn start_chat_validates_project_before_spawn_blocking() {
@@ -448,10 +421,6 @@ mod tests {
     }
 
     // -- JoinError handling tests --
-    //
-    // spawn_blocking returns JoinHandle which can fail with JoinError (e.g.
-    // if the spawned task panics). The outer .await.map_err(…) must convert
-    // this to a String for the Tauri IPC error channel.
 
     #[test]
     fn start_chat_handles_join_error() {
@@ -491,9 +460,7 @@ mod tests {
 
     #[test]
     fn stop_chat_inner_without_active_session_errors() {
-        // interrupt() requires an active stdin (shared_stdin=Some). A freshly
-        // constructed ChatSession has no stdin, so interrupt — and therefore
-        // stop_chat_inner — returns "no active session" instead of panicking.
+        // A fresh ChatSession has no stdin, so interrupt returns "no active session".
         let session_arc: SharedChatSession = Arc::new(Mutex::new(ChatSession::new("test-project")));
         let err = stop_chat_inner(session_arc).expect_err("expected error on idle session");
         assert!(

--- a/desktop/src-tauri/src/clipboard_bridge.rs
+++ b/desktop/src-tauri/src/clipboard_bridge.rs
@@ -31,9 +31,7 @@ fn run(app: AppHandle) -> anyhow::Result<()> {
     let mut watcher: RecommendedWatcher = notify::recommended_watcher(tx)?;
     watcher.watch(&root, RecursiveMode::Recursive)?;
 
-    // Dedup key: the last content we pushed to the clipboard. A single write
-    // to `.clipboard-bridge` fires both Create and Modify events on most
-    // platforms; equal content means we already handled it.
+    // Dedup key: the last content pushed to the clipboard.
     let mut last_content = String::new();
     log::info!("clipboard bridge started: watching {}", root.display());
 
@@ -41,8 +39,7 @@ fn run(app: AppHandle) -> anyhow::Result<()> {
         let event = match res {
             Ok(e) => e,
             Err(e) => {
-                // inotify exhaustion (MaxFilesWatch), permission loss, etc. —
-                // events are now being dropped; surface it.
+                // Watcher error (inotify exhaustion, permission loss); events dropped.
                 log::warn!("clipboard bridge: watcher error: {e}");
                 continue;
             }
@@ -59,17 +56,13 @@ fn run(app: AppHandle) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Reads up to `MAX_PAYLOAD_BYTES + 1` bytes from `path` in a single open —
-/// this collapses the check-then-act window a separate `metadata()` + `read()`
-/// would leave (a container could swap a small file for a huge one in between).
-/// `Ok(None)` means "nothing actionable" (empty, too large, or unreadable —
-/// unreadable is logged at warn unless it's the benign "file already gone").
+/// Reads up to `MAX_PAYLOAD_BYTES + 1` bytes in one open to detect oversized
+/// payloads atomically. `None` means empty, too large, or unreadable.
 fn read_capped(path: &Path) -> Option<String> {
     let mut file = match std::fs::File::open(path) {
         Ok(f) => f,
         Err(e) => {
-            // NotFound is expected — the file can be deleted between the notify
-            // event and this open. Anything else is worth a log line.
+            // NotFound is expected (file can vanish between notify event and open).
             if e.kind() != std::io::ErrorKind::NotFound {
                 log::warn!("clipboard bridge: open failed at {}: {e}", path.display());
             }
@@ -198,9 +191,7 @@ mod tests {
 
     #[test]
     fn dedup_skips_identical_content() {
-        // We can't easily call handle_bridge_write without an AppHandle, but
-        // the dedup decision is observable through the content comparison:
-        // simulate by checking the equality the function uses.
+        // Dedup decision is the String equality the function uses.
         let mut last = String::from("payload-1");
         let new = String::from("payload-1");
         let is_dup = new == last;
@@ -220,9 +211,7 @@ mod tests {
 
     #[test]
     fn bridge_filename_matches_shell_wrapper_literal() {
-        // SSOT cross-check: containers/osc52-copy.sh writes "~/.clipboard-bridge".
-        // If this constant changes, that script must change too (and the BATS
-        // test in _tests/entrypoint/osc52-copy.bats greps for this exact value).
+        // SSOT: containers/osc52-copy.sh and _tests/entrypoint/osc52-copy.bats depend on this value.
         assert_eq!(BRIDGE_FILENAME, ".clipboard-bridge");
     }
 }

--- a/desktop/src-tauri/src/container_logs_cmd.rs
+++ b/desktop/src-tauri/src/container_logs_cmd.rs
@@ -18,9 +18,7 @@ fn read_tail_sanitized(path: &std::path::Path, tail: usize) -> Result<String, St
     ))
 }
 
-// tauri-plugin-log (KeepSome) names rotated files
-// `speedwave-desktop_YYYY-MM-DD_HH-MM-SS.log`; reading only the bare file
-// shows an empty current segment right after rotation.
+// Reads all `speedwave-desktop*.log` segments (tauri-plugin-log rotates them).
 fn read_tail_desktop_logs(dir: &std::path::Path, tail: usize) -> String {
     let entries = match std::fs::read_dir(dir) {
         Ok(e) => e,
@@ -60,16 +58,12 @@ fn read_tail_desktop_logs(dir: &std::path::Path, tail: usize) -> String {
 // Unified `/logs` view — merge of every log source the app produces
 // ---------------------------------------------------------------------------
 //
-// The frontend's `parseLogLine` recognises lines of the form
-// `<source-token> | <rest>`, where `<source-token>` matches `[\w.-]+`. Compose
-// container logs already arrive in that shape (`<container_name> | <ISO> msg`).
-// Host-side log files (tauri-desktop, mcp-os, claude-session) do not, so we
-// reformat them via `prefix_lines` before concatenating with the compose
-// stream into a single string. This is what `get_all_logs` returns.
+// Frontend `parseLogLine` recognises `<source-token> | <rest>` (`<source-token>`
+// matches `[\w.-]+`). Compose lines already match; host files are reformatted
+// via `prefix_lines` before concatenation. `get_all_logs` returns the result.
 
 /// Returns true when the line already carries a `<source-token> | …` prefix
-/// that the frontend parser will recognise. Used to skip re-prefixing compose
-/// container lines (which `nerdctl compose logs` already prefixes for us).
+/// that the frontend parser will recognise.
 fn has_source_prefix(line: &str) -> bool {
     let bytes = line.as_bytes();
     if bytes.is_empty() {
@@ -94,20 +88,11 @@ fn has_source_prefix(line: &str) -> bool {
     i < bytes.len() && bytes[i] == b'|'
 }
 
-/// Rewrites tauri-plugin-log's bracketed level (`[INFO]`, `[WARN]`, …) into
-/// the unbracketed form Angular's `LEVEL_RE` expects after timestamp
-/// extraction.
-///
-/// Production input:
-///   `2026-05-06T19:58:38.724+0200 [INFO][speedwave_desktop::integrations_cmd] msg`
-/// Output:
-///   `2026-05-06T19:58:38.724+0200 INFO [speedwave_desktop::integrations_cmd] msg`
-///
-/// Returns the line unchanged when it does not match the expected layout
-/// (e.g. multi-line stack traces or external library lines).
+/// Rewrites tauri-plugin-log's bracketed level (`[INFO]`) into the unbracketed
+/// form Angular's `LEVEL_RE` expects. Returns the line unchanged when it does
+/// not match the expected layout.
 fn rewrite_desktop_bracketed_level(line: &str) -> String {
-    // ISO timestamp ends at the first space (timestamp contains digits, `-`,
-    // `:`, `.`, `+`, optionally `Z` — never spaces).
+    // ISO timestamp ends at the first space (it contains no spaces).
     let Some(space_idx) = line.find(' ') else {
         return line.to_string();
     };
@@ -125,27 +110,17 @@ fn rewrite_desktop_bracketed_level(line: &str) -> String {
     ) {
         return line.to_string();
     }
-    // `line[..space_idx]` = ISO timestamp (without trailing space)
-    // After the closing `]` comes the rest, which usually starts with `[target]`.
-    // The frontend `LEVEL_RE = /^(LEVEL)\s+(.*)$/i` requires a space after the
-    // level word — without it the line falls back to default `info` and we lose
-    // the WARN/ERROR signal in the level chip.
+    // Frontend `LEVEL_RE` requires a space after the level word.
     let before = &line[..space_idx];
     let after = &after_ts[close_idx + 1..];
     format!("{before} {level} {after}")
 }
 
-/// Reformats the raw output of one log source so that every non-empty line
-/// matches the frontend's `<source> | <rest>` parsing contract.
-///
-/// - Empty lines are dropped (they would break `parseLogLine` and add no value).
-/// - Lines that already carry a `<word> | …` prefix (compose container logs)
-///   have the compose container prefix stripped so the dropdown shows
-///   `mcp_hub` not `speedwave_my_project_mcp_hub` — only when `project` is
-///   supplied (i.e. compose source); host-side sources pass through as-is.
-/// - Other lines (host-side log files) get the `<source> | ` prefix.
-/// - Desktop-log lines additionally have their bracketed level rewritten
-///   so the Angular level chip works (`[INFO]` → `INFO`).
+/// Reformats one log source so every non-empty line matches the frontend's
+/// `<source> | <rest>` contract. Empty lines are dropped; already-prefixed
+/// compose lines have their project prefix stripped (only when `project` is
+/// supplied); other lines get the `<source> | ` prefix. Desktop-log lines also
+/// have their bracketed level rewritten (`[INFO]` → `INFO`).
 pub(crate) fn prefix_lines(source: &str, raw: &str, project: Option<&str>) -> String {
     let mut out = String::with_capacity(raw.len() + raw.lines().count() * (source.len() + 4));
     for line in raw.split('\n') {
@@ -188,16 +163,13 @@ pub(crate) struct LogSources {
     pub desktop: String,
     pub mcp_os: String,
     pub claude: String,
-    /// Lima VM serial log (macOS only; empty elsewhere). Parity with the ZIP —
-    /// it's a displayable log, so it must also appear in /logs.
+    /// Lima VM serial log (macOS only; empty elsewhere).
     pub lima: String,
 }
 
-/// Composes the per-source log buffers into a single newline-separated string,
-/// block-by-block in a deterministic source order. Chronological interleaving
-/// is the frontend's job (`sortLogLinesByTime` in `logs-view.component.ts`) —
-/// every line carries one ISO timestamp, so the renderer parses and merges
-/// them by instant; here we just concatenate.
+/// Concatenates the per-source log buffers into a single newline-separated
+/// string in a deterministic source order. Chronological interleaving is the
+/// frontend's job (`sortLogLinesByTime` in `logs-view.component.ts`).
 pub(crate) fn merge_log_sources(sources: LogSources, project: &str) -> String {
     let compose = prefix_lines("compose", &sources.compose, Some(project));
     let desktop = prefix_lines("desktop", &sources.desktop, None);
@@ -205,30 +177,12 @@ pub(crate) fn merge_log_sources(sources: LogSources, project: &str) -> String {
     let claude = prefix_lines("claude", &sources.claude, None);
     let lima = prefix_lines("lima", &sources.lima, None);
 
-    // Apply the sanitizer once to the merged buffer (idempotent — sources are
-    // already individually sanitized, this is a defence-in-depth pass).
+    // Defence-in-depth sanitizer pass over the merged buffer (idempotent).
     speedwave_runtime::log_sanitizer::sanitize(&format!("{compose}{desktop}{mcp_os}{claude}{lima}"))
 }
 
-/// Reads every host-side log file, fetches the compose stream, and returns a
-/// merged buffer that the frontend's existing `parseLogLine` understands.
-///
-/// Sources merged (in this fixed order, per-source-block):
-///   1. compose   — `nerdctl compose logs --timestamps --tail <N>`
-///   2. desktop   — tauri-plugin-log file (Rust + Angular `LoggerService` +
-///      Swift CLI stderr forwarded by `check_os_permission`)
-///   3. mcp-os    — `~/.speedwave/mcp-os.log`
-///   4. claude    — `~/.speedwave/logs/<project>/claude-session.log` (if exists)
-///
-/// Each source uses the full `tail` budget independently (default 200, cap
-/// 10 000). With 5 sources × 10 000 the upper bound is 50 000 lines — trivial
-/// for the renderer, especially since the frontend further filters by source
-/// in the dropdown.
-///
-/// Compose-only output (e.g. diagnostics export) reads `rt.compose_logs`
-/// directly; this is the only log command the webview invokes.
-/// Give up on the (normally sub-second) compose-logs fetch after this long —
-/// a busy container engine must not blank the file-based sources.
+/// Compose-logs fetch timeout; a busy container engine must not blank the
+/// file-based sources.
 const COMPOSE_LOGS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 /// Single-flight marker: a compose-logs fetch survives its timeout as a
@@ -298,8 +252,7 @@ pub(crate) async fn get_all_logs(project: String, tail: Option<u32>) -> Result<S
             None => String::new(),
         };
 
-        // File-source paths resolved from the SSOT registry (platform-gated), so
-        // /logs and the ZIP draw from the same list. Empty when unavailable.
+        // File-source paths resolved from the SSOT registry (platform-gated).
         let data_dir = speedwave_runtime::consts::data_dir();
         let read_source = |key: &str| -> String {
             speedwave_runtime::diagnostic_sources::resolve_file_path(key, data_dir, &project)
@@ -503,7 +456,6 @@ mod tests {
     #[test]
     fn has_source_prefix_rejects_token_with_spaces() {
         // Token chars are `[\w.-]`; any space inside the token portion fails.
-        // (`a b | c` — frontend `COMPOSE_RE` would not match either.)
         assert!(!has_source_prefix("a b | c"));
     }
 
@@ -533,9 +485,7 @@ mod tests {
 
     #[test]
     fn rewrite_desktop_level_handles_colon_offset_timestamp() {
-        // `log_ts::log_timestamp()` emits the RFC-3339 colon form `+02:00`;
-        // the timestamp still has no space, so the first-space split lands
-        // exactly at the start of `[LEVEL]`.
+        // RFC-3339 colon-offset `+02:00` has no space, so the split lands at `[LEVEL]`.
         let line = "2026-05-12T14:34:02.814+02:00 [WARN][speedwave_desktop::x] msg";
         let out = rewrite_desktop_bracketed_level(line);
         assert_eq!(
@@ -665,10 +615,7 @@ mod tests {
 
     #[test]
     fn logs_view_covers_all_displayable_registry_sources() {
-        // Parity, checked against the ACTUAL merge output (not a proxy array):
-        // give every source a unique marker, run the real merge, and assert each
-        // displayable+available registry source's marker survives prefixed by its
-        // key. A registry source not wired into LogSources/merge fails here.
+        // A displayable registry source not wired into the merge fails here.
         use speedwave_runtime::diagnostic_sources::DIAGNOSTIC_SOURCES;
         let merged = merge_log_sources(
             LogSources {

--- a/desktop/src-tauri/src/containers_cmd.rs
+++ b/desktop/src-tauri/src/containers_cmd.rs
@@ -1,8 +1,6 @@
 // Container lifecycle and setup wizard Tauri commands.
-//
-// Extracted from main.rs — thin #[tauri::command] wrappers that delegate to
-// `setup_wizard` and `speedwave_runtime` functions, converting errors to
-// `Result<T, String>` for Tauri's serialization boundary.
+// Thin #[tauri::command] wrappers delegating to `setup_wizard` and
+// `speedwave_runtime`, mapping errors to `Result<T, String>`.
 
 use speedwave_runtime::config;
 
@@ -45,10 +43,7 @@ pub(crate) fn validate_api_key(value: &str) -> Result<String, String> {
     if trimmed.is_empty() {
         return Ok(String::new());
     }
-    // A bare `Bearer` (no token after it) reaches `strip_bearer_prefix` only
-    // when the trailing space survives the trim — but `trimmed` already
-    // removed it. Detect the prefix-only case explicitly so the user sees
-    // the actionable error instead of having the stripper return `Some("Bearer")`.
+    // Reject a bare `Bearer` (no token) with an actionable error.
     if trimmed.eq_ignore_ascii_case("bearer") {
         return Err("api_key must not be empty after stripping the 'Bearer ' prefix".to_string());
     }
@@ -238,10 +233,7 @@ fn spawn_background_teardown_with(
         }
     });
     if let Some(old) = pending_teardowns_lock().insert(prev, handle) {
-        // Finished by construction: PROJECT_TRANSITION_LOCK serialises
-        // switches and wait_for_pending_teardown precedes every restart of
-        // this project — so an entry can only be replaced after its thread
-        // ran to completion. join() is then a no-op cleanup.
+        // Replaced entry already finished; join() is a no-op cleanup.
         let _ = old.join();
     }
 }
@@ -966,15 +958,9 @@ pub fn get_default_anthropic_model_label() -> Option<&'static str> {
     speedwave_runtime::defaults::default_anthropic_family_label()
 }
 
-/// Applies LLM config to the active project in-memory. Extracted for
-/// testability and reused by `update_llm_config`.
-///
-/// Cross-field invariants are enforced here, not just in `update_llm_config`:
-/// internal callers that build a `LlmConfig` directly (setup wizard, future
-/// migration paths) must not be able to persist `provider=<local>, model=None`.
-/// The Tauri command performs the same checks earlier so the user gets a
-/// human-readable error before the save attempt; the duplicated guard here is
-/// the safety net.
+/// Applies LLM config to the active project in-memory. Enforces the
+/// cross-field invariant (a local provider must have a model) for all
+/// callers, including those bypassing `update_llm_config`.
 fn apply_llm_config(
     user_config: &mut config::SpeedwaveUserConfig,
     update: config::LlmConfig,
@@ -1434,14 +1420,8 @@ mod tests {
         }
     }
 
-    /// Builds a `LlmConfig` for tests. `context_tokens` is always `None` —
-    /// every test in this module covers the boundary either via a real
-    /// provider (where context is discovered, not hand-set) or via the
-    /// model/url validation guards that run before context is consulted.
-    /// Centralising the literal so adding a future `LlmConfig` field
-    /// touches one helper, not 14 inline struct expressions.
-    /// Test helper: returns the legacy `LlmConfig` for callers that exercise
-    /// the lower-level `apply_llm_config` (the in-memory mutator).
+    /// Test helper: builds a `LlmConfig` (`context_tokens` always `None`)
+    /// for the lower-level `apply_llm_config`.
     fn llm(provider: &str, model: Option<&str>, base_url: Option<&str>) -> LlmConfig {
         LlmConfig {
             provider: Some(provider.to_string()),

--- a/desktop/src-tauri/src/diagnostics.rs
+++ b/desktop/src-tauri/src/diagnostics.rs
@@ -21,8 +21,7 @@ pub(crate) struct DiagnosticsInput {
 ///
 /// All textual content is passed through `log_sanitizer::sanitize()` before
 /// being written to the archive. System info is appended without sanitization.
-/// Writes one ZIP entry, ALWAYS sanitized. The single textual-write path —
-/// every secret-bearing entry goes through here, so none can skip redaction.
+/// Writes one ZIP entry, always sanitized.
 fn write_sanitized_entry(
     zip: &mut zip::ZipWriter<std::fs::File>,
     options: zip::write::SimpleFileOptions,
@@ -68,8 +67,7 @@ pub(crate) fn build_diagnostics_zip(
         }
     }
 
-    // Entry names come from the SSOT registry (keyed by source), so a stray
-    // hand-rolled entry can't appear — every name traces to DIAGNOSTIC_SOURCES.
+    // Entry names come from the DIAGNOSTIC_SOURCES registry, keyed by source.
     let zip_entry = |key: &str| -> &'static str {
         speedwave_runtime::diagnostic_sources::DIAGNOSTIC_SOURCES
             .iter()
@@ -100,8 +98,6 @@ pub(crate) fn build_diagnostics_zip(
     }
 
     // System info: compile-time constants, no secrets — the one raw entry.
-    // claude_pinned is what the image SHOULD run; runtime skew surfaces as
-    // the entrypoint WARNING inside this ZIP's compose-logs entry.
     let sys_info = format!(
         "os: {}\narch: {}\nversion: {}\nclaude_pinned: {}\n",
         std::env::consts::OS,
@@ -569,8 +565,7 @@ mod tests {
             container_logs: Some(secrets[2].into()),
             mcp_os_log: Some(mk("mcp.log", secrets[3])),
             compose_path: Some(mk("compose.yml", secrets[0])),
-            // Carries the Bearer token (secrets[4]) so the redaction matrix
-            // still exercises all five secret patterns across the sources.
+            // Carries the Bearer token (secrets[4]).
             claude_session_log: Some(mk("claude.log", secrets[4])),
         };
         build_diagnostics_zip(&zip_path, &input).unwrap();
@@ -616,8 +611,7 @@ mod tests {
 
         let registry_entries: Vec<&str> = DIAGNOSTIC_SOURCES.iter().map(|s| s.zip_entry).collect();
         for name in zip_entry_names(&zip_path) {
-            // system-info.txt is the documented non-source trailing write;
-            // `logs/<file>` are the desktop dir's N dynamic entries (zip_entry "logs/").
+            // system-info.txt is the non-source trailing write; `logs/<file>` are dynamic.
             let traced = name == "system-info.txt"
                 || name.starts_with("logs/")
                 || registry_entries.contains(&name.as_str());

--- a/desktop/src-tauri/src/firewall.rs
+++ b/desktop/src-tauri/src/firewall.rs
@@ -1,16 +1,6 @@
 //! Windows firewall rules (ADR-067) — Desktop runtime fallback.
-//!
 //! Ensures both firewall layers exist before any host listener binds the WSL
-//! adapter IP: the Hyper-V rule (container↔host reachability) and host WDF
-//! per-program allow rules that suppress the "allow an app" prompt for the
-//! bundled node.exe workers + this exe. perUser NSIS installs run un-elevated
-//! so the install-time hook cannot create the (admin-only) rules — this is the
-//! fallback. Runs at most once per process via `FIREWALL_RULE_ONCE`. Fail-open:
-//! never blocks startup.
-//!
-//! No "declined" state is persisted: rule presence is the only source of truth,
-//! checked live each session. The `Once` caps the prompt at one per app launch,
-//! so an accidental "No" is not a permanent lock-out — the next launch retries.
+//! adapter IP. Runs at most once per process; fail-open, never blocks startup.
 
 /// Outcome of one `firewall.ps1 -Mode ensure` invocation.
 #[cfg(any(target_os = "windows", test))]
@@ -88,11 +78,8 @@ mod windows_impl {
         }
     }
 
-    /// Full paths of the host listeners that must be pre-authorized at the WDF
-    /// layer to suppress the per-binary "allow access" prompt: the bundled
-    /// node.exe (mcp-os / oauth workers) and this desktop exe.
-    /// Resolved relative to the running exe so they match the actual install
-    /// location (perUser dir or C:\Speedwave) — WDF needs exact paths.
+    /// Full paths of the host listeners pre-authorized at the WDF layer: the
+    /// bundled node.exe and this exe, resolved relative to the running exe.
     fn host_listener_programs() -> Vec<String> {
         let mut progs = Vec::new();
         if let Ok(exe) = std::env::current_exe() {
@@ -101,9 +88,7 @@ mod windows_impl {
                 let node = dir
                     .join(speedwave_runtime::consts::NODEJS_SUBDIR)
                     .join("node.exe");
-                // Only authorize node.exe if it actually exists — a rule for an
-                // absent binary gives false "firewall configured" confidence and
-                // never matches the real worker.
+                // Only authorize node.exe if it actually exists.
                 if node.is_file() {
                     progs.push(node.to_string_lossy().into_owned());
                 } else {
@@ -117,18 +102,11 @@ mod windows_impl {
         progs
     }
 
-    /// Self-elevates `firewall.ps1 -Mode install-elevated` via UAC. The inner
-    /// PowerShell wraps `Start-Process -Verb RunAs` in try/catch and emits an
-    /// explicit launcher exit code so the outcome is deterministic regardless
-    /// of how PowerShell surfaces a UAC cancellation (verified on Windows:
-    /// 0 = elevated child ran, 10 = UAC cancelled / elevation refused). We
-    /// persist nothing — `Once` already caps this to one prompt per launch.
+    /// Self-elevates `firewall.ps1 -Mode install-elevated` via UAC. Launcher
+    /// exit codes: 0 = elevated child ran, 10 = UAC cancelled / refused.
     fn attempt_elevated_install(script: &std::path::Path, programs: &[String]) {
         let powershell = system_powershell_path();
-        // Build the elevated child's -ArgumentList: fixed flags + the program
-        // paths. Each element is single-quoted for PowerShell; embedded single
-        // quotes are doubled. Windows paths have no single quotes in practice,
-        // but we escape defensively.
+        // Build the elevated child's -ArgumentList; each element PS-quoted.
         let mut args = vec![
             "'-NoProfile'".to_string(),
             "'-NonInteractive'".to_string(),
@@ -149,15 +127,13 @@ mod windows_impl {
             ps = ps_quote(&powershell.to_string_lossy()),
             argv = args.join(","),
         );
-        // system_command applies CREATE_NO_WINDOW so the launcher PowerShell does
-        // not flash a console; the elevated child uses -WindowStyle Hidden above.
+        // system_command applies CREATE_NO_WINDOW so the launcher shows no console.
         let result = speedwave_runtime::binary::system_command(&powershell.to_string_lossy())
             .args(["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command"])
             .arg(&inner)
             .status();
         match result.map(|s| s.code()) {
-            // Launcher ran the elevated child; verify by PRESENCE (the child
-            // itself fail-opens, so its exit code is not authoritative).
+            // Launcher ran the elevated child; verify by rule PRESENCE.
             Ok(Some(0)) => {
                 if matches!(
                     run_firewall_mode(script, "ensure", programs),
@@ -170,8 +146,7 @@ mod windows_impl {
                     );
                 }
             }
-            // UAC cancelled / elevation refused. Not persisted — the next app
-            // launch will try once more (no permanent lock-out on a misclick).
+            // UAC cancelled / elevation refused.
             Ok(Some(10)) => {
                 log::warn!("firewall: UAC declined — WDF prompts may appear until granted")
             }
@@ -191,8 +166,7 @@ mod windows_impl {
         programs: &[String],
     ) -> EnsureOutcome {
         let powershell = system_powershell_path();
-        // system_command applies CREATE_NO_WINDOW so PowerShell does not flash a
-        // console window over the Desktop UI (SSOT: binary.rs).
+        // system_command applies CREATE_NO_WINDOW (SSOT: binary.rs).
         let mut cmd = speedwave_runtime::binary::system_command(&powershell.to_string_lossy());
         cmd.args([
             "-NoProfile",
@@ -204,8 +178,7 @@ mod windows_impl {
         .arg(script)
         .args(["-Mode", mode]);
         if !programs.is_empty() {
-            // Semicolon-separated single string — PowerShell -File cannot bind a
-            // multi-element array; the script splits on ';' (illegal in paths).
+            // Semicolon-separated single string; -File cannot bind an array.
             cmd.arg("-Programs").arg(programs.join(";"));
         }
         match cmd.status() {
@@ -223,16 +196,8 @@ mod windows_impl {
         format!("'{}'", s.replace('\'', "''"))
     }
 
-    /// True when the process runs in an interactive session that can render a
-    /// UAC consent dialog. Avoids hanging on `-Verb RunAs` in headless/SCCM
-    /// contexts. `SESSIONNAME` is set for interactive (`Console`/`RDP-*`)
-    /// sessions and absent for service/non-interactive launches.
-    ///
-    /// Known edge case: a Session-0 System-account launch (SCCM/Intune device
-    /// scope) can have `SESSIONNAME="Console"` with no interactive user, so this
-    /// returns `true` and a `RunAs` would block. The process-wide `Once` guard
-    /// caps the damage to one blocking call per launch; a CreateProcess timeout
-    /// would be the fuller fix if this ever proves a real deployment problem.
+    /// True when the process can render a UAC consent dialog, detected via the
+    /// `SESSIONNAME` env var (set for interactive sessions, absent for services).
     fn is_interactive_session() -> bool {
         std::env::var_os("SESSIONNAME").is_some()
     }

--- a/desktop/src-tauri/src/git_cmd.rs
+++ b/desktop/src-tauri/src/git_cmd.rs
@@ -1,20 +1,11 @@
-// Lightweight git introspection for the chat status bar.
-//
-// Only one command exists: `get_git_branch` — returns the current branch name
-// for the active project's working directory, or `None` when the directory is
-// not a git repo / git is unavailable. The status strip in the composer uses
-// this to display `<branch icon> main` next to the session cost.
+// Git introspection for the chat status bar: `get_git_branch`.
 
 use std::path::Path;
 
 use speedwave_runtime::config;
 
-/// Returns the current git branch for `project`, or `None` if the project
-/// directory is not a git repository (or git can't be executed).
-///
-/// Resolves the project's `dir` from the user config and runs
-/// `git rev-parse --abbrev-ref HEAD` against it. Detached HEADs return
-/// `Some("HEAD")` — the frontend treats that label like any other branch.
+/// Returns the current git branch for `project`, or `None` if not a git repo
+/// or git can't be executed. Detached HEAD returns `Some("HEAD")`.
 #[tauri::command]
 pub(crate) fn get_git_branch(project: String) -> Result<Option<String>, String> {
     let user_config = config::load_user_config().map_err(|e| e.to_string())?;
@@ -28,8 +19,7 @@ pub(crate) fn get_git_branch(project: String) -> Result<Option<String>, String> 
 /// branch name. Any non-zero exit (not a git repo, git missing, etc.) maps
 /// to `None` so the UI silently hides the branch chip.
 fn read_branch(dir: &Path) -> Option<String> {
-    // system_command applies CREATE_NO_WINDOW on Windows so the git probe (run
-    // on chat status-bar init) does not flash a console over the Desktop UI.
+    // system_command applies CREATE_NO_WINDOW on Windows so git does not flash a console.
     let output = speedwave_runtime::binary::system_command("git")
         .arg("-C")
         .arg(dir)
@@ -83,8 +73,7 @@ mod tests {
     fn read_branch_returns_none_for_unborn_head() {
         let tmp = tempfile::tempdir().unwrap();
         run(&["init", "-b", "main"], tmp.path());
-        // No commits yet — HEAD points at an unborn branch, so rev-parse
-        // exits non-zero and we surface that as `None`.
+        // Unborn HEAD: rev-parse exits non-zero → None.
         assert_eq!(read_branch(tmp.path()), None);
     }
 

--- a/desktop/src-tauri/src/health.rs
+++ b/desktop/src-tauri/src/health.rs
@@ -7,8 +7,7 @@ use speedwave_runtime::runtime;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 struct IdeScanState {
-    // Fingerprint built before dedupe so same-port duplicates collapse via set
-    // semantics, not via mtime tie-break.
+    // Fingerprint built pre-dedupe; duplicates collapse via set semantics.
     live: BTreeSet<(String, u16)>,
     anomalies: BTreeSet<String>,
 }
@@ -73,18 +72,9 @@ pub struct IdeBridgeHealth {
     pub port: Option<u16>,
     pub ws_url: Option<String>,
     pub detected_ides: Vec<DetectedIde>,
-    /// SSOT for "is an IDE actively connected to the bridge".
-    /// `None` in three distinct cases that callers should treat the same way
-    /// (UI shows "not connected"):
-    /// 1. No IDE has been selected via `select_ide` yet.
-    /// 2. The previously selected IDE is no longer detected (process exited
-    ///    between health polls).
-    /// 3. `load_user_config` failed (corrupt or unreadable config — see the
-    ///    `log::warn!` in `build_bridge_health`).
-    ///
-    /// Note that `port` / `ws_url` above describe the first detected IDE,
-    /// which may differ from `selected_ide`. Frontends should prefer
-    /// `selected_ide.{port, ws_url}` when both are present.
+    /// SSOT for "is an IDE actively connected to the bridge"; `None` when no
+    /// IDE is selected, the selected IDE is no longer detected, or config load
+    /// failed. Prefer `selected_ide.{port, ws_url}` over `port`/`ws_url` above.
     pub selected_ide: Option<DetectedIde>,
 }
 
@@ -244,9 +234,6 @@ impl HealthMonitor {
 
     pub fn check_ide_bridge() -> IdeBridgeHealth {
         let detected_ides = list_available_ides();
-        // Polled every 5 s — without a log entry an intermittent
-        // permission/IO error would silently degrade the bridge status to
-        // "disconnected" with no diagnostic trail.
         let selected = match speedwave_runtime::config::load_user_config() {
             Ok(cfg) => cfg.selected_ide,
             Err(e) => {
@@ -258,14 +245,9 @@ impl HealthMonitor {
     }
 }
 
-/// Pure helper: pair the live detected-IDE list with the user's selected IDE
-/// (read from config) and assemble the `IdeBridgeHealth` payload. Extracted
-/// from `check_ide_bridge` so the resolution logic is testable without
-/// touching the global config file.
-///
-/// `selected_ide` is `Some(d)` only when the user-selected entry is also
-/// currently detected — a stale config pointing at a dead IDE process
-/// resolves to `None` (UI renders "disconnected" rather than a stale port).
+/// Pairs the detected-IDE list with the selected IDE and assembles the
+/// `IdeBridgeHealth` payload. `selected_ide` resolves to `Some` only when the
+/// selected entry is also currently detected, else `None`.
 pub(crate) fn build_ide_bridge_health(
     detected_ides: Vec<DetectedIde>,
     selected: Option<&speedwave_runtime::config::SelectedIde>,
@@ -297,11 +279,9 @@ pub fn list_available_ides() -> Vec<DetectedIde> {
     lock_dir.map(|d| list_ides_in_dir(&d)).unwrap_or_default()
 }
 
-/// Returns true if `~/.claude/ide/<port>.lock` exists and points at a
-/// live (PID + TCP) IDE instance. Probes a single lock file rather than
-/// scanning the whole directory — used by `select_ide` to validate the
-/// exact port the UI sent, including older-window ports that
-/// `list_available_ides` collapses away during dedupe.
+/// Returns true if `~/.claude/ide/<port>.lock` exists and points at a live
+/// (PID + TCP) IDE instance. Probes the single lock file for `port` rather
+/// than scanning the whole directory.
 pub fn is_ide_port_alive(port: u16) -> bool {
     let Some(home) = dirs::home_dir() else {
         return false;
@@ -313,11 +293,9 @@ pub fn is_ide_port_alive(port: u16) -> bool {
     is_ide_lock_alive(&lock_path)
 }
 
-/// Scans `lock_dir/*.lock` for IDE lock files with live PIDs and listening ports.
-///
-/// Deduplicates by `(pid, ide_name)` — VS Code writes one lock per window,
-/// all sharing the same `pid`. Keeps the entry with the most recent mtime so
-/// the user-visible list collapses to one row per IDE instance.
+/// Scans `lock_dir/*.lock` for IDE lock files with live PIDs and listening
+/// ports. Deduplicates by `(pid, ide_name)` keeping the most recent mtime, so
+/// multiple windows of one IDE (same pid) collapse to one entry.
 fn list_ides_in_dir(lock_dir: &std::path::Path) -> Vec<DetectedIde> {
     let Ok(entries) = std::fs::read_dir(lock_dir) else {
         return Vec::new();
@@ -401,8 +379,7 @@ fn list_ides_in_dir(lock_dir: &std::path::Path) -> Vec<DetectedIde> {
         })
         .collect();
 
-    // Fingerprint built from the full pre-dedupe set so identical (ide, port)
-    // pairs across multiple lock files collapse via BTreeSet, not via mtime.
+    // Fingerprint from the full pre-dedupe set; duplicates collapse via BTreeSet.
     let live_fingerprint: BTreeSet<(String, u16)> =
         live.iter().map(|e| (e.ide_name.clone(), e.port)).collect();
 
@@ -422,8 +399,7 @@ fn list_ides_in_dir(lock_dir: &std::path::Path) -> Vec<DetectedIde> {
         }
     }
 
-    // HashMap iteration is hash-randomised; sort so the frontend's
-    // detected-IDE list does not jump around between 5-second polls.
+    // Sort: HashMap iteration is hash-randomised, frontend needs stable order.
     let mut result: Vec<DetectedIde> = by_key
         .into_values()
         .map(|e| DetectedIde {
@@ -446,8 +422,7 @@ fn list_ides_in_dir(lock_dir: &std::path::Path) -> Vec<DetectedIde> {
         *last = current;
         msgs
     };
-    // Lock released — log writes (possibly involving file rotation) cannot
-    // block a concurrent caller waiting on LAST_IDE_STATE.
+    // Log after lock release so writes do not block concurrent callers.
     for msg in messages {
         info!("{msg}");
     }
@@ -698,8 +673,7 @@ mod tests {
 
     #[test]
     fn parse_strips_runtime_project_prefix() {
-        // Build container names from the live `compose_prefix()` so the test
-        // is independent of `SPEEDWAVE_DATA_DIR`.
+        // Names from live `compose_prefix()`: independent of `SPEEDWAVE_DATA_DIR`.
         let prefix = speedwave_runtime::consts::compose_prefix();
         let json = format!(
             r#"[{{"Name":"{prefix}_my_proj_mcp_hub","State":"running"}},
@@ -824,8 +798,7 @@ mod tests {
         use super::list_ides_in_dir;
 
         let tmp = tempfile::tempdir().unwrap();
-        // Use an external alive PID so the entry passes the PID guard and
-        // actually reaches the TCP port liveness check — port 64999 is not listening.
+        // External alive PID passes the PID guard; port 64999 is not listening.
         let (external_pid, _child) = external_alive_pid();
         std::fs::write(
             tmp.path().join("64999.lock"),
@@ -849,8 +822,7 @@ mod tests {
         // Bind a real TCP listener so the port check passes.
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
-        // Use an external PID so is_lock_entry_alive passes the PID liveness
-        // check without triggering the self-PID filter in list_ides_in_dir.
+        // External PID passes liveness without triggering the self-PID filter.
         let (external_pid, _child) = external_alive_pid();
         let lock_content = format!(
             r#"{{"pid":{},"port":{},"wsUrl":"ws://127.0.0.1:{}","authToken":"tok","workspaceFolders":["/ws"],"ideName":"Cursor","transport":"ws"}}"#,
@@ -874,8 +846,7 @@ mod tests {
         use super::list_ides_in_dir;
 
         let tmp = tempfile::tempdir().unwrap();
-        // One external "VS Code" process with two windows → two lock files,
-        // same pid + ide_name, different ports.
+        // One VS Code process, two windows: two locks, same pid+name, diff ports.
         let (external_pid, _child) = external_alive_pid();
         let listener_a = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let port_a = listener_a.local_addr().unwrap().port();
@@ -1068,8 +1039,7 @@ mod tests {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
 
-        // Lock file named <port>.lock with NO "port" field in JSON — simulates
-        // real IDE lock files from Cursor/VS Code that encode port only in filename.
+        // Lock named <port>.lock with no JSON port field (real Cursor/VS Code shape).
         let lock_path = tmp.path().join(format!("{port}.lock"));
         let current_pid = std::process::id();
         let content = format!(
@@ -1266,21 +1236,12 @@ mod tests {
 
     #[test]
     fn check_mcp_os_returns_false_when_no_files_exist() {
-        // check_mcp_os reads from ~/.speedwave/ which may or may not have
-        // files in a test environment. This test verifies the struct shape
-        // and that the function does not panic when files are absent.
+        // Verify no panic; cannot assert running because a real mcp-os may run.
         let health = HealthMonitor::check_mcp_os();
-        // We cannot assert running == false because a real mcp-os may be
-        // running in the developer's environment. Just verify no panic.
         let _ = health.running;
     }
 
     // ── is_mcp_os_alive tests (via check_mcp_os_alive_in) ──────────────
-    //
-    // After the unified-lock migration (PR3), `is_mcp_os_alive_in` reads
-    // `mcp-os.lock.json` instead of the three legacy `mcp-os-*` files. The
-    // tests below construct the fixture using the runtime SSOT helpers so a
-    // schema change in `LockFile` automatically fans out here.
 
     fn write_mcp_os_lock(data_dir: &std::path::Path, pid: u32, port: u16) {
         use speedwave_runtime::host_mcp_process::lock::{LockFile, LockService};
@@ -1323,9 +1284,7 @@ mod tests {
     fn is_mcp_os_alive_false_when_pid_in_lock_is_dead() {
         let tmp = tempfile::tempdir().unwrap();
         let data_dir = tmp.path();
-        // PID 999_999_999 is virtually guaranteed not to be alive on the
-        // host. Even if its port were somehow listening, `is_pid_alive`
-        // short-circuits before the TCP probe.
+        // PID 999_999_999 is dead; is_pid_alive short-circuits before TCP probe.
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
         write_mcp_os_lock(data_dir, 999_999_999, port);
@@ -1340,8 +1299,7 @@ mod tests {
     fn is_mcp_os_alive_false_when_no_lock_file() {
         let tmp = tempfile::tempdir().unwrap();
         let data_dir = tmp.path();
-        // No lock.json (and no legacy files either) — must return false
-        // rather than crashing on the missing file.
+        // No lock.json: must return false, not crash on the missing file.
         assert!(
             !super::check_mcp_os_alive_in(data_dir),
             "missing lock.json should return false"
@@ -1384,9 +1342,7 @@ mod tests {
 
     #[test]
     fn build_ide_bridge_health_drops_selected_ide_when_no_longer_detected() {
-        // The user previously selected an IDE that has since exited. The
-        // resolver must return None so the UI renders "disconnected" rather
-        // than a stale port.
+        // Selected IDE has since exited; resolver must return None.
         let detected_ides = vec![detected("IntelliJ", 6_901)];
         let stale = selected("VSCode", 6_900);
         let report = super::build_ide_bridge_health(detected_ides, Some(&stale));
@@ -1412,9 +1368,7 @@ mod tests {
 
     #[test]
     fn build_ide_bridge_health_distinguishes_by_port_not_just_name() {
-        // Two IDE instances of the same family on different ports — the
-        // selection key includes port specifically so users can target a
-        // specific window.
+        // Same-family IDEs on different ports; selection key includes port.
         let detected_ides = vec![detected("VSCode", 6_900), detected("VSCode", 6_902)];
         let sel = selected("VSCode", 6_902);
         let report = super::build_ide_bridge_health(detected_ides, Some(&sel));
@@ -1487,8 +1441,7 @@ mod tests {
         };
         let curr = IdeScanState::default();
         let msgs = compute_ide_state_diff(&prev, &curr);
-        // The cleared anomaly fires a "resolved" log so the appearance log has
-        // a matching close-out — operators can correlate the two.
+        // Cleared anomaly fires a "resolved" log to correlate with appearance.
         assert!(
             msgs.iter().any(|m| m.starts_with("IDE anomaly resolved")),
             "got: {msgs:?}"
@@ -1527,8 +1480,7 @@ mod tests {
         for r in [&r1, &r2, &r3] {
             assert_eq!(r.len(), 2, "two IDEs must be detected consistently");
         }
-        // Compare full Vec in input order (no post-sort) — backend MUST return
-        // a stable order so the frontend's detected-IDE list doesn't jump.
+        // Compare full Vec in input order; backend must return a stable order.
         let shape = |r: &Vec<DetectedIde>| -> Vec<(String, Option<u16>)> {
             r.iter().map(|d| (d.ide_name.clone(), d.port)).collect()
         };

--- a/desktop/src-tauri/src/health_cmd.rs
+++ b/desktop/src-tauri/src/health_cmd.rs
@@ -1,8 +1,4 @@
-// Health-check Tauri command.
-//
-// `get_health` aggregates per-container health for the active project. On
-// macOS it also resolves whether any OS-integration is enabled so the report
-// can include the native OS-bridge state.
+// Health-check Tauri command: aggregates per-container and (on macOS) OS-bridge health.
 
 use crate::health::{self, HealthMonitor};
 use crate::types::check_project;

--- a/desktop/src-tauri/src/history.rs
+++ b/desktop/src-tauri/src/history.rs
@@ -1,8 +1,5 @@
 /// Chat history — reads Claude Code JSONL session files and project memory.
-///
-/// All public functions resolve paths from `consts::data_dir()` and delegate to
-/// internal `_impl` functions that accept a `data_dir: &Path` parameter.
-/// Tests call the `_impl` functions directly with `tempfile::TempDir`.
+/// Public fns delegate to `_impl(data_dir: &Path)` variants that tests call directly.
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
@@ -88,17 +85,7 @@ fn sessions_dir_impl(data_dir: &Path, project: &str) -> PathBuf {
 }
 
 /// Resolves the workspace subdirectory inside `.claude/projects/`.
-/// Claude Code derives the dir name from CWD — `/workspace` → `-workspace`.
-/// Falls back to auto-discovery if `-workspace` doesn't exist (handles
-/// Claude Code internal path derivation changes across versions).
-///
-/// **Known limitation:** Auto-discovery is a best-effort heuristic.  When
-/// multiple candidates exist the newest-by-mtime is picked, which could be
-/// wrong if an unrelated process touched a stale directory.  Both session
-/// JSONL files and `memory/MEMORY.md` share the same resolved path, so they
-/// always resolve together (for better or worse).  Callers that get an empty
-/// result despite sessions existing should check the Desktop log for the
-/// "multiple project dirs" warning emitted here.
+/// `/workspace` → `-workspace`; falls back to newest-by-mtime auto-discovery.
 fn resolve_workspace_dir(projects_dir: &Path) -> PathBuf {
     let default = projects_dir.join("-workspace");
     if default.is_dir() {
@@ -120,10 +107,7 @@ fn resolve_workspace_dir(projects_dir: &Path) -> PathBuf {
                 return candidates.remove(0);
             }
             if candidates.len() > 1 {
-                // Sort by mtime (newest first), then alphabetically as
-                // deterministic tiebreak.  mtime is a best-effort heuristic —
-                // some filesystems (ext3, HFS+) have 1-second granularity;
-                // the alphabetical sort is the ultimate deterministic fallback.
+                // Sort by mtime (newest first), alphabetical as tiebreak.
                 candidates.sort_by(|a, b| {
                     let ma = a.metadata().and_then(|m| m.modified()).ok();
                     let mb = b.metadata().and_then(|m| m.modified()).ok();
@@ -188,12 +172,7 @@ fn parse_jsonl_message(line: &str) -> Option<ConversationMessage> {
 
     let msg_type = parsed["type"].as_str().unwrap_or("");
 
-    // Skip Claude Code synthetic meta-entries (slash-command caveats, image
-    // attachment markers, …). They have `type:"user"` but are model-facing
-    // hints, never actual user input. Scoped to "user" so a future
-    // upstream `isMeta` on assistant/result rows isn't silently swallowed.
-    // `isMeta` lives at the top level today; we also probe `message.isMeta`
-    // defensively in case Anthropic nests it later.
+    // Skip synthetic `type:"user"` meta-entries via `isMeta` (top-level or nested) or content sniffing.
     if msg_type == "user" {
         let reason = if parsed["isMeta"].as_bool().unwrap_or(false) {
             Some("isMeta")
@@ -224,18 +203,14 @@ fn parse_jsonl_message(line: &str) -> Option<ConversationMessage> {
     }
 }
 
-/// Detects Claude Code synthetic `type:"user"` entries that aren't real user
-/// input: slash-command markers, slash-command stdout/stderr, and the
-/// SDK CLI's `Commands are in the form …` boilerplate. None of these are
-/// flagged with `isMeta`, so we sniff the content. Caller must ensure
-/// `parsed["type"] == "user"`.
+/// Detects synthetic `type:"user"` entries with no `isMeta` flag by sniffing content.
+/// Caller must ensure `parsed["type"] == "user"`.
 fn is_synthetic_user_entry(parsed: &serde_json::Value) -> bool {
     let content = &parsed["message"]["content"];
     if let Some(s) = content.as_str() {
         text_is_synthetic(s)
     } else if let Some(arr) = content.as_array() {
-        // Check each text block separately so a synthetic tag is caught even
-        // when it isn't the first block of a multi-block content array.
+        // Check each text block so a synthetic tag in any block is caught.
         arr.iter()
             .filter(|b| b["type"].as_str() == Some("text"))
             .filter_map(|b| b["text"].as_str())
@@ -390,8 +365,7 @@ fn parse_result_message(parsed: &serde_json::Value) -> Option<ConversationMessag
     }
 
     let timestamp = parsed["timestamp"].as_str().map(String::from);
-    // Result lines don't carry a stable per-turn uuid in the JSONL — they're
-    // synthetic summary entries. Leave `None` so the retry path skips them.
+    // Result lines carry no stable per-turn uuid; leave `None`.
     let uuid = None;
 
     if is_error {
@@ -477,9 +451,7 @@ fn list_conversations_impl(
             continue;
         }
 
-        // Read first ~50 lines to get timestamp and preview without loading
-        // entire multi-MB JSONL files. We also count messages in those lines
-        // as an approximate count for display.
+        // Scan first ~50 lines for timestamp, preview, and approximate count.
         let file = match fs::File::open(&path) {
             Ok(f) => f,
             Err(e) => {
@@ -501,10 +473,7 @@ fn list_conversations_impl(
                 Err(_) => break,
             };
             if let Some(msg) = parse_jsonl_message(&line) {
-                // Deduplicate: skip result whose content is contained in the
-                // preceding assistant message.  `parse_assistant_message`
-                // concatenates text + "[Tool: X]" placeholders, so the result
-                // text (plain text only) is a substring of the assistant content.
+                // Deduplicate: skip result whose content is a substring of the preceding assistant message.
                 if msg.role == "assistant" {
                     if let Some(ref prev) = last_assistant_content {
                         if prev.contains(&msg.content) {
@@ -573,10 +542,7 @@ fn get_conversation_impl(
     for line in reader.lines().take(MAX_TRANSCRIPT_LINES) {
         let line = line.map_err(|e| anyhow::anyhow!("io error reading session: {e}"))?;
         if let Some(msg) = parse_jsonl_message(&line) {
-            // Deduplicate: skip result message whose content is contained in
-            // the preceding assistant message.  `parse_assistant_message`
-            // concatenates text + "[Tool: X]" placeholders, so the result
-            // text (plain text only) is a substring of the assistant content.
+            // Deduplicate: skip result whose content is a substring of the preceding assistant message.
             if msg.role == "assistant" {
                 if let Some(ref prev) = last_assistant_content {
                     if prev.contains(&msg.content) {
@@ -659,14 +625,8 @@ pub struct ResumeSnapshot {
 }
 
 /// Compute the cumulative session snapshot from an existing JSONL transcript.
-///
-/// The CLI emits `total_cost_usd` and `modelUsage` cumulatively in every
-/// `result` line, so the latest such values describe the full session
-/// state. Token counts are recovered preferring the latest `modelUsage`
-/// (already cumulative) and falling back to the running sum of per-step
-/// flat `usage` payloads — matching the parser's own snapshot accounting in
-/// `compute_turn_usage_from_result`. The model is taken from the most
-/// recent `modelUsage` key, or the last `system init` line if none.
+/// Prefers the latest `modelUsage`, falls back to summed flat `usage`; model
+/// from the latest `modelUsage` else the last `system init` line.
 pub fn compute_resume_snapshot(project: &str, session_id: &str) -> anyhow::Result<ResumeSnapshot> {
     compute_resume_snapshot_impl(consts::data_dir(), project, session_id)
 }
@@ -685,8 +645,7 @@ fn compute_resume_snapshot_impl(
     const MAX_TRANSCRIPT_LINES: usize = 10_000;
     let reader = BufReader::new(file);
 
-    // Running sum of flat `usage` blocks — used as a fallback when the
-    // session has no `modelUsage` (older CLI versions / partial payloads).
+    // Running sum of flat `usage` blocks; fallback when no `modelUsage`.
     let mut summed = ResumeSnapshot::default();
     // Cumulative snapshot from the most recent `result` carrying `modelUsage`.
     let mut latest_cumulative: Option<ResumeSnapshot> = None;
@@ -752,13 +711,7 @@ fn compute_resume_snapshot_impl(
                         if any_field {
                             latest_cumulative = Some(cumulative);
                         }
-                        // Pick the model that produced the most output tokens —
-                        // that's the main response model. A single turn can mix
-                        // models (Opus for the user-facing answer + Haiku for
-                        // background tasks like title generation), so picking
-                        // `keys().next()` would be non-deterministic and tended
-                        // to surface Haiku (alphabetically before Opus) even when
-                        // Opus did the real work.
+                        // Pick the model with the most output tokens (the main response model).
                         if let Some((top_model, _)) = model_usage.iter().max_by_key(|(_, stats)| {
                             stats
                                 .get("outputTokens")
@@ -1101,8 +1054,7 @@ mod tests {
 
     #[test]
     fn parse_result_message_uuid_is_always_none() {
-        // Result lines are synthesized turn summaries — they're not valid
-        // retry anchors, so the parser should never expose a uuid for them.
+        // Result lines must never expose a uuid.
         let line = r#"{"type":"result","is_error":false,"result":"summary"}"#;
         let msg = parse_jsonl_message(line).unwrap();
         assert!(msg.uuid.is_none());
@@ -1287,17 +1239,14 @@ mod tests {
 
     #[test]
     fn parse_jsonl_message_respects_nested_is_meta_under_message() {
-        // Defensive: should Claude Code ever move `isMeta` from top-level
-        // into `message.*`, the filter must still catch it.
+        // `isMeta` nested under `message.*` must still be caught.
         let line = r#"{"type":"user","message":{"role":"user","isMeta":true,"content":"<local-command-caveat>x</local-command-caveat>"}}"#;
         assert!(parse_jsonl_message(line).is_none());
     }
 
     #[test]
     fn parse_jsonl_message_does_not_drop_is_meta_on_non_user_types() {
-        // The `isMeta` filter is intentionally scoped to user entries — an
-        // assistant row with isMeta:true must still parse, so future upstream
-        // tagging of legitimate assistant turns doesn't make them vanish.
+        // The `isMeta` filter is scoped to user entries; an assistant row with isMeta:true must still parse.
         let line = r#"{"type":"assistant","isMeta":true,"message":{"role":"assistant","content":[{"type":"text","text":"hi"}]}}"#;
         let msg = parse_jsonl_message(line).expect("assistant with isMeta should parse");
         assert_eq!(msg.role, "assistant");
@@ -1348,8 +1297,7 @@ mod tests {
 
     #[test]
     fn list_conversations_skips_slash_command_markers() {
-        // Slash-command invocations carry no `isMeta` flag but are still
-        // synthetic — they should not surface as previews or get counted.
+        // Slash-command invocations carry no `isMeta` flag but are still synthetic.
         let tmp = tempfile::tempdir().unwrap();
         let dir = setup_sessions_dir(tmp.path(), "proj");
         let id = "abcdef01-2345-6789-abcd-ef0123456789";
@@ -1373,9 +1321,7 @@ mod tests {
 
     #[test]
     fn list_conversations_drops_sdk_cli_boilerplate_session() {
-        // `claude -p "/cmd"` opens a session whose only user entry is the
-        // boilerplate `Commands are in the form …` (no `isMeta`). Such a
-        // session should never appear in the sidebar.
+        // A session whose only user entry is the `Commands are in the form …` boilerplate must not appear.
         let tmp = tempfile::tempdir().unwrap();
         let dir = setup_sessions_dir(tmp.path(), "proj");
         let id = "abcdef01-2345-6789-abcd-ef0123456789";
@@ -1394,9 +1340,7 @@ mod tests {
 
     #[test]
     fn parse_jsonl_message_drops_command_args_and_command_result_prefixes() {
-        // Defensive: Claude Code today only emits <command-name> first, but
-        // these sibling tags belong to the same family and should they ever
-        // arrive as standalone user rows we still want them filtered.
+        // Sibling command tags must also be filtered, not only <command-name>.
         for tag in ["<command-args>", "<command-result>"] {
             let line = format!(
                 r#"{{"type":"user","message":{{"role":"user","content":"{tag}foo</X>"}}}}"#
@@ -1410,17 +1354,14 @@ mod tests {
 
     #[test]
     fn parse_jsonl_message_drops_boilerplate_with_trailing_punctuation() {
-        // `starts_with` (not `==`) means small upstream wording tweaks —
-        // trailing newline, period, additional context — don't leak the
-        // boilerplate back into the sidebar.
+        // Boilerplate with trailing punctuation/context is still filtered.
         let line = r#"{"type":"user","message":{"role":"user","content":"Commands are in the form `/command [args]`\n\nMore context."}}"#;
         assert!(parse_jsonl_message(line).is_none());
     }
 
     #[test]
     fn parse_jsonl_message_drops_synthetic_tag_in_non_first_text_block() {
-        // Multi-block content where the synthetic marker isn't the first
-        // block — caught per-block instead of after `join("\n")`.
+        // Synthetic marker in a non-first text block is caught per-block.
         let line = r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"preamble"},{"type":"text","text":"<command-name>/clear</command-name>"}]}}"#;
         assert!(parse_jsonl_message(line).is_none());
     }
@@ -1532,8 +1473,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let dir = setup_sessions_dir(tmp.path(), "proj");
 
-        // Create a directory at the MEMORY.md path — reading a directory as a
-        // file produces an I/O error that is NOT ErrorKind::NotFound.
+        // A directory at the MEMORY.md path yields an I/O error that is NOT ErrorKind::NotFound.
         let memory_dir = dir.join("memory").join("MEMORY.md");
         fs::create_dir_all(&memory_dir).unwrap();
 
@@ -1683,8 +1623,7 @@ mod tests {
         );
 
         let result = get_conversation_impl(tmp.path(), "proj", id).unwrap();
-        // Should have 2 messages: user + assistant (result deduplicated even
-        // though assistant content includes "[Tool: Read]" suffix)
+        // 2 messages: user + assistant (result deduplicated).
         assert_eq!(result.messages.len(), 2);
         assert_eq!(result.messages[0].role, "user");
         assert_eq!(result.messages[1].role, "assistant");
@@ -1699,8 +1638,7 @@ mod tests {
         let dir = setup_sessions_dir(tmp.path(), "proj");
         let id = "abcdef01-2345-6789-abcd-ef0123456789";
 
-        // Two turns: each result line carries cumulative `modelUsage` and
-        // cumulative `total_cost_usd`. The latest line is authoritative.
+        // Two cumulative result lines; the latest is authoritative.
         write_session(
             &dir,
             id,
@@ -1727,8 +1665,7 @@ mod tests {
         let dir = setup_sessions_dir(tmp.path(), "proj");
         let id = "abcdef01-2345-6789-abcd-ef0123456789";
 
-        // No `modelUsage` anywhere — only flat per-step `usage`. Must sum
-        // them up to recover the cumulative state.
+        // No `modelUsage` anywhere; flat per-step `usage` must be summed.
         write_session(
             &dir,
             id,
@@ -1745,8 +1682,7 @@ mod tests {
         assert_eq!(snap.cache_read_tokens, 3);
         assert_eq!(snap.cache_write_tokens, 1);
         assert_eq!(snap.total_cost, Some(0.05));
-        // No `modelUsage` ever, so the system init model is used as the
-        // fallback signal.
+        // No `modelUsage` ever, so the system init model is the fallback.
         assert_eq!(snap.model.as_deref(), Some("claude-sonnet-4-7"));
     }
 
@@ -1756,9 +1692,7 @@ mod tests {
         let dir = setup_sessions_dir(tmp.path(), "proj");
         let id = "abcdef01-2345-6789-abcd-ef0123456789";
 
-        // Transcript with no result/init lines (e.g., a session that
-        // crashed before the first turn). Must not error and must report
-        // a zero baseline so the resume parser starts fresh.
+        // Transcript with no result/init lines must not error and reports a zero baseline.
         write_session(
             &dir,
             id,
@@ -1775,8 +1709,7 @@ mod tests {
         let dir = setup_sessions_dir(tmp.path(), "proj");
         let id = "abcdef01-2345-6789-abcd-ef0123456789";
 
-        // Mix of malformed and valid lines — the malformed ones must not
-        // poison the running totals.
+        // Malformed lines must not poison the running totals.
         write_session(
             &dir,
             id,
@@ -1818,9 +1751,7 @@ mod tests {
         let dir = setup_sessions_dir(tmp.path(), "proj");
         let id = "abcdef01-2345-6789-abcd-ef0123456789";
 
-        // The init line declares one model, but the latest `modelUsage`
-        // shows another (mid-session model switch). The seed must reflect
-        // the most recent model so the next turn's pricing is correct.
+        // On a mid-session model switch, the seed reflects the latest `modelUsage` model.
         write_session(
             &dir,
             id,
@@ -1836,13 +1767,7 @@ mod tests {
 
     #[test]
     fn compute_resume_snapshot_picks_dominant_model_from_modelusage() {
-        // Regression: Claude Code emits a `modelUsage` map that may contain
-        // several entries when one turn mixes a main-response model with
-        // background calls (Haiku for title generation, summarization, etc.).
-        // Using `keys().next()` was non-deterministic and tended to surface
-        // Haiku (alphabetically before Opus) even when Opus produced the
-        // real answer, so the chat footer showed the wrong model.
-        // The fix selects the model with the highest `outputTokens`.
+        // From a multi-entry modelUsage map, picks the highest `outputTokens`.
         let tmp = tempfile::tempdir().unwrap();
         let dir = setup_sessions_dir(tmp.path(), "proj");
         let id = "abcdef01-2345-6789-abcd-ef0123456790";

--- a/desktop/src-tauri/src/history_cmd.rs
+++ b/desktop/src-tauri/src/history_cmd.rs
@@ -1,8 +1,5 @@
-// Chat-history Tauri commands.
-//
-// Read-only views over a project's persisted conversations plus its CLAUDE.md
-// project memory. Each command validates the project, then delegates to the
-// `history` module (which owns transcript parsing / on-disk layout).
+//! Chat-history Tauri commands: read-only views of persisted conversations and CLAUDE.md.
+//! Validates the project, then delegates to the `history` module.
 
 use crate::history;
 use crate::types::check_project;

--- a/desktop/src-tauri/src/http_util.rs
+++ b/desktop/src-tauri/src/http_util.rs
@@ -1,24 +1,13 @@
 // Shared HTTP utilities for Tauri commands that make outbound requests from
 // the Desktop host process.
-//
-// Extracted from `redmine_api_cmd` when a second caller (`llm_cmd`) needed the
-// same size-bounded body reader (Rule of Three — two concrete consumers).
-// Future outbound-HTTP commands should import from here rather than copy the
-// streaming-body guard or reinvent the size limit.
 
-/// Maximum response body size the Desktop will buffer from an outbound HTTP
-/// request. Chosen to fit any legitimate JSON API response (Redmine project
-/// lists, LLM model listings) while bounding OOM risk from a rogue or
-/// misconfigured endpoint returning gigabytes of data via chunked transfer
-/// encoding.
+/// Maximum response body size (5 MiB) to prevent OOM from rogue servers.
 pub(crate) const MAX_RESPONSE_BODY_BYTES: usize = 5 * 1024 * 1024; // 5 MiB
 
 /// Reads a response body chunk-by-chunk, aborting if the accumulated size
-/// exceeds `MAX_RESPONSE_BODY_BYTES`. Prevents OOM from rogue servers using
-/// chunked transfer encoding (no Content-Length header).
+/// exceeds `MAX_RESPONSE_BODY_BYTES`.
 ///
-/// `label` is included in error messages so callers can identify which HTTP
-/// operation failed (e.g. "Credentials validation", "LLM model discovery").
+/// `label` is included in error messages to identify the failed HTTP operation.
 pub(crate) async fn read_body_limited(
     resp: reqwest::Response,
     label: &str,
@@ -57,13 +46,7 @@ pub(crate) async fn read_body_limited(
 
 /// Builds a `reqwest::Client` with the ADR-041 host-side hardening baseline:
 /// no redirect following (SSRF defence), Speedwave User-Agent, plus any
-/// caller-supplied default headers (e.g. `Authorization: Bearer …`, custom
-/// per-tenant headers). Body-size cap and Content-Type allow-list are applied
-/// per-request by [`read_body_limited`] / callsite policy.
-///
-/// Two callsites today (LLM probe, Redmine API) — extracting here keeps the
-/// four hardening constants travelling together. Adding a third outbound
-/// client = reuse this, do not retype the four lines.
+/// caller-supplied default headers (e.g. `Authorization: Bearer …`).
 pub(crate) fn build_hardened_client(
     default_headers: Option<reqwest::header::HeaderMap>,
 ) -> Result<reqwest::Client, String> {
@@ -80,15 +63,7 @@ pub(crate) fn build_hardened_client(
 
 /// Translates the canonical container-side host alias to `127.0.0.1`. Host-side only.
 ///
-/// Inside containers, `HOST_GATEWAY_ALIAS` resolves via `extra_hosts`. From the
-/// Desktop host process the alias is absent (Speedwave doesn't bundle Docker
-/// Desktop's resolver, and Lima's native `host.lima.internal` injection only
-/// applies inside the VM — not on the macOS host) — this function rewrites it
-/// to `127.0.0.1` before issuing HTTP requests.
-///
-/// Previously-supported aliases (`host.lima.internal`, `host.speedwave.internal`,
-/// `host.containers.internal`) all return `None` after the SSOT consolidation;
-/// callers must canonicalize to `HOST_GATEWAY_ALIAS` before invoking.
+/// Returns `None` for any host other than `HOST_GATEWAY_ALIAS`.
 pub(crate) fn rewrite_container_alias_to_loopback(host: &str) -> Option<&'static str> {
     if host == speedwave_runtime::consts::HOST_GATEWAY_ALIAS {
         Some("127.0.0.1")
@@ -108,9 +83,7 @@ mod tests {
 
     #[test]
     fn test_max_response_body_bytes_is_5_mib() {
-        // Guard: changing this value affects multiple callers (Redmine + LLM
-        // discovery). Update both tests and downstream error-message assertions
-        // if you bump the limit.
+        // Changing this value requires updating Redmine + LLM discovery tests.
         assert_eq!(MAX_RESPONSE_BODY_BYTES, 5 * 1024 * 1024);
     }
 
@@ -122,8 +95,7 @@ mod tests {
         );
     }
 
-    // Regression negatives: deprecated aliases removed in the host-gateway SSOT
-    // consolidation must not re-enter the rewrite path.
+    // Deprecated aliases must not re-enter the rewrite path.
 
     #[test]
     fn test_rewrite_alias_deprecated_lima_returns_none() {

--- a/desktop/src-tauri/src/ide_bridge_cmd.rs
+++ b/desktop/src-tauri/src/ide_bridge_cmd.rs
@@ -1,9 +1,4 @@
-// IDE-bridge Tauri commands.
-//
-// Lets the UI list detected IDE locks, connect to a chosen window, read the
-// persisted selection, and disconnect. The live bridge + its on-demand
-// starter (`ensure_ide_bridge_running`) live in `main.rs`; this module is the
-// command surface plus config persistence.
+// IDE-bridge Tauri commands for IDE lock detection, connection, and config persistence.
 
 use crate::health;
 use crate::reconcile::SharedIdeBridge;
@@ -21,9 +16,7 @@ pub(crate) fn select_ide(
     state: tauri::State<SharedIdeBridge>,
     app: tauri::AppHandle,
 ) -> Result<(), String> {
-    // Validate against the raw live-port list (pre-dedupe): UI may pick
-    // an older-window port that `list_available_ides` collapsed away, but
-    // we still want the user to be able to connect to that specific window.
+    // Validate against the raw live-port list (pre-dedupe).
     if !health::is_ide_port_alive(port) {
         log::warn!(
             target: "ide_bridge",
@@ -47,8 +40,7 @@ pub(crate) fn select_ide(
     })
     .map_err(|e| e.to_string())?;
 
-    // Start IDE Bridge on-demand if it wasn't started at startup (e.g. after
-    // factory reset when setup_started was false during the initial launch).
+    // Start IDE Bridge on-demand if it wasn't started at startup.
     crate::ensure_ide_bridge_running(&state, &app);
 
     // Update the live Bridge so new connections are proxied immediately

--- a/desktop/src-tauri/src/installer_hooks.rs
+++ b/desktop/src-tauri/src/installer_hooks.rs
@@ -1,7 +1,5 @@
-//! Regression tests pinning security/correctness invariants of
-//! `windows/installer-hooks.nsh` (and its inputs:
-//! `installer-hooks-template.nsh`, `sweep.ps1`, `firewall.ps1`).
-//! See ADR-048 for the full design.
+//! Regression tests for `windows/installer-hooks.nsh` and its inputs
+//! (`installer-hooks-template.nsh`, `sweep.ps1`, `firewall.ps1`). See ADR-048.
 
 #[cfg(test)]
 mod tests {
@@ -97,11 +95,6 @@ mod tests {
 
     #[test]
     fn installer_hooks_nsh_matches_template_plus_generated_macros() {
-        // installer-hooks.nsh = template (with @@SPEEDWAVE_EMBEDDED_MACROS@@
-        // replaced) + macros emitted by scripts/generate-installer-nsh.sh.
-        // We re-derive the expected output here so any drift between the
-        // committed installer-hooks.nsh and its inputs fails CI with a clear
-        // "run make generate-installer-nsh" message.
         let expected = render_expected_hooks(TEMPLATE, SWEEP_PS1, FIREWALL_PS1, RUN_HIDDEN_VBS);
         assert_eq!(
             HOOKS, expected,
@@ -111,8 +104,7 @@ mod tests {
 
     #[test]
     fn run_hidden_vbs_has_no_bom() {
-        // wscript.exe fails to parse a .vbs with a UTF-8 BOM. The generator
-        // strips BOM on materialize, but the source must also be BOM-free.
+        // wscript.exe fails to parse a .vbs with a UTF-8 BOM.
         assert!(
             !RUN_HIDDEN_VBS.starts_with('\u{feff}'),
             "run-hidden.vbs must be ANSI/BOM-free (wscript chokes on a BOM)"
@@ -121,8 +113,7 @@ mod tests {
 
     #[test]
     fn install_hooks_run_powershell_via_hidden_shim() {
-        // All three PowerShell-invoking hooks must go through the wscript shim
-        // (no console flash) and materialize the vbs first.
+        // All three PowerShell-invoking hooks go through the wscript shim.
         let shim_calls = HOOKS
             .matches("wscript.exe\" \"$PLUGINSDIR\\run-hidden.vbs")
             .count();
@@ -137,8 +128,7 @@ mod tests {
             3,
             "each shim hook must materialize run-hidden.vbs first"
         );
-        // No hook may launch powershell.exe directly via nsExec — that is the
-        // flash path. powershell.exe appears ONLY inside the wscript argument.
+        // No hook may launch powershell.exe directly via nsExec.
         assert!(
             !HOOKS.contains("nsExec::ExecToLog `\"$SYSDIR\\WindowsPowerShell"),
             "no hook may call powershell.exe directly via nsExec — must use the wscript shim"
@@ -226,8 +216,7 @@ mod tests {
 
     #[test]
     fn firewall_ps1_creates_wdf_allow_rules() {
-        // The actual fix for the per-binary WDF prompt: host application ALLOW
-        // rules (New-NetFirewallRule -Program), separate from the Hyper-V rule.
+        // Host application ALLOW rules (New-NetFirewallRule -Program), separate from the Hyper-V rule.
         assert!(
             FIREWALL_PS1.contains("New-NetFirewallRule")
                 && FIREWALL_PS1.contains("Action      = 'Allow'")
@@ -238,8 +227,7 @@ mod tests {
 
     #[test]
     fn firewall_ps1_accepts_programs_param_split_on_semicolon() {
-        // Paths arrive as one ';'-joined string ([string], not [string[]]) because
-        // PowerShell -File cannot bind a multi-element array. Verified on Windows.
+        // Paths arrive as one ';'-joined [string] (PowerShell -File cannot bind a [string[]]).
         assert!(
             FIREWALL_PS1.contains("[string]$Programs")
                 && FIREWALL_PS1.contains("$Programs -split ';'"),
@@ -261,8 +249,7 @@ mod tests {
 
     #[test]
     fn firewall_ps1_installer_modes_fail_open() {
-        // The installer-invoked modes (install/uninstall) must never brick a
-        // policy-locked machine. Several exit-0 paths cover success + catch.
+        // Installer-invoked modes (install/uninstall) fail open via several exit-0 paths.
         let exits = FIREWALL_PS1.matches("exit 0").count();
         assert!(
             exits >= 4,
@@ -280,8 +267,7 @@ mod tests {
 
     #[test]
     fn firewall_ps1_ensure_checks_existence_before_signalling_elevation() {
-        // Runtime 'ensure' must do the non-admin existence check (no UAC) and
-        // only exit 3 (needs-elevation) when the rule is genuinely missing.
+        // 'ensure' does the non-admin existence check and exits 3 only when the rule is missing.
         let ensure_idx = FIREWALL_PS1
             .find("$Mode -eq 'ensure'")
             .expect("ensure branch must exist");
@@ -300,9 +286,7 @@ mod tests {
 
     #[test]
     fn firewall_ps1_elevated_mode_does_not_self_relaunch() {
-        // install-elevated runs the privileged body directly; self-elevation is
-        // driven from Rust, so the script must NOT contain -Verb RunAs (no UAC
-        // loop) and must NOT re-check admin in the elevated branch.
+        // install-elevated runs the privileged body directly; self-elevation is Rust-driven.
         assert!(
             !FIREWALL_PS1.contains("-Verb RunAs") && !FIREWALL_PS1.contains("RunAs"),
             "firewall.ps1 must not self-elevate; elevation is driven from Rust"
@@ -311,12 +295,8 @@ mod tests {
 
     #[test]
     fn installers_invoke_only_install_and_uninstall_modes() {
-        // The self-elevating/runtime modes (ensure, install-elevated) are
-        // reachable only from the Desktop runtime. The installers must INVOKE
-        // firewall.ps1 only with -Mode install / -Mode uninstall. Note: the
-        // mode strings legitimately appear inside the materialized firewall.ps1
-        // body (ValidateSet) in installer-hooks.nsh — so we assert on the
-        // invocation pattern (`firewall.ps1...-Mode <runtime>`), not presence.
+        // Runtime-only modes (ensure, install-elevated) are Desktop-only; assert on the
+        // invocation pattern, not presence (the strings appear in the materialized ValidateSet).
         for needle in [
             "firewall.ps1\" -Mode ensure",
             "firewall.ps1\" -Mode install-elevated",
@@ -336,9 +316,7 @@ mod tests {
 
     #[test]
     fn materialized_ps1_scripts_contain_no_backtick() {
-        // A backtick is the NSIS FileWrite string delimiter and has no escape,
-        // so a literal backtick truncates the NSIS string and aborts makensis.
-        // The generator rejects such scripts; this guards the SSOT sources.
+        // Backtick is the NSIS FileWrite delimiter with no escape; it truncates the string.
         for (name, ps1) in [("sweep.ps1", SWEEP_PS1), ("firewall.ps1", FIREWALL_PS1)] {
             assert!(
                 !ps1.contains('`'),
@@ -471,8 +449,7 @@ mod tests {
     }
 
     fn emit_materialize_macro(name: &str, ext: &str, src: &str) -> String {
-        // NSIS !define/label tokens cannot contain '-'; the generator normalizes
-        // name -> UPPER with '-' replaced by '_'.
+        // NSIS !define/label tokens cannot contain '-'; normalize to UPPER with '-' -> '_'.
         let upper = name.to_uppercase().replace('-', "_");
         let file = format!("{name}.{ext}");
         let id = format!("SW_{upper}_ID");
@@ -496,8 +473,7 @@ mod tests {
             for c in line.chars() {
                 match c {
                     '$' => esc.push_str("$$"),
-                    // Backtick has no NSIS escape; the generator rejects any
-                    // source containing one, so it never reaches here.
+                    // Backtick has no NSIS escape; the generator rejects sources containing one.
                     '"' => esc.push_str("$\\\""),
                     other => esc.push(other),
                 }

--- a/desktop/src-tauri/src/integrations_cmd.rs
+++ b/desktop/src-tauri/src/integrations_cmd.rs
@@ -59,8 +59,7 @@ fn detect_oauth_action_required_in(
     project: &str,
     service: &str,
 ) -> Option<String> {
-    // Gate on the descriptor flag (SSOT) rather than a hardcoded service id;
-    // required scopes are resolved per service in `required_scopes_for`.
+    // Gate on the descriptor flag (SSOT) rather than a hardcoded service id.
     match speedwave_runtime::consts::find_mcp_service(service) {
         Some(d) if d.uses_oauth_refresh => {}
         _ => return None,
@@ -124,11 +123,7 @@ fn detect_scope_mismatch_or_stale(oauth_json_raw: &str, required: &[String]) -> 
         .iter()
         .filter_map(|s| s.as_str().map(|s| s.to_lowercase()))
         .collect();
-    // `offline_access` is an OIDC control scope: Microsoft never echoes it in the
-    // token-response `scope` field, so it never lands in grantedScopes. Same rule
-    // as `mcp-servers/oauth/src/providers/microsoft.ts` `refreshMicrosoftToken`
-    // (the `s.toLowerCase() === 'offline_access'` skip) — keep both in sync;
-    // refreshToken is the real proof offline access was granted.
+    // Microsoft never echoes `offline_access` in granted scopes, so skip it.
     let covers = required
         .iter()
         .filter(|r| r.as_str() != OFFLINE_ACCESS_SCOPE)
@@ -404,14 +399,10 @@ pub fn get_integrations(project: String) -> Result<IntegrationsResponse, String>
             (values, None)
         };
 
-        // Computed regardless of `configured`: a stale/malformed providerData
-        // makes the service read as unconfigured, yet the user must still be
-        // led to re-authorise. `detect_oauth_action_required` returns None for a
-        // fresh (absent) file, so a never-configured service shows no banner.
+        // Computed regardless of `configured` so a stale state still re-authorises.
         let oauth_action_required = detect_oauth_action_required(&project, svc);
 
-        // Optional-only services (e.g. context7): badge from descriptor only when
-        // no key is set — once configured, drop the badge to mirror configured state.
+        // Optional-only services: badge from descriptor only when no key is set.
         let all_optional =
             !svc_desc.auth_fields.is_empty() && svc_desc.auth_fields.iter().all(|f| f.optional);
         let badge = if all_optional
@@ -586,9 +577,8 @@ pub fn set_integration_enabled(
 // ---------------------------------------------------------------------------
 
 /// Resolves the absolute path to a native macOS CLI binary.
-/// `resources_dir` is `Some(<BUNDLE_RESOURCES_ENV dir>)` in production (set by
-/// main.rs); `None` selects the dev fallback `CARGO_MANIFEST_DIR ->
-/// ../../native/macos/<pkg>/.build/release/<binary>`. Tests pass a tempdir.
+/// `resources_dir` `Some` selects the bundle dir; `None` selects the dev fallback
+/// `CARGO_MANIFEST_DIR -> ../../native/macos/<pkg>/.build/release/<binary>`.
 // SYNC: binary paths must match mcp-servers/os/src/platform-runner.ts::resolveDarwinPaths()
 fn resolve_native_cli_binary_in(
     service: &str,
@@ -615,13 +605,9 @@ fn resolve_native_cli_binary_in(
         .join(binary_name))
 }
 
-/// Parses the JSON output from a `check_permission` CLI command.
-///
-/// Expected format: `{"granted": true, "status": "granted"}` or
-/// `{"granted": false, "status": "denied", "error": "..."}`.
-/// The `status` field is parsed but not consumed — `error` is the single source
-/// of user-facing text. Returns `Ok(())` if `granted` is boolean `true`.
-/// Returns `Err(message)` if `granted` is `false`, missing, or non-boolean.
+/// Parses `check_permission` JSON `{"granted": bool, "status": str, "error": str}`.
+/// `Ok(())` if `granted` is boolean `true`; `Err(error)` if false, missing, or
+/// non-boolean.
 fn parse_permission_output(stdout: &str) -> Result<(), String> {
     let parsed: serde_json::Value = serde_json::from_str(stdout.trim())
         .map_err(|e| format!("Failed to parse permission check output: {e}"))?;
@@ -635,29 +621,18 @@ fn parse_permission_output(stdout: &str) -> Result<(), String> {
         return Ok(());
     }
 
-    // Per the Swift contract, granted=false ALWAYS carries a non-empty error string.
-    // The status field is parsed but not consumed — error is the single source of
-    // user-facing text. If the contract is violated (synthetic JSON, future bug),
-    // fall through to a generic message.
+    // Fall through to a generic message if the error string is absent.
     let raw_error = parsed
         .get("error")
         .and_then(|v| v.as_str())
         .unwrap_or("Permission denied");
 
-    // Sanitize before returning to the webview. Defense-in-depth: error strings come
-    // from the Swift side which uses static literals + EventKit localizedDescription,
-    // but localizedDescription could in principle contain user paths in future macOS.
+    // Sanitize before returning to the webview.
     Err(speedwave_runtime::log_sanitizer::sanitize(raw_error))
 }
 
 /// Checks macOS TCC/Automation permission for the given OS service.
-///
-/// Spawns the native CLI binary with `check_permission` and parses the JSON
-/// output. Uses a spawn + try_wait polling loop with timeout (same pattern as
-/// `speedwave_runtime::binary::run_with_timeout` but with stdout/stderr capture).
-///
-/// Pipe-buffer deadlock is not a risk: `check_permission` output is <200 bytes,
-/// well within the OS pipe buffer of 64KB. Stdout is read after child exits.
+/// Spawns the native CLI with `check_permission` and parses the JSON output.
 fn check_os_permission(service: &str, launch_if_needed: bool) -> Result<(), String> {
     check_os_permission_with_timeout(
         service,
@@ -667,9 +642,8 @@ fn check_os_permission(service: &str, launch_if_needed: bool) -> Result<(), Stri
 }
 
 /// Inner implementation with configurable timeout for testability.
-/// `launch_if_needed=true` (toggle click) lets the CLI auto-launch the target
-/// app if not running. `false` (startup validate) keeps the check passive so
-/// Speedwave never opens Mail/Notes uninvited at app boot.
+/// `launch_if_needed=true` auto-launches the target app; `false` keeps the check
+/// passive.
 fn check_os_permission_with_timeout(
     service: &str,
     launch_if_needed: bool,
@@ -777,9 +751,7 @@ fn check_os_permission_with_timeout_in(
         stderr.len()
     );
 
-    // Always surface Swift CLI stderr to the log — it carries the per-CLI trace
-    // (AppleEvents OSStatus values, EventKit gate transitions) that's invaluable
-    // when diagnosing TCC silent rejects from a user-supplied logs ZIP.
+    // Surface Swift CLI stderr to the log line by line.
     if !stderr.trim().is_empty() {
         for line in stderr.lines() {
             log::info!("check_os_permission: {service}-cli stderr: {line}");
@@ -894,10 +866,7 @@ pub fn validate_os_integrations_on_startup(
         .map(|s| s.config_key)
         .collect();
 
-    // Phase 1: short config_lock — snapshot enabled state per service.
-    // Holding the lock through ~400ms parallel CLI runs would block any
-    // concurrent toggle/restart from the UI; snapshot-then-unlock keeps the
-    // lock window in microseconds.
+    // Phase 1: short config_lock — snapshot enabled state per service, unlock.
     let prev_state: std::collections::HashMap<&'static str, bool> = config::with_config_lock(|| {
         let user_config = config::load_user_config()?;
         let entry = user_config
@@ -935,9 +904,7 @@ pub fn validate_os_integrations_on_startup(
         }
     }
 
-    // Phase 2: parallel CLI checks — each spawn-and-wait is ~200-400ms; 4
-    // sequential = ~1.4s. Parallel = bounded by the slowest CLI (~400ms).
-    // No config lock held here.
+    // Phase 2: parallel CLI checks, no config lock held.
     let handles: Vec<(&'static str, std::thread::JoinHandle<Result<(), String>>)> = to_check
         .into_iter()
         .map(|svc| {
@@ -974,9 +941,7 @@ pub fn validate_os_integrations_on_startup(
         }
     }
 
-    // Phase 3: short config_lock — apply mutations only when there's something
-    // to write. Skipping the lock entirely on the no-op path keeps the happy
-    // case zero-contention.
+    // Phase 3: short config_lock — apply mutations only when there's something to write.
     if !to_disable.is_empty() {
         config::with_config_lock(|| {
             let mut user_config = config::load_user_config()?;
@@ -1030,20 +995,12 @@ pub fn save_integration_credentials(
         .join(&service);
     std::fs::create_dir_all(&svc_dir).map_err(|e| e.to_string())?;
 
-    // Redmine stores some fields in `config.json` rather than as individual
-    // files; route through its dedicated handler. The Redmine pattern is the
-    // only built-in service that uses `WorkerMountedConfig`, so a per-service
-    // dispatch is simpler than weaving config.json semantics into the generic
-    // routing below.
+    // Redmine stores some fields in `config.json`; route through its handler.
     if service == "redmine" {
         return save_redmine_credentials(&svc_dir, &credentials, allowed);
     }
 
-    // Generic routing driven by `FieldStorage` (plan §PR3:290-299). Each UI
-    // field lands in the storage tier its descriptor declares — `OAuthState`
-    // fields are merged into `oauth/<project>/<service>.json`, everything
-    // else lands in the worker-mounted tokens dir. Adding a new OAuth-using
-    // service means flipping `storage` on its descriptor; no edit here.
+    // Generic routing: each UI field lands in the storage tier its descriptor declares.
     save_with_field_storage(&project, &service, &svc_dir, &credentials)
 }
 
@@ -1260,8 +1217,7 @@ pub fn delete_integration_credentials(project: String, service: String) -> Resul
         }
     }
 
-    // ADR-060: also remove the host-only oauth.json. Top-level (refreshToken,
-    // scopes, timing) + nested providerData are managed by the oauth worker.
+    // ADR-060: also remove the host-only oauth.json.
     let svc_desc = speedwave_runtime::consts::find_mcp_service(&service);
     if svc_desc.is_some_and(|d| d.oauth_state_fields.is_some()) {
         let oauth_path = speedwave_runtime::plugin::oauth_state_file(&project, &service);
@@ -1270,8 +1226,7 @@ pub fn delete_integration_credentials(project: String, service: String) -> Resul
         }
     }
 
-    // Optional-only services (e.g. context7) keep working in anonymous mode after
-    // credential removal — skip auto-disable so the toggle stays as the user left it.
+    // Optional-only services keep working anonymously, so skip auto-disable.
     let all_optional = svc_desc
         .map(|d| !d.auth_fields.is_empty() && d.auth_fields.iter().all(|f| f.optional))
         .unwrap_or(false);
@@ -1416,8 +1371,7 @@ pub async fn restart_integration_containers(
         let rt = speedwave_runtime::runtime::detect_runtime();
         rt.ensure_ready().map_err(|e| e.to_string())?;
 
-        // Build OUTSIDE the compose lock (ADR-066). On failure, undo the
-        // just-enabled config toggle but leave running containers intact.
+        // Build OUTSIDE the compose lock (ADR-066).
         if let Err(sanitized) = ensure_project_images_built(&rt, &project) {
             log::error!("restart_integration_containers: image build failed: {sanitized}");
             if let Some(svc) = just_enabled.as_deref() {
@@ -1429,25 +1383,20 @@ pub async fn restart_integration_containers(
         }
 
         rt.transaction(&project, |rt| -> anyhow::Result<()> {
-            // Hard-fail only on real IO errors (disk full, permission denied);
-            // save_snapshot returns Ok(()) when compose.yml doesn't exist yet.
+            // Hard-fail only on real IO errors.
             speedwave_runtime::update::save_snapshot(&project).map_err(|e| {
                 anyhow::anyhow!(
                     "Cannot safely restart: failed to write rollback snapshot ({e})"
                 )
             })?;
 
-            // Respawn the oauth worker before compose render so the bearer-map
-            // is current after a plugin OAuth toggle (ADR-069). Best-effort.
+            // Respawn the oauth worker before compose render (ADR-069). Best-effort.
             crate::ensure_oauth_running(&oauth_arc, &project);
 
             use crate::types::IntoAnyhow;
             crate::containers_cmd::render_and_save_compose(&project).into_anyhow()?;
 
-            // Idempotent up with NO prior down (ADR-072 tags + config-hash
-            // convergence): creates/removes the toggled worker (--remove-orphans)
-            // and recreates only claude + hub, whose ENABLED_SERVICES changed —
-            // the remaining containers keep running untouched.
+            // Idempotent up with NO prior down (ADR-072): recreates only claude + hub.
             let up_result =
                 speedwave_runtime::runtime::compose_validate_with_retry(rt, &project)
                     .and_then(|()| rt.compose_up(&project));
@@ -1456,8 +1405,7 @@ pub async fn restart_integration_containers(
                 log::error!(
                     "restart_integration_containers: up failed: {e}, attempting rollback"
                 );
-                // Containers roll back below — the config toggle must follow,
-                // or the UI shows an enabled integration with no worker.
+                // Roll the config toggle back alongside the containers.
                 if let Some(svc) = just_enabled.as_deref() {
                     rollback_integration_to_disabled(&project, svc);
                 }
@@ -1492,11 +1440,9 @@ pub async fn restart_integration_containers(
 mod tests {
     use super::*;
 
-    /// Drift guard: the camelCase JSON keys the Desktop save-path derives from the
-    /// `OAuthStateProviderData` descriptors (via `snake_to_oauth_json_key`, which
-    /// delegates to the runtime SSOT) must equal the runtime `IDENTITY_KEYS` the
-    /// migration nests under `providerData`. Catches a descriptor/mapping change
-    /// that would desync the two write paths.
+    /// Drift guard: the camelCase keys derived from `OAuthStateProviderData`
+    /// descriptors must equal the runtime `IDENTITY_KEYS` nested under
+    /// `providerData`.
     #[test]
     fn provider_data_descriptor_keys_match_runtime_identity_keys() {
         let mut got: Vec<&str> = speedwave_runtime::consts::TOGGLEABLE_MCP_SERVICES
@@ -1619,8 +1565,7 @@ mod tests {
 
     #[test]
     fn detect_scope_mismatch_returns_ok_when_granted_matches_with_different_case() {
-        // grantedScopes come back in mixed case from Microsoft (e.g.
-        // `Sites.Manage.All`). The helper normalises both sides.
+        // Microsoft returns mixed-case scopes; the helper normalises both sides.
         let raw = well_formed_state(&["Sites.Manage.All", "User.Read"]);
         let required = vec!["sites.manage.all".to_string(), "user.read".to_string()];
         assert_eq!(
@@ -1629,9 +1574,7 @@ mod tests {
         );
     }
 
-    // Microsoft echoes the fully-qualified resource scopes (e.g.
-    // `https://graph.microsoft.com/sites.manage.all`) in grantedScopes, never
-    // `offline_access`. These mirror the live `documents` / `speedwave` files.
+    // Fully-qualified Graph resource scopes Microsoft echoes; never offline_access.
     const GRAPH_RESOURCE_SCOPES: &[&str] = &[
         "https://graph.microsoft.com/sites.manage.all",
         "https://graph.microsoft.com/files.readwrite.all",
@@ -1640,8 +1583,7 @@ mod tests {
 
     #[test]
     fn detect_scope_mismatch_ok_when_all_resource_scopes_granted_but_offline_access_absent() {
-        // The `documents` live case: every resource scope present, only
-        // `offline_access` "missing" — Microsoft never echoes it. Must be Ok.
+        // Every resource scope present, only offline_access absent: must be Ok.
         let raw = well_formed_state(GRAPH_RESOURCE_SCOPES);
         let required = sharepoint_required_scopes(); // includes offline_access
         assert!(required.iter().any(|r| r == OFFLINE_ACCESS_SCOPE));
@@ -1653,8 +1595,7 @@ mod tests {
 
     #[test]
     fn detect_scope_mismatch_still_trips_when_a_real_resource_scope_is_missing() {
-        // Excluding offline_access must NOT mask a genuinely missing resource
-        // scope (here: sites.manage.all absent).
+        // Excluding offline_access must not mask a missing resource scope.
         let raw = well_formed_state(&[
             "https://graph.microsoft.com/files.readwrite.all",
             "https://graph.microsoft.com/user.read",
@@ -1668,8 +1609,7 @@ mod tests {
 
     #[test]
     fn detect_scope_mismatch_ok_when_offline_access_also_present() {
-        // A freshly re-authed file that happens to carry offline_access in
-        // grantedScopes must still be Ok (the `speedwave` live case).
+        // A file that carries offline_access in grantedScopes must still be Ok.
         let mut granted: Vec<&str> = GRAPH_RESOURCE_SCOPES.to_vec();
         granted.push("offline_access");
         let raw = well_formed_state(&granted);
@@ -1682,8 +1622,7 @@ mod tests {
 
     #[test]
     fn detect_scope_mismatch_stale_guard_unaffected_by_offline_access_filter() {
-        // The Stale guards (missing providerData / grantedScopes) take priority
-        // over the coverage check — filtering offline_access must not change that.
+        // Stale guards take priority over the coverage check.
         let raw = r#"{"provider":"microsoft","providerData":{"clientId":"c"}}"#;
         let required = sharepoint_required_scopes();
         assert_eq!(
@@ -1716,8 +1655,7 @@ mod tests {
 
     #[test]
     fn detect_scope_mismatch_returns_stale_when_provider_data_missing() {
-        // Pre-OAuthProvider-refactor files lack `providerData` — UI banner
-        // must surface re-consent to migrate the user forward.
+        // Files lacking `providerData` are Stale so the UI surfaces re-consent.
         let raw = r#"{"provider":"microsoft","grantedScopes":["sites.manage.all","user.read","files.readwrite.all","offline_access"]}"#;
         let required = vec!["sites.manage.all".to_string()];
         assert_eq!(
@@ -1757,8 +1695,7 @@ mod tests {
 
     #[test]
     fn detect_oauth_action_required_only_acts_on_oauth_refresh_services() {
-        // For non-OAuth-refresh services we never even read the oauth.json —
-        // the fact that consts::data_dir() may be unrelated/empty must not matter.
+        // Non-OAuth-refresh services never read the oauth.json.
         assert!(detect_oauth_action_required("any-project", "redmine").is_none());
         assert!(detect_oauth_action_required("any-project", "gitlab").is_none());
         assert!(detect_oauth_action_required("any-project", "github").is_none());
@@ -1831,8 +1768,7 @@ mod tests {
 
     #[test]
     fn detect_oauth_action_required_slack_some_when_grant_predates_dm_scopes() {
-        // Pins the upgrade path: a sign-in from before the DM feature (8 scopes)
-        // must trip the re-auth banner once the required set widened to 14.
+        // A pre-DM grant must trip the re-auth banner after the scope set widened.
         let tmp = tempfile::tempdir().unwrap();
         let now = chrono::Utc::now().to_rfc3339();
         write_slack_state_for_detect(tmp.path(), LEGACY_PRE_DM_SLACK_SCOPES, &now);
@@ -1856,8 +1792,7 @@ mod tests {
 
     #[test]
     fn detect_oauth_action_required_slack_some_when_refresh_token_aged_out() {
-        // 31 days idle > the 30-day PKCE refresh-token lifetime → banner, even
-        // though the granted scopes fully cover the required set.
+        // 31 days idle exceeds the 30-day PKCE refresh-token lifetime: banner.
         let tmp = tempfile::tempdir().unwrap();
         let old = (chrono::Utc::now() - chrono::Duration::days(31)).to_rfc3339();
         write_slack_state_for_detect(tmp.path(), &all_slack_scopes(), &old);
@@ -1948,9 +1883,7 @@ mod tests {
 
     #[test]
     fn detect_oauth_action_required_some_when_present_but_stale() {
-        // Present file with malformed providerData (the bug state): the service
-        // reads as unconfigured, but the banner MUST still fire so the user can
-        // re-authorise. Stale collapses to "scope_mismatch".
+        // Malformed providerData must still fire the banner (Stale → scope_mismatch).
         let tmp = tempfile::tempdir().unwrap();
         let path = speedwave_runtime::plugin::oauth_state_file_in(tmp.path(), "p", "sharepoint");
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
@@ -2028,20 +1961,11 @@ mod tests {
     }
 
     // -- validate_os_integrations_on_startup --
-    //
-    // The full happy/error/state-transition path requires a temporary
-    // ~/.speedwave/ data dir and a mocked native CLI that returns scripted
-    // status JSON. That harness already exists for set_os_integration_enabled
-    // tests at the integration level (run via `make test-desktop`). The unit
-    // tests here cover the boundary behaviour reachable without spawning
-    // child processes.
 
     #[cfg(target_os = "windows")]
     #[test]
     fn validate_os_integrations_returns_empty_on_windows() {
-        // OS integrations are macOS-only — the validator must short-circuit
-        // with Ok([]) on Windows hosts so the Angular ngOnInit hook can call
-        // it unconditionally.
+        // macOS-only: the validator short-circuits with Ok([]) on Windows.
         let result = validate_os_integrations_on_startup("test".into());
         assert!(result.is_ok(), "expected Ok on non-macOS, got {result:?}");
         assert_eq!(
@@ -2053,11 +1977,7 @@ mod tests {
 
     #[test]
     fn os_integration_validation_serializes_to_camel_case_for_frontend() {
-        // The Tauri command return type is consumed by Angular as
-        // OsIntegrationValidation in models/integration.ts — the field names
-        // must serialize to snake_case (Rust default). If a future PR adds
-        // serde rename rules, this test catches the drift before frontend
-        // breaks at runtime.
+        // Drift guard: the fields must serialize to snake_case for Angular.
         let v = OsIntegrationValidation {
             service: "calendar".to_string(),
             previous_enabled: true,
@@ -2073,9 +1993,7 @@ mod tests {
 
     #[test]
     fn os_integrations_config_get_service_covers_every_toggleable_service() {
-        // SSOT alignment: get_service must accept every config_key in
-        // TOGGLEABLE_OS_SERVICES. A new entry without a matching arm would
-        // make the validator silently skip the service.
+        // SSOT alignment: get_service must accept every config_key in TOGGLEABLE_OS_SERVICES.
         use speedwave_runtime::config::{IntegrationConfig, OsIntegrationsConfig};
         let mut cfg = OsIntegrationsConfig::default();
         for svc in speedwave_runtime::consts::TOGGLEABLE_OS_SERVICES {
@@ -2269,8 +2187,7 @@ mod tests {
 
     #[test]
     fn restart_reconciles_oauth_worker_before_compose_render() {
-        // The oauth worker must respawn before compose render so the bearer-map
-        // is current after a plugin OAuth toggle.
+        // The oauth worker must respawn before compose render.
         let source = include_str!("integrations_cmd.rs");
         let fn_start = source
             .find("fn restart_integration_containers(")
@@ -2291,8 +2208,7 @@ mod tests {
 
     #[test]
     fn restart_rolls_back_just_enabled_on_up_failure_too() {
-        // Both failure arms must converge config with containers — otherwise
-        // the UI shows an enabled integration whose worker does not exist.
+        // Both failure arms must converge config with containers.
         let source = include_str!("integrations_cmd.rs");
         let fn_start = source
             .find("fn restart_integration_containers(")
@@ -2323,8 +2239,7 @@ mod tests {
 
     #[test]
     fn restart_rolls_back_just_enabled_on_build_failure() {
-        // Structural: the build-failure branch must call the rollback helper
-        // with the `just_enabled` arg so the toggled-on row reverts in the UI.
+        // Structural: the build-failure branch must call the rollback helper.
         let source = include_str!("integrations_cmd.rs");
         let fn_start = source
             .find("fn restart_integration_containers(")
@@ -2369,9 +2284,7 @@ mod tests {
 
     #[test]
     fn restart_integration_containers_waits_for_image_readiness() {
-        // Race guard: bundle reconcile may be rebuilding images while a user
-        // toggles an integration; without this gate, compose_up_recreate would
-        // surface "image not available" through nerdctl to the user.
+        // Race guard: a bundle rebuild may collide with a toggle.
         let source = include_str!("integrations_cmd.rs");
         let fn_start = source
             .find("fn restart_integration_containers(")
@@ -2409,8 +2322,7 @@ mod tests {
 
     #[test]
     fn is_service_configured_returns_false_when_only_secrets_exist() {
-        // SharePoint: access_token + refresh_token exist (file-based secrets),
-        // but client_id/tenant_id/site_id are missing → false
+        // Only file-based secrets present; non-secret fields missing → false.
         let tmp = tempfile::tempdir().unwrap();
         let svc_dir = make_svc_token_dir(tmp.path(), "proj", "sharepoint");
         std::fs::write(svc_dir.join("access_token"), "tok").unwrap();
@@ -2424,10 +2336,7 @@ mod tests {
 
     #[test]
     fn is_service_configured_returns_true_when_all_fields_present() {
-        // SharePoint after base_path removal: access_token + site_id are
-        // worker-mounted; refresh_token / client_id / tenant_id live in
-        // oauth.json. is_service_configured_with_home checks the worker-mounted
-        // dir (we feed minimum), and the OAuthState fields via the JSON.
+        // access_token + site_id are worker-mounted; OAuthState fields live in oauth.json.
         let tmp = tempfile::tempdir().unwrap();
         let svc_dir = make_svc_token_dir(tmp.path(), "proj", "sharepoint");
         std::fs::write(svc_dir.join("access_token"), "tok").unwrap();
@@ -2484,8 +2393,7 @@ mod tests {
 
     #[test]
     fn is_service_configured_checks_stored_in_config_json_for_redmine() {
-        // Redmine: api_key (file) + host_url (config.json, required) +
-        // project_id (config.json, optional)
+        // Redmine: api_key (file), host_url (config.json, required), project_id (optional).
         let tmp = tempfile::tempdir().unwrap();
         let svc_dir = make_svc_token_dir(tmp.path(), "proj", "redmine");
 
@@ -2547,8 +2455,7 @@ mod tests {
 
     #[test]
     fn is_service_configured_returns_false_for_empty_files() {
-        // Slack (ADR-071): both halves required — a mounted access_token AND a
-        // refreshToken in the off-mount oauth state.
+        // Slack (ADR-071): both a mounted access_token and an off-mount refreshToken required.
         let tmp = tempfile::tempdir().unwrap();
         let svc_dir = make_svc_token_dir(tmp.path(), "proj", "slack");
 
@@ -2590,8 +2497,7 @@ mod tests {
 
     #[test]
     fn is_service_configured_returns_false_for_empty_config_json_values() {
-        // Redmine: host_url is a required (non-optional) config.json field.
-        // An empty host_url blocks configuration even if optional fields are present.
+        // host_url is required; an empty value blocks configuration.
         let tmp = tempfile::tempdir().unwrap();
         let svc_dir = make_svc_token_dir(tmp.path(), "proj", "redmine");
         std::fs::write(svc_dir.join("api_key"), "secret").unwrap();
@@ -2613,8 +2519,7 @@ mod tests {
 
     #[test]
     fn is_service_configured_returns_true_for_credential_less_service() {
-        // Services like Playwright have no auth_fields; they scrape public URLs.
-        // They must be treated as always-configured so the UI toggle is enabled.
+        // Credential-less services must be treated as always-configured.
         let tmp = tempfile::tempdir().unwrap();
         assert!(
             is_service_configured_with_home(tmp.path(), "proj", "playwright"),
@@ -2691,10 +2596,7 @@ mod tests {
 
     #[test]
     fn parse_permission_output_denied_with_status_and_error() {
-        // Calendar uses sub-identifier `pl.speedwave.desktop.calendar` per
-        // SharedCLI/Utilities.swift::subBundleIdentifier — the `tccutil reset`
-        // command in the error string must use the sub-identifier so that
-        // recovery actually clears the right TCC.db row.
+        // The tccutil command in the error string must use the calendar sub-identifier.
         let result = parse_permission_output(
             r#"{"granted": false, "status": "denied", "error": "tccutil reset Calendar pl.speedwave.desktop.calendar"}"#,
         );
@@ -2719,10 +2621,7 @@ mod tests {
 
     #[test]
     fn parse_permission_output_mail_uses_apple_events_service() {
-        // Mail/Notes use kTCCServiceAppleEvents — `tccutil reset Mail` is wrong
-        // (no such TCC service exists). The Swift composeErrorMessage produces
-        // `tccutil reset AppleEvents pl.speedwave.desktop.mail` and the parser
-        // must surface this string verbatim.
+        // Mail/Notes use kTCCServiceAppleEvents, not `tccutil reset Mail`.
         let result = parse_permission_output(
             r#"{"granted": false, "status": "denied", "error": "tccutil reset AppleEvents pl.speedwave.desktop.mail"}"#,
         );
@@ -2751,10 +2650,7 @@ mod tests {
 
     #[test]
     fn parse_permission_output_target_not_running_omits_tccutil() {
-        // .targetNotRunning (Mail/Notes app not running) is NOT a TCC issue —
-        // the error string must NOT recommend tccutil because resetting
-        // permission would not help. The Swift composeErrorMessage produces
-        // a "open Mail.app and try again" message instead.
+        // .targetNotRunning is not a TCC issue, so the error must not recommend tccutil.
         let result = parse_permission_output(
             r#"{"granted": false, "status": "targetNotRunning", "error": "Mail.app is not running. Open Mail.app and try again — this is not a permission problem."}"#,
         );
@@ -2769,8 +2665,7 @@ mod tests {
 
     #[test]
     fn parse_permission_output_status_field_does_not_affect_message() {
-        // The status field must not affect the returned Err message — only the error field matters.
-        // Example: status="completely_made_up" with error="real error" → Err("real error")
+        // The status field must not affect the Err message; only error matters.
         let result = parse_permission_output(
             r#"{"granted": false, "status": "completely_made_up", "error": "real error"}"#,
         );
@@ -2781,7 +2676,6 @@ mod tests {
     #[test]
     fn parse_permission_output_sanitizes_error() {
         // Error strings must be sanitized before reaching the webview.
-        // Synthesize an error containing a Bearer token pattern.
         let input =
             r#"{"granted": false, "error": "failed with Bearer eyJhbGciOiJIUzI1NiJ9.test.sig"}"#;
         let result = parse_permission_output(input);
@@ -2829,8 +2723,7 @@ mod tests {
 
     #[test]
     fn resolve_native_cli_binary_covers_all_os_services() {
-        // Cross-language consistency with platform-runner.ts must be verified
-        // manually when changing binary names
+        // Cross-language consistency with platform-runner.ts is verified manually.
         let os_services: std::collections::HashSet<&str> =
             speedwave_runtime::consts::TOGGLEABLE_OS_SERVICES
                 .iter()
@@ -2952,8 +2845,7 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn check_os_permission_timeout_kills_child() {
-        // Intentionally slow test (~5s) — spawns a script that sleeps 60s,
-        // but we set a 2s timeout so it gets killed quickly.
+        // Slow test: a 60s-sleep script is killed by a 2s timeout.
         let tmp = tempfile::tempdir().unwrap();
         let script = tmp.path().join("reminders-cli");
         std::fs::write(&script, "#!/bin/sh\nsleep 60\n").unwrap();
@@ -3029,9 +2921,7 @@ mod tests {
 
     #[test]
     fn credential_files_allowlist_covers_legacy_project_name_file() {
-        // project_name was removed from auth_fields (UI no longer shows it),
-        // but credential_files still includes it so delete_integration_credentials
-        // can clean up legacy installations that have a project_name file on disk.
+        // project_name is gone from auth_fields but kept in credential_files for legacy cleanup.
         let svc = speedwave_runtime::consts::find_mcp_service("redmine").unwrap();
 
         assert!(
@@ -3043,8 +2933,7 @@ mod tests {
             "project_name must not appear in auth_fields (removed from UI)"
         );
 
-        // Simulate legacy cleanup: create a temp dir with a project_name file,
-        // then iterate credential_files to delete — mirrors delete_integration_credentials logic.
+        // Simulate legacy cleanup: create a project_name file, then delete via credential_files.
         let tmp = tempfile::tempdir().unwrap();
         let svc_dir = tmp.path();
         std::fs::write(svc_dir.join("project_name"), "Legacy Project").unwrap();
@@ -3202,10 +3091,7 @@ mod tests {
 
     #[test]
     fn merge_oauth_state_json_merges_into_existing_provider_data() {
-        // Existing file already has a populated providerData node (typical
-        // read-modify-write: user updates one field via UI, the others stay).
-        // The merge must add the new field, preserve the old one, and keep
-        // top-level fields intact.
+        // Merge must add the new field and preserve the old and top-level fields.
         let tmp = tempfile::tempdir().unwrap();
         let data_dir = tmp.path();
 
@@ -3297,8 +3183,7 @@ mod tests {
 
     #[test]
     fn merge_oauth_state_json_repairs_missing_provider_data_node() {
-        // Existing file lacks `providerData` (e.g. corrupted at that node).
-        // The merge must repair it rather than silently drop client_id/tenant_id.
+        // Merge must repair a missing providerData node rather than drop identity.
         let tmp = tempfile::tempdir().unwrap();
         let data_dir = tmp.path();
 
@@ -3323,9 +3208,7 @@ mod tests {
 
     #[test]
     fn merge_oauth_state_json_lifts_legacy_top_level_identity() {
-        // Legacy file with clientId/tenantId at top level (pre-providerData).
-        // A re-save must lift them under providerData AND remove the top-level
-        // copies — not leave them orphaned next to an empty providerData.
+        // A re-save must lift top-level clientId/tenantId under providerData and remove the copies.
         let tmp = tempfile::tempdir().unwrap();
         let data_dir = tmp.path();
 

--- a/desktop/src-tauri/src/llm_cmd.rs
+++ b/desktop/src-tauri/src/llm_cmd.rs
@@ -1,14 +1,4 @@
-// LLM model discovery — Tauri command for probing local LLM servers.
-//
-// When a user configures a local-LLM provider in Settings (ollama, lmstudio,
-// llamacpp) the Desktop can hit the server's `/v1/models` or `/api/tags`
-// endpoint and present the advertised models as a `<select>`.
-// The same SSRF-safe validation path (`validate_llm_base_url`) is reused by
-// `containers_cmd::update_llm_config` so both discover and save reject
-// link-local, metadata, and other dangerous URLs.
-//
-// See docs/adr/ADR-041-local-llm-model-discovery.md for the threat model and
-// the RFC1918/loopback/public-domain policy rationale.
+// LLM model discovery via HTTP probes (see ADR-041 for the threat model).
 
 use futures_util::stream::{self, StreamExt};
 use serde::{Deserialize, Serialize};
@@ -28,14 +18,7 @@ const DISCOVERY_TIMEOUT_SECS: u64 = 5;
 // Public DTO surfaced through Tauri to the frontend
 // ---------------------------------------------------------------------------
 
-/// One discovered model from a local LLM server.
-///
-/// `context_tokens` is `None` when the provider's listing endpoint did not
-/// expose the model's context window — the frontend then leaves the chat
-/// footer's `used / max` ratio derived from the stream-level
-/// `context_window_size` (when available) or falls back to the global
-/// default. We deliberately do not invent a value: silent guesses
-/// undermine the SSOT goal.
+/// One discovered model; `context_tokens` is `None` when unavailable.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DiscoveredModel {
     pub id: String,
@@ -43,11 +26,7 @@ pub struct DiscoveredModel {
     pub context_tokens: Option<u32>,
 }
 
-/// Result of a `provider="local"` discovery probe. Pairs the model list with
-/// a chat-endpoint sanity flag so the UI can warn when a server advertises
-/// models via `/v1/models` but does not implement the Anthropic Messages
-/// API (`/v1/messages`). `None` for the flag means "could not determine"
-/// (timeout, transport error) — UI treats it as unknown rather than failure.
+/// Discovery result: model list + optional messages-endpoint flag (`None` = undetermined).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DiscoverResult {
     pub models: Vec<DiscoveredModel>,
@@ -59,14 +38,8 @@ pub struct DiscoverResult {
 // Pure parsers (tested in isolation, no HTTP)
 // ---------------------------------------------------------------------------
 
-/// Parses the JSON returned by `POST /api/show` and locates the model's
-/// context window. The key is dynamic: `model_info["<arch>.context_length"]`
-/// where `<arch>` is the value of `model_info["general.architecture"]`
-/// (`"llama"`, `"qwen2"`, `"mistral"`…). When the architecture key is
-/// absent we still scan for any key ending in `.context_length` so we
-/// degrade gracefully against future Ollama schema tweaks. Returns `None`
-/// when no context length is found — caller persists `context_tokens: None`
-/// and the chat fallback chain takes over.
+/// Parses `POST /api/show` response; extracts context window from the
+/// architecture-specific `*.context_length` key.
 fn parse_ollama_show(body: &[u8]) -> Option<u32> {
     let v: serde_json::Value = serde_json::from_slice(body).ok()?;
     let model_info = v.get("model_info")?.as_object()?;
@@ -90,10 +63,8 @@ fn parse_ollama_show(body: &[u8]) -> Option<u32> {
     None
 }
 
-/// Convert a server-reported context-length to `u32`, treating both overflow
-/// and a literal `0` as "unknown". A zero would otherwise propagate through
-/// to `update_llm_config` and surface as a misleading "context_tokens must
-/// be greater than 0" error at save time.
+/// Converts a server-reported context-length to `u32`, treating overflow and
+/// `0` as "unknown".
 fn non_zero_u32(n: u64) -> Option<u32> {
     u32::try_from(n).ok().filter(|&v| v > 0)
 }
@@ -102,21 +73,9 @@ fn non_zero_u32(n: u64) -> Option<u32> {
 // URL validation (shared between discover and save paths)
 // ---------------------------------------------------------------------------
 
-/// Validates a base URL for a local LLM provider.
-///
-/// Policy (see ADR-041):
-/// - Loopback (127.0.0.0/8, ::1, IPv6-mapped loopback) — allowed with `warn!`.
-/// - RFC 1918 private + IPv6 ULA (fc00::/7) — allowed with `warn!`.
-/// - Link-local / metadata / reserved — rejected via `validate_url`.
-/// - Public IP / public domain — allowed with `warn!` (user-written URL; same
-///   threat model as Redmine's `validate_redmine_host_url`).
-/// - `http://` scheme warns about cleartext transmission.
-///
-/// Rejects embedded credentials, backslashes, query strings, fragments, and
-/// non-HTTP schemes in all cases.
-///
-/// Returns the parsed `url::Url` so callers (the discover pipeline) can reuse
-/// the parse result without re-parsing.
+/// Validates a base URL for a local LLM provider (policy: ADR-041). Allows
+/// loopback/private/public with `warn!`, rejects link-local/metadata/reserved,
+/// credentials, backslashes, query, fragment, and non-HTTP schemes.
 pub(crate) fn validate_llm_base_url(url: &str) -> Result<url::Url, String> {
     // Reject backslashes before parsing (Windows path confusion)
     if url.contains('\\') {
@@ -133,12 +92,7 @@ pub(crate) fn validate_llm_base_url(url: &str) -> Result<url::Url, String> {
         return Err("URL must not contain a fragment".to_string());
     }
 
-    // If the host is a private on-premise address (loopback, RFC1918, ULA) OR
-    // the literal hostname `localhost` (which `validate_url` otherwise blocks),
-    // skip the base validator and check scheme/host ourselves. Otherwise
-    // delegate to `validate_url` which handles link-local rejection, IPv6-mapped
-    // IPv4 bypass prevention, decimal IP bypass, and the full RFC 5737 / 2544 /
-    // 6666 / 3849 reserved-range set.
+    // On-premise/localhost: validate scheme/host here; else delegate to validate_url.
     let host_is_localhost = matches!(
         candidate.host(),
         Some(url::Host::Domain(d)) if d.eq_ignore_ascii_case("localhost")
@@ -154,13 +108,7 @@ pub(crate) fn validate_llm_base_url(url: &str) -> Result<url::Url, String> {
                     ))
                 }
             }
-            // Host is guaranteed present here: host_is_localhost requires
-            // Some(Domain("localhost")); is_private_on_premise returns true
-            // only for Some(Ipv4) or Some(Ipv6). The `<bug:no-host>` token
-            // is a deliberate giveaway in the warning log: if it ever
-            // appears, the upstream guard regressed and host classification
-            // was bypassed — making it impossible to confuse with a real
-            // hostname.
+            // Host guaranteed present here by the on-premise/localhost classifier.
             let host = candidate.host_str().unwrap_or("<bug:no-host>");
             if host_is_localhost || is_loopback_host(&candidate) {
                 log::warn!("Allowing loopback address for local LLM: {}", host);
@@ -170,8 +118,7 @@ pub(crate) fn validate_llm_base_url(url: &str) -> Result<url::Url, String> {
             candidate
         } else {
             let v = validate_url(url)?;
-            // Same invariant as above: `validate_url` rejects schemes / IP
-            // classes that lack a host, so `Ok` guarantees `Some` here.
+            // Host guaranteed present: `validate_url` Ok implies `Some`.
             let host = v.host_str().unwrap_or("<bug:no-host>");
             log::warn!("Allowing public address for local LLM: {}", host);
             v
@@ -182,8 +129,7 @@ pub(crate) fn validate_llm_base_url(url: &str) -> Result<url::Url, String> {
         return Err("URL must not contain embedded credentials".to_string());
     }
 
-    // Warn about cleartext HTTP (credentials are not transmitted, but an
-    // on-path attacker can still read LLM traffic content).
+    // Warn about cleartext HTTP.
     if parsed.scheme() == "http" {
         log::warn!("LLM traffic will be transmitted in cleartext over HTTP");
     }
@@ -218,11 +164,8 @@ fn build_llm_probe_client() -> Result<reqwest::Client, String> {
     build_llm_probe_client_with_auth(None, None)
 }
 
-/// Builds an HTTP client with optional `Authorization: Bearer <token>` and
-/// optional custom headers (`Name: Value` per line). Custom headers are
-/// applied as **default headers** (sent on every request from the client).
-/// `Authorization` in `custom_headers` is rejected defensively — it would
-/// collide with the Bearer token added separately.
+/// Builds an HTTP client with optional Bearer auth and custom default headers.
+/// Rejects `Authorization` in `custom_headers`.
 fn build_llm_probe_client_with_auth(
     bearer: Option<&str>,
     custom_headers: Option<&str>,
@@ -248,9 +191,7 @@ fn build_llm_probe_client_with_auth(
             let name = name.trim();
             let value = rest.trim();
             if name.eq_ignore_ascii_case("authorization") {
-                // Defense-in-depth: validation should have rejected on save,
-                // but we double-check here so a stale config can't smuggle
-                // Authorization back in via the headers blob.
+                // Guard against stale config smuggling Authorization.
                 return Err(
                     "custom_headers must not contain Authorization (use api_key)".to_string(),
                 );
@@ -282,9 +223,7 @@ fn normalize_and_validate_discovery_url(base_url: &str) -> Result<url::Url, Stri
         .parse()
         .map_err(|e: url::ParseError| format!("Invalid base_url: {e}"))?;
 
-    // 3. Rewrite container-side host aliases (host.docker.internal etc.) to
-    //    loopback. On the Desktop host process, those aliases are not in
-    //    /etc/hosts — we need to hit the server on 127.0.0.1 directly.
+    // 3. Rewrite container-side host aliases (host.docker.internal etc.) to loopback.
     if let Some(host_str) = parsed.host_str() {
         if let Some(loopback) = crate::http_util::rewrite_container_alias_to_loopback(host_str) {
             parsed
@@ -303,10 +242,8 @@ fn normalize_and_validate_discovery_url(base_url: &str) -> Result<url::Url, Stri
 // cannot route to but the VM (via Apple VZ NAT / WSL2 mirrored) can.
 // ---------------------------------------------------------------------------
 
-/// Minimal HTTP transport for the discovery probe. Returned `body` is capped
-/// at [`MAX_RESPONSE_BODY_BYTES`]; callers parse it as JSON. Auth headers
-/// (`Authorization: Bearer …`, custom headers) are pre-configured on the
-/// implementation; calls supply only URL + optional JSON body.
+/// Minimal HTTP transport for the discovery probe; `body` capped at
+/// [`MAX_RESPONSE_BODY_BYTES`]. Auth headers are pre-configured on the impl.
 #[async_trait::async_trait]
 pub(crate) trait ProbeTransport: Send + Sync {
     /// `GET url` with `Accept: application/json`. Returns `(status, body)`.
@@ -401,11 +338,8 @@ impl ProbeTransport for HostProbe {
     }
 }
 
-/// VM-side probe via `vm_exec` + `curl`. Used when the host cannot reach the
-/// target URL but the VM can (Apple VZ NAT inherits macOS VPN routing;
-/// WSL2 mirrored mode inherits Windows VPN routing). Falls back to
-/// `HostProbe` automatically in `discover_llm_models` if the VM is not
-/// available (fresh install).
+/// VM-side probe via `vm_exec` + `curl`; reaches corporate-VPN endpoints
+/// (Apple VZ / WSL2 inherit host routing).
 pub(crate) struct VmProbe {
     bearer: Option<String>,
     custom_headers: Option<String>,
@@ -516,9 +450,7 @@ fn run_vm_curl_blocking(
             if line.is_empty() {
                 continue;
             }
-            // Mirror the HostProbe / save-path guard: a stale custom_headers
-            // file must not smuggle an `Authorization` header that collides
-            // with the Bearer added separately.
+            // Reject `Authorization` in custom_headers (mirrors HostProbe/save guard).
             if line
                 .split_once(':')
                 .map(|(name, _)| name.trim().eq_ignore_ascii_case("authorization"))
@@ -600,24 +532,11 @@ fn run_vm_curl_blocking(
 // Core logic (parameterized timeout for testing)
 // ---------------------------------------------------------------------------
 
-/// Issues a GET against `<base>/<path>` with shared status / content-type /
-/// body-size guards. Returns the validated body bytes ready for parsing.
-/// Bounded fan-out for `/api/show` probes. Higher floods Ollama; lower
-/// stretches wall-clock for users with large model libraries.
+/// Bounded fan-out concurrency for `/api/show` probes.
 const MAX_OLLAMA_PROBE_CONCURRENCY: usize = 8;
 
-/// Per-entry context detection for the `provider="local"` path.
-///
-/// Reads `/v1/models` and for each entry tries to extract a context window
-/// from inline metadata in this order:
-/// 1. `meta.n_ctx_train` (llama.cpp / Unsloth / vLLM)
-/// 2. `max_context_length` (LM Studio 0.4.1+)
-///
-/// Entries that lack inline context fall back to Ollama's `POST /api/show`
-/// path — one **sanity** call on the first missing entry decides whether to
-/// fan out: 200 → fan out for the rest; 404/error → all remaining missing
-/// stay `None`. This bounds the worst-case call count for unknown servers
-/// (generic OpenAI gateway = 2 + 1 sanity = 3 calls, never N×404).
+/// Extracts per-entry context from inline `/v1/models` metadata, falling back
+/// to Ollama `/api/show` (one sanity call bounds the fan-out).
 async fn discover_local(
     base: &url::Url,
     transport: &dyn ProbeTransport,
@@ -718,10 +637,9 @@ fn enforce_json_response(resp: &ProbeResponse, url: &str) -> Result<(), String> 
     Ok(())
 }
 
-/// Parses an OpenAI-shape `/v1/models` response, extracting `id` plus an
-/// inline context window from either `meta.n_ctx_train` (llama.cpp shape) or
-/// `max_context_length` (LM Studio shape) on a per-entry basis. Servers that
-/// expose neither return `context_tokens: None` for every entry.
+/// Parses an OpenAI-shape `/v1/models` response, extracting `id` plus a
+/// per-entry inline context window from `meta.n_ctx_train` or
+/// `max_context_length` (`None` when neither is present).
 fn parse_openai_models_with_context(body: &[u8]) -> Result<Vec<DiscoveredModel>, String> {
     let v: serde_json::Value = serde_json::from_slice(body)
         .map_err(|e| format!("failed to parse /v1/models response: {e}"))?;
@@ -805,10 +723,7 @@ async fn discover_openrouter(
 }
 
 /// Strips a leading `Bearer ` (case-insensitive) and trims whitespace.
-/// Returns `None` when the result is empty. Shared between save-time
-/// validation (`containers_cmd::validate_api_key`) and the discovery
-/// resolver so a user who pastes `Bearer sk-…` from a curl example sees
-/// the same normalisation everywhere.
+/// Returns `None` when the result is empty.
 pub(crate) fn strip_bearer_prefix(s: &str) -> Option<String> {
     let trimmed = s.trim();
     let stripped = if trimmed.len() >= 7 && trimmed[..7].eq_ignore_ascii_case("Bearer ") {
@@ -823,10 +738,8 @@ pub(crate) fn strip_bearer_prefix(s: &str) -> Option<String> {
     }
 }
 
-/// Tri-state credential resolver for discovery. Transient UI value wins over
-/// stored on-disk; `Some(None)` / `Some(Some(""))` means "no auth" (ignore
-/// stored). `active_project` is passed in so the caller can load it once
-/// when both `api_key` and `custom_headers` need to be resolved.
+/// Tri-state credential resolver: transient UI value wins over stored on-disk;
+/// `Some(None)` / `Some(Some(""))` means "no auth".
 fn resolve_transient_credential(
     field: Option<&Option<String>>,
     active_project: Option<&str>,
@@ -854,10 +767,7 @@ async fn probe_messages_endpoint(base: &url::Url, transport: &dyn ProbeTransport
     match resp {
         Ok(r) => {
             let status = r.status;
-            // 200/4xx (other than 404/405) → endpoint exists.
-            // 404/405 → endpoint missing.
-            // Anything else → unknown (5xx is also "unknown" because it
-            // could be a transient overload; the model probe was cheap).
+            // 2xx/4xx (not 404/405) = ok; 404/405 = missing; else = unknown.
             match status {
                 404 | 405 => Some(false),
                 s if (200..500).contains(&s) => Some(true),
@@ -868,16 +778,8 @@ async fn probe_messages_endpoint(base: &url::Url, transport: &dyn ProbeTransport
     }
 }
 
-/// Discovers available models from a local LLM server.
-///
-/// `timeout` controls the reqwest-level request timeout for every
-/// individual HTTP call (Ollama issues `1 + N` calls, others `1`).
-/// Production uses `DISCOVERY_TIMEOUT_SECS` via the Tauri wrapper; tests
-/// pass shorter durations to keep the suite fast.
-///
-/// Returns `Err("empty")` when the server responds OK but with no models (a
-/// server up without any model loaded). The UI treats this the same as an
-/// offline server and falls back to the free-text input.
+/// Discovers models from a local LLM server; `timeout` applies per HTTP call.
+/// Returns `Err("empty")` when the server responds OK but lists no models.
 pub(crate) async fn do_discover_llm_models(
     provider: &str,
     base_url: &str,
@@ -901,11 +803,7 @@ pub(crate) async fn do_discover_llm_models(
 
     let validated = normalize_and_validate_discovery_url(base_url)?;
 
-    // All non-anthropic providers route through the unified `discover_local`
-    // path (per-entry inline context detection + Anthropic Messages sanity
-    // probe). Legacy provider names (`ollama`/`lmstudio`/`llamacpp`) are
-    // accepted on read for two release cycles — the Settings UI auto-migrates
-    // them to `local` on the next Save (ADR-040 §"Supported Providers").
+    // Non-anthropic providers route through `discover_local`; legacy names accepted on read.
     let (raw_models, messages_endpoint_ok) = match provider {
         "local" | "ollama" | "lmstudio" | "llamacpp" => {
             let (models, sanity) = futures_util::future::join(
@@ -943,12 +841,9 @@ pub(crate) async fn do_discover_llm_models(
 // Tauri command (thin wrapper)
 // ---------------------------------------------------------------------------
 
-/// Tri-state credential params for discovery.
-///
-/// `api_key == None` (field omitted) — use the stored token file (if any).
-/// `api_key == Some(None)` or `Some(Some(""))` — probe **without** Bearer
-/// even if a token exists on disk. `api_key == Some(Some(value))` — use the
-/// transient value, ignore stored. Same semantics for `custom_headers`.
+/// Tri-state credential params for discovery: `None` = use stored token;
+/// `Some(None)`/`Some(Some(""))` = probe without auth; `Some(Some(v))` =
+/// use transient value. Same semantics for `custom_headers`.
 #[derive(serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DiscoverLlmModelsArgs {
@@ -979,11 +874,7 @@ pub async fn discover_llm_models(args: DiscoverLlmModelsArgs) -> Result<Discover
         "custom_headers",
     );
     let timeout = Duration::from_secs(DISCOVERY_TIMEOUT_SECS);
-    // Try VM-routed probe first when a VM is available — that gives access to
-    // VPN-only servers (Lima vzNAT + WSL2 mirrored inherit host routing).
-    // Fall back to the host-side reqwest client when the VM is missing
-    // (fresh install) or the VM probe fails. The fallback is silent: users
-    // shouldn't have to choose a probe path.
+    // Try VM probe first (reaches VPN servers); fall back to host probe silently.
     let runtime = speedwave_runtime::runtime::detect_runtime();
     let vm_available = runtime.is_available();
     let result = if vm_available {
@@ -1099,8 +990,7 @@ mod tests {
 
     #[test]
     fn parse_ollama_show_resolves_arch_specific_context_length() {
-        // Real /api/show response shape (truncated): `general.architecture`
-        // selects which `<arch>.context_length` key carries the window.
+        // Real /api/show shape: `general.architecture` selects the `<arch>.context_length` key.
         let body = br#"{
             "license": "...",
             "modelfile": "...",
@@ -1115,9 +1005,7 @@ mod tests {
 
     #[test]
     fn parse_ollama_show_falls_back_to_any_context_length_key() {
-        // If the `general.architecture` key is missing we still grab any
-        // `<X>.context_length` we can find. Future Ollama schema tweaks
-        // shouldn't silently drop us back to 200k.
+        // Missing `general.architecture`: still grab any `<X>.context_length`.
         let body = br#"{
             "model_info": {
                 "llama.context_length": 8192
@@ -1143,15 +1031,7 @@ mod tests {
     }
 
     // ── zero-context_tokens guard ───────────────────────────────────────
-    //
-    // A literal `0` from the server (or an overflow on `u32::try_from`)
-    // would otherwise propagate to `update_llm_config`, which rejects it
-    // with a misleading "context_tokens must be greater than 0" error
-    // — confusing because it's an internal invariant, not a user mistake.
-    // `non_zero_u32` flips zero to `None` so the chat fallback chain
-    // takes over instead. The unified `parse_openai_models_with_context`
-    // path is covered by separate tests; legacy LM Studio / llama.cpp
-    // specific parsers have been removed alongside their helpers.
+    // `non_zero_u32` flips a server-reported `0` (or overflow) to `None`.
 
     #[test]
     fn parse_ollama_show_treats_zero_context_length_as_unknown() {
@@ -1185,16 +1065,11 @@ mod tests {
     }
 
     // ── validate_llm_base_url: branch coverage ──────────────────────────
-    //
-    // `url_validation::validate_url` already has 50+ tests covering every
-    // RFC-reserved range and IPv6-mapped IPv4 bypass. These tests cover the
-    // LLM-specific delta: branch selection (on-premise arm vs. delegation
-    // arm) and the policy difference (loopback allowed).
+    // LLM-specific delta: branch selection and policy (loopback allowed).
 
     #[test]
     fn validate_allows_localhost_hostname() {
-        // The `localhost` hostname is special-cased via host_is_localhost in
-        // validate_llm_base_url — must be allowed under the LLM policy.
+        // `localhost` is special-cased and allowed under the LLM policy.
         assert!(validate_llm_base_url("http://localhost:11434").is_ok());
     }
 
@@ -1326,9 +1201,7 @@ mod tests {
     }
 
     // ── Log capture tests ───────────────────────────────────────────────
-    //
-    // Uses a process-global TestLogger behind `serial_test::serial` to avoid
-    // interference from tauri-plugin-log or parallel tests.
+    // Process-global TestLogger behind `serial_test::serial`.
 
     struct TestLogger {
         records: Mutex<Vec<(log::Level, String)>>,
@@ -1363,8 +1236,7 @@ mod tests {
     fn test_logger() -> &'static TestLogger {
         static LOGGER: OnceLock<TestLogger> = OnceLock::new();
         let logger = LOGGER.get_or_init(TestLogger::new);
-        // Safe to call multiple times — only the first succeeds; subsequent
-        // calls return Err which we ignore.
+        // Only the first `set_logger` succeeds; later calls Err (ignored).
         let _ = log::set_logger(logger);
         log::set_max_level(log::LevelFilter::Trace);
         logger
@@ -1464,12 +1336,7 @@ mod tests {
 
     #[tokio::test]
     async fn do_discover_rewrites_docker_internal_via_mockito() {
-        // Start a local mockito server on a dynamic 127.0.0.1 port, then call
-        // do_discover with base_url = host.docker.internal:{port}. The rewrite
-        // helper must substitute 127.0.0.1 so the request actually lands on
-        // our mock (rather than failing DNS resolution for host.docker.internal
-        // on the host). Uses `/v1/models` since legacy provider names route
-        // through `discover_local`.
+        // host.docker.internal:{port} must rewrite to 127.0.0.1 to reach the mock.
         let mut server = mockito::Server::new_async().await;
         let port = server.host_with_port();
         let port = port.split(':').nth(1).unwrap();
@@ -1499,9 +1366,7 @@ mod tests {
 
     #[tokio::test]
     async fn integration_legacy_ollama_alias_routes_to_unified_path() {
-        // Legacy `provider="ollama"` continues to work for 2 release cycles.
-        // Backend routes it through `discover_local` (which hits `/v1/models`
-        // since Ollama 0.14+), not the obsolete `/api/tags`.
+        // Legacy `provider="ollama"` routes through `discover_local` (`/v1/models`).
         let mut server = mockito::Server::new_async().await;
         let _models_mock = server
             .mock("GET", "/v1/models")
@@ -1532,8 +1397,7 @@ mod tests {
 
     #[tokio::test]
     async fn integration_legacy_lmstudio_alias_routes_to_unified_path() {
-        // Legacy `provider="lmstudio"` continues to work — context window is
-        // extracted inline from `/v1/models` (LM Studio 0.4.1+ shape).
+        // Legacy `provider="lmstudio"`: context extracted inline from `/v1/models`.
         let mut server = mockito::Server::new_async().await;
         let _models_mock = server
             .mock("GET", "/v1/models")
@@ -1585,11 +1449,7 @@ mod tests {
 
     #[tokio::test]
     async fn discover_rejects_custom_provider_after_removal() {
-        // Regression guard: `custom` was removed as a first-class provider. Any
-        // lingering config that still passes it through the Tauri command must
-        // now land on the generic unknown-provider path (`Err("unsupported")`),
-        // not a bespoke `custom` branch that routes to `/v1/models`. The client
-        // is unused because the rejection happens before any HTTP call.
+        // Regression guard: removed `custom` provider now returns `Err("unsupported")`.
         let client = build_llm_probe_client().unwrap();
         let err = do_discover_llm_models(
             "custom",
@@ -1602,10 +1462,7 @@ mod tests {
         assert_eq!(err, "unsupported");
     }
 
-    // Generic HTTP-layer integration tests use llama.cpp because it shares the
-    // OpenAI-compatible `/v1/models` endpoint exercised by mockito. They cover
-    // status / content-type / size / timeout / redirect behaviour of
-    // `fetch_json` and apply equally to LM Studio's `/api/v0/models` path.
+    // Generic HTTP-layer tests via llama.cpp; cover status/content-type/timeout/redirect.
     #[tokio::test]
     async fn integration_returns_err_on_500() {
         let mut server = mockito::Server::new_async().await;
@@ -1675,8 +1532,7 @@ mod tests {
 
     #[tokio::test]
     async fn integration_accepts_mixed_case_json_content_type() {
-        // Regression guard: the content-type sanity check must NOT reject
-        // `application/json; charset=utf-8` with unusual casing.
+        // Content-type check must accept `application/json; charset=utf-8` (any casing).
         let mut server = mockito::Server::new_async().await;
         server
             .mock("GET", "/v1/models")
@@ -1759,8 +1615,7 @@ mod tests {
 
     #[tokio::test]
     async fn integration_redirect_not_followed() {
-        // First server returns 302 → second server. Second server must never
-        // be hit because Policy::none() blocks redirect following.
+        // 302 → second server must never be hit (`Policy::none()` blocks redirects).
         let mut target = mockito::Server::new_async().await;
         let never_hit = target
             .mock("GET", "/v1/models")
@@ -1793,10 +1648,7 @@ mod tests {
 
     #[tokio::test]
     async fn integration_redirect_to_metadata_ip_not_followed() {
-        // 302 → http://169.254.169.254/latest/meta-data/. If we were following
-        // redirects, this would turn into a real (slow / refused) network
-        // fetch. Assertion (b): wrap the whole operation in a 500ms timeout —
-        // if we blew through it, something fetched the metadata URL.
+        // 302 → metadata IP; 500ms timeout asserts the URL was never fetched.
         let mut server = mockito::Server::new_async().await;
         server
             .mock("GET", "/v1/models")
@@ -1876,8 +1728,7 @@ mod tests {
 
     #[tokio::test]
     async fn integration_local_with_inline_meta_skips_fallback_calls() {
-        // llama.cpp-shape inline context → exactly 2 calls total:
-        // `/v1/models` and `/v1/messages` sanity. No `/api/show`.
+        // Inline context → exactly 2 calls (`/v1/models` + `/v1/messages`), no `/api/show`.
         let mut server = mockito::Server::new_async().await;
         let models_mock = server
             .mock("GET", "/v1/models")
@@ -1917,9 +1768,7 @@ mod tests {
 
     #[tokio::test]
     async fn integration_local_warns_when_messages_endpoint_missing() {
-        // Server has `/v1/models` but returns 404 on `/v1/messages` — UI
-        // should get `messages_endpoint_ok: Some(false)` so it can warn.
-        // Inline `meta.n_ctx_train` → no `/api/show` fallback fires.
+        // 404 on `/v1/messages` → `messages_endpoint_ok: Some(false)`; inline meta, no `/api/show`.
         let mut server = mockito::Server::new_async().await;
         let models_mock = server
             .mock("GET", "/v1/models")
@@ -1956,9 +1805,7 @@ mod tests {
 
     #[tokio::test]
     async fn integration_local_falls_back_to_ollama_show_when_no_inline_meta() {
-        // Generic `/v1/models` without inline meta + Ollama `/api/show` works.
-        // Expected exact call counts: /v1/models = 1, /api/show = N (one
-        // sanity + N-1 fan-out = 2 for 2 models), /v1/messages = 1.
+        // No inline meta: expect 1 + N `/api/show` calls (sanity + fan-out).
         let mut server = mockito::Server::new_async().await;
         let models_mock = server
             .mock("GET", "/v1/models")
@@ -2003,9 +1850,7 @@ mod tests {
 
     #[tokio::test]
     async fn integration_local_generic_openai_gateway_stays_under_three_calls_for_context() {
-        // Server has `/v1/models` but neither inline meta NOR /api/show.
-        // Expected exact: 1 /v1/models + 1 sanity /api/show (404) + 1
-        // /v1/messages = 3 calls. Critical: must NOT fire N×/api/show.
+        // Generic gateway: 1 `/v1/models` + 1 sanity `/api/show` (404) + 1 `/v1/messages` = 3.
         let mut server = mockito::Server::new_async().await;
         let models_mock = server
             .mock("GET", "/v1/models")
@@ -2120,8 +1965,7 @@ mod tests {
         // Empty / whitespace-only → None.
         assert_eq!(strip_bearer_prefix(""), None);
         assert_eq!(strip_bearer_prefix("   "), None);
-        // `Bearer` alone (no trailing token) is NOT a prefix — trims to the
-        // literal word; caller's validation logic decides what to do with it.
+        // `Bearer` alone is not a prefix; trims to the literal word.
         assert_eq!(strip_bearer_prefix("Bearer"), Some("Bearer".to_string()));
     }
 

--- a/desktop/src-tauri/src/logging_cmd.rs
+++ b/desktop/src-tauri/src/logging_cmd.rs
@@ -2,8 +2,7 @@ use std::sync::OnceLock;
 
 const DEFAULT_BUNDLE_IDENTIFIER: &str = "pl.speedwave.desktop";
 
-// `make dev` overrides identifier to `.dev` via TAURI_CONFIG; must match
-// tauri-plugin-log's runtime LogDir target, not the value in tauri.conf.json.
+// `make dev` overrides identifier to `.dev` via TAURI_CONFIG.
 static BUNDLE_IDENTIFIER: OnceLock<String> = OnceLock::new();
 
 pub(crate) fn init_bundle_identifier(identifier: String) {
@@ -16,10 +15,7 @@ fn bundle_identifier() -> &'static str {
     match BUNDLE_IDENTIFIER.get() {
         Some(s) => s.as_str(),
         None => {
-            // Production build: return the default silently (Tauri setup might not
-            // have run yet during early panic-hook output, etc.). Debug build:
-            // surface the miss — it means desktop_log_dir() was consulted before
-            // init_bundle_identifier and will return the release path under dev.
+            // Debug build warns; production returns the default silently.
             #[cfg(all(debug_assertions, not(test)))]
             log::warn!(
                 "bundle_identifier(): BUNDLE_IDENTIFIER not initialised yet; falling back to {DEFAULT_BUNDLE_IDENTIFIER}"

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -38,10 +38,7 @@ mod oauth_providers;
 mod paste_cmd;
 mod plugin_oauth_cmd;
 mod slack_oauth_cmd;
-// `path_util` is consumed only by `oauth_login_cmd::open_terminal_with_command`
-// which is Windows-only (gnome-terminal / xterm spawning was removed with the
-// Linux backend in ADR-059). Gating the module declaration keeps clippy quiet
-// on macOS without needing per-fn `#[cfg(target_os = "windows")]`.
+// `path_util` is consumed only by the Windows-only `oauth_login_cmd::open_terminal_with_command`.
 #[cfg(target_os = "windows")]
 mod path_util;
 mod plugin_cmd;
@@ -62,8 +59,7 @@ mod updater;
 mod url_validation;
 mod window;
 
-// `check_project` is re-exported at the crate root because `diagnostics`
-// reaches it via `super::check_project`; keep it resolvable here.
+// Re-exported at crate root so `diagnostics` can reach it via `super::check_project`.
 use types::check_project;
 
 use chat::{ChatSession, SharedChatSession};
@@ -84,12 +80,8 @@ use reconcile::{
 pub(crate) use project_cmd::{rebind_chat, rollback_and_emit_failed};
 
 /// Joins a cleanup thread handle with a watchdog that force-exits after
-/// `EXIT_CLEANUP_TIMEOUT_SECS`. If the cleanup thread panics, exits with
-/// code 1. If it completes normally, returns and the caller may exit cleanly.
-///
-/// `drop(watchdog)` detaches the watchdog thread (does NOT cancel it), but
-/// `process::exit` from the main path terminates the process before the
-/// sleeping watchdog fires.
+/// `EXIT_CLEANUP_TIMEOUT_SECS`. Exits with code 1 if the cleanup thread
+/// panics; returns on normal completion.
 pub(crate) fn join_with_exit_watchdog(handle: std::thread::JoinHandle<()>) {
     let watchdog = std::thread::spawn(|| {
         std::thread::sleep(std::time::Duration::from_secs(
@@ -108,18 +100,8 @@ pub(crate) fn join_with_exit_watchdog(handle: std::thread::JoinHandle<()>) {
 }
 
 /// Stashes a cleanup `JoinHandle` into the shared slot so `RunEvent::Exit`
-/// can join it before the process exits.
-///
-/// If the slot is already occupied (the other exit path beat us to it, which
-/// the `CLEANUP_ONCE` guard makes effectively impossible) or the mutex is
-/// poisoned, drops the handle — the cleanup thread will run to completion
-/// independently and the process exit path in `RunEvent::Exit` will join
-/// whatever handle arrived first.
-///
-/// **Must not be called on the Tauri event-loop thread with blocking intent** —
-/// both call sites (WindowEvent::Destroyed and RunEvent::ExitRequested) only
-/// stash the handle; the actual join happens in `RunEvent::Exit` on the same
-/// thread after Tauri has finished processing events.
+/// can join it before the process exits. Drops the handle if the slot is
+/// already occupied or the mutex is poisoned.
 pub(crate) fn stash_cleanup_handle(
     slot: &Arc<Mutex<Option<std::thread::JoinHandle<()>>>>,
     handle: std::thread::JoinHandle<()>,
@@ -129,8 +111,7 @@ pub(crate) fn stash_cleanup_handle(
             if guard.is_none() {
                 *guard = Some(handle);
             }
-            // else: slot already occupied — CLEANUP_ONCE guarantees the
-            // cleanup body runs once, so this handle is a no-op. Drop it.
+            // else: slot occupied; cleanup runs once (CLEANUP_ONCE), so drop this handle.
         }
         Err(e) => {
             log::warn!("exit cleanup handle slot poisoned, cleanup will not be joined: {e}");
@@ -149,10 +130,7 @@ static WATCHDOG_STOP: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicB
 static OAUTH_WATCHDOG_STOP: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
 
-// Chat / history / project / health / IDE-bridge commands now live in their
-// own domain modules: `chat_session_cmd`, `history_cmd`, `project_cmd`,
-// `health_cmd`, `ide_bridge_cmd`. The shared "not authenticated" message stays
-// at crate root because `chat_session_cmd` references it via `crate::`.
+// Shared "not authenticated" message; kept at crate root for `chat_session_cmd` (`crate::`).
 pub(crate) const MSG_NOT_AUTHENTICATED: &str =
     "Claude is not authenticated. Please authenticate first.";
 
@@ -344,8 +322,7 @@ pub(crate) fn ensure_ide_bridge_running(
     ide_bridge: &SharedIdeBridge,
     app_handle: &tauri::AppHandle,
 ) {
-    // Ensure the WSL Hyper-V firewall rule before binding the host listener
-    // (ADR-067). No-op off Windows; runs at most once per process.
+    // Ensure the WSL Hyper-V firewall rule before binding the host listener (ADR-067; no-op off Windows).
     firewall::ensure_firewall_rule();
     let mut guard = match ide_bridge.lock() {
         Ok(g) => g,
@@ -363,9 +340,7 @@ pub(crate) fn ensure_ide_bridge_running(
 }
 
 /// Start mcp-os if not already running. Holds the mutex for the entire
-/// spawn to prevent races (two callers both seeing None and double-spawning).
-/// This can block up to `PORT_READ_TIMEOUT` (10 s) — acceptable for a
-/// single-user desktop app where concurrent Tauri commands are rare.
+/// spawn to prevent races, and can block up to `PORT_READ_TIMEOUT` (10 s).
 fn ensure_mcp_os_running(mcp_os: &SharedMcpOs, app_handle: &tauri::AppHandle) {
     firewall::ensure_firewall_rule();
     let mut guard = match mcp_os.lock() {
@@ -386,10 +361,6 @@ fn ensure_mcp_os_running(mcp_os: &SharedMcpOs, app_handle: &tauri::AppHandle) {
                 log::info!("ensure_mcp_os_running: started (port {})", proc.port());
                 *guard = Some(proc);
                 drop(guard); // release before spawning watchdog thread
-                             // Narrow TOCTOU: factory_reset could set WATCHDOG_STOP=true
-                             // between drop(guard) and the store below, causing a no-op
-                             // watchdog loop on None. Harmless in single-user desktop app
-                             // — the watchdog exits on the next iteration when it sees None.
                 WATCHDOG_STOP.store(false, Ordering::Relaxed);
                 start_mcp_os_watchdog(mcp_os.clone(), app_handle.clone());
             }
@@ -398,10 +369,8 @@ fn ensure_mcp_os_running(mcp_os: &SharedMcpOs, app_handle: &tauri::AppHandle) {
     }
 }
 
-// (`is_service_enabled` lives on `ResolvedIntegrationsConfig` in
-// `speedwave-runtime::config` so the match arms stay in one place. The CLI no
-// longer spawns oauth workers — Desktop is the sole supervisor; see
-// the dual-supervisor exit-137 note in `speedwave-cli::main`.)
+// `is_service_enabled` lives on `ResolvedIntegrationsConfig` in `speedwave-runtime::config`.
+// Desktop is the sole oauth-worker supervisor (see the exit-137 note in `speedwave-cli::main`).
 
 /// What to do with a running oauth worker given current vs. desired consumers.
 #[derive(Debug, PartialEq, Eq)]
@@ -453,16 +422,13 @@ pub(crate) fn ensure_oauth_running(oauth_arc: &SharedOauth, project: &str) -> bo
     };
     let resolved = config::resolve_integrations(&project_dir, &user_config, project);
 
-    // OAuth-consuming services enabled for this project (built-ins + plugins
-    // with `oauth`). SSOT helper keeps this list identical to the one compose
-    // injection reads from the bearer-map.
+    // OAuth-consuming services for this project via the SSOT helper (matches compose injection).
     let installed = speedwave_runtime::plugin::list_installed_plugins().unwrap_or_default();
     let mut oauth_consumers =
         speedwave_runtime::compose::oauth_consumer_service_ids(&resolved, &installed);
     oauth_consumers.sort();
 
-    // A running worker may hold a stale consumer set (its bearer-map is fixed
-    // at spawn). Reconcile against the desired set — see oauth_reconcile_action.
+    // A running worker's consumer set is fixed at spawn; reconcile against the desired set.
     if let Some(running) = map.get(project) {
         let mut current: Vec<String> = running.spec().consumers().to_vec();
         current.sort();
@@ -477,8 +443,7 @@ pub(crate) fn ensure_oauth_running(oauth_arc: &SharedOauth, project: &str) -> bo
                     proc.cleanup_files();
                 }
                 if clear_bearer_map {
-                    // Drop the stale bearer-map so compose stops injecting into
-                    // now-orphaned containers (no respawn rewrites it).
+                    // Drop the stale bearer-map so compose stops injecting into orphaned containers.
                     let dir = speedwave_runtime::oauth_process::oauth_project_dir(
                         speedwave_runtime::consts::data_dir(),
                         project,
@@ -499,8 +464,7 @@ pub(crate) fn ensure_oauth_running(oauth_arc: &SharedOauth, project: &str) -> bo
     }
     let consumer_refs: Vec<&str> = oauth_consumers.iter().map(String::as_str).collect();
 
-    // Only now that a spawn is certain — the rule must precede the worker's
-    // bind, but a NoChange / no-consumer toggle should not pay for it.
+    // Ensure the firewall rule only once a spawn is certain (must precede the worker's bind).
     firewall::ensure_firewall_rule();
 
     let script = match speedwave_runtime::build::resolve_oauth_script() {
@@ -534,10 +498,7 @@ pub(crate) fn ensure_oauth_running(oauth_arc: &SharedOauth, project: &str) -> bo
 }
 
 /// Decide which per-project workers in the map are unhealthy, respawn them,
-/// and return the names of those that should have their consumer containers
-/// recreated. Generic over [`WatchdogWorker`] so the same selection logic
-/// drives the oauth watchdog (and is unit-testable with a fake worker —
-/// see `FakeWorker` in this file's tests).
+/// and return the names of those whose consumer containers must be recreated.
 fn sweep_per_project_workers<P>(
     workers: &mut std::collections::HashMap<String, P>,
     log_prefix: &str,
@@ -588,15 +549,9 @@ impl WatchdogWorker for speedwave_runtime::oauth_process::OauthProcess {
     }
 }
 
-/// Shared watchdog loop for per-project host-side workers (oauth).
-/// Polls every 30 s; under the map mutex, calls [`sweep_per_project_workers`]
-/// to respawn dead workers; releases the lock; then recreates each respawned
-/// project's hub containers so they observe the new worker port (e.g. a fresh
-/// `WORKER_OAUTH_URL`).
-///
-/// Stops cleanly when `stop_flag` is set (used by app exit cleanup). Catches
-/// panics from `recreate_project_containers_if_running` so a single bad
-/// project does not kill the watchdog thread silently.
+/// Shared watchdog loop for per-project host-side workers (oauth). Polls every
+/// 30 s, respawns dead workers via [`sweep_per_project_workers`], then recreates
+/// each respawned project's hub containers. Stops when `stop_flag` is set.
 fn start_per_project_watchdog<P>(
     workers: std::sync::Arc<std::sync::Mutex<std::collections::HashMap<String, P>>>,
     stop_flag: &'static std::sync::atomic::AtomicBool,
@@ -612,8 +567,7 @@ fn start_per_project_watchdog<P>(
             if stop_flag.load(Ordering::Relaxed) {
                 break;
             }
-            // Respawn under the lock; defer container recreate until after we release it
-            // so consumer workers see the new WORKER_<name>_URL.
+            // Respawn under the lock; defer container recreate until after release.
             let respawned: Vec<String> = {
                 let mut map = match workers.lock() {
                     Ok(g) => g,
@@ -624,8 +578,7 @@ fn start_per_project_watchdog<P>(
                 };
                 sweep_per_project_workers(&mut map, log_prefix)
             };
-            // Lock released — recreate containers so consumers pick up the new port.
-            // Catch panics so a single bad project does not kill the watchdog thread silently.
+            // Recreate containers (panic-isolated per project) so consumers pick up the new port.
             for name in respawned {
                 let n = name.clone();
                 let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -660,9 +613,7 @@ fn show_audit_failure_dialog_and_exit(app: &tauri::AppHandle, body: String) -> !
 }
 
 /// Formats the per-plugin failures from `plugin::audit_all` into a
-/// user-actionable dialog message. Tells the user what failed and how
-/// to recover via CLI/manual cleanup — Settings UI is unreachable
-/// while the audit fails.
+/// user-actionable dialog message with CLI/manual recovery steps.
 fn format_audit_failure_message(failures: &[(String, String)]) -> String {
     let mut body = String::from(
         "Speedwave detected one or more plugins that no longer match their\n\
@@ -701,8 +652,7 @@ fn main() {
         #[cfg(not(debug_assertions))]
         {
             let _ = &default_hook; // suppress unused warning
-                                   // Sanctioned panic-hook last-resort fallback (logging.md): the
-                                   // logger may be dead mid-panic, so write to stderr directly.
+                                   // Sanctioned panic-hook stderr fallback (logging.md).
             #[allow(clippy::print_stderr)]
             {
                 eprintln!("PANIC: {sanitized}");
@@ -711,9 +661,6 @@ fn main() {
     }));
 
     // True when setup has been *started* (at least check_runtime passed).
-    // After factory reset or fresh install, runtime_ready is false so we
-    // skip IDE Bridge / mcp-os / link_cli / resources marker to keep
-    // ~/.speedwave/ non-existent until the wizard explicitly creates it.
     let setup_started = setup_wizard::SetupState::load().runtime_ready;
 
     // Bundled binary resolution for app bundles.
@@ -722,9 +669,7 @@ fn main() {
             if let Some(res) = reconcile::resolve_resources_dir(parent) {
                 // Env var always set — Desktop uses it directly, never reads the marker file
                 std::env::set_var(speedwave_runtime::consts::BUNDLE_RESOURCES_ENV, &res);
-                // Marker written to disk only if setup was completed at least once.
-                // After factory reset or fresh install: don't recreate ~/.speedwave/.
-                // CLI needs the marker only after the wizard finishes and links the binary.
+                // Marker written to disk only after setup completed at least once.
                 if setup_started {
                     if let Err(e) = speedwave_runtime::build::write_resources_marker(&res) {
                         log::warn!("could not write resources-dir marker: {e}");
@@ -736,9 +681,7 @@ fn main() {
 
     let initial_session: SharedChatSession = Arc::new(Mutex::new(ChatSession::new("default")));
     let queue_service = speedwave_runtime::session::QueuedMessageService::new();
-    // Meeting-transcription stores (ADR-056). Active sessions live in memory;
-    // both stores walk the disk lazily on first access. `transcript_drivers`
-    // maps an in-flight recording to its stop signal.
+    // Meeting-transcription stores (ADR-056); `transcript_drivers` maps a recording to its stop signal.
     let transcript_store: transcription_cmd::TranscriptStoreHandle =
         Arc::new(speedwave_runtime::transcription::TranscriptStore::new());
     let model_store: transcription_cmd::ModelStoreHandle =
@@ -757,9 +700,7 @@ fn main() {
     let oauth: SharedOauth = Arc::new(Mutex::new(std::collections::HashMap::new()));
     let auto_check_handle: SharedAutoCheckHandle = Arc::new(Mutex::new(None));
 
-    // Publish the plugin-bridges map globally so compose-render call sites
-    // in setup_wizard / containers_cmd can read it without taking tauri::State
-    // (they are free functions and reachable from CLI helpers too).
+    // Publish the plugin-bridges map globally so compose-render call sites can read it without tauri::State.
     reconcile::set_global_plugin_bridges(plugin_bridges.clone());
 
     let tray_available = Arc::new(AtomicBool::new(false));
@@ -784,15 +725,10 @@ fn main() {
         .unwrap_or(false);
     let tray_state = tray::TrayMenuState::new(initial_beta_enabled);
 
-    // Register SIGTERM/SIGINT handler so process signals trigger the same
-    // cleanup as graceful window close. The CLEANUP_ONCE guard in
-    // run_exit_cleanup ensures the body runs at most once even when both
-    // the signal handler and WindowEvent::Destroyed fire concurrently.
+    // Register SIGTERM/SIGINT handler so signals run the same cleanup as window close
+    // (idempotent via the CLEANUP_ONCE guard in run_exit_cleanup).
     let cleanup_ctx_signal = cleanup_ctx.clone();
-    // The ctrlc crate runs handlers on a dedicated thread (not a real signal
-    // handler), so blocking with `.join()` here is safe and necessary —
-    // `std::process::exit` would otherwise kill the cleanup thread mid-flight
-    // and the Lima VM would never stop.
+    // ctrlc runs handlers on a dedicated thread, so blocking with `.join()` here is safe.
     match ctrlc::set_handler(move || {
         if let Some(handle) = reconcile::run_exit_cleanup(&cleanup_ctx_signal) {
             join_with_exit_watchdog(handle);
@@ -807,11 +743,7 @@ fn main() {
         }
     }
 
-    // Shared slot for the cleanup `JoinHandle` produced inside
-    // `WindowEvent::Destroyed` or `RunEvent::ExitRequested` (whichever fires
-    // first for the given exit path). The Tauri `RunEvent::Exit` hook drains
-    // and joins it so the Lima VM stop completes before `Builder::run`
-    // returns (and the process exits).
+    // Shared slot for the cleanup `JoinHandle`; `RunEvent::Exit` drains and joins it before exit.
     let exit_cleanup_handle: Arc<Mutex<Option<std::thread::JoinHandle<()>>>> =
         Arc::new(Mutex::new(None));
     let exit_cleanup_handle_window = exit_cleanup_handle.clone();
@@ -819,11 +751,7 @@ fn main() {
 
     let builder = tauri::Builder::default();
 
-    // WebDriver server for E2E tests — only present when the "e2e" feature is
-    // enabled. The plugin embeds a W3C WebDriver server on 127.0.0.1:4445 so
-    // E2E specs can drive the real app via WebdriverIO.
-    // Production releases are built without the feature — the crate is not
-    // compiled or linked, so zero attack surface.
+    // WebDriver server for E2E tests on 127.0.0.1:4445; only compiled under the "e2e" feature.
     #[cfg(feature = "e2e")]
     let builder = builder.plugin(tauri_plugin_webdriver::init());
 
@@ -892,60 +820,34 @@ fn main() {
 
             clipboard_bridge::spawn(app.handle().clone());
 
-            // Hard-fail on tampered plugins. `plugin::audit_all` re-verifies
-            // every plugin under `~/.speedwave/plugins/`; failures are
-            // collected and shown to the user in one dialog. Recovery
-            // path is the CLI (`speedwave plugin remove <slug>`) or
-            // manual deletion — Settings UI is behind this gate.
-            //
-            // Hard-fail semantics: the dialog shows the user every failed
-            // plugin synchronously, then the process exits. Returning
-            // `Ok(())` from `setup` would let Tauri continue starting
-            // the webview and registering command handlers — a tampered
-            // plugin would still be inert (`#[tauri::command]` callers
-            // go through the verified-only command gates), but the
-            // command surface would be live for unrelated calls. We
-            // refuse to bring the rest of the app online at all: the
-            // dialog is shown via the OS-native blocking path and the
-            // process exits the moment the user dismisses it.
+            // Hard-fail on tampered plugins: `plugin::audit_all` re-verifies every plugin,
+            // collects failures into one blocking dialog, then exits. Recovery is CLI/manual deletion.
             if let Err(failures) = speedwave_runtime::plugin::audit_all() {
                 let body = format_audit_failure_message(&failures);
                 log::error!("plugin audit failed:\n{}", body);
-                // Diverges (`-> !`) — `process::exit` is the last call.
-                // No `Ok(())` / `Err(...)` follows because Tauri must
-                // not bring up the webview / command surface for a
-                // tampered plugin set.
                 show_audit_failure_dialog_and_exit(app.handle(), body);
             }
 
-            // Rotated-log cleanup is owned by `RotationStrategy::KeepSome(10)` —
-            // tauri-plugin-log prunes on every rotation. No separate timer needed.
+            // Rotated-log cleanup is owned by `RotationStrategy::KeepSome(10)` (pruned on rotation).
 
             if setup_started {
-                // Sanitise any v1 SharePoint secrets still in the worker-mounted
-                // token dir (refresh_token / client_id / tenant_id). Best-effort,
-                // idempotent. Secrets are never migrated — see module docs.
+                // Sanitise v1 SharePoint secrets from the worker-mounted token dir (best-effort, idempotent).
                 let cleaned =
                     speedwave_runtime::legacy_token_cleanup::run_legacy_token_cleanup_at_startup();
                 if cleaned > 0 {
                     log::info!("legacy_token_cleanup: {cleaned} project(s) sanitised");
                 }
 
-                // Self-heal legacy/partial oauth.json whose clientId/tenantId sit
-                // top-level instead of under providerData (ADR-060 addendum).
-                // Shape-only, idempotent — never moves secrets. It logs its own
-                // summary; do not re-log the return value (CodeQL taints it).
+                // Self-heal legacy oauth.json shape (ADR-060 addendum); shape-only, never moves secrets.
+                // Do not re-log the return value (CodeQL taints it).
                 let _ =
                     speedwave_runtime::oauth_state_migration::run_oauth_state_migration_at_startup();
 
                 // Start IDE Bridge
                 init_and_start_ide_bridge(&ide_bridge, app.handle());
 
-                // Start a `PluginHostBridge` for every verified plugin whose
-                // manifest declares a `host_bridge` block. Always on,
-                // mirroring IDE Bridge's "passive listener" behavior — when
-                // the corresponding plugin is disabled in a project the
-                // bridge sits idle on its loopback port.
+                // Start a `PluginHostBridge` for every verified plugin declaring a `host_bridge` block.
+                // Always on; sits idle on its loopback port when the plugin is disabled in a project.
                 crate::bridges::plugin_bridge_manager::init_and_start(
                     &plugin_bridges,
                     app.handle(),
@@ -974,9 +876,7 @@ fn main() {
 
                 start_mcp_os_watchdog(mcp_os.clone(), app.handle().clone());
 
-                // Start the per-project oauth watchdog. No worker is spawned
-                // here — oauth workers are per-project and spawned on demand;
-                // the watchdog simply respawns any that die.
+                // Start the per-project oauth watchdog; workers are spawned on demand, not here.
                 OAUTH_WATCHDOG_STOP.store(false, Ordering::Relaxed);
                 start_oauth_watchdog(oauth.clone());
             } else {
@@ -991,8 +891,6 @@ fn main() {
             }
 
             // Re-link CLI binary on every startup to keep it in sync after updates.
-            // Gated behind setup_started: CLI doesn't exist on fresh install,
-            // and we must not recreate ~/.speedwave/ after factory reset.
             if setup_started {
                 #[cfg(target_os = "macos")]
                 if let Err(e) = setup_wizard::ensure_lima_vm_config() {
@@ -1004,9 +902,7 @@ fn main() {
                     log::warn!(".wslconfig VPN-compat migration failed: {e}");
                 }
 
-                // Startup/post-update: apply automount=metadata for existing
-                // distros via `IfIdle` (terminates only when idle). Err is
-                // non-fatal here — never block app launch (see ADR-052).
+                // Apply automount=metadata for existing distros via `IfIdle`; non-fatal (ADR-052).
                 #[cfg(target_os = "windows")]
                 {
                     use setup_wizard::TerminateOnChange;
@@ -1113,11 +1009,8 @@ fn main() {
             // macOS/Windows: left-click on tray icon toggles window visibility.
             {
                 use std::sync::atomic::AtomicU64;
-                // Debounce: ignore clicks within 500ms of the previous one
-                // to prevent double-toggle from rapid clicks. 500ms equals the
-                // Windows default double-click interval, though users with
-                // accessibility settings may have a longer interval (up to 900ms).
-                // On Windows a double-click fires two Click::Up events.
+                // Debounce: ignore clicks within 500ms (Windows default double-click interval,
+                // which fires two Click::Up events) to prevent double-toggle.
                 static LAST_CLICK_MS: AtomicU64 = AtomicU64::new(0);
                 const DEBOUNCE_MS: u64 = 500;
 
@@ -1176,8 +1069,7 @@ fn main() {
                     tray_available_setup.store(true, Ordering::Relaxed);
                 }
                 Err(e) => {
-                    // Tray creation failed. Window is already visible
-                    // (tauri.conf.json: visible=true), so no fallback needed.
+                    // Tray creation failed; window is already visible (tauri.conf.json: visible=true).
                     log::error!("tray: failed to create system tray: {e}");
                 }
             }
@@ -1340,8 +1232,7 @@ fn main() {
             // CloudStorage TCC
             system_settings_cmd::open_files_folders_pane,
             cloudstorage_cmd::detect_cloudstorage_path,
-            // Meeting-transcription TCC (ADR-056) — deep-links to the macOS
-            // Microphone / Audio Recording privacy panes for permission recovery.
+            // Meeting-transcription TCC (ADR-056) — deep-links to the macOS Microphone / Audio panes.
             system_settings_cmd::open_microphone_pane,
             system_settings_cmd::open_audio_capture_pane,
         ])
@@ -1361,10 +1252,7 @@ fn main() {
                     if !should_run_cleanup(window.label()) {
                         return;
                     }
-                    // Spawn cleanup but DO NOT join here — joining on the
-                    // Tauri main thread would deadlock the event loop. Stash
-                    // the handle so `RunEvent::Exit` can join before the
-                    // process actually exits.
+                    // Do NOT join here (would deadlock the event loop); stash the handle for `RunEvent::Exit`.
                     if let Some(handle) = reconcile::run_exit_cleanup(&cleanup_ctx_window) {
                         stash_cleanup_handle(&exit_cleanup_handle_window, handle);
                     }
@@ -1383,58 +1271,20 @@ fn main() {
     };
 
     app.run(move |app_handle, event| match event {
-        // `ExitRequested` covers the paths where `WindowEvent::Destroyed`
-        // does NOT fire on the main window before exit:
-        //   - Tray menu "Quit" (calls `app.exit(0)`)
-        //   - macOS app menu "Quit Speedwave" / Cmd+Q (NSApplication terminate)
-        //   - SIGTERM via the Tauri runtime
-        // In tray mode the main window is hidden (not destroyed), so the
-        // `WindowEvent::Destroyed` branch never runs and the VM would stay
-        // up after the process exits. Spawning cleanup here guarantees it
-        // runs for every exit path. `CLEANUP_ONCE` inside
-        // `run_exit_cleanup` makes this idempotent with respect to the
-        // `WindowEvent::Destroyed` call site.
+        // Covers exit paths where `WindowEvent::Destroyed` does not fire (tray Quit, macOS Cmd+Q, SIGTERM).
+        // `CLEANUP_ONCE` in `run_exit_cleanup` makes this idempotent with the `Destroyed` call site.
         tauri::RunEvent::ExitRequested { .. } => {
-            // Hide the main window immediately so macOS stops waiting for
-            // the window to respond during the cleanup join in
-            // `RunEvent::Exit`. Without this, the user sees a beachball
-            // for ~1s on Cmd+Q because the event loop blocks joining the
-            // limactl stop thread while the window is still visible —
-            // WindowServer then draws the beachball.
-            //
-            // Safe on Windows too: the window is typically already being
-            // destroyed when ExitRequested fires (tray-less setups),
-            // making this a harmless no-op. Do NOT gate this to macOS —
-            // a `#[cfg(target_os = "macos")]` guard would re-introduce
-            // the beachball if macOS ever reorders event delivery, and
-            // removing it costs nothing elsewhere.
+            // Hide the window first to avoid a beachball on Cmd+Q; harmless no-op on Windows.
             hide_main_window(app_handle);
             if let Some(handle) = reconcile::run_exit_cleanup(&cleanup_ctx_runevent) {
                 stash_cleanup_handle(&exit_cleanup_handle_runevent, handle);
             }
         }
         tauri::RunEvent::Exit => {
-            // Drain and join the cleanup thread spawned in
-            // `WindowEvent::Destroyed` or `RunEvent::ExitRequested` so
-            // `limactl stop` finishes before Tauri returns from `.run()`
-            // and the process exits.
-            //
-            // Fallback: on macOS, Cmd+Q / app-menu-Quit delivers
-            // `applicationWillTerminate`, which tao maps to
-            // `Event::LoopDestroyed`, which tauri-runtime-wry maps
-            // directly to `RunEvent::Exit` — bypassing
-            // `RunEvent::ExitRequested` and (for a hidden tray-mode
-            // window) `WindowEvent::Destroyed` entirely. If neither
-            // earlier arm ran, the slot is empty here and the Lima VM
-            // would be orphaned. Spawn cleanup inline as a last resort.
-            // `CLEANUP_ONCE` inside `run_exit_cleanup` makes this
-            // idempotent with the other entry points.
-            //
-            // NOTE: `exit_arm_runs_cleanup_when_handle_slot_is_empty` in
-            // the tests below asserts that this arm contains the literal
-            // strings `run_exit_cleanup(&cleanup_ctx_runevent)` and
-            // `hide_main_window(app_handle)` — if you rename either
-            // identifier, update the test assertions too.
+            // Join the stashed cleanup thread so `limactl stop` finishes before `.run()` returns.
+            // Fallback: macOS Cmd+Q bypasses earlier arms, so spawn cleanup inline if the slot is empty.
+            // Test `exit_arm_runs_cleanup_when_handle_slot_is_empty` asserts the literals
+            // `run_exit_cleanup(&cleanup_ctx_runevent)` and `hide_main_window(app_handle)` — update it on rename.
             let handle = match exit_cleanup_handle_runevent.lock() {
                 Ok(mut slot) => slot.take(),
                 Err(e) => {
@@ -1613,8 +1463,7 @@ mod tests {
         }
         fn respawn(&mut self) -> anyhow::Result<u16> {
             self.respawn_calls.set(self.respawn_calls.get() + 1);
-            // After a successful respawn the fake reports alive=true so a
-            // re-sweep wouldn't pick it again (matches real OauthProcess behaviour).
+            // After a successful respawn the fake reports alive=true (matches real OauthProcess).
             match &self.respawn_result {
                 Ok(p) => {
                     self.alive = true;
@@ -1653,8 +1502,7 @@ mod tests {
 
     #[test]
     fn sweep_per_project_workers_failed_respawn_excluded_from_respawned() {
-        // Bug class: caller would recreate containers for a project whose
-        // worker actually didn't come back up — wasted compose churn.
+        // Bug class: recreating containers for a worker that didn't come back up.
         let mut map = std::collections::HashMap::new();
         map.insert(
             "bad".to_string(),
@@ -1688,9 +1536,6 @@ mod tests {
         //   1. fn join_with_exit_watchdog definition
         //   2. ctrlc signal handler call site (blocks — safe on ctrlc's dedicated thread)
         //   3. RunEvent::Exit call site (blocks — after Tauri finishes processing events)
-        // The stash_cleanup_handle helper used by WindowEvent::Destroyed and
-        // RunEvent::ExitRequested drops handles rather than joining on the event-loop
-        // thread, so it does NOT add occurrences here.
         // Total: at least 3 (fn def + 2 call sites) outside the test module.
         let non_test_count = occurrences
             .iter()
@@ -1699,8 +1544,7 @@ mod tests {
                 let before = &source[..*idx];
                 let last_mod_tests = before.rfind("mod tests");
                 let last_cfg_test = before.rfind("#[cfg(test)]");
-                // If both markers are found and cfg(test) is close before mod tests,
-                // this occurrence is inside the test module.
+                // Inside the test module when cfg(test) precedes the nearest `mod tests`.
                 match (last_mod_tests, last_cfg_test) {
                     (Some(mt), Some(ct)) if ct < mt && *idx > mt => false,
                     _ => true,
@@ -1716,15 +1560,7 @@ mod tests {
     }
 
     /// Regression guard: the `ExitRequested` arm must hide the main window
-    /// BEFORE spawning cleanup. Without this, the user sees a beachball
-    /// on Cmd+Q because the event loop blocks joining the cleanup thread
-    /// while the main window is still visible — macOS WindowServer then
-    /// draws the beachball. Hiding the window first releases WindowServer
-    /// from expecting paint responses.
-    ///
-    /// The hide is performed via `hide_main_window(app_handle)` — the
-    /// canonical helper in `window.rs` that also sets the macOS activation
-    /// policy to Accessory so the Dock icon disappears immediately.
+    /// (via `hide_main_window`) before spawning cleanup, to avoid a Cmd+Q beachball.
     #[test]
     fn exit_requested_arm_hides_main_window_before_cleanup() {
         let source = include_str!("main.rs");
@@ -1750,10 +1586,8 @@ mod tests {
         );
     }
 
-    /// Regression guard: the `ExitRequested` arm must stash its cleanup handle
-    /// into `exit_cleanup_handle_runevent` so that `RunEvent::Exit` can join it
-    /// before the process exits. A future refactor that drops the stash would
-    /// silently break the join and leave the Lima VM running after quit.
+    /// Regression guard: the `ExitRequested` arm must stash its cleanup handle into
+    /// `exit_cleanup_handle_runevent` so `RunEvent::Exit` can join it before the process exits.
     #[test]
     fn exit_requested_arm_stashes_handle_for_exit_join() {
         let source = include_str!("main.rs");
@@ -1777,14 +1611,8 @@ mod tests {
         );
     }
 
-    /// Regression guard: the `RunEvent::Exit` arm must have a fallback that
-    /// calls `run_exit_cleanup` when the handle slot is empty. On macOS,
-    /// Cmd+Q / app-menu-Quit delivers `applicationWillTerminate`, which tao
-    /// maps to `Event::LoopDestroyed`, which tauri-runtime-wry maps directly
-    /// to `RunEvent::Exit` — bypassing `RunEvent::ExitRequested` and (for a
-    /// hidden tray-mode window) `WindowEvent::Destroyed`. Without the
-    /// fallback, the slot stays empty, nothing is joined, and the Lima VM
-    /// is orphaned after quit.
+    /// Regression guard: the `RunEvent::Exit` arm must call `run_exit_cleanup` as a
+    /// fallback when the handle slot is empty (macOS Cmd+Q bypasses the earlier arms).
     #[test]
     fn exit_arm_runs_cleanup_when_handle_slot_is_empty() {
         let source = include_str!("main.rs");
@@ -1813,9 +1641,7 @@ mod tests {
     }
 
     /// Behavioral test for `stash_cleanup_handle` happy path: handle is
-    /// stashed into an empty slot. Covers the dominant branch; other
-    /// branches (slot-occupied, poisoned-mutex) are unreachable under
-    /// `CLEANUP_ONCE` or documented-contract-only.
+    /// stashed into an empty slot.
     #[test]
     fn stash_cleanup_handle_stores_into_empty_slot() {
         let slot: Arc<Mutex<Option<std::thread::JoinHandle<()>>>> = Arc::new(Mutex::new(None));
@@ -1823,8 +1649,7 @@ mod tests {
         stash_cleanup_handle(&slot, handle);
 
         let stashed = slot.lock().unwrap().take();
-        // Regression guard: if the empty-slot branch were ever inverted
-        // (e.g. `if guard.is_some()` instead of `is_none()`), this would be None.
+        // Regression guard: an inverted empty-slot branch would leave this None.
         assert!(
             stashed.is_some(),
             "first handle must be stashed into empty slot"

--- a/desktop/src-tauri/src/oauth_cmd.rs
+++ b/desktop/src-tauri/src/oauth_cmd.rs
@@ -99,9 +99,7 @@ struct SpOAuthState<'a> {
     expires_in: u64,
 }
 
-/// `data_dir`-parameterised so tests pass a tempdir, bypassing the
-/// `consts::data_dir()` OnceLock (cf. `plugin::oauth_state_file_in`).
-/// Production reaches this via `save_tokens`.
+/// `data_dir`-parameterised variant; production reaches this via `save_tokens`.
 fn save_oauth_state_in(
     data_dir: &std::path::Path,
     project: &str,
@@ -207,8 +205,7 @@ fn save_tokens_in(
     tenant_id: &str,
     tokens: &MsTokenResponse,
 ) -> Result<(), String> {
-    // State first, mounted token second: a crash in between leaves
-    // recoverable state, never a mounted token without refresh state.
+    // State first, mounted token second.
     save_oauth_state_in(
         data_dir,
         project,
@@ -627,10 +624,8 @@ mod tests {
         }
     }
 
-    /// SSOT parity guard: the written key set must equal the schema that
-    /// `mcp-servers/oauth/src/oauth-state.ts::assertOAuthState` requires. A field
-    /// rename on either side (e.g. `refreshToken` → `refresh_token`) breaks token
-    /// refresh at runtime with no other guard — this pins it at build time.
+    /// SSOT parity guard: written key set must equal
+    /// `mcp-servers/oauth/src/oauth-state.ts::assertOAuthState`.
     #[test]
     fn save_oauth_state_key_set_matches_documented_ts_schema() {
         // Mirror of OAuthState in oauth-state.ts (top-level + providerData keys).
@@ -804,8 +799,7 @@ mod tests {
 
     #[test]
     fn classify_sp_other_error_redacts_description() {
-        // The `other` branch routes error_description through redaction — a
-        // tenant/request detail must not leak verbatim into the failure message.
+        // The `other` branch routes error_description through redaction.
         let body =
             br#"{"error":"invalid_grant","error_description":"AADSTS9000 secret tenant detail"}"#;
         match classify_sharepoint_response(400, body) {

--- a/desktop/src-tauri/src/oauth_flow.rs
+++ b/desktop/src-tauri/src/oauth_flow.rs
@@ -1,5 +1,4 @@
-// Shared OAuth Device Flow scaffolding. Per-provider `FlowRegistry` owns
-// state + event name; the surrounding state machine is identical.
+// Shared OAuth Device Flow scaffolding; per-provider `FlowRegistry` owns state + event name.
 
 use serde::Serialize;
 use std::sync::Mutex;
@@ -22,9 +21,8 @@ struct OAuthProgressEvent {
 }
 
 /// Every `status` the host emits on an OAuth progress event. TS mirror:
-/// `OAuthProgressEvent['status']` in `models/integration.ts` (which adds the
-/// frontend-only `starting`/`polling`); `progress_statuses_match_ts_union`
-/// keeps the two in sync.
+/// `OAuthProgressEvent['status']` in `models/integration.ts`; guarded by
+/// `progress_statuses_match_ts_union`.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(crate) enum ProgressStatus {
     AwaitingRedirect,
@@ -85,9 +83,7 @@ impl FlowRegistry {
         }
     }
 
-    /// Recovers from poisoning: `FlowState` is two plain fields that stay
-    /// coherent across a panic, and `cancel`/`clear_if_current` must still
-    /// work mid-teardown (a poisoned lock must not leave a flow uncancelled).
+    /// Recovers from poisoning so cancellation still works mid-teardown.
     fn lock_state(&self) -> std::sync::MutexGuard<'_, FlowState> {
         self.state
             .lock()
@@ -223,19 +219,15 @@ impl PollAction {
     }
 }
 
-/// Per-provider token-endpoint behaviour. The shared `run_device_code_poll`
-/// owns the deadline / cancel / sleep / HTTP / read-body state machine; the
-/// provider supplies only what differs: the request and the response handling
-/// (including any token persistence, which classifies its own failures).
+/// Per-provider token-endpoint behaviour: the request and the response
+/// handling (including token persistence and failure classification).
 pub(crate) trait DeviceCodeProvider: Send + Sync + 'static {
     /// Builds the token-endpoint POST (URL, body, provider-specific headers).
     /// Called once per poll iteration from the shared loop.
     fn token_request(&self, client: &reqwest::Client) -> reqwest::RequestBuilder;
 
-    /// Classifies a token-endpoint response. `body_bytes` is the size-limited
-    /// body. On success the provider persists tokens and returns a terminal
-    /// `Emit`; on `authorization_pending`/`slow_down` it returns `KeepPolling`;
-    /// on a terminal error it returns `Emit` with the user-facing message.
+    /// Classifies a token-endpoint response into a `PollStep`. `body_bytes`
+    /// is the size-limited body; provider persists tokens on success.
     fn handle_token_response(
         &self,
         http_status: reqwest::StatusCode,
@@ -243,11 +235,8 @@ pub(crate) trait DeviceCodeProvider: Send + Sync + 'static {
     ) -> PollStep;
 }
 
-/// Shared device-code polling loop (RFC 8628 §3.4–3.5). Drives the deadline,
-/// cancellation, fixed-interval sleep, token POST, body-size guard, and
-/// progress emission; delegates request construction + response classification
-/// to `provider`. Always clears the `FLOW_STATE` entry for `request_id` on
-/// every exit so a superseding flow is never erased.
+/// Inputs to the shared device-code polling loop (RFC 8628 §3.4–3.5);
+/// `run_device_code_poll` clears the flow slot for `request_id` on every exit.
 pub(crate) struct DeviceCodePoll {
     pub app: tauri::AppHandle,
     pub registry: &'static FlowRegistry,
@@ -416,8 +405,7 @@ mod tests {
         assert!(reg.current_generation() > before);
     }
 
-    // A panic while holding the lock must not disable cancellation — every
-    // FlowRegistry method recovers from poisoning via lock_state.
+    // A poisoned lock must not disable cancellation.
     #[test]
     #[serial]
     fn registry_methods_survive_poisoned_lock() {
@@ -480,9 +468,7 @@ mod tests {
         }
     }
 
-    // Cross-language SSOT guard (cf. allowed_auth_field_types_match_ts_union):
-    // the TS OAuthProgressEvent['status'] union must equal the Rust-emitted
-    // statuses plus the two frontend-only states ('starting', 'polling').
+    // SSOT guard: TS OAuthProgressEvent['status'] == Rust statuses + 'starting'/'polling'.
     #[test]
     fn progress_statuses_match_ts_union() {
         let src = include_str!("../../src/src/app/models/integration.ts");
@@ -513,8 +499,7 @@ mod tests {
 
     #[test]
     fn device_code_expired_msg_is_reconciled_single_wording() {
-        // Both providers emit this exact string on expiry — the GitHub
-        // ("reconnect") / SharePoint ("try again") drift was reconciled here.
+        // Both providers emit this exact string on expiry.
         assert_eq!(
             DEVICE_CODE_EXPIRED_MSG,
             "Device code expired — please try again."

--- a/desktop/src-tauri/src/oauth_login_cmd.rs
+++ b/desktop/src-tauri/src/oauth_login_cmd.rs
@@ -1,15 +1,6 @@
 //! Tauri command: open the host's terminal application running
-//! `speedwave login` for the chosen project.
-//!
-//! Why a system terminal? Claude Code's `/login` (the OAuth interactive flow
-//! the user triggers at the TUI prompt) requires a real TTY. Tauri commands
-//! have no TTY, and embedding xterm.js + node-pty would add a heavy frontend
-//! dependency just to host one interactive command. Spawning the OS-native
-//! terminal keeps the host invariants (no PTY in the desktop), reuses the CLI
-//! TTY path that already works, and gives the user an experience identical to
-//! "open Terminal and run …" but without copy-paste friction. The actual
-//! OAuth flow itself happens inside Claude Code in the container — Speedwave
-//! never sees or stores the token.
+//! `speedwave login` for the chosen project. OAuth happens in the container;
+//! Speedwave never sees or stores the token.
 
 use crate::auth_commands::{build_auth_command_for_platform, resolve_project_dirs};
 use crate::types::check_project;
@@ -77,8 +68,6 @@ fn iterm2_installed_in(roots: &[&std::path::Path]) -> bool {
 }
 
 /// True iff iTerm2 is installed in `/Applications/` or `~/Applications/`.
-/// macOS prefers iTerm2 over Terminal.app because iTerm2 honors OSC 52 (the
-/// wrapper that makes "press c to copy URL" work in the container).
 #[cfg(target_os = "macos")]
 fn iterm2_installed() -> bool {
     let system = std::path::PathBuf::from("/Applications");
@@ -92,11 +81,7 @@ fn iterm2_installed() -> bool {
 
 #[cfg(target_os = "macos")]
 fn spawn_iterm2(cmd: &str) -> anyhow::Result<()> {
-    // iTerm2's `command "..."` runs argv directly via execvp — no shell parsing.
-    // `$SHELL -ilc 'cmd'` runs the user's login shell with PATH from .zshrc.
-    // We do NOT chain a follow-up interactive shell — Claude is the foreground
-    // process that owns the TTY for the entire session. iTerm2 closes the
-    // window on shell exit per its profile setting.
+    // `$SHELL -ilc 'cmd'` runs argv via the login shell with PATH from .zshrc.
     let shell = safe_login_shell();
     let inner_escaped = cmd.replace('\'', "'\\''");
     let wrapped = format!("{shell} -ilc '{inner_escaped}'");
@@ -154,14 +139,6 @@ fn open_terminal_with_command(cmd: &str) -> anyhow::Result<()> {
 }
 
 /// Encodes a PowerShell command for `-EncodedCommand`: UTF-16LE then base64.
-///
-/// `-EncodedCommand` sidesteps every quoting/splitting hazard: the base64 output
-/// is `[A-Za-z0-9+/=]` only — no spaces, no `;` — so neither wt.exe's argument
-/// parser (which treats a literal `;` as an action delimiter) nor PowerShell's
-/// own parser can mangle the command. Our auth command contains `;`
-/// (`Set-Location '...'; speedwave login ...`); passed raw via `-Command`, wt.exe
-/// split it on the `;` and tried to launch the tail as a separate action,
-/// failing with "file not found" (0x80070002).
 #[cfg(any(target_os = "windows", test))]
 fn encode_powershell_command(cmd: &str) -> String {
     let utf16le: Vec<u8> = cmd.encode_utf16().flat_map(|u| u.to_le_bytes()).collect();
@@ -196,14 +173,7 @@ fn base64_standard(input: &[u8]) -> String {
 }
 
 /// Argv for launching the login terminal via Windows Terminal:
-/// `wt.exe new-tab <ps> -NoExit -EncodedCommand <b64>`. Preferred because
-/// wt.exe uses a ConPTY pipeline that pumps stdin to the child from the start.
-/// The old `cmd.exe /c start "" <ps> ...` pattern created a detached console
-/// whose ConPTY input buffer was not pumped to the interactive wsl.exe child
-/// until the window received focus — so Enter was dropped until the user clicked
-/// the window (ADR-052 login terminal; Windows-only bug). `-EncodedCommand`
-/// (vs `-Command`) keeps the `;` in the auth command from being eaten by
-/// wt.exe's action-delimiter parser.
+/// `wt.exe new-tab <ps> -NoExit -EncodedCommand <b64>` (ADR-052).
 #[cfg(any(target_os = "windows", test))]
 fn build_wt_terminal_argv(ps_exe: &str, cmd: &str) -> [String; 5] {
     [
@@ -215,11 +185,8 @@ fn build_wt_terminal_argv(ps_exe: &str, cmd: &str) -> [String; 5] {
     ]
 }
 
-/// Argv for launching PowerShell directly (no `cmd /c start`, no wt.exe):
-/// `<ps> -NoExit -EncodedCommand <b64>`. Spawned as its own process so it
-/// attaches a console that pumps input immediately. Fallback when wt.exe is
-/// unavailable. Uses `-EncodedCommand` for the same quoting-safety reason as the
-/// wt.exe path, so both code paths run an identical command.
+/// Argv for launching PowerShell directly:
+/// `<ps> -NoExit -EncodedCommand <b64>`. Fallback when wt.exe is unavailable.
 #[cfg(any(target_os = "windows", test))]
 fn build_powershell_argv(cmd: &str) -> [String; 3] {
     [
@@ -229,17 +196,9 @@ fn build_powershell_argv(cmd: &str) -> [String; 3] {
     ]
 }
 
-/// Spawns a new terminal window running `cmd` (PowerShell syntax).
-/// `build_auth_command_for_platform` emits PowerShell syntax (`Set-Location`,
-/// `$env:`, `;`) on Windows, so we spawn PowerShell. Prefers `pwsh.exe`
-/// (PowerShell 7+) when on PATH. `-NoExit` keeps the window open so the user
-/// can read output and paste the OAuth code.
-///
-/// Prefers Windows Terminal (`wt.exe`) so the interactive `wsl.exe` child gets
-/// keystrokes without needing a focus/mouse event first (see argv docs above);
-/// falls back to launching PowerShell directly when wt.exe is not installed
-/// (older Windows / locked-down hosts). We do NOT use `cmd /c start` — its
-/// detached console is the cause of the Enter-not-registered bug.
+/// Spawns a new terminal window running `cmd` (PowerShell syntax). Prefers
+/// `pwsh.exe`, then `powershell.exe`; prefers Windows Terminal, else direct
+/// PowerShell spawn. `-NoExit` keeps the window open.
 #[cfg(target_os = "windows")]
 fn open_terminal_with_command(cmd: &str) -> anyhow::Result<()> {
     let ps = if crate::path_util::which_in_path("pwsh.exe").is_some() {
@@ -248,12 +207,7 @@ fn open_terminal_with_command(cmd: &str) -> anyhow::Result<()> {
         "powershell.exe"
     };
 
-    // Try wt.exe directly — do NOT pre-check with `which_in_path`/`is_file`:
-    // wt.exe ships as a Windows App Execution Alias (a zero-byte reparse point
-    // under WindowsApps), and `Path::is_file()` returns false for it even when
-    // it launches fine. CreateProcess DOES resolve the alias, so spawning by
-    // name is the reliable detection. A spawn error (not installed) or non-zero
-    // status falls through to the direct PowerShell spawn.
+    // wt.exe is an App Execution Alias; spawn by name (is_file() returns false).
     let argv = build_wt_terminal_argv(ps, cmd);
     match std::process::Command::new("wt.exe").args(argv).status() {
         Ok(s) if s.success() => return Ok(()),
@@ -278,8 +232,7 @@ pub async fn start_oauth_login(project: String) -> Result<(), String> {
 
         let (project_dir, data_dir, default_data_dir) = resolve_project_dirs(&project)?;
 
-        // Same renderer as get_auth_command's copy-paste fallback, so the
-        // auto-spawned command and the one a user could paste are identical.
+        // Same renderer as get_auth_command's copy-paste fallback.
         let cmd = build_auth_command_for_platform(
             &project,
             &project_dir,

--- a/desktop/src-tauri/src/oauth_loopback.rs
+++ b/desktop/src-tauri/src/oauth_loopback.rs
@@ -70,8 +70,7 @@ pub(crate) async fn wait_for_callback(
                 Ok(None) => {
                     let _ = write_http_response(&mut stream, "Waiting…").await;
                 }
-                // A single broken connection (port scan, etc.) must not abort the
-                // flow — keep waiting, but record why for support.
+                // A broken connection (port scan, etc.) must not abort the flow.
                 Err(e) => {
                     log::debug!("oauth callback read error (ignored): {e}");
                     continue;
@@ -150,9 +149,7 @@ pub(crate) fn parse_callback_query(query: &str, expected_state: &str) -> Result<
             _ => {}
         }
     }
-    // Verify CSRF state first — for BOTH the success and error branches, so a
-    // forged `?error=...` without a valid state can't terminate the flow
-    // (RFC 6749 §10.12).
+    // Verify CSRF state before the error branch (RFC 6749 §10.12).
     if state.as_deref() != Some(expected_state) {
         return Err("state mismatch (possible CSRF)".to_string());
     }
@@ -209,8 +206,7 @@ mod tests {
 
     #[test]
     fn build_authorize_url_uses_custom_scope_param() {
-        // Slack: scopes travel as `user_scope`; a plain `scope` key must NOT
-        // appear (it would request bot scopes, forbidden on desktop redirects).
+        // Slack: scopes travel as `user_scope`; a plain `scope` key must NOT appear.
         let url = build_authorize_url(
             "https://slack.com/oauth/v2/authorize",
             "cid",
@@ -271,8 +267,7 @@ mod tests {
 
     #[test]
     fn parse_callback_query_checks_state_before_error() {
-        // A forged ?error= without a valid state is a CSRF mismatch, not a
-        // "provider denied" — state is verified first on both branches.
+        // A forged ?error= without a valid state is a CSRF mismatch, not "provider denied".
         let err = parse_callback_query("error=access_denied", "xyz").unwrap_err();
         assert!(err.contains("state mismatch"), "got: {err}");
     }
@@ -283,8 +278,7 @@ mod tests {
         assert!(err.contains("missing authorization code"), "got: {err}");
     }
 
-    // The request line may arrive split across TCP segments; read_callback_request
-    // must accumulate until CRLF, not truncate on the first read.
+    // read_callback_request must accumulate a request line split across TCP segments.
     #[tokio::test]
     async fn read_callback_request_handles_fragmented_request_line() {
         use std::time::Duration;
@@ -333,8 +327,7 @@ mod tests {
         writer.await.unwrap();
     }
 
-    // An endless request line must not grow the accumulator unboundedly — the
-    // reader stops at MAX_REQUEST_LINE_BYTES and parses what it has.
+    // The reader stops at MAX_REQUEST_LINE_BYTES and parses what it has.
     #[tokio::test]
     async fn read_callback_request_caps_oversized_request_line() {
         use tokio::io::AsyncWriteExt;
@@ -356,8 +349,7 @@ mod tests {
         let _ = writer.await;
     }
 
-    // User cancellation must surface as CallbackFailure::Cancelled (quiet
-    // `cancelled` UI terminal), never as the red `error` status.
+    // User cancellation must surface as CallbackFailure::Cancelled, never as error.
     #[tokio::test]
     async fn wait_for_callback_cancellation_is_distinct_from_error() {
         let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
@@ -372,8 +364,7 @@ mod tests {
         );
     }
 
-    // Dual-stack: a connection on the SECONDARY listener must be served too
-    // (a `localhost` redirect may resolve to ::1 while the primary is IPv4).
+    // Dual-stack: a connection on the SECONDARY listener must be served too.
     #[tokio::test]
     async fn wait_for_callback_accepts_on_secondary_listener() {
         use tokio::io::AsyncWriteExt;

--- a/desktop/src-tauri/src/path_util.rs
+++ b/desktop/src-tauri/src/path_util.rs
@@ -13,9 +13,7 @@ pub(crate) fn which_in_path_var(path_var: &OsStr, name: &str) -> Option<PathBuf>
 }
 
 /// Minimal `which` — looks for `name` on the process `$PATH`. Returns
-/// `Some(path)` of the first directory entry that is a file. (Does not check
-/// the executable bit; on Windows that is not a meaningful test, and on Unix
-/// the caller spawns the binary anyway and will see the failure.)
+/// `Some(path)` of the first directory entry that is a file.
 pub(crate) fn which_in_path(name: &str) -> Option<PathBuf> {
     let path = std::env::var_os("PATH")?;
     which_in_path_var(&path, name)

--- a/desktop/src-tauri/src/plugin_cmd.rs
+++ b/desktop/src-tauri/src/plugin_cmd.rs
@@ -29,20 +29,14 @@ pub(crate) struct PluginStatusEntry {
     pub(crate) configured: bool,
     pub(crate) auth_fields: Vec<plugin::AuthFieldDef>,
     pub(crate) current_values: HashMap<String, String>,
-    /// Keys of `auth_fields` that currently have a non-empty value stored
-    /// on disk. **Metadata only** — the secret contents are NOT read, only
-    /// the file's existence + non-zero length is checked. This lets the UI
-    /// show a per-field "configured" indicator for secret fields without
-    /// ever exposing the secret (unlike `current_values`, which skips
-    /// secrets entirely and so can't drive that indicator).
+    /// Keys of `auth_fields` with a non-empty value stored on disk.
+    /// Metadata only — secret contents are NOT read, only existence + non-zero length.
     pub(crate) configured_fields: Vec<String>,
     pub(crate) token_mount: String,
     pub(crate) settings_schema: Option<serde_json::Value>,
     pub(crate) requires_integrations: Vec<String>,
     /// Outcome of `runtime::plugin::list_for_ui` for this entry.
     /// Serializes to snake_case (`verified`, `missing_signature`, …).
-    /// Anything but `Verified` disables the enable toggle and
-    /// credential editing in the UI but keeps the remove button active.
     pub(crate) verification_status: plugin::VerificationStatus,
     /// Human-readable diagnostic when `verification_status != Verified`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -71,20 +65,13 @@ fn token_dir_for(project: &str, service_id: &str) -> Result<std::path::PathBuf, 
 }
 
 /// True when a credential file exists on disk with non-zero length.
-///
-/// Metadata-only: never reads the file contents, so it is safe to call
-/// for secret fields. Backs the per-field "configured" indicator. A
-/// zero-byte file counts as not-configured (matches `save_plugin_credentials`,
-/// which only writes non-empty values).
+/// Metadata-only: never reads the file contents, so it is safe for secret fields.
 fn field_has_stored_value(path: &std::path::Path) -> bool {
     match std::fs::metadata(path) {
         Ok(m) => m.len() > 0,
         // A missing file legitimately means "not configured".
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => false,
-        // Permission/IO errors are NOT "not configured" — the file may well
-        // exist. We still report false (the UI degrades to "set it"), but log
-        // so the cause is visible instead of silently swallowed. The path is
-        // a token-dir filename, not the secret contents.
+        // Permission/IO error: report false but log (path is a filename, not secret contents).
         Err(e) => {
             log::warn!("could not stat credential file {}: {e}", path.display());
             false
@@ -93,10 +80,7 @@ fn field_has_stored_value(path: &std::path::Path) -> bool {
 }
 
 /// Returns the manifest `instructions` to surface in `PluginStatusEntry`.
-/// `None` when the plugin is unverified, when no instructions are declared,
-/// or when the cap would be exceeded — the latter is install-time invariant,
-/// re-checked here as defence-in-depth (a >cap blob never reaches the
-/// webview's `[innerHTML]`).
+/// `None` when unverified, when no instructions are declared, or when the cap is exceeded.
 fn instructions_for_ui(verified: bool, instructions: Option<&str>) -> Option<String> {
     if !verified {
         return None;
@@ -146,17 +130,12 @@ pub fn get_plugins(project: String) -> Result<PluginsResponse, String> {
     let integrations =
         config::resolve_integrations(std::path::Path::new(project_dir), &user_config, &project);
 
-    // Tolerant lister: every installed directory becomes one entry, with
-    // `verification_status` carrying the verdict. Unverified entries are
-    // shown so users know *why* a plugin is disabled and what to do
-    // about it — hiding them would force users to inspect the filesystem.
+    // Every installed directory becomes one entry; `verification_status` carries the verdict.
     let ui_entries = plugin::list_for_ui();
 
     let mut entries = Vec::new();
     for ui in &ui_entries {
-        // For entries without a parseable manifest, surface what we know
-        // (slug = directory name) and a clear status; everything else
-        // gets sensible empty defaults.
+        // No parseable manifest: surface slug = directory name + status, rest empty defaults.
         let Some(manifest) = ui.manifest.as_ref() else {
             entries.push(PluginStatusEntry {
                 slug: ui.slug.clone(),
@@ -182,9 +161,7 @@ pub fn get_plugins(project: String) -> Result<PluginsResponse, String> {
         };
 
         let sid = manifest.service_id.as_deref().unwrap_or(&manifest.slug);
-        // An unverified plugin must NOT count as enabled, even if the
-        // user previously enabled a (now-tampered) version. The frontend
-        // additionally disables the enable toggle for non-verified entries.
+        // An unverified plugin must NOT count as enabled.
         let verified = matches!(ui.verification_status, plugin::VerificationStatus::Verified);
         let enabled = verified && integrations.is_plugin_enabled(sid);
 
@@ -198,8 +175,7 @@ pub fn get_plugins(project: String) -> Result<PluginsResponse, String> {
             &project,
             sid,
         );
-        // Only OAuth plugins can have an off-mount state file — skip the disk
-        // read for the rest.
+        // Only OAuth plugins can have an off-mount state file.
         let has_oauth = manifest.auth_fields.iter().any(|f| f.oauth_flow);
         let oauth_expires_at = if has_oauth {
             plugin_oauth_expires_at(&project, sid)
@@ -216,8 +192,7 @@ pub fn get_plugins(project: String) -> Result<PluginsResponse, String> {
         let mut current_values = HashMap::new();
         let mut configured_fields = Vec::new();
         for field in &manifest.auth_fields {
-            // An oauth_flow field is "configured" once its credential is SAVED
-            // to the seed (so Authorize can unlock before the flow runs).
+            // An oauth_flow field is "configured" once its credential is saved to the seed.
             if field.oauth_flow {
                 if seed_keys.contains(&field.key) || oauth_authorized {
                     configured_fields.push(field.key.clone());
@@ -225,14 +200,11 @@ pub fn get_plugins(project: String) -> Result<PluginsResponse, String> {
                 continue;
             }
             let path = svc_token_dir.join(&field.key);
-            // Metadata-only existence + non-empty check — drives the
-            // per-field "configured" indicator for ALL fields (secret or
-            // not) without reading secret contents.
+            // Metadata-only existence + non-empty check, without reading secret contents.
             if field_has_stored_value(&path) {
                 configured_fields.push(field.key.clone());
             }
-            // current_values exposes only NON-secret values (host URLs etc.)
-            // so the form can prefill them; secrets stay write-only.
+            // current_values exposes only non-secret values; secrets stay write-only.
             if field.is_secret {
                 continue;
             }
@@ -257,11 +229,7 @@ pub fn get_plugins(project: String) -> Result<PluginsResponse, String> {
             service_id: manifest.service_id.clone(),
             version: manifest.version.clone(),
             description: manifest.description.clone(),
-            // Trust boundary for free-form Markdown: only verified plugins,
-            // and re-check the install-time cap (defence-in-depth — if
-            // signature verify is ever bypassed, the renderer still won't see
-            // an oversized blob). The frontend `@if (verified)` is the third
-            // layer.
+            // Free-form Markdown gated to verified plugins, with the install-time cap re-checked.
             instructions: instructions_for_ui(verified, manifest.instructions.as_deref()),
             enabled,
             configured,
@@ -436,9 +404,6 @@ pub async fn install_plugin(
     };
 
     // Auto-enable only when image is ready and no required secret is missing.
-    // Plugins with optional secret fields (e.g. tokens that unlock extra
-    // capabilities but are not needed for the baseline) can run right away;
-    // the user fills them later if needed.
     let should_auto_enable = matches!(outcome, plugin::InstallOutcome::Installed(_))
         && !manifest
             .auth_fields
@@ -479,10 +444,7 @@ pub fn remove_plugin(slug: String) -> Result<(), String> {
     log::info!("remove_plugin: slug={slug}");
     crate::bridges::plugin_bridge_manager::stop_for(&slug);
 
-    // Recovery action: removal must work for tampered plugins too.
-    // Use the tolerant lister so an unparseable manifest still gives us
-    // the slug-as-fallback path. We need `service_id` and `auth_fields`
-    // for cleanup; both default sensibly when the manifest is missing.
+    // Removal must work for tampered plugins too; tolerant lister gives a slug fallback.
     let entries = plugin::list_for_ui();
     let entry = entries.iter().find(|e| e.slug == slug);
     let manifest = entry.and_then(|e| e.manifest.as_ref());
@@ -491,10 +453,7 @@ pub fn remove_plugin(slug: String) -> Result<(), String> {
         .map(|s| s.to_string())
         .unwrap_or_else(|| slug.clone());
 
-    // Delete plugin files from ~/.speedwave/plugins/<slug>/ and clean up
-    // the cached container image. Runtime is best-effort: when the
-    // detected runtime is unavailable we skip image cleanup, mirroring
-    // the install_plugin code path.
+    // Delete plugin files + cached image; image cleanup is best-effort if no runtime.
     let rt = speedwave_runtime::runtime::detect_runtime();
     let rt_ref: Option<&speedwave_runtime::runtime::LockedRuntime> =
         if rt.is_available() { Some(&rt) } else { None };
@@ -531,18 +490,14 @@ pub fn remove_plugin(slug: String) -> Result<(), String> {
     })
     .map_err(|e| e.to_string())?;
 
-    // Delete tokens from ~/.speedwave/tokens/<project>/<service_id>/ and the
-    // off-mount OAuth secrets (state + seed hold the refresh token + client
-    // secret; access_token is a literal filename, not an auth_fields key).
+    // Delete the token dir and the off-mount OAuth secrets (state + seed).
     for project_name in &project_names {
         let svc_dir = token_dir_for(project_name, &service_id)?;
         if svc_dir.exists() {
-            // Whole-dir wipe covers access_token too — leaving it behind would
-            // both orphan a live bearer and block the empty-dir removal below.
+            // Whole-dir wipe covers access_token too.
             std::fs::remove_dir_all(&svc_dir).map_err(|e| e.to_string())?;
         }
-        // Off-mount OAuth state/seed never live under tokens/, so the wipe
-        // above cannot reach them.
+        // Off-mount OAuth state/seed never live under tokens/.
         remove_oauth_offmount(project_name, &service_id)?;
     }
 
@@ -583,14 +538,7 @@ pub fn set_plugin_enabled(
     check_project(&project)?;
     log::info!("set_plugin_enabled: project={project} service_id={service_id} enabled={enabled}");
 
-    // Verified-only on enable: a tampered plugin (missing SIGNATURE,
-    // dir/slug mismatch, etc.) must not become enabled. We use the
-    // tolerant `list_for_ui` so the presence of *another* unverified
-    // plugin doesn't block the user from enabling a verified one. The
-    // frontend already disables the toggle for non-verified entries, but
-    // we re-check here so direct command calls from tests/scripts can't
-    // bypass it. Disable requests skip the check — the user must always
-    // be able to turn off a bad plugin.
+    // Verified-only on enable (re-checked here, UI gate is advisory); disable skips the check.
     if enabled {
         let entries = plugin::list_for_ui();
         let matches_id = |m: &plugin::PluginManifest| {
@@ -653,10 +601,7 @@ pub fn save_plugin_credentials(
     check_project(&project)?;
     log::info!("save_plugin_credentials: project={project} slug={slug}");
 
-    // Verified-only: writing credentials for an unverified plugin is an
-    // attack — the manifest's `auth_fields` allowlist (and `service_id`,
-    // which decides the on-disk token path) come from a manifest we
-    // can't trust until the signature checks out.
+    // Verified-only: reject credential writes for an unverified plugin.
     let manifest = require_verified_with_manifest(&slug)?;
 
     let sid = manifest.service_id.as_deref().unwrap_or(&manifest.slug);
@@ -669,9 +614,7 @@ pub fn save_plugin_credentials(
     let svc_dir = token_dir_for(&project, sid)?;
     std::fs::create_dir_all(&svc_dir).map_err(|e| e.to_string())?;
 
-    // OAuth fields (`oauth_flow: true`) are kept off-mount: a compromised
-    // worker must not read a client secret from `/tokens`. They accumulate
-    // into the seed file instead of `svc_dir`.
+    // OAuth fields (`oauth_flow: true`) are kept off-mount, accumulating into the seed file.
     let mut oauth_seed: HashMap<String, String> = HashMap::new();
 
     for (key, value) in &credentials {
@@ -679,8 +622,7 @@ pub fn save_plugin_credentials(
             return Err(format!("field '{}' not allowed for plugin '{}'", key, slug));
         }
         validate_credential_field(key, value)?;
-        // Enforce the field's optional regex constraint host-side — the UI's
-        // HTML `pattern` check is advisory (a crafted IPC call bypasses it).
+        // Enforce the field's optional regex constraint host-side (UI `pattern` is advisory).
         let field = manifest
             .auth_fields
             .iter()
@@ -701,8 +643,7 @@ pub fn save_plugin_credentials(
     }
 
     if !oauth_seed.is_empty() {
-        // Key the seed on `sid` (service_id ?? slug), matching the token dir and
-        // every other OAuth off-mount path (state, access token, readiness).
+        // Key the seed on `sid` (service_id ?? slug), matching the token dir.
         write_oauth_seed(&project, sid, &oauth_seed)?;
     }
 
@@ -745,15 +686,10 @@ pub fn plugin_save_settings(
     check_project(&project)?;
     log::info!("plugin_save_settings: project={project} slug={slug}");
 
-    // Verified-only: settings are stored under a slug whose meaning
-    // comes from the manifest; persisting settings for a tampered
-    // plugin would let an attacker pre-populate state for a future
-    // (re)installed legitimate plugin.
+    // Verified-only: reject settings writes for an unverified plugin.
     let manifest = require_verified_with_manifest(&slug)?;
 
-    // Cap settings JSON size to prevent a runaway plugin from bloating
-    // user_config.json. The bound is shared with `settings_schema`
-    // validation (see `consts::PLUGIN_SETTINGS_MAX_BYTES`).
+    // Cap settings JSON size (`consts::PLUGIN_SETTINGS_MAX_BYTES`).
     let serialised = serde_json::to_vec(&settings).map_err(|e| e.to_string())?;
     if serialised.len() > consts::PLUGIN_SETTINGS_MAX_BYTES {
         return Err(format!(
@@ -763,11 +699,7 @@ pub fn plugin_save_settings(
         ));
     }
 
-    // If the plugin declared a `settings_schema`, the payload must
-    // validate against it. Without this, the manifest field is
-    // documentation only — the user_config could end up holding values
-    // outside the schema's enum/type, which the worker would later
-    // crash on or, worse, silently misinterpret.
+    // If the plugin declared a `settings_schema`, the payload must validate against it.
     if let Some(ref schema) = manifest.settings_schema {
         validate_settings_against_schema(&slug, schema, &settings)?;
     }
@@ -789,18 +721,12 @@ pub fn plugin_save_settings(
     .map_err(|e| e.to_string())
 }
 
-/// Helper: rejects calls that target a plugin whose verification
-/// status is not `Verified`. Used by every Tauri command that *acts
-/// on* a plugin's identity — credentials, settings — to keep the
-/// "tampered plugins are inert" invariant in one place.
+/// Rejects calls targeting a plugin whose verification status is not `Verified`.
 fn require_verified(slug: &str) -> Result<(), String> {
     require_verified_with_manifest(slug).map(|_| ())
 }
 
-/// Same gate as [`require_verified`] but returns the parsed manifest
-/// so callers that need to inspect declared fields (e.g. the
-/// `settings_schema` for `plugin_save_settings`) don't have to look
-/// it up a second time.
+/// Same gate as [`require_verified`] but returns the parsed manifest.
 pub(crate) fn require_verified_with_manifest(slug: &str) -> Result<plugin::PluginManifest, String> {
     let entries = plugin::list_for_ui();
     let entry = entries
@@ -822,18 +748,8 @@ pub(crate) fn require_verified_with_manifest(slug: &str) -> Result<plugin::Plugi
         .ok_or_else(|| format!("plugin '{}' has no manifest", slug))
 }
 
-/// Validates a settings payload against a plugin's declared JSON Schema
-/// (Draft 7). Pure function — extracted from `plugin_save_settings` so
-/// the schema-rejection invariant can be unit-tested without standing
-/// up a project/config/verified-plugin fixture. Returns a
-/// user-presentable error string on a malformed schema or a payload
-/// that doesn't validate; `Ok(())` when the payload conforms.
-///
-/// The runtime side already gates `settings_schema` shape and size at
-/// install time (`plugin::validate_manifest`), so a *malformed* schema
-/// reaching here is unusual — but we still return a clean error rather
-/// than panicking, in case an older plugin was installed before that
-/// gate existed.
+/// Validates a settings payload against a plugin's declared JSON Schema (Draft 7).
+/// Returns an error string on a malformed schema or non-conforming payload; `Ok(())` otherwise.
 fn validate_settings_against_schema(
     slug: &str,
     schema: &serde_json::Value,
@@ -855,11 +771,7 @@ pub fn plugin_load_settings(project: String, slug: String) -> Result<serde_json:
     check_project(&project)?;
     log::info!("plugin_load_settings: project={project} slug={slug}");
 
-    // Verified-only: a tampered plugin must not be able to read settings
-    // saved for a previously-legitimate version of itself. Settings can
-    // contain non-secret-but-private project metadata (host names,
-    // ticket IDs, model selections) that a tampered plugin should not
-    // be allowed to scrape.
+    // Verified-only: settings can hold non-secret private project metadata.
     require_verified(&slug)?;
 
     let user_config = config::load_user_config().map_err(|e| e.to_string())?;
@@ -881,15 +793,8 @@ pub fn delete_plugin_credentials(project: String, slug: String) -> Result<(), St
     check_project(&project)?;
     log::info!("delete_plugin_credentials: project={project} slug={slug}");
 
-    // Recovery action: a user must be able to clear the credentials of
-    // a tampered plugin even if its signature no longer verifies — this
-    // is the cleanup half of `remove_plugin`. We use the tolerant
-    // lister and tolerate a missing/unparseable manifest. The token
-    // directory is identified by `service_id` (or the slug when the
-    // manifest is absent), and EVERY path we touch is canonicalised and
-    // checked to stay inside that directory — a tampered `plugin.json`
-    // with an `auth_field` key like `../../../other-project/token`
-    // must not let us delete outside the service token dir.
+    // Recovery action: clear credentials even for a tampered plugin (tolerant lister).
+    // Token dir keyed by service_id (or slug when no manifest); every deletion stays inside it.
     let entries = plugin::list_for_ui();
     let entry = entries.iter().find(|e| e.slug == slug);
     let manifest = entry.and_then(|e| e.manifest.as_ref());
@@ -899,10 +804,7 @@ pub fn delete_plugin_credentials(project: String, slug: String) -> Result<(), St
 
     let svc_dir = token_dir_for(&project, sid)?;
     if svc_dir.exists() {
-        // Which token files to delete: the manifest's auth_fields if we
-        // have a (possibly unverified) manifest, otherwise everything in
-        // the service token dir (slug-based cleanup, mirroring
-        // `remove_plugin`).
+        // Delete the manifest's auth_fields, or everything in the dir when no manifest.
         let keys: Vec<String> = match manifest {
             Some(m) => m.auth_fields.iter().map(|f| f.key.clone()).collect(),
             None => std::fs::read_dir(&svc_dir)
@@ -911,9 +813,7 @@ pub fn delete_plugin_credentials(project: String, slug: String) -> Result<(), St
                 .filter_map(|e| e.file_name().into_string().ok())
                 .collect(),
         };
-        // Use the single symlink-aware helper so bulk and per-field delete
-        // share one safety contract (no-follow + refuse all symlinks + only
-        // remove the literal path).
+        // Single symlink-aware helper shared by bulk and per-field delete.
         for key in &keys {
             remove_credential_file_guarded(&svc_dir, key)?;
         }
@@ -946,35 +846,22 @@ pub fn delete_plugin_credential_field(
     let manifest = require_verified_with_manifest(&slug)?;
     let sid = manifest.service_id.as_deref().unwrap_or(&manifest.slug);
 
-    // The key must be a declared auth_field — refuse arbitrary deletions
-    // even for a verified plugin.
+    // The key must be a declared auth_field.
     if !manifest.auth_fields.iter().any(|f| f.key == key) {
         return Err(format!(
             "field '{}' is not declared in plugin '{}' auth_fields",
             key, slug
         ));
     }
-    // Reuse the field-name safety check (rejects '/', '\\', '..', null).
-    // The empty value arg only exercises the key checks here.
+    // Reuse the field-name safety check (rejects '/', '\\', '..', null); empty value is unchecked.
     validate_credential_field(&key, "")?;
 
     let svc_dir = token_dir_for(&project, sid)?;
     remove_credential_file_guarded(&svc_dir, &key)
 }
 
-/// Removes a single credential file under `svc_dir`. Refuses any symlink —
-/// credentials are only ever written by `save_plugin_credentials` via
-/// `fs::write`, never as symlinks, so a symlink in the token dir is treated
-/// as adversarial regardless of where its target points. Idempotent: a
-/// genuinely missing entry is success; other IO errors (permission, dangling
-/// symlinks via `metadata` after refusal-by-symlink-type) are surfaced.
-///
-/// Uses `symlink_metadata` (no-follow) so we delete `path` itself rather than
-/// its symlink target (defence-in-depth — addresses both the M1 case where a
-/// same-dir symlink would otherwise have its target unlinked, and the Low
-/// case where a dangling symlink would short-circuit `canonicalize` as
-/// "already gone"). Extracted so the safety guard is unit-testable without
-/// a verified-plugin fixture.
+/// Removes a single credential file under `svc_dir`, refusing any symlink
+/// (via no-follow `symlink_metadata`). Idempotent: a missing entry is success.
 fn remove_credential_file_guarded(svc_dir: &std::path::Path, key: &str) -> Result<(), String> {
     let path = svc_dir.join(key);
     match std::fs::symlink_metadata(&path) {
@@ -997,9 +884,7 @@ fn remove_credential_file_guarded(svc_dir: &std::path::Path, key: &str) -> Resul
 mod tests {
     use super::*;
 
-    // remove_oauth_offmount must delete the off-mount state + seed (refresh
-    // token + client secret), and tolerate their absence. Uses the `_in`
-    // variant so the tempdir bypasses the data_dir() OnceLock.
+    // remove_oauth_offmount must delete the off-mount state + seed and tolerate their absence.
     #[test]
     fn remove_oauth_offmount_deletes_state_and_seed() {
         let tmp = tempfile::tempdir().unwrap();
@@ -1051,9 +936,7 @@ mod tests {
         let json = serde_json::to_string(&entry).unwrap();
         assert!(json.contains("test-plugin"));
         assert!(json.contains("api_key"));
-        // The Angular frontend's `PluginVerificationStatus` union depends
-        // on the snake_case wire literals — pin one here so a mis-annotated
-        // `VerificationStatus` enum (e.g. PascalCase) is caught.
+        // Pin the snake_case wire literal the Angular `PluginVerificationStatus` union depends on.
         assert!(json.contains(r#""verification_status":"verified""#));
         // instructions is None here → omitted from the wire (skip_serializing_if).
         assert!(
@@ -1097,8 +980,7 @@ mod tests {
         assert_eq!(instructions_for_ui(false, Some("# Setup")), None);
         // Verified + no instructions → still None.
         assert_eq!(instructions_for_ui(true, None), None);
-        // Verified + oversized → withheld (defence-in-depth re-check of the
-        // install-time cap in case signature verify is ever bypassed).
+        // Verified + oversized → withheld (install-time cap re-checked).
         let huge = "a".repeat(speedwave_runtime::consts::PLUGIN_INSTRUCTIONS_MAX_BYTES + 1);
         assert_eq!(instructions_for_ui(true, Some(&huge)), None);
         // Verified + exactly at cap → passes (cap is inclusive).
@@ -1149,12 +1031,6 @@ mod tests {
     }
 
     // ── settings-schema validation (the `plugin_save_settings` gate) ─────
-    //
-    // `plugin_save_settings` is a Tauri command and needs a project /
-    // config / verified-plugin fixture to drive end-to-end. The
-    // schema-validation step is the security-relevant part, so it's
-    // extracted into `validate_settings_against_schema` and tested
-    // directly here.
 
     #[test]
     fn validate_settings_against_schema_accepts_conforming_payload() {
@@ -1427,8 +1303,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn remove_credential_file_guarded_refuses_symlink_escape() {
-        // A symlink whose target lives outside the token dir must be refused
-        // and the target must survive intact.
+        // A symlink targeting outside the token dir must be refused; the target survives.
         let svc = tempfile::tempdir().unwrap();
         let outside = tempfile::tempdir().unwrap();
         let victim = outside.path().join("victim");
@@ -1446,10 +1321,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn remove_credential_file_guarded_refuses_intra_dir_symlink() {
-        // A symlink whose target also lives INSIDE the token dir: the old
-        // implementation would have unlinked the target (M1). The new
-        // symlink_metadata-based check refuses every symlink, so the target
-        // is preserved unconditionally.
+        // An intra-dir symlink is refused and its target is preserved.
         let svc = tempfile::tempdir().unwrap();
         let target = svc.path().join("real");
         std::fs::write(&target, "real credential").unwrap();
@@ -1466,9 +1338,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn remove_credential_file_guarded_refuses_dangling_symlink() {
-        // A symlink whose target never existed used to short-circuit through
-        // canonicalize's NotFound branch as "idempotent success"; now we use
-        // symlink_metadata (no-follow), so the symlink is rejected outright.
+        // A dangling symlink is rejected outright.
         let svc = tempfile::tempdir().unwrap();
         std::os::unix::fs::symlink("/no/such/thing", svc.path().join("ghost")).unwrap();
 
@@ -1478,9 +1348,7 @@ mod tests {
 
     #[test]
     fn delete_field_rejects_key_not_in_auth_fields_allowlist() {
-        // Mirror of save_plugin_credentials_rejects_field_not_in_auth_fields:
-        // delete_plugin_credential_field builds the same allowlist from the
-        // verified manifest's auth_fields and rejects anything outside it.
+        // delete_plugin_credential_field rejects keys outside the verified manifest's auth_fields.
         let manifest = plugin::PluginManifest {
             name: "Test".to_string(),
             service_id: Some("test-plugin".to_string()),
@@ -1883,8 +1751,7 @@ mod tests {
         assert!(validate_credential_field("key", &over_limit).is_err());
     }
 
-    // OAuth seed lives under oauth/, NOT under the tokens/ mount — a worker
-    // must never read a client secret from /tokens.
+    // OAuth seed lives under oauth/, NOT under the tokens/ mount.
     #[test]
     fn oauth_seed_path_is_off_mount() {
         let base = std::path::Path::new("/data");
@@ -1972,13 +1839,9 @@ mod tests {
         }
     }
 
-    // The tests below use the `_in` variants with a tempdir directly — env-var
-    // juggling cannot work here because data_dir() pins via OnceLock at first
-    // call, which both flaked these tests and leaked fixtures into the real
-    // ~/.speedwave.
+    // The tests below use the `_in` variants with a tempdir (data_dir() pins via OnceLock).
 
-    // An oauth_flow plugin is NOT configured until an authorized oauth state
-    // file exists — its secret lives off-mount, not in /tokens.
+    // An oauth_flow plugin is NOT configured until an authorized oauth state file exists.
     #[test]
     fn is_plugin_configured_false_for_oauth_plugin_without_state() {
         let tmp = tempfile::tempdir().unwrap();
@@ -2038,8 +1901,7 @@ mod tests {
         );
     }
 
-    // A seed file alone (credentials saved, not yet authorized) must NOT count
-    // as authorized — only the full state file (<slug>.json) does.
+    // A seed file alone must NOT count as authorized; only the full state file does.
     #[test]
     fn plugin_oauth_authorized_false_with_seed_but_no_state() {
         let tmp = tempfile::tempdir().unwrap();
@@ -2053,8 +1915,7 @@ mod tests {
         );
     }
 
-    // A saved seed marks its fields configured (so Authorize unlocks) BEFORE any
-    // authorization has happened — otherwise the button would deadlock.
+    // A saved seed marks its fields configured before any authorization has happened.
     #[test]
     fn oauth_seed_keys_returns_saved_credential_keys() {
         let tmp = tempfile::tempdir().unwrap();
@@ -2202,10 +2063,7 @@ mod tests {
 
     #[test]
     fn save_credentials_enforces_field_validation_pattern() {
-        // Mirrors the per-field check inside save_plugin_credentials: locate
-        // the AuthFieldDef by key, then run the runtime regex validator. The
-        // full command needs a verified on-disk plugin, so this isolates the
-        // wiring the same way save_plugin_credentials_rejects_* does.
+        // Mirrors save_plugin_credentials: locate the AuthFieldDef by key, run the regex validator.
         let field = plugin::AuthFieldDef {
             key: "example_pat".to_string(),
             label: "Example Token".to_string(),

--- a/desktop/src-tauri/src/plugin_oauth_cmd.rs
+++ b/desktop/src-tauri/src/plugin_oauth_cmd.rs
@@ -64,8 +64,7 @@ pub async fn start_plugin_oauth(
             oauth.grant_type.as_str()
         ));
     }
-    // Credentials + per-instance base URL come from the seed saved by
-    // save_plugin_credentials, not from the command args.
+    // Credentials + per-instance base URL come from the saved seed, not args.
     let seed = read_oauth_seed(&project, &slug)?;
     let client_id = seed
         .get(&oauth.client_id_field)
@@ -76,8 +75,7 @@ pub async fn start_plugin_oauth(
         .as_ref()
         .and_then(|k| seed.get(k).cloned());
 
-    // Static endpoints from the manifest, or per-instance ones resolved (and
-    // SSRF-validated) from the seed's base URL. See ADR-069.
+    // Static manifest endpoints, or per-instance SSRF-validated ones from the seed. See ADR-069.
     let (resolved_authorize, token_url) = resolve_endpoints(oauth, &seed)?;
     let authorize_url =
         resolved_authorize.ok_or_else(|| "oauth.authorize_url missing".to_string())?;
@@ -89,8 +87,7 @@ pub async fn start_plugin_oauth(
     let pkce = speedwave_runtime::pkce::generate_pkce();
     let state = speedwave_runtime::pkce::generate_state();
 
-    // Bind the loopback callback server on 127.0.0.1 (browser-side). Fixed port
-    // if the manifest demands a registered redirect URI; else an ephemeral port.
+    // Loopback callback server on 127.0.0.1; manifest port, else ephemeral.
     let bind_port = oauth.redirect_port.unwrap_or(0);
     // SSOT-allow: browser-side OAuth redirect URI is 127.0.0.1, not the container-reach host_bind_address (WSL adapter IP on Windows). See ADR-069.
     let listener = tokio::net::TcpListener::bind(("127.0.0.1", bind_port))
@@ -119,9 +116,7 @@ pub async fn start_plugin_oauth(
     )
     .inspect_err(|_| FLOW_STATE.clear_if_current(&request_id))?;
 
-    // Own everything the spawned task needs; the command returns request_id
-    // immediately so the UI can correlate progress events (the flow may block
-    // on the browser callback for up to 300s — it must not block the command).
+    // Command returns request_id immediately; the flow runs in a spawned task.
     let oauth = oauth.clone();
     let seed = seed.clone();
     let resp = PluginOAuthResult {
@@ -196,8 +191,7 @@ pub async fn start_plugin_oauth(
                 return;
             }
         };
-        // Re-check after the exchange — reqwest ignores the CancellationToken,
-        // so a superseding flow could have started during the round-trip.
+        // Re-check after the exchange (reqwest ignores the CancellationToken).
         if oauth_flow::superseded(&FLOW_STATE, my_generation, &request_id) {
             return;
         }
@@ -217,8 +211,7 @@ pub async fn start_plugin_oauth(
             oauth_flow::emit_terminal(&app, &FLOW_STATE, ProgressStatus::Error, &e, &request_id);
             return;
         }
-        // A freshly-authorized OAuth plugin is now ready, so auto-enable it (the
-        // user still applies via the restart banner). Best-effort. See ADR-069.
+        // Auto-enable the freshly-authorized plugin, best-effort. See ADR-069.
         if let Err(e) = crate::plugin_cmd::set_plugin_enabled_in_config(&project, &slug, true) {
             log::warn!("oauth[{slug}]: authorized but auto-enable failed: {e}");
         }
@@ -240,11 +233,7 @@ pub fn cancel_plugin_oauth() {
 #[tauri::command]
 pub fn forget_plugin_oauth(project: String, slug: String) -> Result<(), String> {
     check_project(&project)?;
-    // Cancel any in-flight flow first, else it would re-create the files we
-    // delete here when the user completes sign-in after disconnecting.
-    // Intentionally global: the singleton FLOW_STATE holds at most one flow
-    // across all plugins, so disconnecting plugin B also cancels plugin A's
-    // in-flight flow (terminates with the quiet `cancelled` status).
+    // Cancel any in-flight flow first; FLOW_STATE is a singleton across all plugins.
     FLOW_STATE.cancel();
     crate::plugin_cmd::remove_oauth_offmount(&project, &slug)?;
     let access = access_token_path(&project, &slug)?;
@@ -455,10 +444,7 @@ mod tests {
         }
     }
 
-    // A successful authorization auto-enables the plugin (before emitting
-    // success), so the user doesn't have to toggle it on manually.
-    // Limitation: a source-order check, not behavioral (the real ordering
-    // needs a Tauri AppHandle) — it pins statement ORDER, not execution.
+    // Auto-enable must precede the success event; source-order check, not behavioral.
     #[test]
     fn start_plugin_oauth_auto_enables_on_success() {
         let src = include_str!("plugin_oauth_cmd.rs");
@@ -710,8 +696,7 @@ mod tests {
         let _ = handle.await;
     }
 
-    // An IdP returning an access token without refresh_token must fail loudly
-    // — silently authorizing without durable state strands the user in 1h.
+    // An access token without refresh_token must fail loudly.
     #[test]
     fn persist_state_rejects_missing_refresh_token() {
         let token = TokenResponse {
@@ -733,8 +718,7 @@ mod tests {
         assert!(err.contains("no refresh_token"), "got: {err}");
     }
 
-    // The worker's generic refresh reads these exact keys (GenericProviderData
-    // in generic.ts) — a renamed key breaks refresh after the first hour.
+    // The worker's generic refresh reads these exact keys (GenericProviderData in generic.ts).
     #[test]
     fn build_provider_data_carries_worker_contract_keys() {
         let data =

--- a/desktop/src-tauri/src/project_cmd.rs
+++ b/desktop/src-tauri/src/project_cmd.rs
@@ -1,10 +1,4 @@
-// Project-management Tauri commands.
-//
-// `list_projects` / `switch_project` plus the pure helpers behind the project
-// switch (config mutation, container transition, chat rebind, and the
-// rollback/failure-payload logic). The container orchestration lives in
-// `containers_cmd`; this module owns the command surface and the
-// config/event-payload glue.
+// Project-management Tauri commands: list/switch, config mutations, event payloads.
 
 use crate::chat::{ChatSession, SharedChatSession};
 use crate::reconcile;
@@ -60,10 +54,7 @@ pub(crate) async fn switch_project(
         return Err("A project switch is already in progress".to_string());
     };
 
-    // Config is committed first to keep the config lock brief — holding it
-    // across the blocking container transition would starve other config
-    // readers. If the container switch fails, rollback_and_emit_failed
-    // restores active_project to `previous`.
+    // Commit config first to keep the lock brief; rollback restores `previous` on failure.
     let previous = config::with_config_lock(|| {
         let mut user_config = config::load_user_config()?;
         let prev = user_config.active_project.clone();
@@ -99,24 +90,15 @@ pub(crate) async fn switch_project(
             if let Err(sanitized) = integrations_cmd::ensure_project_images_built(rt, proj) {
                 return Err(format!("Image build failed: {sanitized}"));
             }
-            // Eager-start host workers before compose render — live WORKER_*_URLs
-            // prevent the first-message container recreate.
+            // Eager-start host workers before compose render so WORKER_*_URLs are live.
             crate::ensure_oauth_running(&oauth_arc, proj);
-            // Previous project is stopped in the background after the switch
-            // fully succeeds — never here.
-            // Wrap the destination project's render → validate → up sequence in a
-            // single transaction so it shares semantics with every other compose
-            // callsite (see ADR-066) and benefits from compose_validate_with_retry's
-            // virtiofs/9p propagation-lag recovery.
+            // Previous project is stopped in the background after success, not here.
+            // Wrap render → validate → up in one transaction (ADR-066).
             use crate::types::IntoAnyhow;
             rt.transaction(proj, |rt| -> anyhow::Result<()> {
                 containers_cmd::render_and_save_compose(proj).into_anyhow()?;
                 speedwave_runtime::runtime::compose_validate_with_retry(rt, proj)?;
-                // Idempotent up, not force-recreate: nerdctl ≥ 2.2.0 config-hash
-                // convergence recreates only containers whose config (or
-                // content-addressed image tag) actually changed — so a changed
-                // image or integration re-runs the entrypoint, while an
-                // unchanged destination is left in place instead of churned.
+                // Idempotent up, not force-recreate: nerdctl ≥ 2.2.0 config-hash convergence (ADR-068).
                 rt.compose_up(proj)?;
                 Ok(())
             })
@@ -148,10 +130,7 @@ pub(crate) async fn switch_project(
             .map_err(|e| e.to_string())?;
 
     if let Err(e) = rebind_result {
-        // Previous is still running (teardown deferred) — only tear
-        // down the new project, then rebind chat back to previous.
-        // The eagerly-started host workers for the destination must be
-        // retired too, or they linger pointing at downed containers.
+        // Tear down the new project and its host workers, then rebind chat to previous.
         reconcile::teardown_oauth_for_project(&oauth_for_teardown, &name);
         let mut cleanup_parts: Vec<String> = Vec::new();
 
@@ -192,9 +171,7 @@ pub(crate) async fn switch_project(
         return Err(full_error);
     }
 
-    // Switch fully succeeded — stop the previous project in the background
-    // and retire its host workers. Doing this only AFTER success keeps a
-    // failed switch's previous project fully functional.
+    // Switch succeeded: stop the previous project and retire its host workers in the background.
     if let Some(prev) = pending_teardown {
         reconcile::teardown_oauth_for_project(&oauth_for_teardown, &prev);
         spawn_background_teardown(prev);
@@ -221,12 +198,8 @@ pub(crate) fn rebind_chat(
     session.start(app.clone(), None).map_err(|e| e.to_string())
 }
 
-/// Parses a prefix-encoded CloudStorage TCC error into the `(stable_id, dir)`
-/// pair if present, otherwise returns `None`.
-///
-/// Format produced by `cloudstorage::check_project_readable_or_err`:
-/// `"CloudStorage TCC required: {stable_id}|{dir}"`. Tolerates extra suffix
-/// text that downstream wrappers may have appended after the dir.
+/// Parses a CloudStorage TCC error `"CloudStorage TCC required: {stable_id}|{dir}"`
+/// into `(stable_id, dir)`, or `None`. Tolerates appended suffix text after the dir.
 fn parse_cloudstorage_tcc_error(error: &str) -> Option<(&str, &str)> {
     let body = error.strip_prefix(speedwave_runtime::cloudstorage::CLOUDSTORAGE_TCC_PREFIX)?;
     let pipe_idx = body.find('|')?;
@@ -241,11 +214,8 @@ fn parse_cloudstorage_tcc_error(error: &str) -> Option<(&str, &str)> {
 
 /// Builds the JSON payload for the `project_switch_failed` Tauri event.
 ///
-/// Pure function (no IO) so it can be unit-tested independently of Tauri.
-/// When the error string is prefix-encoded with `CLOUDSTORAGE_TCC_PREFIX`,
-/// emits structured `error_kind`/`provider`/`project_dir` fields so the
-/// frontend can route to the CloudStorage remediation modal. Otherwise
-/// emits only `project` + `error`.
+/// Emits structured CloudStorage TCC fields if the error is prefix-encoded,
+/// else generic `project` + `error`.
 pub(crate) fn compute_project_switch_failure_payload(
     previous: Option<&str>,
     full_error: &str,
@@ -336,9 +306,7 @@ mod tests {
     }
 
     /// Structural: project switch must use idempotent `compose_up`, not
-    /// `compose_up_recreate`. nerdctl ≥ 2.2.0 config-hash convergence recreates
-    /// only what changed (config or content-addressed image tag); an unchanged
-    /// destination is left in place. See the nerdctl SSOT pin.
+    /// `compose_up_recreate` (nerdctl ≥ 2.2.0 config-hash convergence, ADR-068).
     #[test]
     fn switch_uses_idempotent_compose_up() {
         let source = include_str!("project_cmd.rs");
@@ -411,9 +379,7 @@ mod tests {
             prev_oauth > success_marker,
             "previous-project worker teardown must live in the success path"
         );
-        // ...while the rebind-failure block retires the DESTINATION's
-        // eagerly-started workers (they would otherwise point at downed
-        // containers for the rest of the session).
+        // ...while the rebind-failure block retires the DESTINATION's workers.
         let rebind_fail = body
             .find("rebind_result {")
             .expect("rebind-failure block must exist");

--- a/desktop/src-tauri/src/reconcile.rs
+++ b/desktop/src-tauri/src/reconcile.rs
@@ -20,9 +20,7 @@ pub(crate) type SharedIdeBridge = Arc<Mutex<Option<ide_bridge::IdeBridge>>>;
 pub(crate) type SharedPluginBridges = Arc<Mutex<HashMap<String, PluginHostBridge>>>;
 
 /// Process-global handle to the active plugin bridges. Set once in
-/// `main.rs::setup()`; read from free functions like
-/// `compose::render_compose` callers in setup_wizard / containers_cmd
-/// which do not receive Tauri state. Empty until init.
+/// `main.rs::setup()`; read from free functions without Tauri state. Empty until init.
 static GLOBAL_PLUGIN_BRIDGES: OnceLock<SharedPluginBridges> = OnceLock::new();
 
 /// Register the plugin-bridges map for global access. Called once at
@@ -160,9 +158,8 @@ pub(crate) fn wait_for_images_ready(timeout: Duration) -> Result<(), String> {
                     .unwrap_or_else(|e| e.into_inner());
                 state = result.0;
                 if result.1.timed_out() {
-                    // Re-check after timeout: the state may have changed between the
-                    // wait returning and this check. Treating ambiguous state as success
-                    // avoids blocking startup when the builder thread is merely slow.
+                    // Re-check after timeout: state may have changed since the wait
+                    // returned. Ambiguous state is treated as success.
                     match &*state {
                         ImageReadiness::Ready => return Ok(()),
                         ImageReadiness::Failed(msg) => return Err(msg.clone()),
@@ -192,9 +189,8 @@ struct ImageReadinessGuard;
 
 impl Drop for ImageReadinessGuard {
     fn drop(&mut self) {
-        // Scope guard: if this thread exits without explicitly signaling Ready or Failed,
-        // the guard transitions Checking/Building->Failed and wakes all waiters. This
-        // covers early returns and panics not caught by catch_unwind.
+        // Scope guard: if this thread exits without signaling Ready or Failed,
+        // transition Checking/Building->Failed and wake all waiters.
         let (lock, cvar) = &*IMAGES_READY;
         let mut state = lock.lock().unwrap_or_else(|e| e.into_inner());
         if matches!(&*state, ImageReadiness::Checking | ImageReadiness::Building) {
@@ -293,10 +289,7 @@ pub(crate) fn restore_projects(
     rt: &speedwave_runtime::runtime::LockedRuntime,
 ) -> Result<(), String> {
     for project in projects {
-        // NB1-v4 (Option C): substitute CloudStorage TCC prefix BEFORE the
-        // error escapes this function, so set_bundle_error and the wrapping
-        // "Project restore failed: {e}" caller receive user-readable text.
-        // The raw prefix is logged at warn level for diagnostics.
+        // Substitute CloudStorage TCC prefix before the error escapes this function.
         if let Err(e) = restore_one_project(project, rt) {
             if e.starts_with(speedwave_runtime::consts::CLOUDSTORAGE_TCC_PREFIX) {
                 log::warn!("restore_projects: CloudStorage TCC required (raw prefix): {e}");
@@ -360,8 +353,6 @@ fn reconcile_id_changed(state: &bundle::BundleState, manifest: &bundle::BundleMa
 }
 
 /// INVARIANT: `ensure_ready()` must NOT be gated behind `is_available()`.
-/// A stopped Lima VM returns `is_available() == false` but `ensure_ready()`
-/// can start it; gating one behind the other silently skips VM auto-start.
 /// Behavioral test: `lima.rs` → `test_ensure_ready_stopped_vm_starts_it`.
 fn reconcile_bundle_update_inner(app_handle: &tauri::AppHandle) -> Result<(), String> {
     log::info!("reconcile_bundle: loading current bundle manifest");
@@ -398,10 +389,8 @@ fn reconcile_bundle_update_inner(app_handle: &tauri::AppHandle) -> Result<(), St
 
     let rt = speedwave_runtime::runtime::detect_runtime();
 
-    // Reconcile-id change is decided WITHOUT starting the VM, so the gate can
-    // close before any slow work — preserving #781's start-vs-rebuild fix.
-    // The images-missing fallback (id unchanged but images gone) needs a probe,
-    // which runs after the gate opens in the no-change branch below (as in #781).
+    // Reconcile-id change is decided without starting the VM, so the gate closes
+    // before any slow work (#781). The images-missing fallback needs a probe.
     if reconcile_id_changed(&state, &manifest) {
         // Gate first, then the slow ensure_ready (VM start) — closes the
         // start_containers vs rebuild race ("image not available", #781).
@@ -413,10 +402,8 @@ fn reconcile_bundle_update_inner(app_handle: &tauri::AppHandle) -> Result<(), St
             )
         })?;
     } else if state.phase.is_before(bundle::BundleReconcilePhase::Done) {
-        // Id matches but a previous reconcile was interrupted before completion.
-        // Resources or images on disk may reflect a different app version
-        // (e.g. a downgrade after a partially-applied upgrade). Force a full
-        // re-reconcile from scratch to guarantee consistency.
+        // Previous reconcile was interrupted; resources on disk may reflect a
+        // different app version, so force a full re-reconcile (ADR-072).
         log::warn!(
             "reconcile_bundle: bundle id unchanged but phase={:?} — \
              previous reconcile was interrupted, forcing re-reconcile",
@@ -430,9 +417,8 @@ fn reconcile_bundle_update_inner(app_handle: &tauri::AppHandle) -> Result<(), St
             )
         })?;
     } else {
-        // Id matches and previous reconcile completed (phase=Done).
-        // Restore any projects a no-op update left stopped, open the gate,
-        // then repair missing images (needs a running VM, ADR-072).
+        // Id matches and previous reconcile completed (phase=Done). Restore stopped
+        // projects, open the gate, then repair missing images (needs a running VM, ADR-072).
         if !state.pending_running_projects.is_empty() {
             match rt.ensure_ready() {
                 Ok(()) => {
@@ -474,9 +460,8 @@ fn reconcile_bundle_update_inner(app_handle: &tauri::AppHandle) -> Result<(), St
         set_image_readiness(ImageReadiness::Ready);
         emit_bundle_status(app_handle);
 
-        // Converge crash-orphans: ONLY projects whose background teardown a
-        // previous process recorded but never finished. Never ps-diff against
-        // active_project — non-active projects run legitimately (CLI).
+        // Converge crash-orphans: only projects whose recorded background teardown
+        // never finished. Never ps-diff against active_project.
         match config::load_user_config() {
             Ok(cfg) => {
                 for project in crate::containers_cmd::crashed_teardown_intents() {
@@ -528,10 +513,7 @@ fn reconcile_bundle_update_inner(app_handle: &tauri::AppHandle) -> Result<(), St
         .phase
         .is_before(bundle::BundleReconcilePhase::ResourcesSynced)
     {
-        // The sync atomically REPLACES the resources dir that running
-        // containers bind-mount — their mounted tree would vanish for the
-        // whole build window (forever, on build failure). Stop them first;
-        // the restore phase brings them back from pending_running_projects.
+        // Sync atomically replaces the mounted resources dir; stop running projects first (ADR-072).
         if rt.is_available() {
             if let Ok(cfg) = config::load_user_config() {
                 if let Ok(running) = list_running_projects(&rt, &cfg) {
@@ -574,14 +556,8 @@ fn reconcile_bundle_update_inner(app_handle: &tauri::AppHandle) -> Result<(), St
             "reconcile_bundle: building images for bundle {}",
             manifest.bundle_id,
         );
-        // Old-bundle prune moved to the end of reconcile (after ProjectsRestored).
-        // Atomicity: if the build/restore sequence fails partway, the previous
-        // bundle's images remain on disk so the project can keep running with
-        // the last-known-good set and a retry has something to roll back to.
-        // build.rs handles: build → fail → prune → retry → SnapshotterRecoveryFailed.
-        // Here we escalate: restart engine → retry build. Safe because we are in the
-        // pre-restore phase — no containers are running yet (see ContainerRuntime
-        // trait docs for restart_container_engine).
+        // Old-bundle prune runs at the end of reconcile (after ProjectsRestored)
+        // for atomicity (ADR-072). On failure: restart engine, retry build.
         let enabled = build::enabled_images(&active_integrations);
         // Missing-only under the build lock — a present per-image tag is
         // already the exact build this manifest needs (ADR-072).
@@ -702,10 +678,7 @@ fn reconcile_bundle_update_inner(app_handle: &tauri::AppHandle) -> Result<(), St
         emit_bundle_status(app_handle);
     }
 
-    // Atomicity: only prune superseded images now that every earlier phase
-    // succeeded (per-image replaced tags + one-time legacy prune, ADR-072).
-    // If reconcile failed earlier (image build, project restore, ensure_ready),
-    // the previous images stay on disk so a restart resumes known-good.
+    // Prune superseded images only after every earlier phase succeeded (ADR-072).
     build::prune_superseded_images(
         &rt,
         &state.applied_image_hashes,
@@ -748,14 +721,12 @@ pub(crate) fn reconcile_bundle_update(app_handle: &tauri::AppHandle) {
 
     let handle = app_handle.clone();
     std::thread::spawn(move || {
-        // Scope guard: if this thread exits without explicitly signaling Ready or Failed,
-        // the guard transitions Building->Failed and wakes all waiters. This covers
-        // early returns and panics not caught by catch_unwind.
+        // Scope guard: if this thread exits without signaling Ready or Failed,
+        // transition Building->Failed and wake all waiters.
         let _guard = ImageReadinessGuard;
 
         // catch_unwind so panics produce a specific error message and explicit
-        // Failed signaling, rather than relying solely on the scope guard's
-        // generic failure transition.
+        // Failed signaling.
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             reconcile_bundle_update_inner(&handle)
         }));
@@ -780,12 +751,9 @@ pub(crate) fn reconcile_bundle_update(app_handle: &tauri::AppHandle) {
     });
 }
 
-/// After mcp-os starts on a new dynamic port, check if running containers have
-/// a stale WORKER_OS_URL in their compose.yml. If so, regenerate compose and
-/// recreate containers so the hub connects to the correct port.
-///
-/// Runs in a background thread. Per-project compose lock serialises this
-/// with `start_chat`/`resume_conversation`/`restart_integration_containers`.
+/// When running containers have a stale `WORKER_OS_URL`, regenerate compose and
+/// recreate them so the hub connects to the new mcp-os port. Runs in a background
+/// thread; serialised per-project by the compose lock.
 pub(crate) fn reconcile_compose_port(app_handle: &tauri::AppHandle) {
     let handle = app_handle.clone();
     std::thread::spawn(move || {
@@ -896,16 +864,8 @@ pub(crate) fn reconcile_compose_port(app_handle: &tauri::AppHandle) {
     });
 }
 
-/// Stop containers for all projects. Best-effort — failures are logged
-/// but do not prevent remaining cleanup.
-///
-/// Runs on Windows, where container state outlives the runtime process: the
-/// WSL2 distro is system-managed and `WslRuntime::stop_vm` inherits the no-op
-/// default from `ContainerRuntime` — see
-/// `crates/speedwave-runtime/src/runtime/mod.rs:142-149`. On macOS,
-/// `LimaRuntime::stop_vm` hard-powers the Apple Virtualization VM off via
-/// `limactl stop --force` and reaps containers with it, so this function is
-/// not called on macOS (compiled out by the cfg).
+/// Stop containers for all projects (best-effort). Windows-only (ADR-062);
+/// on macOS the VM poweroff reaps containers instead.
 #[cfg(target_os = "windows")]
 fn stop_all_containers(
     rt: &speedwave_runtime::runtime::LockedRuntime,
@@ -922,24 +882,8 @@ fn stop_all_containers(
     }
 }
 
-/// Stops all containers (where applicable) and stops the VM (where
-/// applicable). Extracted so tests can call it directly with a mock
-/// runtime.
-///
-/// Platform split:
-///
-/// - macOS (Lima): `limactl stop --force` poweroffs the VM. Every
-///   container inside dies with the VM, so the per-project `compose_down`
-///   loop is pure UX drag (each `compose down` waits up to ~10 s for
-///   nerdctl's hard-coded graceful stop). Skipped.
-/// - Windows (WSL2): `WslRuntime::stop_vm` is a no-op (Speedwave does not
-///   own the WSL distro lifecycle), so without `compose_down` containers
-///   would keep running in the `Speedwave` distro until next Windows boot
-///   or manual `wsl --shutdown`. `compose_down` is required.
-///
-/// Safety: the per-project loop is best-effort on every platform — a
-/// failing `compose_down` only logs a warning. Skipping it on macOS loses
-/// no information, since VM shutdown imminently replaces it.
+/// Stops all containers and the VM. Platform-specific: macOS skips per-project
+/// compose_down; Windows requires it (ADR-062). Best-effort per project.
 pub(crate) fn run_container_cleanup(
     rt: &speedwave_runtime::runtime::LockedRuntime,
     projects: &[config::ProjectUserEntry],
@@ -956,16 +900,8 @@ pub(crate) fn run_container_cleanup(
     }
 }
 
-/// Runs cleanup when the app exits: stops containers, stops VM, stops IDE
-/// Bridge, mcp-os process, and aborts the background auto-update check.
-///
-/// Guarded by `CLEANUP_ONCE` — safe to call from `WindowEvent::Destroyed`,
-/// `RunEvent::ExitRequested`, and a signal handler concurrently. The first
-/// call starts the cleanup work in a background thread and returns its
-/// `JoinHandle`; subsequent calls return `None`. Callers that intend to
-/// terminate the process (e.g. signal handlers calling `std::process::exit`,
-/// or the Tauri `RunEvent::Exit` hook) MUST `.join()` the handle before exit,
-/// otherwise the cleanup thread is killed mid-flight and the VM never stops.
+/// Runs cleanup on exit: stops containers, VM, IDE Bridge, mcp-os, and aborts
+/// the auto-update check. Guarded by `CLEANUP_ONCE`; idempotent.
 #[must_use = "join the returned handle before process exit, or VM cleanup will be killed mid-flight"]
 pub(crate) fn run_exit_cleanup(ctx: &ExitCleanupContext) -> Option<std::thread::JoinHandle<()>> {
     static CLEANUP_ONCE: AtomicBool = AtomicBool::new(false);
@@ -1054,13 +990,8 @@ pub(crate) fn run_exit_cleanup(ctx: &ExitCleanupContext) -> Option<std::thread::
     Some(handle)
 }
 
-/// Resolves the bundled resources directory from the executable's parent path.
-///
-/// Platform conventions:
-/// - macOS: `<exe>/../../Resources` (inside .app bundle)
-/// - Windows: `<exe>/resources` (NSIS installer)
-///
-/// Returns `None` in dev mode (no bundle structure present).
+/// Resolves the bundled resources directory from the executable's parent path
+/// (macOS: `../Resources`; Windows: `exe_parent` or `resources/`). `None` in dev.
 pub(crate) fn resolve_resources_dir(exe_parent: &std::path::Path) -> Option<std::path::PathBuf> {
     let candidates: Vec<std::path::PathBuf> = if cfg!(target_os = "macos") {
         exe_parent
@@ -1073,13 +1004,8 @@ pub(crate) fn resolve_resources_dir(exe_parent: &std::path::Path) -> Option<std:
         vec![exe_parent.to_path_buf(), exe_parent.join("resources")]
     };
 
-    // Verify the candidate actually contains bundled resources (not just that
-    // the directory exists — exe_parent always exists).  Check for a known
-    // bundled file to confirm it's the right directory.
-    //
-    // On Windows, check for the actual CLI binary (cli/speedwave.exe) to avoid
-    // false positives from an empty cli/ directory. On Unix, check for the
-    // directory since the binary name is platform-constant.
+    // Check for bundled files to distinguish a resource dir from an empty exe_parent.
+    // Windows: check cli/speedwave.exe (the binary); Unix: check cli/ dir.
     candidates.into_iter().find(|p| {
         let has_cli = if cfg!(target_os = "windows") {
             p.join("cli").join("speedwave.exe").exists()
@@ -1181,9 +1107,7 @@ mod tests {
 
     #[test]
     fn teardown_convergence_skips_when_config_unreadable() {
-        // An unreadable config must skip convergence entirely (fail closed):
-        // with the active project unknown, a teardown could race the
-        // post-reconcile start of that very project.
+        // An unreadable config must skip convergence entirely (fail closed).
         let source = include_str!("reconcile.rs");
         let anchor = source
             .find("Converge crash-orphans")
@@ -1207,10 +1131,8 @@ mod tests {
 
     #[test]
     fn id_changed_branch_also_converges_teardown_intents() {
-        // Crash-interrupted teardowns must be converged in BOTH reconcile paths:
-        // the no-change path (else branch) AND the id-changed path. Without the
-        // id-changed path, orphaned containers accumulate whenever a crash and a
-        // bundle update happen in the same window.
+        // Crash-interrupted teardowns must converge in BOTH reconcile paths:
+        // the no-change path (else branch) AND the id-changed path.
         let source = include_str!("reconcile.rs");
 
         // Find the id-changed convergence block — it uses the same call but the
@@ -1244,10 +1166,8 @@ mod tests {
 
     #[test]
     fn restore_one_project_wraps_full_sequence_in_transaction() {
-        // Structural test: restore_one_project must wrap compose_down (best-effort),
-        // render_and_save_compose, compose_validate_with_retry, and compose_up_recreate
-        // in a single rt.transaction(project, ...) so the per-project lock covers
-        // the whole sequence.
+        // Structural test: restore_one_project must wrap the whole compose sequence
+        // in a single rt.transaction(project, ...).
         let source = include_str!("reconcile.rs");
         let fn_start = source
             .find("fn restore_one_project(")
@@ -1282,10 +1202,8 @@ mod tests {
 
     #[test]
     fn reconcile_compose_port_waits_for_image_readiness() {
-        // Race guard: mcp-os respawn may race with bundle image rebuild;
-        // compose_up_recreate against a missing tag emits image-not-available.
-        // Anchor the find on `pub(crate) fn` to skip the bare `fn ...` inside
-        // tests that quote the function name.
+        // Race guard: mcp-os respawn may race with bundle image rebuild. Anchor the
+        // find on `pub(crate) fn` to skip the bare `fn ...` quoted inside tests.
         let source = include_str!("reconcile.rs");
         let fn_body = extract_fn_body_braced(source, "pub(crate) fn reconcile_compose_port(");
 
@@ -1326,9 +1244,7 @@ mod tests {
         panic!("closing brace not found for {fn_signature}")
     }
 
-    // stop_all_containers is compiled out on macOS (see its definition).
-    // Its tests are gated to match, otherwise the `use super::stop_all_containers`
-    // would fail to resolve on macOS.
+    // stop_all_containers is compiled out on macOS; its tests are gated to match.
     #[cfg(target_os = "windows")]
     mod stop_all_containers_tests {
         use super::stop_all_containers;
@@ -1397,11 +1313,7 @@ mod tests {
         #[cfg(target_os = "windows")]
         #[test]
         fn full_cleanup_calls_in_order_on_windows() {
-            // Note: runs on any non-macOS target. Windows dev hosts execute
-            // this test routinely, but Windows CI
-            // (.github/workflows/desktop-build.yml) runs only `cargo build`,
-            // not `cargo test`. Enabling `cargo test` on the Windows matrix
-            // leg is tracked as a follow-up PR.
+            // Runs on any non-macOS target.
             let (rt, handles) = MockRuntimeBuilder::new().build();
             let projects = vec![project("alpha"), project("beta")];
             run_container_cleanup(&rt, &projects);
@@ -1422,10 +1334,8 @@ mod tests {
         #[cfg(target_os = "macos")]
         #[test]
         fn cleanup_skips_compose_down_when_vm_will_stop() {
-            // On macOS the Lima VM is hard-powered off by `limactl stop
-            // --force`, which reaps containers for free. Per-project
-            // compose_down would waste up to 10s per project (nerdctl's
-            // hard-coded graceful stop) and kill the Quit UX.
+            // On macOS the VM poweroff reaps containers, so per-project
+            // compose_down is skipped.
             let (rt, handles) = MockRuntimeBuilder::new().build();
             let projects = vec![project("alpha"), project("beta")];
             run_container_cleanup(&rt, &projects);
@@ -1478,9 +1388,8 @@ mod tests {
 
         #[test]
         fn app_version_only_update_is_a_reconcile() {
-            // Release with zero image changes: the reconcile id differs
-            // (app_version) → full run; build phase is missing-only (0 builds)
-            // but restore brings stopped projects back. Decided without a VM.
+            // Release with zero image changes: reconcile id differs (app_version)
+            // → full run, missing-only build (0 builds), restore brings projects back.
             let manifest = bundle::BundleManifest::for_tests("new-id");
             let state = bundle::BundleState {
                 applied_bundle_id: Some("old-id".to_string()),
@@ -1542,9 +1451,7 @@ mod tests {
         }
 
         /// Structural: when the runtime isn't ready in the unchanged-id restore
-        /// branch, the code must return early (keeping pending for next launch)
-        /// BEFORE the dirty-state cleanup that would clear pending — otherwise a
-        /// transiently-down VM silently strands the stopped projects (ADR-072).
+        /// branch, return early keeping pending, before the cleanup that clears it (ADR-072).
         #[test]
         fn unchanged_branch_not_ready_keeps_pending() {
             let source = include_str!("reconcile.rs");
@@ -1570,10 +1477,7 @@ mod tests {
         }
 
         /// Structural: `prepare_rebuild` must reset phase to Pending WITHOUT
-        /// clearing `pending_running_projects`. A new bundle may arrive while
-        /// a previous interrupted reconcile left projects in pending — they must
-        /// survive into the new reconcile so they get restored at the end.
-        /// The CAS guard ensures there is no concurrent reconcile to race this.
+        /// clearing `pending_running_projects`.
         #[test]
         fn prepare_rebuild_resets_phase_preserves_pending_projects() {
             let source = include_str!("reconcile.rs");
@@ -1602,12 +1506,7 @@ mod tests {
         }
 
         /// Structural: when the bundle id matches but the previous reconcile was
-        /// interrupted (phase != Done), the code must force a full re-reconcile
-        /// via `prepare_rebuild`. This covers the downgrade-after-interrupted-update
-        /// scenario: v2 sync completed (phase=ResourcesSynced) but app rolled back to
-        /// v1 — the bundle id matches the pre-v2 applied id, but resources on disk
-        /// may reflect v2 content. Without the re-reconcile, v1 images run against
-        /// v2 claude-resources.
+        /// interrupted (phase != Done), force a full re-reconcile via `prepare_rebuild`.
         #[test]
         fn interrupted_reconcile_with_matching_id_forces_rebuild() {
             let source = include_str!("reconcile.rs");
@@ -1635,10 +1534,8 @@ mod tests {
     mod bundle_status_tests {
         use super::*;
 
-        /// All tests use `bundle_status_from()` with an explicit `BundleState`
-        /// to avoid dependence on the global `data_dir()` OnceLock, which
-        /// points to the real `~/.speedwave/` directory during test runs.
-        /// Tests that mutate `BUNDLE_RECONCILE_PHASE` must be `#[serial]`.
+        /// All tests use `bundle_status_from()` with an explicit `BundleState` to
+        /// avoid the global `data_dir()` OnceLock. Phase-mutating tests must be `#[serial]`.
 
         #[test]
         #[serial]
@@ -1968,16 +1865,11 @@ mod tests {
     }
 
     /// Structural test: verifies that `reconcile_bundle_update` in main.rs
-    /// is gated behind `setup_started`. On a fresh install the Lima VM does
-    /// not exist yet, so running reconcile would fail with "Runtime not
-    /// available" and poison `ImageReadiness`, blocking the setup wizard's
-    /// Start Containers step.
+    /// is gated behind `setup_started`.
     #[test]
     fn reconcile_gated_behind_setup_started_in_main() {
         let main_source = include_str!("main.rs");
         // The reconcile call must be inside an `if setup_started` block.
-        // Find the reconcile_bundle_update call and verify it's preceded by
-        // `if setup_started`.
         let idx = main_source
             .find("reconcile::reconcile_bundle_update(app.handle())")
             .expect("main.rs must call reconcile_bundle_update");
@@ -2093,14 +1985,8 @@ mod tests {
     }
 
     /// Verifies that `run_exit_cleanup` is idempotent: the first call returns
-    /// `Some(JoinHandle)` and the second returns `None`. This tests the
-    /// `CLEANUP_ONCE` AtomicBool guard.
-    ///
-    /// NOTE: Because `CLEANUP_ONCE` is a `static` inside `run_exit_cleanup`, once
-    /// set it stays set for the entire process lifetime. This test must run last
-    /// (or in a separate test binary) — any subsequent test calling `run_exit_cleanup`
-    /// in the same process will see `None`. `#[serial]` ensures ordering within this
-    /// module.
+    /// `Some(JoinHandle)` and the second `None` (the `CLEANUP_ONCE` guard).
+    /// Process-wide `static`, so `#[serial]` must order it after other callers.
     #[test]
     #[serial]
     fn cleanup_once_idempotency() {
@@ -2177,15 +2063,7 @@ mod tests {
     }
 
     /// Structural test: image-build errors return via `set_bundle_error`
-    /// before any code that mutates `applied_bundle_id`. This is the atomicity
-    /// guarantee for the partial-build-failure path: if build fails after the
-    /// prune-old block was moved to the end of reconcile, the old bundle id
-    /// must remain so the project keeps running with the previous images.
-    ///
-    /// We cannot run `reconcile_bundle_update_inner` behaviorally in a unit
-    /// test (it depends on `tauri::AppHandle`, `runtime::detect_runtime`,
-    /// `config::load_user_config`, ...) — instead we assert on the source
-    /// that the bail path is structurally correct.
+    /// before any code that mutates `applied_bundle_id`.
     #[test]
     fn reconcile_partial_build_failure_does_not_mutate_applied_bundle_id() {
         let source = include_str!("reconcile.rs");
@@ -2229,10 +2107,7 @@ mod tests {
     }
 
     /// Structural test: `prune_old_bundle_images` must run AFTER the full
-    /// build/restore sequence (after `ProjectsRestored`) in
-    /// `reconcile_bundle_update_inner`. Atomicity: previous-bundle images stay
-    /// on disk until the new bundle has been built AND every project restored,
-    /// so a partial failure leaves the previous bundle intact.
+    /// build/restore sequence (after `ProjectsRestored`).
     #[test]
     fn reconcile_prunes_old_images_after_full_restore() {
         let source = include_str!("reconcile.rs");

--- a/desktop/src-tauri/src/redmine_api_cmd.rs
+++ b/desktop/src-tauri/src/redmine_api_cmd.rs
@@ -1,8 +1,5 @@
 // Redmine API proxy — Tauri commands for direct Redmine API calls.
-//
 // Used during integration configuration before the MCP container exists.
-// The Desktop host calls the Redmine API directly to validate credentials
-// and fetch enumerations (projects, statuses, trackers, priorities, activities).
 
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
@@ -100,11 +97,8 @@ struct RedmineActivitiesResponse {
 // ---------------------------------------------------------------------------
 
 /// Validates and normalizes a Redmine host URL for API use.
-///
-/// Rejects backslashes, embedded credentials, and non-HTTP schemes.
-/// Allows RFC1918 private IPs and IPv6 ULA addresses (common for on-premise
-/// Redmine) with a warning, but blocks loopback, link-local, and unspecified
-/// addresses. Strips trailing slashes for consistent URL construction.
+/// Allows private on-premise IPs (RFC1918/ULA/CGNAT) with a warning; blocks
+/// loopback, link-local, embedded credentials, and non-HTTP schemes.
 fn validate_redmine_host_url(url: &str) -> Result<String, String> {
     // Reject backslashes before parsing (Windows path confusion)
     if url.contains('\\') {
@@ -114,9 +108,7 @@ fn validate_redmine_host_url(url: &str) -> Result<String, String> {
     // Parse URL first to check for RFC1918 before delegating to base validation
     let candidate: url::Url = url.parse().map_err(|e: url::ParseError| e.to_string())?;
 
-    // If private on-premise address (RFC1918 or IPv6 ULA), skip base validation
-    // (which blocks all private IPs) and validate scheme/host ourselves.
-    // Redmine policy blocks loopback — use `PrivatePolicy::BlockLoopback`.
+    // Private on-premise: validate scheme/host ourselves; Redmine policy blocks loopback.
     let parsed = if crate::url_validation::is_private_on_premise(
         &candidate,
         crate::url_validation::PrivatePolicy::BlockLoopback,
@@ -153,15 +145,13 @@ fn validate_redmine_host_url(url: &str) -> Result<String, String> {
         log::warn!("Redmine credentials will be transmitted in cleartext over HTTP");
     }
 
-    // Strip trailing slash from the string representation for consistent URL construction.
-    // url::Url always appends a trailing `/` for root paths, so we trim at string level.
+    // Strip trailing slash for consistent URL construction.
     let result = parsed.as_str().trim_end_matches('/').to_string();
 
     Ok(result)
 }
 
-// read_body_limited + MAX_RESPONSE_BODY_BYTES moved to `crate::http_util`
-// (Rule of Three: the LLM discovery command is the second consumer).
+// read_body_limited + MAX_RESPONSE_BODY_BYTES moved to `crate::http_util`.
 
 // ---------------------------------------------------------------------------
 // HTTP client helper
@@ -349,9 +339,7 @@ async fn do_fetch_enumerations(
 // ---------------------------------------------------------------------------
 
 /// Validates Redmine credentials by calling `/users/current.json`.
-///
-/// Returns a `RedmineValidationResult` indicating whether the credentials
-/// are valid, along with the authenticated user's info on success.
+/// Returns a `RedmineValidationResult` with the authenticated user's info on success.
 #[tauri::command]
 pub async fn validate_redmine_credentials(
     host_url: String,
@@ -366,11 +354,7 @@ pub async fn validate_redmine_credentials(
 }
 
 /// Fetches Redmine enumerations (projects, statuses, trackers, priorities, activities).
-///
-/// Makes 5 parallel requests via `tokio::join!`. Per-endpoint error handling:
-/// - 404 → empty vec + log::info (endpoint may be disabled)
-/// - 500 → empty vec + log::warn
-/// - Success → validate JSON shape, then parse
+/// Makes 5 parallel requests via `tokio::join!`; each endpoint maps 404/500 to an empty vec.
 #[tauri::command]
 pub async fn fetch_redmine_enumerations(
     host_url: String,
@@ -385,9 +369,7 @@ pub async fn fetch_redmine_enumerations(
 }
 
 /// Fetches and parses a single Redmine enumeration endpoint.
-///
-/// Returns `Ok(T)` on success, `Err(())` on non-success status codes
-/// (with appropriate logging), or propagates errors for connection failures.
+/// Returns `Ok(T)` on success, `Err(())` on non-success status, or propagates connection errors.
 async fn fetch_enum_endpoint<T: serde::de::DeserializeOwned>(
     client: &reqwest::Client,
     base_url: &str,
@@ -495,10 +477,7 @@ mod tests {
 
     #[test]
     fn validate_url_allows_cgnat_lower_boundary() {
-        // RFC 6598 CGNAT (100.64.0.0/10) — commonly seen on Tailscale and
-        // carrier-grade NAT networks. Previously blocked by Redmine's
-        // is_private_on_premise (which only covered RFC 1918); now accepted
-        // via the shared url_validation::is_private_on_premise(BlockLoopback).
+        // RFC 6598 CGNAT (100.64.0.0/10) is accepted as on-premise (Tailscale).
         let result = validate_redmine_host_url("http://100.64.1.1:3000/");
         assert!(
             result.is_ok(),
@@ -520,16 +499,9 @@ mod tests {
 
     #[test]
     fn validate_url_rejects_just_outside_cgnat() {
-        // 100.128.x.x is outside /10 — must NOT be classified as CGNAT and
-        // must NOT be mistaken for on-premise by the IP classifier.
-        // It's a regular public IP, which Redmine accepts with a warn; this
-        // test documents that it goes through the public-IP path, not CGNAT.
+        // 100.128.x.x is outside /10 — a public IP, not CGNAT/on-premise.
         let result = validate_redmine_host_url("http://100.128.0.1/");
-        // Public IP — Redmine's policy is to allow with warn (user-written).
-        // The important invariant is that it does NOT go through the
-        // CGNAT/on-premise arm; this is exercised indirectly by the test
-        // passing (if the classifier were wrong, validate_url rejection
-        // logic would differ).
+        // Public IP — allowed with a warn.
         assert!(
             result.is_ok(),
             "100.128.0.1 (outside CGNAT) should still resolve as a public IP: {:?}",
@@ -661,8 +633,7 @@ mod tests {
 
     #[test]
     fn validate_url_octal_ip_blocked() {
-        // The url crate correctly interprets octal notation: 0177 = 127 decimal.
-        // So "0177.0.0.1" is parsed as 127.0.0.1 (loopback) and blocked.
+        // 0177.0.0.1 parses as 127.0.0.1 (octal) and is blocked as loopback.
         let result = validate_redmine_host_url("http://0177.0.0.1/");
         assert!(
             result.is_err(),
@@ -783,18 +754,8 @@ mod tests {
     }
 
     // ── HTTP integration tests (mockito) ────────────────────────────────
-    //
-    // These tests call the core functions (do_validate_credentials,
-    // do_fetch_enumerations) directly with the mockito server URL,
-    // bypassing URL validation (mockito runs on 127.0.0.1 which is
-    // intentionally blocked by validate_redmine_host_url).
-    //
-    // Not covered here:
-    // - TLS certificate errors: mockito serves plain HTTP, so the reqwest
-    //   TLS error path (certificate keyword detection) cannot be triggered.
-    // - Connection timeout: mockito doesn't support delaying responses past
-    //   the reqwest timeout. The connection-refused test below verifies the
-    //   error path for unreachable servers instead.
+    // Mockito runs on 127.0.0.1, so these call do_* core fns directly, bypassing URL validation.
+    // Not covered: TLS cert errors (mockito is plain HTTP), connection timeout (see connection_refused test).
 
     #[tokio::test]
     async fn http_401_returns_invalid() {
@@ -1039,8 +1000,7 @@ mod tests {
 
     #[tokio::test]
     async fn connection_refused_returns_error() {
-        // Bind a port, get its number, then close the listener to guarantee
-        // nothing is listening when we connect.
+        // Bind a port then drop the listener so nothing is listening on connect.
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
         drop(listener);
@@ -1155,9 +1115,7 @@ mod tests {
         );
     }
 
-    // Note: is_private_on_premise helper + its coverage moved to url_validation.rs
-    // as part of the consolidation for LLM model discovery (ADR-041). Redmine uses
-    // PrivatePolicy::BlockLoopback; LLM discovery uses PrivatePolicy::AllowLoopback.
+    // is_private_on_premise helper + coverage moved to url_validation.rs (ADR-041).
     // See url_validation::tests for private_on_premise_*_policy tests.
 
     #[test]
@@ -1226,9 +1184,7 @@ mod tests {
             result.is_err(),
             "Body one byte over limit should be rejected"
         );
-        // The error mentions either "too large" (Content-Length pre-check) or
-        // "exceeded" (streaming check) depending on whether mockito includes
-        // a Content-Length header.
+        // Error is "too large" (Content-Length pre-check) or "exceeded" (streaming check).
         let err = result.unwrap_err();
         assert!(
             err.contains("too large") || err.contains("exceeded"),
@@ -1284,11 +1240,7 @@ mod tests {
 
     #[tokio::test]
     async fn body_too_large_content_length_preflight_rejected() {
-        // Exercises the Content-Length pre-flight guard in read_body_limited
-        // using a real HTTP server. mockito sets Content-Length automatically
-        // from the body, so reqwest sees it in the response header and the
-        // pre-flight guard rejects before streaming. We assert on "bytes, limit"
-        // to distinguish from the streaming guard ("exceeded ... byte limit").
+        // Exercises the Content-Length pre-flight guard; assert "bytes, limit" to distinguish from the streaming guard.
         let mut server = mockito::Server::new_async().await;
         let body = vec![b'x'; MAX_RESPONSE_BODY_BYTES + 1];
         let _mock = server

--- a/desktop/src-tauri/src/retry_cmd.rs
+++ b/desktop/src-tauri/src/retry_cmd.rs
@@ -1,22 +1,5 @@
 //! Tauri command — retry the last assistant turn via Claude Code's native
 //! `--resume-session-at` flag (ADR-046).
-//!
-//! The frontend owns the conversation state-tree and passes the retry
-//! anchor explicitly: the current
-//! `session_id` and the UUID of the user prompt to rewind to. The backend
-//! does not mutate the session JSONL file — Claude Code's native resume
-//! handles the trim-and-regenerate atomically.
-//!
-//! Flow:
-//! 1. Validate the session id and user UUID.
-//! 2. Swap the live `ChatSession` out of its mutex so `stop()` runs without
-//!    starving other commands.
-//! 3. Stop the old session (kills the child, drains reader threads).
-//! 4. Start a new session with `--resume <session> --resume-session-at <uuid>`.
-//!
-//! Errors are serialised as a tagged `RetryError` enum so the frontend can
-//! react (disable the button, show a banner, prompt re-auth, …) without
-//! string-matching error messages.
 
 use serde::{Deserialize, Serialize};
 use tauri::AppHandle;
@@ -52,9 +35,6 @@ impl std::fmt::Display for RetryError {
 impl std::error::Error for RetryError {}
 
 /// Pure core of `retry_last_turn` — does not touch Tauri types.
-///
-/// Extracted so unit tests can exercise the validation/stop/spawn sequence
-/// against a mocked `ChatSession` layer via the `SessionDriver` trait below.
 pub(crate) fn retry_last_turn_inner(
     session_id: &str,
     user_uuid: &str,
@@ -118,10 +98,7 @@ impl SessionDriver for ChatSessionDriver<'_> {
 
 /// Tauri command — retry the last assistant turn in the active session.
 ///
-/// The frontend passes the `session_id` of the current conversation and
-/// `user_uuid` of the user message to rewind to (ADR-046). On success, a
-/// fresh Claude Code spawn starts streaming a replacement turn via the
-/// usual `chat_stream` event channel.
+/// The frontend passes the `session_id` and the `user_uuid` to rewind to (ADR-046).
 #[tauri::command]
 pub async fn retry_last_turn(
     session_id: String,
@@ -129,12 +106,7 @@ pub async fn retry_last_turn(
     app_handle: AppHandle,
     state: tauri::State<'_, SharedChatSession>,
 ) -> Result<(), RetryError> {
-    // Don't log the session_id at all — even a short prefix is flagged by
-    // CodeQL `rust/cleartext-logging`, and the desktop log file is
-    // readable by any process running as the same user. Logging only the
-    // structural metadata (id length / uuid length) keeps the trace useful
-    // for diagnosing malformed-input regressions without leaking either
-    // identifier.
+    // Log only lengths, never the session_id/user_uuid (CodeQL cleartext-logging).
     log::info!(
         "retry_last_turn: session_id_len={} user_uuid_len={}",
         session_id.len(),
@@ -226,9 +198,6 @@ mod tests {
 
     #[test]
     fn retry_with_empty_uuid_returns_no_assistant_turn() {
-        // An empty UUID in this architecture means the frontend tried to
-        // retry without a committed user UUID — which the `canRetry` signal
-        // should have prevented, but we belt-and-brace it on the backend.
         let mut drv = MockDriver::default();
         let r = retry_last_turn_inner(VALID_SESSION, "", &mut drv);
         assert_eq!(r, Err(RetryError::NoAssistantTurn));
@@ -245,8 +214,7 @@ mod tests {
 
     #[test]
     fn retry_stop_failure_returns_resume_failed_without_start() {
-        // If stop fails we MUST NOT proceed to start — otherwise the old
-        // child could race stdout with the new one.
+        // If stop fails, start must not run.
         let mut drv = MockDriver {
             stop_err: Some("stop boom".to_string()),
             ..Default::default()
@@ -285,8 +253,7 @@ mod tests {
 
     #[test]
     fn retry_error_round_trips() {
-        // Round-trip every variant to prove the serde tag/content layout is
-        // stable for the frontend kind-matching.
+        // Round-trip every variant.
         let cases = [
             RetryError::NoAssistantTurn,
             RetryError::SessionNotFound,
@@ -303,15 +270,7 @@ mod tests {
 
     #[test]
     fn retry_does_not_open_session_jsonl_in_mock_driver() {
-        // The mock driver never touches disk. This test documents the
-        // contract: retry_last_turn_inner does NOT interact with the
-        // session JSONL file directly — file mutation is delegated to
-        // Claude Code's native `--resume-session-at` flag (ADR-046).
-        //
-        // An E2E test in `desktop-e2e/` checksums the file before/after
-        // and asserts equality against the pre-retry state. This unit
-        // test stands as a type-level guard against future changes that
-        // might sneak in fs::File::open calls.
+        // retry_last_turn_inner does not touch the session JSONL file.
         let mut drv = MockDriver::default();
         let r = retry_last_turn_inner(VALID_SESSION, VALID_UUID, &mut drv);
         assert!(r.is_ok());

--- a/desktop/src-tauri/src/setup_wizard.rs
+++ b/desktop/src-tauri/src/setup_wizard.rs
@@ -19,21 +19,8 @@ pub struct SetupState {
 }
 
 impl SetupState {
-    /// Derives the current wizard step from the boolean flags.
-    ///
-    /// Returns the number of completed sequential steps (0 = nothing done).
-    /// The wizard steps execute in this order:
-    ///   1. runtime_ready  (Check Runtime)
-    ///   2. vm_ready       (Initialize VM)
-    ///   3. images_built   (Build Images)
-    ///   4. project_created (Create Project)
-    ///   5. containers_started (Start Containers)
-    ///   6. cli_linked     (Finalize / CLI symlink)
-    ///
-    /// Previously this was a stored field (`current_step: u8`) that could
-    /// diverge from the boolean flags. Now it is derived, so it is always
-    /// consistent. Old serialized JSON that includes `"current_step"` is
-    /// silently ignored on deserialization (serde default behavior).
+    /// Derives the wizard step from the boolean flags: count of completed
+    /// sequential steps (0 = nothing done, 6 = all done).
     #[cfg(test)]
     pub fn current_step(&self) -> u8 {
         if !self.runtime_ready {
@@ -68,8 +55,7 @@ impl SetupState {
         match Self::load_from(&path) {
             Ok(state) => state,
             Err(e) => {
-                // Missing file is the normal first-run case; anything else
-                // (corrupt JSON, unreadable) silently restarts onboarding, so warn.
+                // Missing file is the normal first-run case; warn on anything else.
                 if !Self::is_missing_state_file(&e) {
                     log::warn!(
                         "SetupState::load: {} unreadable/corrupt, restarting onboarding from scratch: {e}",
@@ -111,10 +97,8 @@ impl SetupState {
         Ok(())
     }
 
-    /// Pure-logic check: returns `true` when all required setup steps have been completed.
-    ///
-    /// `cli_linked` is intentionally excluded — CLI symlink creation is optional
-    /// (the Desktop app works without it) and may fail on restricted systems.
+    /// `true` when all required setup steps completed. `cli_linked` is
+    /// excluded — CLI symlink creation is optional.
     pub fn is_complete(&self) -> bool {
         self.runtime_ready
             && self.vm_ready
@@ -136,16 +120,11 @@ pub enum RuntimeStatus {
 
 pub fn check_runtime() -> anyhow::Result<RuntimeStatus> {
     let rt = runtime::detect_runtime();
-    // ensure_ready() verifies the full stack: binary exists, correct version,
-    // AND containerd is running. is_available() only checks the binary, which
-    // causes the wizard to skip init_vm even when containerd is not started.
+    // ensure_ready() verifies the full stack (binary + version + containerd running).
     if rt.ensure_ready().is_ok() {
         let mut state = SetupState::load();
         state.runtime_ready = true;
-        // When the runtime is already Ready, the VM is also ready — ensure_ready()
-        // verifies the full stack (binary + containerd running). Without this,
-        // the wizard skips init_vm (which normally sets vm_ready) and
-        // is_complete() returns false because vm_ready stays false.
+        // A Ready runtime implies the VM is ready (the wizard skips init_vm).
         state.vm_ready = true;
         state.save()?;
         Ok(RuntimeStatus::Ready)
@@ -158,26 +137,16 @@ pub fn check_runtime() -> anyhow::Result<RuntimeStatus> {
 // Step 3: Initialize VM (macOS only — Lima)
 // ---------------------------------------------------------------------------
 
-// VM provisioning primitives (Lima YAML builder, WSL2 import, nerdctl-full
-// install, .wslconfig / wsl.conf mergers) live in the runtime SSOT
-// `speedwave_runtime::provision`. `init_vm()` below dispatches into it.
+// VM provisioning primitives live in the runtime SSOT `speedwave_runtime::provision`.
 
 /// Returns a `Command` for `limactl` with bundled-binary resolution and
-/// isolated `LIMA_HOME`. Delegates to [`speedwave_runtime::binary::command`]
-/// which resolves the binary path and ensures LIMA_HOME is set.
-///
-/// Retained here (not in `provision`) because `factory_reset` — wizard-state
-/// orchestration — is the only remaining direct `limactl` caller in this crate.
+/// isolated `LIMA_HOME`, via [`speedwave_runtime::binary::command`].
 #[cfg(target_os = "macos")]
 fn limactl_command() -> std::process::Command {
     speedwave_runtime::binary::command("limactl")
 }
 
-/// Decode output from `wsl.exe` which may be UTF-16LE (with or without BOM) or UTF-8.
-///
-/// Windows `wsl.exe --list` often outputs UTF-16LE text. Using `String::from_utf8_lossy()`
-/// on such output corrupts the data (inserts replacement characters and null bytes), causing
-/// string comparisons like distro name matching to silently fail.
+/// Decodes `wsl.exe` output which may be UTF-16LE (with or without BOM) or UTF-8.
 #[cfg(test)]
 use runtime::decode_wsl_output;
 
@@ -204,11 +173,6 @@ pub fn init_vm() -> anyhow::Result<()> {
 
     Ok(())
 }
-
-// VM provisioning primitives (Lima create/start, WSL2 import, nerdctl-full
-// install, .wslconfig / wsl.conf mergers) moved to the runtime SSOT
-// `speedwave_runtime::provision`. The wizard re-exports the items its public
-// API + `main.rs` reference; `init_vm()` above dispatches into the module.
 
 /// Ensures `%USERPROFILE%\.wslconfig` declares VPN-compatible `[wsl2]` keys.
 /// Re-exported from the runtime SSOT — called at startup from `main.rs`.
@@ -248,13 +212,9 @@ pub fn create_project(name: &str, dir: &str) -> anyhow::Result<()> {
 // Setup completeness check
 // ---------------------------------------------------------------------------
 
-/// Returns `true` when all required setup steps have been completed AND the
-/// VM / WSL distro still physically exists. `cli_linked` is excluded — CLI
-/// symlink creation is optional. The runtime check catches external removal
-/// (factory reset, manual unregister, data_dir rename) that leaves stale state.
-///
-/// **Cost:** `is_installed()` spawns `limactl list` (macOS) or `wsl.exe --list`
-/// (Windows) per call. Safe for navigation/route guards; do not poll.
+/// `true` when all required setup steps completed AND the VM / WSL distro
+/// still exists (`cli_linked` excluded). Spawns `limactl list` / `wsl.exe
+/// --list` per call — safe for route guards, do not poll.
 pub fn is_setup_complete() -> bool {
     let state = SetupState::load();
     if !state.is_complete() {
@@ -270,10 +230,7 @@ pub fn is_setup_complete() -> bool {
 pub fn build_images() -> anyhow::Result<()> {
     let rt = runtime::detect_runtime();
     rt.ensure_ready()?;
-    // Build the active project's enabled set (+ claude/mcp-hub always). On a
-    // fresh setup there is no active project, so only claude/mcp-hub are
-    // built — workers come on demand when an integration is first enabled
-    // (ADR-057).
+    // Build the active project's enabled set (+ claude/mcp-hub always).
     let active_integrations = {
         let user_config = match config::load_user_config() {
             Ok(c) => c,
@@ -305,15 +262,11 @@ pub fn build_images() -> anyhow::Result<()> {
         Err(e) => return Err(e),
     }
 
-    // Sync claude-resources to data_dir so they are available for
-    // compose volume mounts and container entrypoints.
+    // Sync claude-resources to data_dir for compose volume mounts.
     let build_root = build::resolve_build_root()?;
     bundle::sync_claude_resources(&build_root)?;
 
-    // Record that the current bundle's images are now built so that
-    // reconcile_bundle_update (on next startup) sees bundle_changed=false
-    // and skips the unnecessary rebuild. The per-image map must be persisted
-    // too, else the first reconcile would re-prune/rebuild (ADR-072).
+    // Persist the built bundle id + per-image map so next reconcile skips the rebuild (ADR-072).
     let manifest = bundle::load_current_bundle_manifest()?;
     let mut bundle_state = bundle::load_bundle_state();
     bundle_state.applied_bundle_id = Some(manifest.bundle_id);
@@ -341,18 +294,12 @@ pub fn start_containers(project: &str) -> anyhow::Result<()> {
     rt.ensure_ready()?;
     log::info!("runtime ready, rendering compose");
 
-    // Re-render compose.yml before every start. Dynamic config (mcp-os token,
-    // auth keys, addons) may have changed since create_project() first rendered it.
-    // Without this, WORKER_OS_URL is missing if mcp-os started after project creation.
+    // Re-render compose.yml before every start: dynamic config may have changed.
     let user_config = config::load_user_config()?;
     let project_dir = &user_config.require_project(project)?.dir;
     let project_path = std::path::Path::new(project_dir);
     let resolved = config::resolve_claude_config(project_path, &user_config, project);
     let integrations = config::resolve_integrations(project_path, &user_config, project);
-    // Bridge info is sourced from the globally-shared plugin-bridges map
-    // via crate::reconcile::current_bridges_info(). When no host-bridged
-    // plugins are running yet (e.g. during early setup), the registration
-    // list is empty and the corresponding env vars stay absent in compose.yml.
     let yaml = compose::render_compose(
         project,
         project_dir,
@@ -381,29 +328,19 @@ pub fn start_containers(project: &str) -> anyhow::Result<()> {
         compose::save_compose(project, &yaml)?;
         log::info!("starting containers via idempotent compose_up");
         speedwave_runtime::runtime::compose_validate_with_retry(rt, project)?;
-        // Idempotent up, not force-recreate: config-hash convergence plus
-        // content-addressed image tags (ADR-072) recreate exactly what
-        // changed; an unchanged running project starts in seconds.
+        // Idempotent up, not force-recreate (ADR-072).
         rt.compose_up(project)?;
         Ok(())
     })?;
     log::info!("containers started, verifying health");
 
-    // Windows: `compose up` auto-creates the `/home/speedwave/.claude` bind
-    // mount-point (for the read-only ide-bridge mount) as ROOT, even after we
-    // chowned claude-home — so the uid-1000 entrypoint's `mkdir .claude/skills`
-    // hits EACCES and the container exits(1). Chown the tree AFTER compose
-    // created the mount-points, then ensure_exec_healthy's recovery recreate
-    // re-runs the entrypoint against the now-1000-owned tree. Verified on the
-    // live distro. Fail-open. (ADR-052 mount ownership.)
+    // Windows: chown claude-home AFTER compose created the bind mount-points (ADR-052). Fail-open.
     #[cfg(target_os = "windows")]
     if let Err(e) = ensure_claude_home_owner(project) {
         log::warn!("ensure_claude_home_owner failed (non-fatal): {e}");
     }
 
-    // Verify containers are actually functional before marking as started.
-    // Only probes the claude container — MCP workers are health-checked
-    // separately via get_health.
+    // Verify functional before marking started: probes the claude container only.
     let claude_container = format!(
         "{}_{}_claude",
         speedwave_runtime::consts::compose_prefix(),
@@ -422,10 +359,8 @@ pub fn start_containers(project: &str) -> anyhow::Result<()> {
 // Check Claude auth status inside the container
 // ---------------------------------------------------------------------------
 
-/// Pure lookup for the project's LLM provider name from the user config.
-/// Returns `None` when the project is missing or `claude.llm.provider` is
-/// unset. Separated out so the local-provider branch in `check_claude_auth`
-/// can be covered without mocking the container runtime.
+/// Looks up the project's LLM provider name. `None` when the project is
+/// missing or `claude.llm.provider` is unset.
 pub(crate) fn lookup_project_provider<'a>(
     user_config: &'a speedwave_runtime::config::SpeedwaveUserConfig,
     project: &str,
@@ -437,13 +372,8 @@ pub(crate) fn lookup_project_provider<'a>(
         .and_then(|l| l.provider.as_deref())
 }
 
-/// True when the project's sessions authenticate to Anthropic (the only
-/// case where the in-container `claude auth status` check is meaningful).
-///
-/// v2 configs (ADR-073) decide by the active provider kind: only
-/// `AnthropicOauth` needs the OAuth check (`AnthropicApiKey` injects a key
-/// — no interactive login). Legacy configs fall back to the v1 rule:
-/// anything non-local is Anthropic.
+/// True when the project's sessions need the in-container Anthropic OAuth
+/// check: v2 (ADR-073) only for `AnthropicOauth`; legacy for anything non-local.
 pub(crate) fn project_needs_anthropic_auth(
     user_config: &speedwave_runtime::config::SpeedwaveUserConfig,
     project: &str,
@@ -494,10 +424,8 @@ pub fn check_claude_auth(project: &str) -> anyhow::Result<bool> {
 // Lima VM config migration — upgrade memory from older installs
 // ---------------------------------------------------------------------------
 
-/// Migrates the Lima VM config on existing installs when it drifts from the
-/// SSOT (memory, cpus, or the VPN netplan drop-in). Re-exported from the
-/// runtime SSOT [`speedwave_runtime::provision`] — called at startup from
-/// `main.rs` before `reconcile_bundle_update`.
+/// Migrates the Lima VM config when it drifts from the SSOT (memory, cpus, or
+/// the VPN netplan drop-in). Re-exported from [`speedwave_runtime::provision`].
 #[cfg(target_os = "macos")]
 pub use speedwave_runtime::provision::ensure_lima_vm_config;
 
@@ -508,18 +436,10 @@ pub use speedwave_runtime::provision::ensure_lima_vm_config;
 pub fn factory_reset() -> anyhow::Result<()> {
     let state = SetupState::load();
 
-    // 1. Stop containers for the wizard's project (if any) — with timeout.
-    //    Only stops the single project from setup_state.json, not all projects
-    //    from config.json. This is intentional: the VM force-delete (step 2)
-    //    destroys all containers regardless, and config.json may already be
-    //    corrupt or missing at this point. Best-effort graceful stop here.
-    //    Even is_available() could theoretically hang, so run the entire
-    //    "check + compose_down" block with a timeout.
+    // 1. Stop only the wizard's project (VM force-delete destroys all containers anyway), with timeout.
     if let Some(ref project) = state.project_created {
         log::info!("stopping containers for project={project}");
         let project_clone = project.clone();
-        // Uses thread+channel (not run_with_timeout) because compose_down goes
-        // through the ContainerRuntime trait, which returns Result — not a Command.
         let (tx, rx) = std::sync::mpsc::channel();
         std::thread::spawn(move || {
             let rt = runtime::detect_runtime();
@@ -564,12 +484,7 @@ pub fn factory_reset() -> anyhow::Result<()> {
         }
     }
 
-    // 2b. Reset VM/distro across platforms.
-    //     Windows: WslRuntime::reset_vm runs `wsl --terminate` + `--unregister`,
-    //     each bounded by CommandRunner::run_with_timeout (10s + 25s).
-    //     macOS: trait default no-op (Lima VM already destroyed above).
-    //     Run BEFORE wipe_data_dir so the WSL VHDX path is still where WSL
-    //     expects it (~/.speedwave/wsl/Speedwave/ext4.vhdx).
+    // 2b. Reset VM/distro before wipe_data_dir (WSL VHDX still lives under the data dir).
     {
         let rt = runtime::detect_runtime();
         if let Err(e) = rt.reset_vm() {
@@ -609,12 +524,8 @@ fn wipe_data_dir(data_dir: &std::path::Path) -> anyhow::Result<()> {
 // Step 7: Copy CLI binary to user PATH
 // ---------------------------------------------------------------------------
 
-/// Resolves the CLI binary bundled in Tauri resources.
-///
-/// Layout at runtime:
-/// - macOS:   `.app/Contents/Resources/cli/speedwave`
-/// - Windows: `<exe_dir>/resources/cli/speedwave.exe`
-/// - Dev mode fallback: `<exe_dir>/speedwave` (existing behaviour)
+/// Resolves the CLI binary bundled in Tauri resources, with a dev fallback
+/// next to the exe.
 pub fn resolve_cli_source() -> Option<std::path::PathBuf> {
     let exe = std::env::current_exe().ok()?;
     let exe_dir = exe.parent()?;
@@ -728,11 +639,8 @@ enum UserShell {
     Unknown,
 }
 
-/// Detects the user's default shell from the `$SHELL` environment variable.
-///
-/// Falls back to [`UserShell::Zsh`] on macOS when `$SHELL` is unset (common when
-/// the Desktop app is launched from Dock/Finder, where launchd may not propagate
-/// `$SHELL`). macOS has defaulted to zsh since Catalina (10.15).
+/// Detects the user's default shell from `$SHELL`. Falls back to
+/// [`UserShell::Zsh`] on macOS when `$SHELL` is unset.
 #[cfg(unix)]
 fn detect_shell() -> UserShell {
     let shell = std::env::var("SHELL").unwrap_or_default();
@@ -740,9 +648,6 @@ fn detect_shell() -> UserShell {
 }
 
 /// Parses a `$SHELL` value into a [`UserShell`].
-///
-/// Separated from [`detect_shell`] so unit tests can exercise the parsing logic
-/// directly without depending on (or mutating) the `$SHELL` environment variable.
 #[cfg(unix)]
 fn parse_shell_env(shell: &str) -> UserShell {
     if shell.ends_with("/bash") {
@@ -751,7 +656,6 @@ fn parse_shell_env(shell: &str) -> UserShell {
         UserShell::Zsh
     } else if shell.is_empty() {
         // $SHELL may be unset when launched from macOS Dock/Finder (launchd).
-        // macOS default shell is zsh since Catalina (10.15).
         #[cfg(target_os = "macos")]
         return UserShell::Zsh;
         #[cfg(target_os = "windows")]
@@ -761,14 +665,9 @@ fn parse_shell_env(shell: &str) -> UserShell {
     }
 }
 
-/// Returns the shell config file path(s) to modify for the given shell.
-///
-/// Selection rules per shell initialization order:
-/// - **bash on macOS**: login shell reads first of `.bash_profile` > `.bash_login` >
-///   `.profile` (then stops). macOS terminals always open login shells, so only the
-///   login file is needed. Creates `.bash_profile` if none of the three exist.
-/// - **zsh**: `.zshrc` is sourced for both login and interactive shells on all platforms.
-/// - **Unknown**: `.profile` — POSIX portable fallback.
+/// Shell config file(s) to modify: zsh → `.zshrc`; bash → first of
+/// `.bash_profile`/`.bash_login`/`.profile` (creates `.bash_profile` if none);
+/// unknown → `.profile`.
 #[cfg(unix)]
 fn shell_config_targets(home: &std::path::Path, shell: UserShell) -> Vec<std::path::PathBuf> {
     match shell {
@@ -789,12 +688,8 @@ fn shell_config_targets(home: &std::path::Path, shell: UserShell) -> Vec<std::pa
     }
 }
 
-/// Ensures `~/.local/bin` is on PATH by appending an `export` line to the correct
-/// shell config file(s) for the user's detected shell and platform.
-///
-/// Detects the user's shell via `$SHELL` and writes to the appropriate config file
-/// (e.g., `.bash_profile` for bash on macOS, `.zshrc` for zsh). Creates the target
-/// file if it doesn't exist. Skips files that already contain `.local/bin`.
+/// Ensures `~/.local/bin` is on PATH by appending an `export` line to the
+/// detected shell's config file. Idempotent: skips files already containing it.
 #[cfg(unix)]
 fn ensure_local_bin_on_path(home: &std::path::Path) -> anyhow::Result<()> {
     ensure_local_bin_on_path_for_shell(home, detect_shell())
@@ -836,14 +731,8 @@ fn ensure_local_bin_on_path_for_shell(
     Ok(())
 }
 
-/// Returns the platform-specific path where the CLI binary is installed.
-///
-/// - Unix: `~/.local/bin/speedwave`
-/// - Windows: `~/.speedwave/bin/speedwave.exe`
-///
-/// Returns the install path of the CLI binary for an explicit `data_dir`.
-/// Only the Windows branch consults `data_dir`; on Unix the path derives from
-/// the home dir. Used only in tests to verify the path matches `link_cli_from`.
+/// CLI install path (Unix: `~/.local/bin/speedwave`, Windows:
+/// `<data_dir>/bin/speedwave.exe`).
 #[cfg(test)]
 fn cli_install_path_in(_data_dir: &std::path::Path) -> Option<std::path::PathBuf> {
     #[cfg(unix)]
@@ -858,17 +747,10 @@ fn cli_install_path_in(_data_dir: &std::path::Path) -> Option<std::path::PathBuf
     Some(path)
 }
 
-/// Copies the CLI binary into the user's PATH and updates shell configuration.
-///
-/// Called both unconditionally on app startup (to keep the CLI in sync after updates)
-/// and during the setup wizard finalize step. Both calls are idempotent.
-///
-/// Uses [`link_cli_from`] internally for the filesystem operations, then updates
-/// the persisted [`SetupState`] to mark `cli_linked = true`.
+/// Copies the CLI binary into PATH, updates shell config, and marks
+/// `cli_linked` in [`SetupState`]. Idempotent.
 pub fn link_cli() -> anyhow::Result<()> {
-    // Guard: skip if data directory does not exist — factory reset wiped it
-    // or this is a fresh install. The wizard will link the CLI after creating
-    // the data directory. Defense in depth: main.rs also guards the call site.
+    // Guard: skip if the data directory does not exist.
     let home =
         dirs::home_dir().ok_or_else(|| anyhow::anyhow!("cannot determine home directory"))?;
     if !consts::data_dir().exists() {
@@ -886,9 +768,6 @@ pub fn link_cli() -> anyhow::Result<()> {
     link_cli_from(&cli_source, &home)?;
 
     // Write resources-dir marker so the external CLI can find build context.
-    // On startup this write is gated behind setup_started (to avoid
-    // recreating ~/.speedwave/ after factory reset). Here in link_cli() the
-    // data dir is guaranteed to exist, so write the marker unconditionally.
     if let Ok(res) = std::env::var(consts::BUNDLE_RESOURCES_ENV) {
         if let Err(e) = build::write_resources_marker(std::path::Path::new(&res)) {
             log::warn!("link_cli: could not write resources-dir marker: {e}");
@@ -952,11 +831,9 @@ pub(crate) fn system_powershell_path() -> std::path::PathBuf {
         .join("powershell.exe")
 }
 
-/// Defense-in-depth: kill any stale Speedwave / Node / CLI process holding
-/// the binaries we are about to overwrite. Runs at every Tauri Desktop
-/// startup, complementing the install-time sweep in NSIS + WiX. Fails open
-/// (logs warn, returns) so AppLocker / WDAC policy cannot brick startup.
-/// SSOT for the kill predicate is `windows/sweep.ps1`.
+/// Kills stale Speedwave / Node / CLI processes holding binaries about to be
+/// overwritten. Runs at every Desktop startup, fails open. SSOT for the kill
+/// predicate is `windows/sweep.ps1`.
 #[cfg(target_os = "windows")]
 fn run_pre_link_sweep() {
     let Some(sweep) = resolve_sweep_script() else {
@@ -970,10 +847,7 @@ fn run_pre_link_sweep() {
     let data_dir = consts::data_dir();
     let powershell = system_powershell_path();
 
-    // Runtime mode: kill only ~/.speedwave/bin/speedwave.exe. Full mode is
-    // reserved for install-time hooks (NSIS/MSI) — Tauri Desktop must not
-    // target its own workers or self. system_command applies CREATE_NO_WINDOW
-    // so PowerShell does not flash a console over the Desktop UI.
+    // Runtime mode: kill only ~/.speedwave/bin/speedwave.exe (full mode is install-time only).
     let result = speedwave_runtime::binary::system_command(&powershell.to_string_lossy())
         .args([
             "-NoProfile",
@@ -1004,10 +878,7 @@ fn run_pre_link_sweep() {
     }
 }
 
-/// Inner implementation that copies the CLI binary and configures PATH using explicit paths.
-///
-/// Separated from [`link_cli`] for unit testing without depending on `current_exe()` or
-/// the real home directory.
+/// Copies the CLI binary and configures PATH using explicit paths.
 fn link_cli_from(cli_source: &std::path::Path, home: &std::path::Path) -> anyhow::Result<()> {
     #[cfg(unix)]
     {
@@ -1036,10 +907,7 @@ fn link_cli_from(cli_source: &std::path::Path, home: &std::path::Path) -> anyhow
             );
         }
 
-        // Defense-in-depth: kill any stale CLI / worker process holding
-        // ~/.speedwave/bin/speedwave.exe before we try to overwrite it.
-        // Covers MSI users (no NSIS PRE-INSTALL sweep), AppLocker failures,
-        // and post-install processes spawned by containers (ADR-048).
+        // Kill any stale process holding ~/.speedwave/bin/speedwave.exe before overwrite (ADR-048).
         run_pre_link_sweep();
 
         copy_cli_binary(cli_source, &cli_dir)?;

--- a/desktop/src-tauri/src/slack_oauth_cmd.rs
+++ b/desktop/src-tauri/src/slack_oauth_cmd.rs
@@ -1,7 +1,4 @@
 // Slack OAuth2 authorization_code flow (loopback redirect + PKCE, ADR-071).
-// Bundled public client_id, user_scope only — Claude acts as the signed-in
-// human. The rotating refresh token stays host-side under oauth/; only the
-// short-lived access token reaches the worker container.
 
 use crate::oauth_flow::{self, FlowRegistry, ProgressStatus};
 use crate::oauth_loopback::{build_authorize_url, wait_for_callback, CallbackFailure};
@@ -88,11 +85,7 @@ pub async fn start_slack_oauth(
     let pkce = speedwave_runtime::pkce::generate_pkce();
     let state = speedwave_runtime::pkce::generate_state();
 
-    // The redirect is registered on the Slack app as
-    // `http://localhost:<port>/callback` and Slack matches it exactly, so the
-    // port is fixed and the host is `localhost` — which the browser may
-    // resolve to either 127.0.0.1 or ::1. Bind both; one failing is fine
-    // (IPv6-less hosts), both failing means another process owns the port.
+    // Fixed port registered on the Slack app; bind both 127.0.0.1 and ::1.
     let port = consts::SLACK_OAUTH_REDIRECT_PORT;
     // SSOT-allow: browser-side OAuth redirect listener, not a container-reach bind (see ADR-071; same rationale as plugin_oauth_cmd).
     let v4 = tokio::net::TcpListener::bind(("127.0.0.1", port)).await;
@@ -122,7 +115,7 @@ pub async fn start_slack_oauth(
         &scopes,
         &state,
         &pkce.challenge,
-        // user_scope, never scope: bot scopes are forbidden on desktop redirects.
+        // user_scope, never scope (bot scopes).
         "user_scope",
     )
     .inspect_err(|_| FLOW_STATE.clear_if_current(&request_id))?;
@@ -265,10 +258,8 @@ fn pick_display_name(user: SlackUserInfoUser) -> Option<String> {
     from_profile.or(user.real_name.filter(|s| !s.is_empty()))
 }
 
-/// Best-effort display-name lookup via `users.info` on the freshly-issued user
-/// token. Returns None on any failure — sign-in must never fail because the
-/// cosmetic name lookup did (the card falls back to the user ID).
-/// `users_info_url` is derived from the token URL so there is no second SSOT.
+/// Best-effort display-name lookup via `users.info`; returns None on any
+/// failure. `users_info_url` is derived from the token URL.
 async fn fetch_slack_display_name(
     users_info_url: &str,
     access_token: &str,
@@ -346,8 +337,7 @@ async fn exchange_slack_code(
     let access_token = user.access_token.filter(|t| !t.is_empty()).ok_or_else(|| {
         "Slack returned no user access token — check the app's user_scope configuration".to_string()
     })?;
-    // Rotation is mandatory on the Speedwave Slack app; a response without
-    // refresh_token/expires_in means the app is misconfigured.
+    // Rotation is mandatory; refresh_token/expires_in are required.
     let refresh_token = user
         .refresh_token
         .filter(|t| !t.is_empty())

--- a/desktop/src-tauri/src/slash_cmd.rs
+++ b/desktop/src-tauri/src/slash_cmd.rs
@@ -1,9 +1,5 @@
 //! Tauri command for the slash-menu popover.
-//!
-//! Thin wrapper that delegates to [`speedwave_runtime::slash`]. The
-//! runtime crate owns all I/O, caching, and filesystem access; this
-//! module only resolves the active project and converts errors to
-//! strings so Tauri can serialize them.
+//! Delegates to [`speedwave_runtime::slash`].
 
 use crate::types::check_project;
 use speedwave_runtime::config;
@@ -12,11 +8,8 @@ use speedwave_runtime::slash;
 use std::path::PathBuf;
 
 /// Lists every slash command Claude Code exposes for `project_id`.
-///
-/// Returns the cached result when fresh (see `slash::CACHE_STALENESS`).
-/// Falls back to a hardcoded built-in list if the container is not
-/// running or discovery times out — callers should treat the
-/// `source` field as the source-of-truth indicator.
+/// Returns cached results when fresh, else a built-in fallback list;
+/// the `source` field marks which.
 #[tauri::command]
 pub(crate) async fn list_slash_commands(
     project_id: String,
@@ -67,8 +60,7 @@ mod tests {
 
     #[test]
     fn invalidate_slash_cache_accepts_valid_project_name() {
-        // Valid name passes the check; the cache lookup itself is a no-op
-        // for an unknown project, so the call should succeed.
+        // Valid name passes the check; cache lookup is a no-op for an unknown project.
         let res = invalidate_slash_cache("acme".to_string());
         assert!(res.is_ok());
     }

--- a/desktop/src-tauri/src/system_settings_cmd.rs
+++ b/desktop/src-tauri/src/system_settings_cmd.rs
@@ -20,8 +20,7 @@ fn open_privacy_subpane(anchor: &str) -> Result<(), String> {
 pub fn open_files_folders_pane() -> Result<(), String> {
     #[cfg(target_os = "macos")]
     {
-        // The "Files and Folders" sub-pane is not directly addressable, but
-        // opening the parent pane with this anchor guides the user there.
+        // "Files and Folders" sub-pane is not directly addressable; use parent anchor.
         open_privacy_subpane("Privacy_FilesAndFolders")?;
     }
     Ok(())
@@ -67,8 +66,7 @@ mod tests {
             assert!(open_microphone_pane().is_ok());
             assert!(open_audio_capture_pane().is_ok());
         }
-        // On macOS we can only verify the source carries the expected anchors —
-        // spawning `open` in CI would pop System Settings.
+        // On macOS verify the source carries the expected anchors.
         #[cfg(target_os = "macos")]
         {
             let source = include_str!("system_settings_cmd.rs");

--- a/desktop/src-tauri/src/transcription_cmd.rs
+++ b/desktop/src-tauri/src/transcription_cmd.rs
@@ -1,9 +1,5 @@
 //! Tauri commands for the meeting-transcription feature (ADR-056).
-//!
-//! Thin layer over `speedwave_runtime::transcription`: stores live in Tauri
-//! managed state; events forwarded via per-session `transcript_event::<id>`
-//! Tauri event channels (subscribe returns `{event_name, snapshot}` so a late
-//! subscriber doesn't miss what already happened — ADR-043 delivery shape).
+//! Stores live in Tauri state; events forwarded via per-session event channels (ADR-043).
 
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
@@ -46,9 +42,7 @@ fn parse_transcript_id(s: &str) -> Result<Uuid, String> {
 
 /// Caps a user-supplied speaker name length (matches `TranscriptSession::relabel_speaker`).
 const MAX_SPEAKER_NAME_LEN: usize = 64;
-/// Defensive upper bound on the diarizer's `num_clusters` hint. Real meetings
-/// rarely exceed a dozen distinct speakers; we cap well above that so a UI
-/// glitch or a malicious caller can't pass a giant value straight to sherpa.
+/// Defensive upper bound on the diarizer's `num_clusters` hint.
 const MAX_EXPECTED_SPEAKERS: u32 = 50;
 
 fn cap_name(name: &str) -> String {
@@ -78,8 +72,7 @@ fn validate_expected_speakers(n: Option<u32>) -> Result<Option<u32>, String> {
 
 // ---- 1) feature-toggle commands (top-level user config, ADR-056 §13) ------
 
-// Synchronous file I/O for the four toggle commands is wrapped in
-// `spawn_blocking` so it never stalls the Tokio runtime thread.
+// File I/O wrapped in spawn_blocking to avoid blocking the Tokio runtime.
 
 #[tauri::command]
 pub async fn transcription_enabled() -> Result<bool, String> {
@@ -211,8 +204,7 @@ pub async fn start_transcription(
     // Defend at the boundary (the UI should already hide unsupported choices).
     validate_source_against_caps(&audio_source, &caps)?;
 
-    // Pick live model: override wins, else recommendation, else any downloaded.
-    // Never download implicitly — error with a hint if nothing is present.
+    // Override wins, else recommendation, else first downloaded; never implicit download.
     let store_arc = store.inner().clone();
     let models_arc = models.inner().clone();
     let recommended = transcription::recommended_live_model(&transcription::compiled_backends())
@@ -243,8 +235,7 @@ pub async fn start_transcription(
             .map_err(|e| e.to_string())?
     };
 
-    // Optional diarizer: best-effort — if the diarization models are present,
-    // load them; otherwise run without speaker labels.
+    // Optional diarizer: load if models present, else run without speaker labels.
     let diarize_opts = DiarizeOptions {
         num_speakers: expected_speakers.map(|n| n as usize),
         ..DiarizeOptions::default()
@@ -277,10 +268,7 @@ pub async fn start_transcription(
         }
     };
 
-    // Create the session, then start capture.
-    // The audio.wav path lives under `<root>/<id>/`, so we need the id before
-    // creating the session — pick it now so the path is correct from the first
-    // persisted write (no fragile post-create patch).
+    // Pick the id before session creation so the audio.wav path is correct from the first write.
     let session_id = Uuid::new_v4();
     let session_dir = store.session_dir(session_id);
     let audio_wav = session_dir.join("audio.wav");
@@ -341,16 +329,13 @@ pub async fn start_transcription(
     let drivers_for_cleanup = drivers.inner().clone();
     tokio::task::spawn_blocking(move || {
         if let Err(e) = driver.run(&audio_wav) {
-            // Log only the first chunk of the id — UUIDs are not secrets, but
-            // CodeQL's heuristics flag any "session_id"-looking variable in a
-            // log line. The short form is enough to correlate diagnostics.
+            // Log short id only (CodeQL flags session_id in logs; 8 chars enough to correlate).
             log::warn!(
                 "transcript driver for {} ended with error: {e}",
                 short_id(session_id)
             );
         }
-        // Drop the stop-signal entry once the driver has wound down, then
-        // wake anyone waiting on `await_finished()` (e.g. `stop_transcription`).
+        // Remove stop-signal and wake anyone waiting on await_finished (e.g. stop_transcription).
         if let Ok(mut g) = drivers_for_cleanup.lock() {
             g.remove(&session_id);
         }
@@ -373,9 +358,7 @@ pub async fn stop_transcription(
     drivers: tauri::State<'_, DriversHandle>,
 ) -> Result<(), String> {
     let id = parse_transcript_id(&session_id)?;
-    // Signal the driver to wind down and grab its finish-notifier (idempotent
-    // if the driver already exited — `await_finished` will then just suspend
-    // until the wind-down notify, or the timeout below trips).
+    // Signal driver to wind down and grab its finish-notifier (idempotent if already exited).
     let stop_handle = drivers
         .lock()
         .map_err(|e| format!("drivers lock poisoned: {e}"))?
@@ -384,27 +367,23 @@ pub async fn stop_transcription(
     if let Some(stop) = stop_handle.as_ref() {
         stop.stop();
     } else {
-        // No live driver: just flip to Finalizing so a subsequent finalize pass
-        // (below) can run against whatever was recorded.
+        // No live driver: flip to Finalizing so a subsequent finalize can run against recorded audio.
         let _ = store.set_status(id, TranscriptStatus::Finalizing { progress: 0.0 });
     }
 
-    // Wait for the driver loop to actually exit, bounded so a wedged driver
-    // can't hang the command. 5 s mirrors the previous spin-poll budget.
+    // Wait for driver loop to exit, bounded so a wedged driver can't hang (5s mirrors prior budget).
     if let Some(stop) = stop_handle {
         let _ =
             tokio::time::timeout(std::time::Duration::from_secs(5), stop.await_finished()).await;
     }
 
-    // Offline pass: re-transcribe the WAV (prefer `large-v3`, fall back to the
-    // live model) and mark Done; on failure the live transcript stays.
+    // Offline pass: prefer large-v3, fall back to live model, mark Done (live transcript stays on error).
     let store_arc = store.inner().clone();
     let models_arc = models.inner().clone();
     let session_dir = store.session_dir(id);
     let audio_wav = session_dir.join("audio.wav");
     tokio::task::spawn_blocking(move || {
-        // Pick the offline model: `large-v3` if present, else fall back to any
-        // downloaded Whisper model (the live one is guaranteed present).
+        // Pick offline model: large-v3 if present, else first downloaded (live model guaranteed present).
         let offline_key = pick_offline_model(&models_arc);
         let Some(key) = offline_key else {
             let _ = store_arc.set_status(
@@ -462,8 +441,7 @@ pub async fn stop_transcription(
         } else {
             None
         };
-        // Live turns aren't tracked across the driver boundary in v1; offline
-        // diarizer's clusters win.
+        // Live turns not tracked across driver boundary in v1; offline diarizer's clusters win.
         let cfg = FinalizeConfig {
             id,
             store: store_arc.clone(),
@@ -488,16 +466,13 @@ fn validate_source_against_caps(
     src: &AudioSource,
     caps: &CaptureCapabilities,
 ) -> Result<(), String> {
-    // Exhaustive (no `_` arm) so a new `AudioSource` variant forces a conscious
-    // validation decision here.
+    // Exhaustive (no `_` arm) so a new AudioSource variant forces a validation decision here.
     let (needs_per_process, needs_microphone): (bool, bool) = match src {
         AudioSource::SystemWide => (false, false),
         AudioSource::Process { .. } => (true, false),
         AudioSource::Microphone { .. } => (false, true),
         AudioSource::Mixed { system, mic: _ } => {
-            // The system side of a mix must itself be capturable — System or a
-            // process, not a microphone or another mix. Reject the bad shape
-            // here so the error comes from the boundary, not a deep backend.
+            // System side must be System or Process (not Microphone or nested Mix); reject bad shape at boundary.
             match system.as_ref() {
                 AudioSource::SystemWide => {}
                 AudioSource::Process { .. } => {}
@@ -540,8 +515,7 @@ fn source_label(
             AudioSource::SystemWide => "System (everything)".to_string(),
             AudioSource::Process { .. } => "App audio".to_string(),
             AudioSource::Microphone { .. } => "Microphone".to_string(),
-            // A Mixed not in the picker (e.g. an explicit process + mic via the
-            // API): "<system> + microphone".
+            // Mixed not in the picker: "<system> + microphone".
             AudioSource::Mixed { system, .. } => format!("{} + microphone", generic(system)),
         }
     }
@@ -570,8 +544,7 @@ fn pick_offline_model(models: &ModelStore) -> Option<String> {
 /// Picks the model for the live pass:
 /// 1. `override_key` if given — must be downloaded, else an error.
 /// 2. The `recommended` model if it's downloaded.
-/// 3. Otherwise the first downloaded Whisper model (we don't auto-download a
-///    multi-GB file — the UI prompts for that).
+/// 3. Otherwise the first downloaded Whisper model (never auto-downloads).
 /// 4. If nothing is downloaded: an error with a download hint.
 fn pick_live_model(
     models: &ModelStore,
@@ -632,8 +605,7 @@ fn spawn_event_forwarder(
     forwarders: ForwardersHandle,
     id: Uuid,
 ) {
-    // Already-running forwarder: skip — emitting twice would duplicate every
-    // event to the frontend.
+    // Already-running forwarder: skip to avoid emitting duplicates to frontend.
     if let Ok(mut set) = forwarders.lock() {
         if !set.insert(id) {
             return;
@@ -712,8 +684,7 @@ pub async fn discard_transcript_audio(
     store: tauri::State<'_, TranscriptStoreHandle>,
 ) -> Result<(), String> {
     let id = parse_transcript_id(&session_id)?;
-    // Routed through the store so the in-memory cache, disk, and broadcast
-    // stream stay in sync (subscribers see an `AudioDiscarded` event).
+    // Routed through the store so cache, disk, and broadcast stream stay in sync.
     store.discard_audio(id).map_err(|e| e.to_string())?;
     Ok(())
 }
@@ -870,10 +841,7 @@ mod tests {
         assert_eq!(short_id(id), "550e8400");
     }
 
-    /// Driving Tauri commands fully requires a `tauri::State` wrapper that
-    /// isn't trivial to fabricate in unit tests; instead, exercise the
-    /// underlying `TranscriptStore` calls that each command makes, plus the
-    /// validation helpers above (`parse_transcript_id` already covered).
+    /// Exercise underlying TranscriptStore calls (not full Tauri integration); validation helpers already covered.
     #[tokio::test]
     async fn store_round_trip_matches_what_the_commands_will_do() {
         let dir = tempfile::tempdir().unwrap();
@@ -939,10 +907,7 @@ mod tests {
 
     #[test]
     fn download_routing_distinguishes_whisper_from_diarization_keys() {
-        // download_transcription_model decides which ensure_* to call by
-        // whether the key is a diarization-catalogue key. Verify that split
-        // (the bug was: a diarization key went to ensure_model → "no such
-        // model in the catalogue").
+        // download_transcription_model routes by whether the key is a diarization-catalogue key.
         use speedwave_runtime::transcription::{diarization_model, whisper_model};
         assert!(diarization_model("pyannote-segmentation-3-0").is_some());
         assert!(diarization_model("nemo-titanet-small").is_some());
@@ -956,8 +921,7 @@ mod tests {
     fn pick_live_model_errors_with_a_download_hint_when_nothing_downloaded() {
         let dir = tempfile::tempdir().unwrap();
         let store = ModelStore::with_root(dir.path());
-        // No model on disk: an override errors naming that model; no override
-        // errors naming the recommended one — both with "download" guidance.
+        // No model on disk: override errors naming that model, no override names the recommended one.
         let e1 = pick_live_model(&store, Some("small"), "large-v3-turbo").unwrap_err();
         assert!(e1.contains("'small'") && e1.contains("download"));
         let e2 = pick_live_model(&store, None, "large-v3-turbo").unwrap_err();
@@ -966,8 +930,7 @@ mod tests {
 
     #[test]
     fn pick_live_model_uses_a_known_catalogue_key_for_the_override_error() {
-        // Sanity: the message references the requested key verbatim even for an
-        // unknown one (whisper_is_present_by_key returns false → error path).
+        // The error message references the requested key verbatim even for an unknown one.
         let dir = tempfile::tempdir().unwrap();
         let store = ModelStore::with_root(dir.path());
         let err = pick_live_model(&store, Some("nonexistent-model"), "small").unwrap_err();
@@ -976,8 +939,7 @@ mod tests {
 
     #[test]
     fn source_label_falls_back_when_no_match() {
-        // FileAudioCapture's enumerate_sources lists only the bound file (or
-        // nothing) — so a SystemWide source has no match and we fall back.
+        // FileAudioCapture lists only the bound file, so a SystemWide source has no match.
         let cap = speedwave_runtime::transcription::FileAudioCapture::new();
         assert_eq!(
             source_label(
@@ -1084,8 +1046,7 @@ mod tests {
             validate_source_against_caps(&AudioSource::Microphone { device: None }, &no_mic)
                 .is_err()
         );
-        // A structurally-invalid Mixed (mic-as-system, or nested Mixed) is
-        // rejected at the boundary regardless of capabilities.
+        // A structurally-invalid Mixed (mic-as-system or nested Mixed) is rejected regardless of caps.
         let full = CaptureCapabilities {
             supports_per_process: true,
             supports_system_audio: true,

--- a/desktop/src-tauri/src/tray.rs
+++ b/desktop/src-tauri/src/tray.rs
@@ -12,10 +12,8 @@ const TRAY_ICON_PNG: &[u8] = include_bytes!("../icons/tray-icon.png");
 #[cfg(target_os = "windows")]
 const TRAY_ICON_PNG: &[u8] = include_bytes!("../icons/tray-icon-white.png");
 
-/// Variable inputs to the tray menu — `update_version` (set by the updater) and
-/// `beta_enabled` (toggled by the user). Managed via `app.manage`; the inner
-/// mutexes are private so all access goes through the accessors below, which
-/// recover from poisoning rather than panicking.
+/// Variable tray-menu inputs (`update_version`, `beta_enabled`) managed via
+/// `app.manage`; access through the accessors, which recover from poisoning.
 #[derive(Default)]
 pub(crate) struct TrayMenuState {
     update_version: Mutex<Option<String>>,
@@ -72,9 +70,7 @@ pub(crate) enum TrayItemSpec {
 }
 
 /// Returns the ordered menu items for the given inputs. Beta toggle is hidden
-/// before setup completion — the toggle writes to user-config and the wizard
-/// owns data-dir creation, so we don't show a developer switch that could
-/// race the wizard.
+/// before setup completion.
 pub(crate) fn tray_menu_spec(
     update_version: Option<&str>,
     beta_enabled: bool,
@@ -100,11 +96,7 @@ pub(crate) fn tray_menu_spec(
 }
 
 /// Loads the platform-appropriate tray icon embedded in the binary.
-///
-/// macOS uses a black glyph paired with `icon_as_template(true)` so the system
-/// inverts it for the active appearance. Windows uses a white glyph because the
-/// notification area commonly renders on a dark background and has no template
-/// mode.
+/// macOS: black glyph (template, system-inverted). Windows: white glyph.
 pub(crate) fn load_tray_icon() -> Result<Image<'static>, tauri::Error> {
     Image::from_bytes(TRAY_ICON_PNG)
 }

--- a/desktop/src-tauri/src/types.rs
+++ b/desktop/src-tauri/src/types.rs
@@ -5,9 +5,7 @@ use serde::{Deserialize, Serialize};
 
 pub(crate) const MAX_CREDENTIAL_BYTES: usize = 4096;
 
-/// Converts a `Result<T, String>` into `anyhow::Result<T>` — eliminates the
-/// repeated `.map_err(|e| anyhow::anyhow!("{e}"))` boilerplate at compose
-/// transaction callsites where the inner function returns `String` errors.
+/// Converts a `Result<T, String>` into `anyhow::Result<T>`.
 pub(crate) trait IntoAnyhow<T> {
     fn into_anyhow(self) -> anyhow::Result<T>;
 }
@@ -43,29 +41,14 @@ pub(crate) struct BundleReconcileStatus {
     pub(crate) applied_bundle_id: Option<String>,
 }
 
-/// Frontend-facing snapshot of `claude.llm` for the active project plus the
-/// computed `default_base_url`. We flatten the underlying `LlmConfig` so
-/// every new field added to the SSOT struct (`speedwave_runtime::config::LlmConfig`)
-/// surfaces here automatically — without this, `provider`/`model`/`base_url`/
-/// `context_tokens` had to be hand-copied at three layers (LlmConfig → this
-/// response → frontend interface) and a missed step would silently drop the
-/// field.
-///
-/// Write-only direction (backend → frontend). The struct does not derive
-/// `Deserialize` so the type-system makes that explicit.
-///
-/// Footgun warning: when adding a new field to `LlmConfig`, mark optional
-/// fields with `#[serde(default, skip_serializing_if = "Option::is_none")]`
-/// — `#[serde(flatten)]` here propagates the field but does not omit
-/// `null`s, so a bare `Option` would surface as `field: null` in the JSON
-/// payload and the frontend's exact-shape assertions would diverge.
+/// Write-only (backend → frontend) flattened snapshot of `claude.llm` plus
+/// the computed `default_base_url`. Optional fields added to `LlmConfig` must
+/// use `#[serde(default, skip_serializing_if = "Option::is_none")]`.
 #[derive(Serialize)]
 pub(crate) struct LlmConfigResponse {
     #[serde(flatten)]
     pub(crate) llm: speedwave_runtime::config::LlmConfig,
-    /// Backend-authoritative default for the selected provider — exposed so
-    /// the UI can render it as a placeholder without duplicating provider URL
-    /// strings on the frontend.
+    /// Backend-authoritative default base URL for the selected provider.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) default_base_url: Option<String>,
 }
@@ -77,13 +60,8 @@ pub(crate) struct AuthStatusResponse {
     pub(crate) oauth_authenticated: bool,
 }
 
-/// Update DTO for the LLM settings save path.
-///
-/// Mirrors `speedwave_runtime::config::LlmConfig` fields but adds two
-/// tri-state credential fields that the runtime struct doesn't carry (it
-/// only stores presence flags). The `api_key` / `custom_headers` *values*
-/// land in token files on disk; only `has_api_key` / `has_custom_headers`
-/// reach `LlmConfig` in `config.json`.
+/// Update DTO for the LLM settings save path. Mirrors `LlmConfig` plus two
+/// tri-state credential fields (`api_key`/`custom_headers`) stored off-config.
 ///
 /// Tri-state semantics via `serde_with::rust::double_option`:
 /// - **field omitted** (`None`) — leave on-disk file unchanged
@@ -136,11 +114,8 @@ pub(crate) struct IntegrationStatusEntry {
     pub(crate) current_values: std::collections::HashMap<String, String>,
     pub(crate) mappings: Option<std::collections::HashMap<String, serde_json::Value>>,
     pub(crate) badge: Option<String>,
-    /// Reason the integration needs the user's attention even though it is
-    /// configured (OAuth-refresh services: SharePoint, Slack). Set when the
-    /// stored `grantedScopes` is a strict subset of the currently-required
-    /// scopes, the state is stale, or the Slack refresh token aged out — the
-    /// UI surfaces a "Re-authorize" banner. `None` = no action required.
+    /// OAuth re-authorization required (stale scopes, expired token, etc.).
+    /// `None` = no action required.
     pub(crate) oauth_action_required: Option<String>,
     /// "Connected to <workspace>" hint for OAuth services persisting identity
     /// in providerData (Slack: teamName · authedUserId). `None` = nothing to show.
@@ -274,11 +249,7 @@ mod tests {
 
     #[test]
     fn allowed_fields_match_auth_fields() {
-        // Every UI auth field must live in exactly one storage tier:
-        // credential_files (worker-mounted) OR oauth_state_fields (off-mount,
-        // plan §PR3:290-299). Earlier versions of this test only checked
-        // credential_files — that became wrong when PR3 moved SharePoint's
-        // refresh_token / client_id / tenant_id off-mount.
+        // Verify auth fields belong to credential_files or oauth_state_fields storage tier.
         for svc in speedwave_runtime::consts::TOGGLEABLE_MCP_SERVICES {
             let auth_fields = get_auth_fields(svc.config_key);
             for field in &auth_fields {
@@ -343,8 +314,7 @@ mod tests {
 
     #[test]
     fn secret_fields_list_covers_sensitive_keys() {
-        // Descriptor-derived: keys exist in TOGGLEABLE_MCP_SERVICES with
-        // is_secret=true (bot_token/user_token left with the manual Slack setup).
+        // Descriptor-derived keys with is_secret=true.
         assert!(is_secret_field("api_key"));
         assert!(is_secret_field("token"));
         assert!(is_secret_field("access_token"));
@@ -391,11 +361,7 @@ mod tests {
 
     #[test]
     fn get_auth_fields_classic_form_services_no_oauth_flow() {
-        // Services that authenticate with a single user-entered token (PAT,
-        // API key) — none of their fields should be flagged as
-        // OAuth-flow-driven. SharePoint, GitHub, and Slack are intentionally
-        // NOT in this list because they use OAuth flows (the UI renders a
-        // "Sign in with X" button instead of a text input for the OAuth field).
+        // Services using PAT/API key auth (not OAuth flows like SharePoint, GitHub, Slack).
         for svc_key in &["gitlab", "atlassian", "redmine"] {
             let fields = get_auth_fields(svc_key);
             for field in &fields {
@@ -410,10 +376,7 @@ mod tests {
 
     #[test]
     fn get_auth_fields_github_token_uses_oauth_flow() {
-        // GitHub `token` field is populated by the OAuth App device flow
-        // (`start_github_oauth` Tauri command) — the UI must not render a
-        // text input for it. SharePoint has the analogous invariant tested
-        // in `get_auth_fields_includes_oauth_flow` above.
+        // GitHub `token` is populated by the OAuth App device flow, so oauth_flow=true.
         let fields = get_auth_fields("github");
         let token = fields
             .iter()
@@ -442,10 +405,7 @@ mod tests {
     fn toggleable_services_have_auth_fields() {
         for svc in speedwave_runtime::consts::TOGGLEABLE_MCP_SERVICES {
             let fields = get_auth_fields(svc.config_key);
-            // Credential-less services (e.g. Playwright) declare `auth_fields: &[]`
-            // in their descriptor; `get_auth_fields` faithfully returns an empty vec.
-            // Only fail if the descriptor says the service has auth fields but the
-            // getter returns nothing — a real bug.
+            // Credential-less services (e.g. Playwright) declare `auth_fields: &[]`.
             if svc.auth_fields.is_empty() {
                 assert!(
                     fields.is_empty(),
@@ -463,12 +423,7 @@ mod tests {
         }
     }
 
-    /// Wire-format guard: flattening `LlmConfig` into `LlmConfigResponse`
-    /// must keep `provider`/`model`/`base_url`/`context_tokens` at the top
-    /// level of the JSON payload — the frontend reads them from there
-    /// (mirror declared in `desktop/src/src/app/settings/llm-provider/`).
-    /// If a future serde change buries them under an `llm:` key the
-    /// frontend silently breaks.
+    /// Verify `#[serde(flatten)]` surfaces `LlmConfig` fields at top level (not nested under `llm:`).
     #[test]
     fn llm_config_response_flattens_inner_llm_at_top_level() {
         let resp = LlmConfigResponse {
@@ -501,9 +456,7 @@ mod tests {
 
     #[test]
     fn llm_config_response_omits_context_tokens_when_unset() {
-        // Backend returns `LlmConfig::default()` when no project is active —
-        // the response must skip the `context_tokens` key entirely so the
-        // frontend's `?? null` fallback kicks in cleanly.
+        // Default config (no active project) must skip the `context_tokens` key entirely.
         let resp = LlmConfigResponse {
             llm: speedwave_runtime::config::LlmConfig::default(),
             default_base_url: None,
@@ -517,11 +470,7 @@ mod tests {
 
     #[test]
     fn max_credential_bytes_matches_ts_constant() {
-        // Cross-language SSOT guard (cf. allowed_auth_field_types_match_ts_union
-        // in plugin.rs): TS `MAX_PLUGIN_CREDENTIAL_BYTES` must equal Rust
-        // `MAX_CREDENTIAL_BYTES` so the form's <input maxlength=…> exactly
-        // mirrors the server-side reject threshold. Bumping one without the
-        // other = silent drift.
+        // Cross-language SSOT guard: TS `MAX_PLUGIN_CREDENTIAL_BYTES` must equal Rust `MAX_CREDENTIAL_BYTES`.
         let src = include_str!("../../src/src/app/models/plugin.ts");
         let needle = "export const MAX_PLUGIN_CREDENTIAL_BYTES";
         let idx = src

--- a/desktop/src-tauri/src/ui_prefs_cmd.rs
+++ b/desktop/src-tauri/src/ui_prefs_cmd.rs
@@ -1,9 +1,4 @@
 //! UI preferences commands — currently the beta-features toggle (ADR-058).
-//!
-//! `apply_beta_toggle_inner` is the shared write path used by the tray menu's
-//! `toggle_beta` arm; it locks the user-config, persists the new value, updates
-//! `TrayMenuState`, rebuilds the tray menu, and emits `beta-changed` so the
-//! frontend can react. `get_beta_enabled` exposes the persisted flag to the UI.
 
 use speedwave_runtime::config;
 use tauri::{AppHandle, Emitter, Manager};

--- a/desktop/src-tauri/src/updater.rs
+++ b/desktop/src-tauri/src/updater.rs
@@ -8,10 +8,7 @@ use tauri_plugin_updater::UpdaterExt;
 /// Mutex to serialize load-modify-save cycles on update-settings.json.
 static SETTINGS_LOCK: Mutex<()> = Mutex::new(());
 
-/// Authoritative update endpoint. Replaces `plugins.updater.endpoints` in tauri.conf.json at runtime.
-/// Keep both in sync for documentation purposes.
-///
-/// Stable update endpoint — GitHub Releases latest (non-draft, non-prerelease).
+/// Stable update endpoint — GitHub Releases latest. Mirrors `plugins.updater.endpoints` in tauri.conf.json.
 const STABLE_ENDPOINT: &str =
     "https://github.com/speednet-software/speedwave/releases/latest/download/latest.json";
 
@@ -102,8 +99,7 @@ fn save_update_settings_inner(settings: &UpdateSettings) -> Result<(), String> {
     let mut clamped = settings.clone();
     clamped.normalize();
     let json = serde_json::to_string_pretty(&clamped).map_err(|e| e.to_string())?;
-    // Atomic write: write to a temporary file in the same directory, then rename.
-    // This prevents partial/corrupt reads if the process is interrupted mid-write.
+    // Atomic write: temp file in the same directory, then rename.
     let tmp_path = path.with_extension("json.tmp");
     std::fs::write(&tmp_path, json).map_err(|e| e.to_string())?;
     std::fs::rename(&tmp_path, &path).map_err(|e| e.to_string())
@@ -125,12 +121,7 @@ fn detect_critical(body: &Option<String>) -> bool {
     })
 }
 
-/// Builds a Tauri Updater configured for the stable update channel.
-///
-/// Checks GitHub Releases `/releases/latest/download/latest.json`.
-///
-/// The `version_comparator` uses semver to only allow upgrades (remote > current),
-/// preventing downgrade attacks where a compromised endpoint serves an older version.
+/// Builds a stable-channel Tauri Updater. `version_comparator` allows upgrades only (remote > current).
 fn build_updater(app: &AppHandle) -> Result<tauri_plugin_updater::Updater, String> {
     let parsed_url: url::Url = STABLE_ENDPOINT
         .parse()
@@ -140,8 +131,6 @@ fn build_updater(app: &AppHandle) -> Result<tauri_plugin_updater::Updater, Strin
         .map_err(|e| e.to_string())?
         .version_comparator(|current, remote| {
             // Only update when remote version is strictly newer (no downgrades).
-            // Both `current` and `remote.version` are already parsed semver::Version
-            // (tauri-plugin-updater handles parsing), so direct comparison is safe.
             remote.version > current
         })
         .build()
@@ -186,7 +175,6 @@ pub async fn install_update(app: &AppHandle, expected_version: String) -> Result
     let update = update.ok_or("No update available")?;
 
     // Verify the version matches what the user approved (TOCTOU mitigation).
-    // If the server returns a different version between check and install, abort.
     let installing_version = update.version.clone();
     if installing_version != expected_version {
         return Err(format!(
@@ -211,9 +199,7 @@ pub async fn install_update(app: &AppHandle, expected_version: String) -> Result
         .await
         .map_err(|e| e.to_string())?;
 
-    // Do not restart immediately from the auto-check flow — containers may be running.
-    // Emit an event so the frontend can handle it. Note: the Settings page
-    // "Install & Restart" intentionally uses force restart as an explicit user action.
+    // Do not restart from the auto-check flow (containers may be running); emit an event for the frontend.
     use tauri::Emitter;
     if let Err(e) = app.emit(
         "update_installed",
@@ -522,9 +508,7 @@ pub fn spawn_auto_check(app_handle: AppHandle) -> tauri::async_runtime::JoinHand
                 }
             }
 
-            // Sleep in 60-second increments so that settings changes
-            // (e.g. disabling auto-check or adjusting the interval) take
-            // effect within one minute rather than after the full interval.
+            // Sleep in 60-second increments so settings changes take effect within a minute.
             let interval_secs = (settings.check_interval_hours as u64) * 3600;
             let mut elapsed: u64 = 0;
             while elapsed < interval_secs {

--- a/desktop/src-tauri/src/window.rs
+++ b/desktop/src-tauri/src/window.rs
@@ -4,28 +4,19 @@
 use super::MAIN_WINDOW_LABEL;
 use tauri::Manager;
 
-/// Returns `true` if a click should be suppressed (debounced).
-///
-/// A click is suppressed when the elapsed time since the previous click
-/// (`now_ms.saturating_sub(prev_ms)`) is less than `threshold_ms`. Uses saturating
-/// subtraction so that a backward clock jump suppresses rather than
-/// double-toggles.
+/// Returns `true` if a click should be suppressed (debounced): elapsed since
+/// the previous click (`now_ms.saturating_sub(prev_ms)`) is `< threshold_ms`.
 pub(crate) fn should_debounce(prev_ms: u64, now_ms: u64, threshold_ms: u64) -> bool {
     now_ms.saturating_sub(prev_ms) < threshold_ms
 }
 
-/// Determines what the `CloseRequested` handler should do.
-///
-/// Returns `true` when the close should be intercepted (prevent close + hide).
-/// Returns `false` when the close should proceed normally (app exits).
+/// Whether `CloseRequested` should be intercepted: `true` prevents close + hides,
+/// `false` lets the close proceed (app exits).
 pub(crate) fn should_prevent_close(window_label: &str, tray_available: bool) -> bool {
     window_label == MAIN_WINDOW_LABEL && tray_available
 }
 
-/// Returns `true` if the `Destroyed` event should trigger cleanup.
-///
-/// Only the main window destruction runs cleanup — dialog or secondary
-/// windows must not prematurely stop services.
+/// Returns `true` if the `Destroyed` event should trigger cleanup (main window only).
 pub(crate) fn should_run_cleanup(window_label: &str) -> bool {
     window_label == MAIN_WINDOW_LABEL
 }
@@ -92,22 +83,19 @@ mod tests {
 
     #[test]
     fn debounce_allows_click_at_exact_threshold() {
-        // At exactly 500ms elapsed, the click should go through
-        // (condition is strict less-than).
+        // Exactly 500ms elapsed goes through (strict less-than).
         assert!(!should_debounce(1000, 1500, 500));
     }
 
     #[test]
     fn debounce_suppresses_when_clock_goes_backward() {
-        // Clock jumped backward: now < prev. saturating_sub returns 0,
-        // which is < threshold → suppressed. This is the safe behavior.
+        // Backward clock (now < prev): saturating_sub is 0 < threshold → suppressed.
         assert!(should_debounce(5000, 3000, 500));
     }
 
     #[test]
     fn debounce_allows_first_click_ever() {
-        // prev=0 (initial AtomicU64 value), now is any reasonable time.
-        // Elapsed time is huge → not debounced.
+        // prev=0 (initial AtomicU64): huge elapsed → not debounced.
         assert!(!should_debounce(0, 1_700_000_000_000, 500));
     }
 
@@ -125,8 +113,7 @@ mod tests {
 
     #[test]
     fn debounce_handles_u64_max_prev() {
-        // prev is u64::MAX, now is small (extreme backward jump).
-        // saturating_sub(u64::MAX) = 0 → suppressed.
+        // prev=u64::MAX, small now: saturating_sub is 0 → suppressed.
         assert!(should_debounce(u64::MAX, 1000, 500));
     }
 

--- a/desktop/src/src/app/a11y.spec.ts
+++ b/desktop/src/src/app/a11y.spec.ts
@@ -44,12 +44,7 @@ const EFFECTIVE_MODES: readonly EffectiveMode[] = THEME_MODES.filter(
   (m): m is EffectiveMode => m !== 'auto'
 );
 
-/**
- * Stubs `window.matchMedia` so ThemeService can construct in jsdom even though
- * jsdom does not implement the media query API. We don't rely on the listener
- * for axe assertions — accents and `.dark` are set directly via
- * activateTheme/activateMode.
- */
+/** Stubs `window.matchMedia` so ThemeService can construct in jsdom. */
 function stubMatchMedia(): void {
   if (typeof window.matchMedia === 'function') return;
   Object.defineProperty(window, 'matchMedia', {
@@ -86,11 +81,7 @@ interface ViewUnderTest {
   readonly prepare?: (fixture: ComponentFixture<unknown>) => void;
 }
 
-/**
- * Configurable mock responses for routed views. Anything a route-level
- * component requests during `ngOnInit` must resolve here so jsdom can
- * render the baseline layout that axe-core inspects.
- */
+/** Configurable mock responses for routed views during jsdom render. */
 function buildMockTauri(): MockTauriService {
   const mock = new MockTauriService();
   mock.invokeHandler = async (cmd: string) => {
@@ -149,9 +140,6 @@ function activateTheme(id: ThemeId): void {
 
 /**
  * Renders a component in a detached fixture for axe inspection.
- *
- * Runs the full change-detection loop so dynamic content (e.g. conditional
- * error banners) is reflected in the DOM axe scans.
  * @param view - The view under test.
  * @param mockTauri - The mock TauriService used for invoke/listen calls.
  */
@@ -238,9 +226,7 @@ const VIEWS: readonly ViewUnderTest[] = [
 ];
 
 /**
- * Classifies axe serious violations worth blocking on. Discards advisory
- * rules (e.g. landmark-one-main in a detached fragment) since fragment-only
- * rendering cannot satisfy document-level rules.
+ * Classifies axe serious violations, discarding fragment-only advisory rules.
  * @param results - The full axe-core scan results.
  */
 function seriousViolations(results: AxeResults): AxeResults['violations'] {

--- a/desktop/src/src/app/app.routes.ts
+++ b/desktop/src/src/app/app.routes.ts
@@ -18,9 +18,7 @@ export const routes: Routes = [
       { path: '', redirectTo: 'chat', pathMatch: 'full' },
       {
         path: 'chat',
-        // No authRequiredGuard — the chat view itself surfaces an inline
-        // "auth required" block (mockup-aligned) so the user can still see
-        // where they are and one-click jump to Settings.
+        // No authRequiredGuard — chat surfaces an inline "auth required" block
         loadComponent: () => import('./chat/chat.component').then((m) => m.ChatComponent),
       },
       {

--- a/desktop/src/src/app/chat/blocks/ask-user-block.component.spec.ts
+++ b/desktop/src/src/app/chat/blocks/ask-user-block.component.spec.ts
@@ -386,8 +386,7 @@ describe('AskUserBlockComponent', () => {
     component.freeformText.set('partial draft');
     expect(component.selected().size).toBe(1);
 
-    // Parent reducer advances current_index after a successful answer —
-    // simulate that by handing in a new block with the slot filled.
+    // Parent reducer advances current_index: new block with slot filled.
     setBlock(
       makeBlock({
         questions: [makeQuestion({ question: 'Q0' }), makeQuestion({ question: 'Q1' })],

--- a/desktop/src/src/app/chat/blocks/ask-user-block.component.ts
+++ b/desktop/src/src/app/chat/blocks/ask-user-block.component.ts
@@ -163,19 +163,9 @@ export class AskUserBlockComponent {
     return q.questions[idx];
   });
 
-  /**
-   * Wires the per-input reset effect that clears `selected` and `freeformText`
-   * whenever the parent reducer hands us a new `question()` block.
-   */
+  /** Wires the per-input reset effect for each new `question()` block. */
   constructor() {
-    // Reset transient input state whenever the parent reducer hands us a
-    // new question() input. Lives in an effect (not a computed) because
-    // Angular forbids signal writes inside computed(). Note: the
-    // dependency is the entire `question()` input — any reducer-driven
-    // replacement (which always happens via spread, not in-place mutation)
-    // triggers the reset, not just `current_index` changes. That's
-    // intentional: `selected` and `freeformText` are scoped to the active
-    // slot, so a fresh block reference means a fresh slot to clear.
+    // Reset input state on new question(); effect because computed forbids signal writes.
     effect(() => {
       void this.question();
       this.selected.set(new Set());

--- a/desktop/src/src/app/chat/blocks/diff-view.component.ts
+++ b/desktop/src/src/app/chat/blocks/diff-view.component.ts
@@ -11,24 +11,16 @@ export interface DiffLine {
 type DiffSegment = { type: 'line'; line: DiffLine } | { type: 'omitted'; count: number };
 
 /**
- * Computes a unified line diff between two strings.
- *
- * Delegates to the `diff` package's `diffLines` (Myers diff) and flattens its
- * change-object stream into per-line `add`/`remove`/`ctx` rows. CRLF is
- * normalized to LF before diffing so Windows-saved files do not appear as
- * fully-changed against LF-only inputs.
+ * Computes a unified line diff between two strings; normalizes CRLF to LF.
  * @param oldStr - Original text content (lines separated by "\n" or "\r\n").
  * @param newStr - Replacement text content (lines separated by "\n" or "\r\n").
  */
 export function computeLineDiff(oldStr: string, newStr: string): DiffLine[] {
-  // Normalize CRLF -> LF so Windows files don't diff against Unix files
-  // line-by-line. `diffLines` does not normalize line endings on its own.
+  // Normalize CRLF -> LF so Windows files don't diff line-by-line vs Unix.
   const oldNormalized = oldStr.replace(/\r\n/g, '\n');
   const newNormalized = newStr.replace(/\r\n/g, '\n');
   return diffLines(oldNormalized, newNormalized).flatMap((part) => {
-    // `part.value` is the concatenated content for the change run, with
-    // newline separators preserved. Split into lines and drop the empty
-    // tail produced by a trailing "\n" so each line maps to one row.
+    // Split the run into lines, dropping the empty tail from a trailing "\n".
     const lines = part.value.split('\n');
     if (part.value.endsWith('\n')) {
       lines.pop();
@@ -40,13 +32,7 @@ export function computeLineDiff(oldStr: string, newStr: string): DiffLine[] {
 
 /**
  * Per-line unified diff renderer used by tool-block for Edit/Write tools.
- *
- * The container (`overflow-hidden rounded ring-1 ring-line bg-bg-1`) clips the
- * per-line background tints to rounded corners. Each line is a `<div>` with
- * `whitespace-pre` applied individually — never on the wrapper — to avoid
- * blank-line artifacts between the row divs (see implementation-prompt.md).
- * Diffs longer than `truncateLines` collapse to a head/tail view with an
- * `expand full diff` button.
+ * Diffs longer than `truncateLines` collapse to a head/tail view with an expand button.
  */
 @Component({
   selector: 'app-diff-view',
@@ -113,10 +99,7 @@ export class DiffViewComponent {
    * Resets the expand-toggle whenever the diff input strings change.
    */
   constructor() {
-    // Reset the user's expand-toggle when either input string changes —
-    // otherwise an instance reused for a different file (live tool block
-    // streaming an edit, recycled for a later edit) keeps the previous expand
-    // state.
+    // Reset expand-toggle on input change so a recycled instance has no stale state.
     effect(() => {
       // Touch both inputs so the effect re-runs on either change.
       this.oldString();

--- a/desktop/src/src/app/chat/blocks/error-block.component.ts
+++ b/desktop/src/src/app/chat/blocks/error-block.component.ts
@@ -37,12 +37,7 @@ const ERROR_META: Record<ErrorBlockKind, { shape: ErrorShape; label: string; act
   },
 };
 
-/**
- * Renders a chat error in one of three timeline shapes — red (failure), amber
- * (operator-recoverable), or muted gray (stopped by user). Mirrors the mockup
- * lines 861–910: every variant is `mono border-l-2 border-<color>/50 pl-4
- * text-[12.5px]` — NEVER a callout box. Pure Tailwind, no inline `<style>`.
- */
+/** Renders a chat error in one of three timeline shapes: red, amber, or gray. */
 @Component({
   selector: 'app-error-block',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -79,11 +74,7 @@ export class ErrorBlockComponent {
   /** Error message content displayed next to the kind label. */
   readonly content = input.required<string>();
 
-  /**
-   * Discriminator driving both shape and label. Missing/invalid values are
-   * normalised to `'generic'` via `kindOrDefault()` so callers may pass
-   * `undefined` without a crash.
-   */
+  /** Discriminator driving both shape and label; missing/invalid normalised to `'generic'`. */
   readonly kind = input<ErrorBlockKind>('generic');
 
   /** Parent can listen for user clicks on the inline action button. */
@@ -104,11 +95,7 @@ export class ErrorBlockComponent {
   /** Operator-recoverable hints render as amber timeline events. */
   readonly isAmberTimeline = computed(() => this.meta().shape === 'amber-timeline');
 
-  /**
-   * Boolean accessor preserved for downstream callers that switched on
-   * "is this a callout-shape error" — every actionable error is now an amber
-   * timeline, so the flag aliases to `isAmberTimeline`.
-   */
+  /** Alias for `isAmberTimeline`. */
   readonly isCallout = computed(() => this.isAmberTimeline());
 
   /** True when any of the three timeline variants applies (always, post-rewrite). */

--- a/desktop/src/src/app/chat/blocks/permission-prompt.component.spec.ts
+++ b/desktop/src/src/app/chat/blocks/permission-prompt.component.spec.ts
@@ -39,11 +39,6 @@ describe('PermissionPromptComponent', () => {
   });
 
   it('happy: each button emits the expected decision (separate components per click)', () => {
-    // After the self-protect guard lands (single emission per component), each
-    // button-decision pair needs its own component instance. Seed the outer
-    // fixture's required input first so the global change-detection pass
-    // triggered by the inner `f.detectChanges()` does not raise NG0950 on the
-    // sibling component still attached to the test bed.
     fixture.componentRef.setInput('command', 'ls');
     for (const expected of ['allow_once', 'allow_always', 'deny'] as const) {
       const f = TestBed.createComponent(PermissionPromptComponent);

--- a/desktop/src/src/app/chat/blocks/permission-prompt.component.ts
+++ b/desktop/src/src/app/chat/blocks/permission-prompt.component.ts
@@ -4,14 +4,7 @@ import { IconComponent } from '../../shared/icon.component';
 /** Decision emitted by the permission prompt. */
 export type PermissionDecision = 'allow_once' | 'allow_always' | 'deny';
 
-/**
- * Amber callout asking the user to authorise a tool invocation.
- *
- * Matches the terminal-minimal mockup (lines 796–808): rounded amber-bordered
- * box with a 4% amber wash, mono header (warning glyph + label + tool name),
- * monospaced command preview, and three action buttons (allow-once primary
- * accent, allow-always neutral bordered, deny red bordered).
- */
+/** Amber callout asking the user to authorise a tool invocation. */
 @Component({
   selector: 'app-permission-prompt',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -89,12 +82,7 @@ export class PermissionPromptComponent {
   /** Parent receives the user's typed decision. */
   readonly decided = output<PermissionDecision>();
 
-  /**
-   * Stable DOM id for `aria-labelledby` on the dialog wrapper. Generated once
-   * at construction so re-renders don't break the ARIA pairing — uses an
-   * incrementing counter rather than `Math.random` so test fixtures get
-   * deterministic ids.
-   */
+  /** Stable per-instance DOM id base for `aria-labelledby` on the dialog wrapper. */
   private static instanceCounter = 0;
   private readonly instanceId = ++PermissionPromptComponent.instanceCounter;
   readonly headerId = `permission-header-${this.instanceId}`;

--- a/desktop/src/src/app/chat/blocks/text-block.component.spec.ts
+++ b/desktop/src/src/app/chat/blocks/text-block.component.spec.ts
@@ -74,14 +74,7 @@ describe('TextBlockComponent', () => {
   });
 
   it('does NOT rewrite data: or vbscript: URLs — only javascript: is prefixed with unsafe:', () => {
-    // Angular's URL sanitizer for [innerHTML] anchors only rewrites the
-    // javascript: scheme (SRC_URL_SANITIZATION_REGEX = /^(?!javascript:)/i).
-    // data: and vbscript: pass through unchanged. Any future user-facing
-    // render path that can receive attacker-controlled URLs must rely on
-    // CSP (img-src/frame-src restrictions) or its own pre-sanitization —
-    // it cannot assume Angular's HTML sanitizer will block these schemes.
-    // This test locks that contract in so a future refactor can't silently
-    // widen the trust boundary.
+    // Angular's [innerHTML] URL sanitizer rewrites only javascript:; data: and vbscript: pass through unchanged.
     fixture.componentRef.setInput('content', '[d](data:text/html,x) [v](vbscript:MsgBox(1))');
     fixture.detectChanges();
 

--- a/desktop/src/src/app/chat/blocks/text-block.component.ts
+++ b/desktop/src/src/app/chat/blocks/text-block.component.ts
@@ -2,23 +2,8 @@ import { ChangeDetectionStrategy, Component, computed, input } from '@angular/co
 import { marked } from 'marked';
 
 /**
- * Renders markdown-formatted text content as HTML, with an optional streaming caret.
- *
- * Markdown is parsed by the `marked` library, which does NOT sanitize its HTML output.
- * XSS protection comes from Angular's built-in `DomSanitizer`, which runs automatically
- * when the string is assigned via the `[innerHTML]` property binding — stripping `<script>`
- * tags, event-handler attributes (`onerror`, `onclick`, etc.), and rewriting `javascript:`
- * URLs to the inert `unsafe:javascript:` prefix so they cannot execute.
- *
- * SCOPE LIMIT: Angular's HTML sanitizer only rewrites the `javascript:` scheme; `data:`
- * and `vbscript:` URLs pass through unchanged. Speedwave relies on assistant-controlled
- * (not user-controlled) chat content here, so those schemes are not an active threat —
- * but any future render path that accepts attacker-controlled markdown must add its own
- * scheme filtering or rely on CSP, not on this component alone.
- *
- * WARNING: Do not switch this binding to a `SafeHtml` produced by
- * `DomSanitizer.bypassSecurityTrustHtml(...)` — doing so disables all sanitization and
- * would make `<script>` tags, event-handler attributes, and `javascript:` URLs executable.
+ * Renders markdown text as HTML with an optional streaming caret.
+ * `marked` does not sanitize; XSS protection relies on Angular's `[innerHTML]` DomSanitizer.
  */
 @Component({
   selector: 'app-text-block',

--- a/desktop/src/src/app/chat/blocks/thinking-block.component.spec.ts
+++ b/desktop/src/src/app/chat/blocks/thinking-block.component.spec.ts
@@ -17,12 +17,7 @@ describe('ThinkingBlockComponent', () => {
     el = fixture.nativeElement as HTMLElement;
   });
 
-  /**
-   * Simulates a native `<details>` toggle, which jsdom does not fire from a
-   * `summary.click()` call. Sets `open` on the `<details>` element and then
-   * dispatches the native `toggle` event so the production component's
-   * `(toggle)` handler runs and the `collapsed()` signal updates.
-   */
+  /** Sets `open` on `<details>` and dispatches the native `toggle` event. */
   function activateToggle(): void {
     const details = el.querySelector('details') as HTMLDetailsElement;
     details.open = !details.open;
@@ -139,9 +134,7 @@ describe('ThinkingBlockComponent', () => {
   });
 
   it('omits aria-controls when collapsed (details closed)', () => {
-    // ARIA forbids aria-controls referencing a non-visible region; the
-    // production component nulls the attribute while collapsed even though
-    // <details> keeps the content in the DOM.
+    // aria-controls is nulled while collapsed.
     fixture.componentRef.setInput('content', 'x');
     fixture.componentRef.setInput('collapsedDefault', true);
     fixture.detectChanges();
@@ -161,11 +154,7 @@ describe('ThinkingBlockComponent', () => {
   });
 
   it('toggles the collapsed signal when the native <details> toggle event fires', () => {
-    // Native <summary> elements toggle the parent <details> on click in real
-    // browsers, but jsdom does not fire the toggle event from a summary click.
-    // We dispatch the toggle event manually to verify the (toggle) handler
-    // updates the signal — browser-level click→toggle translation is provided
-    // by the platform, not our code.
+    // jsdom does not fire toggle from a summary click; dispatched manually.
     fixture.componentRef.setInput('content', 'click activates');
     fixture.detectChanges();
 

--- a/desktop/src/src/app/chat/blocks/thinking-block.component.ts
+++ b/desktop/src/src/app/chat/blocks/thinking-block.component.ts
@@ -2,10 +2,7 @@ import { ChangeDetectionStrategy, Component, OnInit, input, signal } from '@angu
 import { IconComponent } from '../../shared/icon.component';
 
 /**
- * Collapsible "thinking" block — terminal-minimal timeline event with a violet
- * left border. Pure-Tailwind classes; the chevron is an inline SVG that
- * rotates 90° on open via the `rotate-90` utility (no glyph swap).
- *
+ * Collapsible thinking block with violet left border. Chevron rotates 90° on toggle.
  * Mockup reference: lines 591–613.
  */
 @Component({
@@ -62,9 +59,7 @@ export class ThinkingBlockComponent implements OnInit {
   }
 
   /**
-   * Mirrors the native `<details>` open/closed state into the signal so the
-   * chevron and `aria-expanded` stay in sync with the user's interaction
-   * (clicks the summary toggle the disclosure natively).
+   * Sync native `<details>` open/closed state to the signal for chevron and aria-expanded.
    * @param event Native toggle event from the `<details>` element.
    */
   onToggle(event: Event): void {

--- a/desktop/src/src/app/chat/blocks/tool-block.component.spec.ts
+++ b/desktop/src/src/app/chat/blocks/tool-block.component.spec.ts
@@ -81,9 +81,6 @@ describe('ToolBlockComponent', () => {
       fixture.detectChanges();
 
       const status = fixture.nativeElement.querySelector('[data-testid="tool-status"]');
-      // Production renders a centred two-layer Material spinner (root SVG
-      // rotates at one period, the inner circle's stroke-dasharray grows
-      // and shrinks at a coprime period) so the loop seam is invisible.
       expect(status?.tagName.toLowerCase()).toBe('svg');
       expect(status?.classList.contains('spin-svg')).toBe(true);
       const circle = status?.querySelector('circle');
@@ -125,8 +122,6 @@ describe('ToolBlockComponent', () => {
       );
       fixture.detectChanges();
 
-      // The border color class is applied to the outer wrapper; assert the
-      // rendered classes contain the muted gray rail and not the red one.
       const region = fixture.nativeElement.querySelector('[role="region"]') as HTMLElement | null;
       expect(region?.className).toContain('border-[var(--ink-mute)]/50');
       expect(region?.className).not.toContain('red');
@@ -158,9 +153,6 @@ describe('ToolBlockComponent', () => {
   });
 
   describe('collapse default', () => {
-    // Every tool block now starts collapsed regardless of status — the user
-    // expands by clicking the header. This avoids surprise expansion of long
-    // outputs in fresh chats.
     it('collapses running tools by default', () => {
       setTool(makeTool({ status: 'running' }));
       fixture.detectChanges();
@@ -419,8 +411,7 @@ describe('ToolBlockComponent', () => {
     it('wires role=region and aria-labelledby/aria-controls/aria-expanded', () => {
       setTool(makeTool({ status: 'running' }));
       fixture.detectChanges();
-      // Tool blocks default to collapsed — expand first so the body region
-      // (the [role="region"] container) is rendered for the ARIA assertions.
+      // Expand first so the [role="region"] body renders.
       component.toggleCollapsed();
       fixture.detectChanges();
 
@@ -458,9 +449,6 @@ describe('ToolBlockComponent', () => {
     });
 
     it('toggles when the header button is activated (Enter/Space dispatch click)', () => {
-      // Native <button> elements receive a synthesised `click` from Enter/Space.
-      // We assert the click pathway here; browser-level key→click translation is
-      // covered by Angular's own DOM tests, not ours.
       setTool(makeTool({ status: 'done' }));
       fixture.detectChanges();
 
@@ -515,8 +503,7 @@ describe('ToolBlockComponent', () => {
 
       component.toggleCollapsed();
 
-      // toggleCollapsed must not mutate the bound tool — the override lives
-      // in component-private state, so every original key must be unchanged.
+      // toggleCollapsed must not mutate the bound tool.
       expect(tool).toEqual(snapshot);
     });
 

--- a/desktop/src/src/app/chat/blocks/tool-block.component.ts
+++ b/desktop/src/src/app/chat/blocks/tool-block.component.ts
@@ -11,12 +11,7 @@ import { ToolNormalizerService } from '../../services/tool-normalizer.service';
 import { DiffViewComponent } from './diff-view.component';
 import { SpinIconComponent } from '../../shared/spin-icon.component';
 
-/**
- * Semantic status → timeline border color class.
- *
- * Mirrors the design-proposals/06-terminal-minimal.html mockup: amber while
- * running, green on success, red-500 on error.
- */
+/** Semantic status → timeline border color class. */
 const STATUS_BORDER: Readonly<Record<ToolUseBlock['status'], string>> = Object.freeze({
   running: 'border-[var(--amber)]/50',
   done: 'border-[var(--green)]/50',
@@ -32,16 +27,7 @@ const STATUS_INK: Readonly<Record<ToolUseBlock['status'], string>> = Object.free
 
 /**
  * Renders a Claude tool invocation as a collapsible timeline event.
- *
- * The header row (status glyph · tool name · inline summary) is always
- * visible; clicking it toggles the body. The body template is chosen by
- * `NormalizedToolInput.kind` — bash, read, edit, write, todo_write, glob,
- * grep, web_search, web_fetch, agent, or a generic JSON fallback. Edit and
- * Write delegate their diff pane to `<app-diff-view>`.
- *
- * Default collapsed state: every tool block starts collapsed regardless of
- * status. The user expands a block by clicking the header — explicit choices
- * override the default and survive status transitions (running → done).
+ * Body template chosen by `NormalizedToolInput.kind`; starts collapsed.
  */
 @Component({
   selector: 'app-tool-block',
@@ -244,15 +230,7 @@ export class ToolBlockComponent {
   readonly headerId = `tool-block-header-${this.instanceId}`;
   readonly bodyId = `tool-block-body-${this.instanceId}`;
 
-  /**
-   * User-toggle state, keyed by tool_id.
-   *
-   * Absent entries fall back to the status-derived default (`running` →
-   * expanded, everything else → collapsed). Keying by id means the user's
-   * explicit choice survives a status transition (running → done) without
-   * snapping back to the "done collapses" default; swapping the bound tool
-   * instance starts fresh.
-   */
+  /** User-toggle state keyed by tool_id; survives status transitions. */
   private readonly overrides: Record<string, boolean> = {};
 
   /** Returns the normalized tool input — recomputes only when input_json changes. */
@@ -267,8 +245,7 @@ export class ToolBlockComponent {
     if (override !== undefined) {
       return override;
     }
-    // All tool blocks default to collapsed regardless of status — the user
-    // expands them on demand by clicking the header.
+    // Default to collapsed regardless of status.
     return true;
   }
 
@@ -281,10 +258,7 @@ export class ToolBlockComponent {
 
   /** Tailwind border-color class for the timeline left rail, keyed by tool status. */
   readonly borderClass = computed<string>(() => {
-    // Stopped tools surface as status="error" but visually use a muted gray rail
-    // (matches the "stopped gray" rule in the design-system spec). The host
-    // element already carries `border-l-2 pl-4`, so only the color class is
-    // returned here.
+    // Stopped tools use a muted gray rail.
     if (this.isStopped()) return 'border-[var(--ink-mute)]/50';
     return STATUS_BORDER[this.tool().status];
   });

--- a/desktop/src/src/app/chat/chat.component.spec.ts
+++ b/desktop/src/src/app/chat/chat.component.spec.ts
@@ -83,10 +83,6 @@ describe('ChatComponent', () => {
       expect(fixture.nativeElement.querySelector('app-chat-header')).toBeTruthy();
       expect(fixture.nativeElement.querySelector('app-chat-message-list')).toBeTruthy();
     });
-
-    // Read-only transcript overlay was removed — sidebar row click resumes
-    // directly. The `viewingTranscript` / `viewConversation` / `closeTranscript`
-    // surface no longer exists, so the related behaviour tests were dropped.
   });
 
   // ── handleStreamChunk: 'Text' ──────────────────────────────────────────────
@@ -203,8 +199,7 @@ describe('ChatComponent', () => {
 
   describe('sendMessage guards', () => {
     it('does not send when input text is empty', async () => {
-      // ComposerComponent contract: emits already-trimmed text, so an empty
-      // payload here represents a whitespace-only or empty composer state.
+      // ComposerComponent emits already-trimmed text; empty payload = empty composer state.
       await component.sendMessage({ payload: '', displayText: '' });
 
       expect(chatState.messages).toHaveLength(0);
@@ -837,8 +832,7 @@ describe('ChatComponent', () => {
 
   describe('Stop button and ESC handler', () => {
     it('shows Stop button when streaming, hides it when idle', () => {
-      // After Unit 9 (composer extraction), the Send button lives inside
-      // <app-composer>; chat.component owns only the Stop button alongside.
+      // Send button lives in <app-composer>; chat.component owns only the Stop button.
       projectState.status = 'ready';
       chatState.isStreaming = false;
       fixture.detectChanges();
@@ -856,8 +850,7 @@ describe('ChatComponent', () => {
       projectState.status = 'ready';
       const spy = vi.spyOn(chatState, 'stopConversation').mockResolvedValue();
       chatState.isStreaming = true;
-      // Stop-button visibility is driven by `isStreamingFromState()`; the
-      // signal projection only refreshes once notifyChange rebuilds the tree.
+      // isStreamingFromState() refreshes only after notifyChange rebuilds the tree.
       chatState['notifyChange']();
       fixture.detectChanges();
       fixture.nativeElement.querySelector('[data-testid="chat-stop"]').click();
@@ -895,8 +888,7 @@ describe('ChatComponent', () => {
           },
         ],
       });
-      // `hasUnansweredQuestion` reads `currentBlocksFromState()`; the signal
-      // projection only sees the block once notifyChange rebuilds the tree.
+      // currentBlocksFromState() sees the block only after notifyChange rebuilds the tree.
       chatState['notifyChange']();
       document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
       expect(spy).not.toHaveBeenCalled();

--- a/desktop/src/src/app/chat/chat.component.ts
+++ b/desktop/src/src/app/chat/chat.component.ts
@@ -60,14 +60,12 @@ export class ChatComponent implements OnInit, OnDestroy {
   memoryError = '';
   /**
    * Current git branch of the active project's working tree, or `null` when
-   * the project is not a git repo. Re-read after each turn finishes because
-   * the assistant may have switched branches via a shell tool.
+   * the project is not a git repo. Re-read after each turn finishes.
    */
   readonly gitBranch = signal<string | null>(null);
   /**
    * Index of the most recent assistant message in `messagesFromState()`;
-   * `-1` when none. A `computed` so the per-row `isLastAssistant` lookup is
-   * O(1) and recomputes lazily whenever the state-tree projection changes.
+   * `-1` when none.
    */
   readonly lastAssistantIndex = computed(() => {
     const msgs = this.chat.messagesFromState();
@@ -78,11 +76,7 @@ export class ChatComponent implements OnInit, OnDestroy {
   });
   private resumeInProgress = false;
 
-  /**
-   * Composer reference used to refocus the textarea after parent-driven
-   *  state resets (new conversation, etc.) — autofocus on mount happens
-   *  inside the composer's own `ngAfterViewInit`.
-   */
+  /** Composer reference used to refocus the textarea after parent-driven state resets. */
   @ViewChild('composer') private composer?: { focusInput: () => void };
 
   readonly chat = inject(ChatStateService);
@@ -105,10 +99,8 @@ export class ChatComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Optimistic session id stamped the moment the user clicks a row in the
-   * conversations drawer. The backend may take a turn or two to surface the
-   * resumed session id in `chat.sessionStats`, so we keep this local override
-   * to drive the drawer's accent indicator without flickering.
+   * Optimistic session id stamped when the user clicks a row in the
+   * conversations drawer.
    */
   private optimisticSessionId: string | null = null;
 
@@ -122,10 +114,7 @@ export class ChatComponent implements OnInit, OnDestroy {
 
   /** Wires effects driven by the state-tree signal and the drawer toggles. */
   constructor() {
-    // Refresh the branch chip on every streaming -> idle transition so a
-    // turn that ran `git checkout` updates the status strip without a full
-    // page reload. The effect re-runs whenever the state-tree's streaming
-    // projection flips; `markForCheck` keeps OnPush in sync with the signal.
+    // Refresh branch on streaming->idle to catch mid-turn git checkout.
     let wasStreaming = false;
     effect(() => {
       const streaming = this.chat.isStreamingFromState();
@@ -137,9 +126,7 @@ export class ChatComponent implements OnInit, OnDestroy {
       // Live-chat scrolling is owned by <app-chat-message-list>; no-op here.
     });
 
-    // Decouple data loading from the toggle source so the keyboard shortcut
-    // (⌘B in shell.component, which only flips the signal) loads data the
-    // same way the History button does.
+    // Decouple toggle from data load so keyboard shortcut works like button.
     effect(() => {
       if (this.ui.sidebarOpen()) void this.loadConversations();
     });
@@ -150,8 +137,7 @@ export class ChatComponent implements OnInit, OnDestroy {
 
   /** Boots the chat session and subscribes to project lifecycle events (auth + ready). */
   async ngOnInit(): Promise<void> {
-    // Independent — running in parallel saves one git-fork's latency on
-    // cold start.
+    // Run init and branch read in parallel; they are independent.
     await Promise.all([this.chat.init(), this.refreshGitBranch()]);
     this.cdr.markForCheck();
 
@@ -168,8 +154,7 @@ export class ChatComponent implements OnInit, OnDestroy {
       this.projectMemory = '';
       this.memoryError = '';
       this.cdr.markForCheck();
-      // Bypass the TTL — switching projects is a strong signal the branch
-      // could be different.
+      // Bypass TTL: project switch is a strong signal the branch could be different.
       await this.refreshGitBranch(true);
       if (wasHistoryOpen) {
         await this.loadConversations();
@@ -180,11 +165,7 @@ export class ChatComponent implements OnInit, OnDestroy {
     });
   }
 
-  /**
-   * Min interval between two `get_git_branch` IPC roundtrips. Branches
-   * rarely change mid-session; a short TTL eliminates 90%+ of forks
-   * during rapid turns without making the chip feel stale.
-   */
+  /** Min interval between two `get_git_branch` IPC roundtrips. */
   private static readonly GIT_BRANCH_TTL_MS = 1500;
   /** Epoch-ms of the last branch read; `0` forces the next call. */
   private gitBranchLastReadAt = 0;
@@ -297,9 +278,7 @@ export class ChatComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Returns true when the assistant entry at `index` is the most recent
-   * assistant message — used to gate the per-message Retry button. Reads the
-   * `lastAssistantIndex` computed, so the per-row template lookup is O(1).
+   * Returns true when the assistant entry is the most recent message; gates Retry.
    * @param index - Index into `messagesFromState()` of the entry under test.
    */
   isLastAssistant(index: number): boolean {
@@ -337,13 +316,7 @@ export class ChatComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Resumes a session in live chat mode. The drawer click is the primary
-   * action — there is no longer a "view transcript" intermediate step.
-   *
-   * Flow: clear local state -> fetch the persisted transcript and surface its
-   * messages immediately (Claude Code's `--resume` reuses the session but
-   * does not replay history on the stream-json channel) -> invoke
-   * `resume_conversation` so subsequent user turns continue the same session.
+   * Resumes a session in live chat mode. Clears local state, fetches transcript, surfaces messages.
    * @param sessionId - session UUID to resume.
    */
   async resumeConversation(sessionId: string): Promise<void> {
@@ -351,9 +324,7 @@ export class ChatComponent implements OnInit, OnDestroy {
     this.resumeInProgress = true;
 
     this.chat.resetForNewConversation();
-    // Stamp the active session id immediately so the drawer's accent
-    // indicator follows the user's click without waiting for the backend
-    // to surface session_id on the next stream chunk.
+    // Stamp session id optimistically so drawer accent follows click without flicker.
     this.optimisticSessionId = sessionId;
     this.ui.closeSidebar();
     this.cdr.markForCheck();
@@ -362,10 +333,7 @@ export class ChatComponent implements OnInit, OnDestroy {
       const project = this.projectState.activeProject;
       if (!project) return;
 
-      // Run transcript fetch and the live-session relaunch in parallel —
-      // the two backend calls are independent (resume_conversation does
-      // not need the transcript). When both resolve we load the messages
-      // even if `resume_conversation` finished first.
+      // Run transcript fetch and resume_conversation in parallel; both independent.
       const transcriptPromise = this.tauri
         .invoke<ConversationTranscript>('get_conversation', { project, sessionId })
         .catch((err) => {
@@ -377,8 +345,7 @@ export class ChatComponent implements OnInit, OnDestroy {
       const [transcript] = await Promise.all([transcriptPromise, resumePromise]);
       if (transcript) {
         this.chat.loadMessages(toChatMessages(transcript));
-        // Seed the session id immediately so retry / queue work without
-        // waiting for the next live `Result` event to land.
+        // Seed session id immediately so retry/queue work without waiting for live Result.
         this.chat.seedResumedSession(sessionId);
       }
     } catch (err) {
@@ -408,9 +375,7 @@ export class ChatComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Deletes a conversation's transcript file. If the active session is the one
-   * being deleted, we reset live chat too — the underlying JSONL is gone, so
-   * resume/retry would fail.
+   * Deletes a conversation's transcript file; resets live chat if currently active.
    * @param sessionId - session UUID to delete.
    */
   async deleteConversation(sessionId: string): Promise<void> {
@@ -442,8 +407,7 @@ export class ChatComponent implements OnInit, OnDestroy {
     this.chat.resetForNewConversation();
     this.cdr.markForCheck();
     await this.chat.init();
-    // Re-focus the composer so the user can start typing right after
-    // hitting "+ new conversation" without an extra click.
+    // Re-focus composer so user can type immediately after clicking new conversation.
     this.composer?.focusInput();
   }
 
@@ -518,12 +482,7 @@ interface HistoryToolResultBlock {
 }
 
 /**
- * Maps a backend `ConversationTranscript` into the live-chat `ChatMessage[]`
- * shape used by `ChatStateService.loadMessages`.
- *
- * Each transcript entry carries either pre-built `blocks` or a flat `content`
- * string. We prefer `blocks` so tool calls / thinking sections survive the
- * round-trip; otherwise we fall back to a single text block.
+ * Maps a backend `ConversationTranscript` into the live-chat `ChatMessage[]` shape.
  * @param transcript - Backend conversation transcript to convert.
  */
 function toChatMessages(transcript: ConversationTranscript): ChatMessage[] {
@@ -535,9 +494,7 @@ function toChatMessages(transcript: ConversationTranscript): ChatMessage[] {
         : ([{ type: 'text' as const, content: msg.content }] as MessageBlock[]);
     const blocks = normalizeHistoryBlocks(rawBlocks);
     const timestamp = msg.timestamp ? new Date(msg.timestamp).getTime() : Date.now();
-    // History entries are by definition durable — propagate the JSONL uuid
-    // (when present) and mark it `Committed` so `canRetryLastAssistant`
-    // accepts the resumed conversation as a valid retry anchor (ADR-046).
+    // Propagate JSONL uuid and mark Committed so retry accepts it as anchor (ADR-046).
     const base: ChatMessage = { role, blocks, timestamp };
     if (msg.uuid) {
       base.uuid = msg.uuid;
@@ -548,13 +505,7 @@ function toChatMessages(transcript: ConversationTranscript): ChatMessage[] {
 }
 
 /**
- * Converts blocks from the backend history format to the live-chat format.
- *
- * History `tool_use` blocks are flat (`{ type, tool_name, input_json }`),
- * while live-chat blocks nest the tool data inside
- * `{ type: 'tool_use', tool: ToolUseBlock }`. History `tool_result` blocks
- * are consumed and merged into the preceding `tool_use` block — they never
- * appear standalone in the returned array.
+ * Converts blocks from backend history format to live-chat format, merging tool_result into tool_use.
  * @param blocks - Raw blocks from the backend history payload.
  */
 function normalizeHistoryBlocks(

--- a/desktop/src/src/app/chat/composer/composer.component.ts
+++ b/desktop/src/src/app/chat/composer/composer.component.ts
@@ -44,24 +44,14 @@ interface AttachmentRecord {
   preprocessed: PreprocessedImage | null;
 }
 
-/**
- * Inline directive prepended to a user message when plan mode is active.
- * Stream-json has no first-class plan toggle, so we encode the intent in the
- * prompt itself. The wording mirrors Claude Code's CLI plan mode banner.
- */
+/** Inline directive prepended to a user message when plan mode is active. */
 const PLAN_MODE_PREFIX =
   '[Plan mode] Produce a plan only — do NOT modify files, do NOT run tools that mutate state. Then ask me to confirm before acting.\n\n';
 
 /**
- * Stateless composer that wraps a textarea, slash button, slash-menu popover, and a
- * send button. Input is managed by a reactive `FormControl<string>`; Enter
- * submits while Shift+Enter inserts a newline. Typing `/` at the start of the
- * textarea (or clicking the `/` toolbar button) opens the slash-menu popover.
- *
- * ADR-045: when `streaming` is true and a user submits, the composer emits
- * `queueRequested` instead of `submitted`; the parent wires the queue
- * Tauri command. The "queued: …" preview line surfaces the active slot
- * with an X button that emits `queueCancelled`.
+ * Stateless composer: textarea, slash button, slash-menu popover, send button.
+ * Enter submits, Shift+Enter inserts a newline; `/` at start opens the slash menu.
+ * ADR-045: while `streaming`, submit emits `queueRequested` instead of `submitted`.
  */
 @Component({
   selector: 'app-composer',
@@ -147,11 +137,7 @@ const PLAN_MODE_PREFIX =
       <div
         class="mono flex flex-wrap items-center gap-x-3 gap-y-1 border-t border-[var(--line)] px-3 py-1.5 text-[11px] text-[var(--ink-mute)]"
       >
-        <!-- Plan / Act mode toggle — first control in the toolbar so the
-             active mode is the most visible piece of the row. Plan mode
-             prepends a planning directive to the backend payload (Claude
-             produces a plan and asks before acting); the local bubble
-             keeps the user's raw text. -->
+        <!-- Plan / Act mode toggle. -->
         <button
           type="button"
           data-testid="composer-plan-toggle"
@@ -262,11 +248,7 @@ export class ComposerComponent implements AfterViewInit {
   /** True to disable input and prevent submits, false to enable. */
   readonly disabled = input(false);
 
-  /**
-   * True when a turn is currently streaming (ADR-045). The composer stays
-   * enabled — the user can keep typing — but submits route to
-   * `queueRequested` instead of `submitted`.
-   */
+  /** True when a turn is streaming (ADR-045); submits route to `queueRequested`. */
   readonly streaming = input(false);
 
   /** Current queued message preview, when one is set (ADR-045). */
@@ -315,11 +297,7 @@ export class ComposerComponent implements AfterViewInit {
   /** Active query used to filter the slash menu (text after `/`). */
   readonly slashQuery = signal<string>('');
 
-  /**
-   * Plan mode state. When true, the next submitted message is prefixed with
-   * the planning directive (`PLAN_MODE_PREFIX`). Persists across messages
-   * until the user toggles it off — mirrors the CLI's plan mode behaviour.
-   */
+  /** Plan mode state; when true the next submit is prefixed with `PLAN_MODE_PREFIX`. */
   readonly planMode = signal<boolean>(false);
 
   /** Pending image attachments; cleanup effect below revokes blob URLs on remove. */
@@ -360,12 +338,7 @@ export class ComposerComponent implements AfterViewInit {
     this.textareaRef?.nativeElement ? `${this.textareaRef.nativeElement.offsetWidth}px` : 'auto'
   );
 
-  /**
-   * True when the user explicitly closed the slash menu (Esc / backdrop click)
-   * while the textarea still matches the slash trigger. Prevents the menu from
-   * immediately re-opening on the next keystroke until the user clears the
-   * trigger or explicitly clicks the slash button again.
-   */
+  /** True when the user closed the slash menu while the trigger still matches, suppressing auto-reopen. */
   private slashSuppressedByUser = false;
 
   /**
@@ -377,8 +350,7 @@ export class ComposerComponent implements AfterViewInit {
       const id = this.projectState.activeProject;
       if (id) void this.slashService.refresh(id);
     });
-    // Mirror the legacy setter side-effect: enable/disable the FormControl
-    // whenever the `disabled` input changes.
+    // Enable/disable the FormControl when the `disabled` input changes.
     effect(() => {
       const value = this.disabled();
       if (value) this.text.disable({ emitEvent: false });
@@ -540,8 +512,7 @@ export class ComposerComponent implements AfterViewInit {
   private async ingest(files: File[]): Promise<void> {
     const images = files.filter((f) => f.type.startsWith('image/'));
     if (images.length === 0) {
-      // Non-image drop/paste is silently ignored — surfacing an error
-      // would be noisy (e.g. user dragging a PDF onto the window by mistake).
+      // Non-image drop/paste is silently ignored.
       return;
     }
     const project = this.projectState.activeProject;
@@ -657,11 +628,7 @@ export class ComposerComponent implements AfterViewInit {
     this.closeSlash();
   }
 
-  /**
-   * Closes the popover and returns focus to the textarea. If the textarea
-   * still matches the slash trigger, suppress automatic re-opening until the
-   * user clears the trigger or explicitly clicks the slash button again.
-   */
+  /** Closes the popover, refocuses the textarea, and suppresses auto-reopen while the trigger matches. */
   closeSlash(): void {
     const ta = this.textareaRef?.nativeElement;
     if (ta) {
@@ -676,9 +643,7 @@ export class ComposerComponent implements AfterViewInit {
   }
 
   /**
-   * Handle keystrokes inside the overlay. Esc closes the menu without
-   * propagating up to the textarea (which would otherwise re-trigger
-   * the menu via `updateSlashState`).
+   * Handle keystrokes inside the overlay; Esc closes the menu without propagating.
    * @param event Keyboard event raised by the CDK overlay.
    */
   onOverlayKeydown(event: KeyboardEvent): void {

--- a/desktop/src/src/app/chat/composer/file-drop.directive.spec.ts
+++ b/desktop/src/src/app/chat/composer/file-drop.directive.spec.ts
@@ -79,8 +79,6 @@ describe('FileDropDirective', () => {
   });
 
   it('drops are no-op when disabled', () => {
-    // Re-create the fixture with disabled=true from the start; flipping the
-    // input mid-test triggers a stale change-detection check on Angular 21.
     const disabledFixture = TestBed.createComponent(HostComponent);
     disabledFixture.componentInstance.disabled = true;
     disabledFixture.detectChanges();

--- a/desktop/src/src/app/chat/conversations-sidebar/conversations-sidebar.component.spec.ts
+++ b/desktop/src/src/app/chat/conversations-sidebar/conversations-sidebar.component.spec.ts
@@ -50,10 +50,8 @@ const sample: readonly ConversationSummary[] = [
 ];
 
 /**
- * Query the drawer content rendered into the CDK overlay container.
- * The component renders via CDK Overlay portal attached to `document.body`,
- * not inside the host fixture, so we query the global document.
- * @param sel CSS selector to locate the element under document.
+ * Query the CDK overlay portal under document.body.
+ * @param sel - CSS selector to locate the element under document.
  */
 function q(sel: string): HTMLElement | null {
   return document.querySelector(sel) as HTMLElement | null;
@@ -91,11 +89,7 @@ describe('ConversationsSidebarComponent', () => {
     });
 
     it('detaches the overlay when open transitions back to false', () => {
-      // Drive the child input directly to bypass OnPush propagation issues
-      // when mutating the host wrapper's plain fields. Verifies that the
-      // CDK overlay portal attaches/detaches in lockstep with the open input.
-      // The shared host fixture defaults to open=true, so destroy it first to
-      // avoid having two drawers in the overlay container at the same time.
+      // Destroy the shared open=true fixture to avoid two drawers in the overlay.
       fixture.destroy();
       const childFixture = TestBed.createComponent(ConversationsSidebarComponent);
       childFixture.componentRef.setInput('conversations', sample);
@@ -158,8 +152,6 @@ describe('ConversationsSidebarComponent', () => {
     });
 
     it('falls back to a dash when timestamp is null', () => {
-      // The drawer now formats timestamps as short relative labels
-      // (e.g. "2m", "1h", "3d") and uses "—" for missing values.
       host.conversations = sample;
       fixture.detectChanges();
       const drawer = q('[data-testid="conversations-sidebar"]')!;
@@ -172,8 +164,6 @@ describe('ConversationsSidebarComponent', () => {
       host.conversations = sample;
       host.currentSessionId = 's2';
       fixture.detectChanges();
-      // Row click resumes directly (single primary action), so the test-id is
-      // `conversation-resume-<sid>` rather than the legacy `view-<sid>`.
       const active = q('[data-testid="conversation-resume-s2"]');
       expect(active).not.toBeNull();
       expect(active!.getAttribute('aria-current')).toBe('true');
@@ -260,8 +250,6 @@ describe('ConversationsSidebarComponent', () => {
     });
 
     it('clears the confirm state when the drawer is closed and reopened', () => {
-      // Drive the child input directly so we can toggle `open` without going
-      // through the host wrapper's separate fixture lifecycle.
       fixture.destroy();
       const childFixture = TestBed.createComponent(ConversationsSidebarComponent);
       childFixture.componentRef.setInput('conversations', sample);

--- a/desktop/src/src/app/chat/conversations-sidebar/conversations-sidebar.component.ts
+++ b/desktop/src/src/app/chat/conversations-sidebar/conversations-sidebar.component.ts
@@ -20,12 +20,9 @@ import type { ConversationSummary } from '../../models/chat';
 import { IconComponent } from '../../shared/icon.component';
 
 /**
- * Buckets a conversation summary into a relative-day group.
- *
- * Mirrors the mockup's `today / yesterday / older` headers (lines 443/462/475).
- * Falls back to `older` when a timestamp can't be parsed so we never drop a row.
+ * Buckets a conversation summary into a relative-day group (today/yesterday/older).
  * @param ts ISO timestamp of the conversation's last activity.
- * @param now Reference epoch in ms; defaults to `Date.now()` for testability.
+ * @param now Reference epoch in ms; defaults to `Date.now()`.
  */
 function bucketForTimestamp(ts: string | null | undefined, now: number = Date.now()): string {
   if (!ts) return 'older';
@@ -38,11 +35,7 @@ function bucketForTimestamp(ts: string | null | undefined, now: number = Date.no
   return 'older';
 }
 
-/**
- * One conversation row prepared for rendering — preview/timestamp passed
- * through the cleanup helpers once when the buckets are computed, so the
- * template never re-runs the regexes per CD tick.
- */
+/** One conversation row prepared for rendering with cleaned preview/timestamp. */
 interface ConversationRow {
   readonly conv: ConversationSummary;
   readonly preview: string;
@@ -275,18 +268,13 @@ export class ConversationsSidebarComponent {
     });
   });
 
-  /**
-   * Sync the `open` input with the CDK overlay lifecycle. Opening builds a
-   * left-anchored full-height panel with a dark backdrop and dispatches close
-   * on backdrop click or Escape. Closing detaches the portal (no DOM remains).
-   */
+  /** Sync the `open` input with the CDK overlay lifecycle (open/close panel). */
   constructor() {
     effect(() => {
       if (this.open()) this.openOverlay();
       else this.closeOverlay();
     });
-    // Defensive: dispose the overlay if the host is torn down while open
-    // (e.g., a route swap with the drawer left open).
+    // Dispose the overlay if the host is torn down while open.
     inject(DestroyRef).onDestroy(() => this.closeOverlay());
   }
 

--- a/desktop/src/src/app/chat/header/chat-header.component.spec.ts
+++ b/desktop/src/src/app/chat/header/chat-header.component.spec.ts
@@ -35,9 +35,7 @@ describe('ChatHeaderComponent', () => {
   });
 
   // ── Project pill ──────────────────────────────────────────────────────
-  // The project pill was extracted to <app-project-pill> (single SSOT used
-  // across every view header). Behaviour is covered by project-pill.spec.ts;
-  // here we just verify the chat header still renders the host element.
+  // Project pill extracted to <app-project-pill>; behaviour in project-pill.spec.ts.
 
   it('renders the shared project pill component', () => {
     fixture.detectChanges();

--- a/desktop/src/src/app/chat/memory-panel/memory-panel.component.spec.ts
+++ b/desktop/src/src/app/chat/memory-panel/memory-panel.component.spec.ts
@@ -22,9 +22,7 @@ class HostComponent {
 }
 
 /**
- * Query the drawer content rendered into the CDK overlay container.
- * The component renders via CDK Overlay portal attached to `document.body`,
- * not inside the host fixture, so we query the global document.
+ * Query the drawer content in the CDK overlay container on document.body.
  * @param sel CSS selector to locate the element under document.
  */
 function q(sel: string): HTMLElement | null {

--- a/desktop/src/src/app/chat/memory-panel/memory-panel.component.ts
+++ b/desktop/src/src/app/chat/memory-panel/memory-panel.component.ts
@@ -19,21 +19,7 @@ import { IconComponent } from '../../shared/icon.component';
 
 /**
  * Left overlay drawer that surfaces the active project's CLAUDE.md.
- *
- * Anchored to the left edge of the viewport via Angular CDK Overlay so the
- * memory button in the chat header opens its panel in the same place as the
- * conversations history drawer. The component itself renders no inline DOM —
- * its template is a single `<ng-template>` portalled by the overlay when the
- * `open` input flips to `true`.
- *
- * - Header: mono "memory" + neutral pill with section count + close ×.
- * - Body: when the source markdown contains the canonical section markers
- *   (## User / ## Project / ## Feedback / ## Reference) we render each as a
- *   mono kicker + dimmed text block — matching the mockup. Otherwise we render
- *   the raw source as preformatted plain text inside a <pre>. We deliberately
- *   do not run the markdown pipeline here: MEMORY.md often contains relative
- *   markdown links to per-memory files, and rendering them as <a> would let a
- *   click navigate the embedded webview off the SPA route (white screen).
+ * Rendered via CDK overlay portal; link-stripping prevents off-route navigation.
  */
 @Component({
   selector: 'app-memory-panel',
@@ -132,18 +118,13 @@ export class MemoryPanelComponent {
   private readonly viewContainerRef = inject(ViewContainerRef);
   private overlayRef: OverlayRef | null = null;
 
-  /**
-   * Sync the `open` input with the CDK overlay lifecycle. Opening builds a
-   * left-anchored full-height panel with a dark backdrop and dispatches close
-   * on backdrop click or Escape. Closing detaches the portal (no DOM remains).
-   */
+  /** Sync the `open` input with the CDK overlay lifecycle. */
   constructor() {
     effect(() => {
       if (this.open()) this.openOverlay();
       else this.closeOverlay();
     });
-    // Defensive: dispose the overlay if the host is torn down while open
-    // (e.g., a route swap with the drawer left open).
+    // Dispose the overlay if the host is torn down while open.
     inject(DestroyRef).onDestroy(() => this.closeOverlay());
   }
 
@@ -187,9 +168,7 @@ const SECTION_MARKERS: readonly { id: string; label: string; pattern: RegExp }[]
 
 /**
  * Splits a CLAUDE.md-style memory document into mockup-shaped sections.
- *
- * Returns an empty array when none of the canonical headers are present so the
- * caller can fall back to the standard markdown renderer.
+ * Returns an empty array when no canonical headers are present (caller falls back).
  * @param markdown - Raw markdown source.
  */
 export function parseSections(
@@ -216,8 +195,7 @@ export function parseSections(
 }
 
 /**
- * Collapses `- [title](file.md) — desc` to `- desc` so the drawer never renders
- * a clickable pointer link (would navigate the webview off-route and white-screen).
+ * Collapses `- [title](file.md) — desc` to `- desc`, stripping clickable pointer links.
  * @param text - Raw markdown source.
  */
 export function stripPointerLinks(text: string): string {

--- a/desktop/src/src/app/chat/message-list/chat-message-list.component.spec.ts
+++ b/desktop/src/src/app/chat/message-list/chat-message-list.component.spec.ts
@@ -22,11 +22,7 @@ describe('ChatMessageListComponent', () => {
     fixture.componentRef.setInput('messages', []);
   });
 
-  /**
-   * Replays `ngOnChanges` after a manual property set — mirrors what Angular
-   * does when a template binding changes. Signal `input()` does NOT trigger
-   * lifecycle `ngOnChanges`, so tests must invoke it explicitly.
-   */
+  /** Replays `ngOnChanges` after a manual property set. */
   function fakeOnChanges(): void {
     component.ngOnChanges();
   }
@@ -72,9 +68,7 @@ describe('ChatMessageListComponent', () => {
     );
     expect(streamingEl).not.toBeNull();
 
-    // When the last block is a text block, the per-block streaming caret renders
-    // (data-testid="streaming-caret") and the message-level cursor is suppressed
-    // by lastBlockIsText.
+    // A text last block renders the per-block streaming caret.
     const caret = fixture.nativeElement.querySelector('[data-testid="streaming-caret"]');
     expect(caret).not.toBeNull();
   });
@@ -175,10 +169,7 @@ describe('ChatMessageListComponent', () => {
   });
 
   it('re-arms auto-scroll on a new message even after the user scrolled up', () => {
-    // Product decision: a new turn (length grew) snaps the view back to the
-    // bottom unconditionally. Streaming deltas that arrive on the *same*
-    // turn still respect a manual scroll-up, but the next user-visible
-    // message wins so the freshly-arrived content is always in sight.
+    // A new turn snaps the view back to the bottom unconditionally.
     fixture.componentRef.setInput('messages', [
       { role: 'user', blocks: [{ type: 'text', content: 'first' }], timestamp: 1 },
     ]);

--- a/desktop/src/src/app/chat/message-list/chat-message-list.component.ts
+++ b/desktop/src/src/app/chat/message-list/chat-message-list.component.ts
@@ -53,12 +53,7 @@ const SCROLL_BOTTOM_THRESHOLD_PX = 16;
             (questionAnswered)="questionAnswered.emit($event)"
           />
         } @else if (showAwaitingCaret()) {
-          <!-- Streaming has started but no block has arrived yet. Show a
-               blinking caret so the user has visual confirmation that
-               the assistant is working — same caret used inline during
-               text streaming, just rendered as a standalone placeholder.
-               No horizontal padding so the caret aligns flush-left with
-               the rule columns of the surrounding tool/thinking blocks. -->
+          <!-- Standalone caret placeholder: streaming started, no block yet. -->
           <div data-testid="chat-message-list-awaiting">
             <span class="caret" aria-label="Assistant is responding"></span>
           </div>
@@ -87,24 +82,14 @@ export class ChatMessageListComponent implements AfterViewChecked, OnChanges {
   /** Tracks message-count to detect new turns (vs. mere streaming deltas). */
   private lastMessageCount = 0;
 
-  /**
-   * Wires the streaming-aware scroll sync — re-runs on every signal input
-   *  change so streaming deltas (which mutate `currentBlocks` in place) and
-   *  new turns alike trigger a scroll-to-bottom.
-   */
+  /** Wires the streaming-aware scroll sync, re-run on every signal-input change. */
   constructor() {
-    // Re-run on every signal-input change. `messages`, `currentBlocks` and
-    // `isStreaming` all need to drive a scroll sync — relying on
-    // `ngOnChanges` alone misses streaming deltas where the array reference
-    // stays stable but its contents grow.
     effect(() => {
       const count = this.messages().length;
       // Reading these signals subscribes the effect to streaming chunks too.
       this.currentBlocks();
       this.isStreaming();
-      // A genuinely new turn (length grew) re-arms auto-scroll even if the
-      // user had previously scrolled up — they almost always want to see
-      // the freshly-sent message + the assistant's reply.
+      // A new turn (length grew) re-arms auto-scroll.
       if (count > this.lastMessageCount) {
         this.shouldAutoScroll = true;
       }
@@ -118,11 +103,7 @@ export class ChatMessageListComponent implements AfterViewChecked, OnChanges {
     return this.isStreaming() && this.currentBlocks().length > 0;
   }
 
-  /**
-   * Whether to render the standalone blinking caret. True only in the gap
-   * between sending a message and the first streamed block — once any block
-   * arrives the regular streaming bubble takes over.
-   */
+  /** Whether to render the standalone caret: streaming with no block yet. */
   showAwaitingCaret(): boolean {
     return this.isStreaming() && this.currentBlocks().length === 0;
   }

--- a/desktop/src/src/app/chat/message/chat-message.component.spec.ts
+++ b/desktop/src/src/app/chat/message/chat-message.component.spec.ts
@@ -120,16 +120,13 @@ describe('ChatMessageComponent', () => {
 
     const edited = fixture.nativeElement.querySelector('[data-testid="user-message-edited"]');
     expect(edited).not.toBeNull();
-    // The "user · HH:MM" header was removed — there is no `user-message-time`
-    // element to assert against any more.
+    // The "user · HH:MM" header was removed — no `user-message-time` element.
     const time = fixture.nativeElement.querySelector('[data-testid="user-message-time"]');
     expect(time).toBeNull();
   });
 
   it('host stretches messages full-width (terminal-minimal: no role-based alignment)', () => {
-    // The terminal-minimal layout removes role-based horizontal alignment —
-    // both user and assistant messages stretch to the column width with the
-    // mono meta line as the visual differentiator instead of a bubble.
+    // Terminal-minimal layout removes role-based alignment; both roles stretch full-width.
     fixture.componentRef.setInput('blocks', [{ type: 'text', content: 'ok' }]);
     fixture.componentRef.setInput('role', 'user');
     fixture.detectChanges();
@@ -152,10 +149,7 @@ describe('ChatMessageComponent', () => {
   });
 
   it('user role dispatches to <app-user-message> (terminal-minimal: no bubble)', () => {
-    // After Unit 8 (refactor: extract chat header, list, user-message), user
-    // messages render via <app-user-message> in terminal-minimal style — no
-    // sized "bubble" with w-fit/max-w-[85%]. This replaces the prior bubble
-    // test which assumed both roles shared the same wrapper styling.
+    // User messages render via <app-user-message>, no sized bubble.
     fixture.componentRef.setInput('blocks', [{ type: 'text', content: 'ok' }]);
     fixture.componentRef.setInput('role', 'user');
     fixture.detectChanges();
@@ -164,9 +158,7 @@ describe('ChatMessageComponent', () => {
   });
 
   it('assistant role renders without a bubble (terminal-minimal: plain article)', () => {
-    // After the terminal-minimal redesign, assistant messages are plain
-    // articles — no max-width, no border, no rounded background. The mono
-    // `speedwave · model · time` meta line is the only visual delimiter.
+    // Assistant messages are plain articles — no max-width, border, or rounded background.
     fixture.componentRef.setInput('blocks', [{ type: 'text', content: 'ok' }]);
     fixture.componentRef.setInput('role', 'assistant');
     fixture.detectChanges();
@@ -181,9 +173,7 @@ describe('ChatMessageComponent', () => {
   });
 
   it('shows the block-level cursor when streaming and last block is NOT text', () => {
-    // The per-text-block streaming caret renders inside <app-text-block>;
-    // the parent block-level cursor is suppressed when the last block is a
-    // text block to avoid a double-cursor visual bug.
+    // Per-text-block caret renders in <app-text-block>; block-level cursor suppressed when last block is text.
     fixture.componentRef.setInput('blocks', [
       {
         type: 'tool_use',
@@ -310,8 +300,7 @@ describe('ChatMessageComponent', () => {
     let emitted: { toolId: string; questionIdx: number; value: string } | null = null;
     component.questionAnswered.subscribe((e) => (emitted = e));
 
-    // Drive the child ask-user-block via its real option + send buttons —
-    // exercises the `(answered)` binding path.
+    // Drive the child ask-user-block via its real option + send buttons.
     const el = fixture.nativeElement as HTMLElement;
     const optionBtn = el.querySelector(
       '[data-testid="ask-option-btn"]'

--- a/desktop/src/src/app/chat/message/chat-message.component.ts
+++ b/desktop/src/src/app/chat/message/chat-message.component.ts
@@ -10,15 +10,7 @@ import { UserMessageComponent } from './user-message.component';
 import { MessageActionsComponent } from './message-actions.component';
 import { MessageMetadataComponent } from './message-metadata.component';
 
-/**
- * Renders a single chat message in the terminal-minimal layout.
- *
- * - User messages → delegate to `<app-user-message>` (mono "user · time" meta
- *   line + plain content, no bubble).
- * - Assistant messages → mono "speedwave · time" meta line, then body blocks,
- *   then `<app-message-metadata>` (model · edited · tokens · cache · cost),
- *   then `<app-message-actions>` (copy / retry).
- */
+/** Renders a single chat message in the terminal-minimal layout. */
 @Component({
   selector: 'app-chat-message',
   imports: [
@@ -41,11 +33,6 @@ import { MessageMetadataComponent } from './message-metadata.component';
       </article>
     } @else {
       <article data-testid="chat-message" [attr.data-role]="role()">
-        <!-- Author + timestamp meta line removed: identity is conveyed by
-             alignment (assistant on the left, user-bubble on the right) and
-             the per-message metadata row at the bottom already shows model
-             + tokens + cost; an explicit "speedwave · HH:MM" header was
-             redundant. Streaming state is signalled by the trailing caret. -->
         <div class="text-[14px] leading-[1.7] text-[var(--ink)]">
           @for (block of blocks(); track $index) {
             @switch (block.type) {

--- a/desktop/src/src/app/chat/message/message-actions.component.spec.ts
+++ b/desktop/src/src/app/chat/message/message-actions.component.spec.ts
@@ -9,11 +9,7 @@ class FakeChatState {
   copyMessage = vi.fn().mockReturnValue(true);
   retryLastAssistant = vi.fn().mockResolvedValue(undefined);
   canRetryLastAssistant = vi.fn().mockReturnValue(true);
-  /**
-   * Mirrors the real `ChatStateService.retryEnabled` signal — the component's
-   * template binds `[disabled]="!chat.retryEnabled()"` so we expose a writable
-   * signal here whose `set(...)` lets each test toggle the disabled state.
-   */
+  /** Writable mirror of `ChatStateService.retryEnabled` so tests can toggle it. */
   private readonly retrySig = signal(true);
   retryEnabled = this.retrySig.asReadonly();
   setRetryEnabled(v: boolean): void {
@@ -159,10 +155,6 @@ describe('MessageActionsComponent', () => {
   });
 
   it('briefly disables copy button while copyMessage runs and re-enables after', () => {
-    // CDK Clipboard.copy is synchronous, so the disabled flag is observed
-    // via the busy guard: while the handler is running the button is disabled,
-    // and after it returns the button is re-enabled (and the "✓ copied"
-    // indicator appears separately for 1.5s).
     let observedDisabledDuringCopy = false;
     chat.copyMessage = vi.fn().mockImplementation(() => {
       observedDisabledDuringCopy = component.copyBusy;

--- a/desktop/src/src/app/chat/message/message-metadata.component.spec.ts
+++ b/desktop/src/src/app/chat/message/message-metadata.component.spec.ts
@@ -306,8 +306,7 @@ describe('MessageMetadataComponent', () => {
   });
 
   it('keeps a single [1m] suffix when the raw id ends with one', () => {
-    // Claude Code surfaces 1M-context model variants with a `[1m]` suffix —
-    // the chat footer should preserve it on the prettified id.
+    // Preserve a single `[1m]` suffix on the prettified id.
     setEntry(baseAssistant({ meta: { model: 'claude-opus-4-7[1m]' } }));
 
     const el = fixture.nativeElement as HTMLElement;
@@ -317,10 +316,7 @@ describe('MessageMetadataComponent', () => {
   });
 
   it('collapses repeated [1m] suffixes (regression: opus-4-7[1m][1m])', () => {
-    // Workaround: when `ANTHROPIC_DEFAULT_OPUS_MODEL` already carries `[1m]`
-    // and Claude Code re-appends the suffix while resolving the alias, the
-    // model id arrives doubled. The chat footer must dedupe so the user
-    // sees a single `[1m]`.
+    // Dedupe a doubled `[1m][1m]` suffix to a single `[1m]`.
     setEntry(baseAssistant({ meta: { model: 'claude-opus-4-7[1m][1m]' } }));
 
     const el = fixture.nativeElement as HTMLElement;

--- a/desktop/src/src/app/chat/message/message-metadata.component.ts
+++ b/desktop/src/src/app/chat/message/message-metadata.component.ts
@@ -50,11 +50,7 @@ export class MessageMetadataComponent {
     const raw = this.entry().meta?.model;
     if (!raw) return '';
     const stripped = raw.replace(/^claude-/, '');
-    // Collapse repeated `[1m]` suffixes. They appear when Claude Code
-    // resolves the `opus`/`sonnet` alias against `ANTHROPIC_DEFAULT_*_MODEL`
-    // (which already carries `[1m]`) and re-appends the suffix on top —
-    // surfaces as `opus-4-7[1m][1m]` in the chat footer. The functional
-    // 1M-context behaviour is unaffected; this is purely a display fix.
+    // Collapse repeated `[1m]` suffixes.
     const dedup = stripped.replace(/(\[1m\])+$/, '[1m]');
     return dedup.replace(/-(\d+)-(\d+)(\[1m\])?$/, '-$1.$2$3');
   });

--- a/desktop/src/src/app/chat/message/user-message.component.spec.ts
+++ b/desktop/src/src/app/chat/message/user-message.component.spec.ts
@@ -80,10 +80,7 @@ describe('UserMessageComponent', () => {
   });
 
   // ── Timestamp formatting ─────────────────────────────────────────────
-  // The "user · HH:MM" header was removed from the bubble — identity comes
-  // from right-alignment + bubble background, and the timestamp would have
-  // duplicated info already present in the assistant's metadata row. So
-  // there is no `user-message-time` element to assert against any more.
+  // No `user-message-time` element; the timestamp header was removed.
 
   // ── Edge case — empty blocks ─────────────────────────────────────────
 

--- a/desktop/src/src/app/chat/message/user-message.component.ts
+++ b/desktop/src/src/app/chat/message/user-message.component.ts
@@ -7,12 +7,7 @@ import type { MessageBlock } from '../../models/chat';
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: { class: 'flex justify-end' },
   template: `
-    <!-- Right-aligned bubble (max 80% column width) so user turns sit on the
-         opposite side of assistant turns — standard chat orientation. The
-         "user · HH:MM" header was removed: identity is conveyed by alignment
-         and the bubble background, and the timestamp duplicated info that
-         already lived in the assistant's per-turn metadata row. The "edited"
-         badge survives because it carries non-redundant signal. -->
+    <!-- Right-aligned bubble, max 80% column width. -->
     <div data-testid="user-message" class="max-w-[80%]">
       @if (editedAt() !== undefined) {
         <div

--- a/desktop/src/src/app/chat/pricing.spec.ts
+++ b/desktop/src/src/app/chat/pricing.spec.ts
@@ -10,12 +10,7 @@ import {
 import { _resetUnknownModelWarnings } from './pricing.testing';
 import type { TurnUsage } from '../models/chat';
 
-/**
- * Stand-in for the `list_anthropic_models` payload (the Rust SSOT
- * `AnthropicModelInfo` serialized). Mirrors the ids, contexts, and rates in
- * `defaults.rs::ANTHROPIC_MODELS` so the parity assertion is meaningful — bump
- * this together with the catalog when a model is added.
- */
+/** Stand-in for `list_anthropic_models`; mirror `defaults.rs::ANTHROPIC_MODELS` when a model is added. */
 const CATALOG: PricedAnthropicModel[] = [
   {
     id: 'claude-fable-5',
@@ -56,10 +51,7 @@ const CATALOG: PricedAnthropicModel[] = [
 ];
 
 /**
- * Counts how many `plugin:log|log` warn-level (level 4) calls the stubbed
- * tauri invoke received. `pluginLogWarn` (used by pricing for unknown-model
- * warnings) forwards to `invoke('plugin:log|log', { message, level: 4 })`, the
- * same pipeline LoggerService uses; we assert on it rather than the raw console.
+ * Counts `plugin:log|log` warn-level (level 4) calls the stubbed invoke received.
  * @param invokeSpy - The stubbed `__TAURI_INTERNALS__.invoke` spy.
  */
 function logWarnCalls(invokeSpy: ReturnType<typeof vi.fn>): unknown[][] {
@@ -210,12 +202,7 @@ describe('calculateCost', () => {
   });
 
   it('sums all four components for a realistic turn', () => {
-    // Opus: input 11_000 (1000 billed after subtracting cache_read) + 10k cache-read +
-    //   5k cache-write + 500 output
-    //   billedInput = max(0, 11000 - 10000) = 1000
-    //   = 1000 * 5 / 1e6 + 10000 * 0.5 / 1e6 + 5000 * 6.25 / 1e6 + 500 * 25 / 1e6
-    //   = 0.005 + 0.005 + 0.03125 + 0.0125
-    //   = 0.05375
+    // Opus: 1000 billed input (11k - 10k cache_read) + cache_read + cache_write + output = 0.05375
     const usage: TurnUsage = {
       input_tokens: 11_000,
       output_tokens: 500,

--- a/desktop/src/src/app/chat/pricing.testing.ts
+++ b/desktop/src/src/app/chat/pricing.testing.ts
@@ -1,14 +1,6 @@
 import { _unknownModelWarningsForTest } from './pricing';
 
-/**
- * Test-only helper: resets the set of unknown models that have already
- * logged a warning, so subsequent calls log again. Lives in a `.testing.ts`
- * file so it stays out of the production bundle (tree-shaken under the
- * Angular production build because no production code imports it).
- *
- * Spec files should `import { _resetUnknownModelWarnings } from
- * './pricing.testing';` rather than reaching into `pricing.ts` directly.
- */
+/** Test-only: resets the unknown-model warning set so subsequent calls log again. */
 export function _resetUnknownModelWarnings(): void {
   _unknownModelWarningsForTest.clear();
 }

--- a/desktop/src/src/app/chat/pricing.ts
+++ b/desktop/src/src/app/chat/pricing.ts
@@ -17,12 +17,8 @@ export interface ModelPricing {
 }
 
 /**
- * Catalog entry shape consumed from the Rust SSOT
- * (`speedwave_runtime::defaults::AnthropicModelInfo`, served by the
- * `list_anthropic_models` Tauri command). Only the fields pricing needs are
- * declared here so the module has no dependency on the full `AnthropicModel`
- * interface. `pricing` / `pricing_1m` use snake_case to match the serialized
- * Rust struct; `pricing_1m` is `null` for sub-1M families (no `[1m]` variant).
+ * Catalog entry from the Rust SSOT `defaults::AnthropicModelInfo`.
+ * snake_case matches the serialized struct; `pricing_1m` is null for sub-1M families.
  */
 export interface PricedAnthropicModel {
   id: string;
@@ -32,23 +28,8 @@ export interface PricedAnthropicModel {
 }
 
 /**
- * Bootstrap pricing seed, keyed by the exact served model id (base alias plus
- * its `[1m]` variant). The numbers are the Rust SSOT
- * (`defaults.rs::ANTHROPIC_MODELS` pricing fields) restated here so the
- * synchronous cost reducer (`buildEntryMeta` in `chat-state.service.ts`) can
- * price a turn before the async `list_anthropic_models` round-trip lands. Once
- * the catalog loads, {@link setPricingCatalog} replaces this index with the
- * backend's numbers — so the running app is always SSOT-on-Rust; this seed
- * only covers the pre-load window. A parity test
- * (`pricing.spec.ts` → "parity: …") asserts this seed covers every catalog id
- * (and its `[1m]` variant where the context window is 1M), so a model bump in
- * `defaults.rs` cannot silently leave a price-less entry here.
- *
- * Conventions across the Claude 4.x/5 generation: cache-read = 10% of input,
- * cache-write = 125% of input. Fable 5 is $10/$50 (1M window is the default,
- * standard-priced); Opus 4.5+ is $5/$25 with the 1M window at the base rate;
- * Sonnet 4.6 is $3/$15 base with a 1M-context premium ($6/$22.5); Haiku 4.5
- * is $1/$5 with no 1M variant.
+ * Bootstrap pricing seed keyed by served model id, from `defaults.rs::ANTHROPIC_MODELS`.
+ * Replaced by {@link setPricingCatalog} once the backend catalog loads; parity test in `pricing.spec.ts`.
  */
 const SEED_PRICING: Readonly<Record<string, ModelPricing>> = {
   // Fable family — $10 / $50 per 1M; 1M context is the default ([1m] == base)
@@ -71,21 +52,11 @@ const SEED_PRICING: Readonly<Record<string, ModelPricing>> = {
   'claude-haiku-4-5': { input: 1, cachedInput: 0.1, cacheWrite: 1.25, output: 5 },
 };
 
-/**
- * Live pricing index, keyed by the served model id. Initialised from
- * {@link SEED_PRICING} and replaced wholesale by {@link setPricingCatalog} once
- * the backend catalog loads. `calculateCost` reads this synchronously so the
- * cost reducer stays non-async.
- */
+/** Live pricing index keyed by served model id; seeded from {@link SEED_PRICING}. */
 const PRICING = new Map<string, ModelPricing>(Object.entries(SEED_PRICING));
 
 /**
- * Replaces the pricing index with rates derived from the backend catalog
- * (the Rust SSOT). Idempotent — clears first, so a re-fetch never leaves stale
- * ids. Each entry contributes its base id and, for 1M-context families, the
- * `[1m]` variant id (the suffix Claude Code appends to unlock the upgraded
- * window). Entries with a missing/malformed `pricing` block are skipped so a
- * partial payload never stores an undefined rate.
+ * Replaces the pricing index with backend catalog rates. Clears first; skips malformed entries.
  * @param models - Catalog entries from `list_anthropic_models`.
  */
 export function setPricingCatalog(models: readonly PricedAnthropicModel[]): void {
@@ -116,59 +87,41 @@ export function _pricingEntryCountForTest(): number {
 }
 
 /**
- * Normalizes a model id from chat/session metadata into a key the pricing
- * index can resolve. Strips a snapshot date (`claude-opus-4-7-20260501` →
- * `claude-opus-4-7`) and re-prepends `claude-` to the short form Claude Code
- * sometimes emits (`opus-4.7` → `claude-opus-4-7`). A `[1m]` suffix is
- * preserved so the 1M variant resolves to its own rate.
+ * Normalizes a model id into a pricing-index key: strips snapshot date, re-prepends `claude-`, keeps `[1m]`.
  * @param model - Raw model id as reported in a turn's usage metadata.
  */
 function normalizeModelId(model: string): string {
   const oneM = model.endsWith('[1m]') ? '[1m]' : '';
   let base = oneM ? model.slice(0, -oneM.length) : model;
   base = base.startsWith('claude-') ? base : `claude-${base.replace('.', '-')}`;
-  // Drop a trailing snapshot date (`-YYYYMMDD`) so dated ids in saved sessions
-  // fall back to the stable alias the catalog carries.
+  // Drop a trailing snapshot date (`-YYYYMMDD`).
   base = base.replace(/-\d{8}$/, '');
   return `${base}${oneM}`;
 }
 
-/**
- * Models seen without a PRICING entry — ensures one warning per id, not per
- * turn. The underscore-prefixed export is module-internal: only the
- * companion `pricing.testing.ts` should import it (so tests can reset the
- * warning state between cases without polluting the production surface).
- */
+/** Models seen without a PRICING entry — dedupes the unknown-model warning to one per id. */
 export const _unknownModelWarningsForTest = new Set<string>();
 
 /**
- * Computes per-turn cost in USD for a given Claude model and token usage.
- * Looks the model up against the pricing index, normalizing dated/short ids to
- * their stable alias first. Logs a single warning per unknown id so unknown
- * models do not spam the log pipeline in long sessions.
+ * Computes per-turn cost in USD for a Claude model and token usage; warns once per unknown id.
  * @param model - Claude model id (e.g. `"claude-opus-4-7"`, `"opus-4.7"`,
  *   `"claude-sonnet-4-6[1m]"`).
  * @param usage - Per-turn token usage (from {@link TurnUsage}).
- * @returns Cost in USD; `null` when the model is not in the pricing index so
- *   the UI can hide the cost segment instead of displaying a misleading
- *   $0.000 for an unrecognised model id.
+ * @returns Cost in USD; `null` when the model is not in the pricing index.
  */
 export function calculateCost(model: string, usage: TurnUsage): number | null {
   const pricing = PRICING.get(model) ?? PRICING.get(normalizeModelId(model));
   if (!pricing) {
     if (!_unknownModelWarningsForTest.has(model)) {
       _unknownModelWarningsForTest.add(model);
-      // Route through the tauri-plugin-log pipeline (same as LoggerService) so
-      // the warning lands in the logs ZIP, not the raw browser console.
+      // Route through the tauri-plugin-log pipeline so the warning lands in the logs ZIP.
       pluginLogWarn(`[pricing] Unknown model "${model}" — cost segment will be hidden.`).catch(
         () => {}
       );
     }
     return null;
   }
-  // input_tokens already excludes cached reads in Anthropic's API output; we
-  // still subtract defensively in case a future CLI version emits the raw
-  // total (clamped to ≥0).
+  // Subtract cached reads defensively (clamped to ≥0).
   const billedInput = Math.max(0, usage.input_tokens - usage.cache_read_tokens);
   return (
     (billedInput * pricing.input) / 1_000_000 +

--- a/desktop/src/src/app/chat/session-stats/session-stats.component.spec.ts
+++ b/desktop/src/src/app/chat/session-stats/session-stats.component.spec.ts
@@ -93,7 +93,6 @@ describe('SessionStatsComponent', () => {
       fixture.detectChanges();
       const txt = rootText();
       // in: = input_tokens only (new uncached input), NOT input + cache.
-      // cache_read (22,562 = re-sent history) must NOT inflate `in:`.
       expect(txt).toContain('in:');
       expect(txt).toContain('1,234');
       expect(txt).not.toContain('23,871'); // 1234 + 22562 + 75 — the old (wrong) totalInput
@@ -159,10 +158,7 @@ describe('SessionStatsComponent', () => {
   // ── regression: `in:` must not echo the context numerator ───────────────
   describe('in: vs ctx separation (regression)', () => {
     it('reproduces the screenshot: short chat shows small `in:` but full ctx gauge', () => {
-      // Real session: a tiny new message (181 input) on top of a large
-      // re-sent prompt served from cache (181,532). The ctx gauge correctly
-      // shows the full occupancy (~182k / 1M = 18%), but `in:` must show only
-      // the 181 new tokens — NOT the 181,713 it used to echo from the gauge.
+      // `in:` shows only the 181 new tokens, not the 181,713 gauge numerator.
       fixture.componentRef.setInput('stats', {
         session_id: 'abc',
         total_cost: 0.5,
@@ -188,8 +184,7 @@ describe('SessionStatsComponent', () => {
     });
 
     it('does not sum input across turns — gauge reflects only the latest turn', () => {
-      // Each turn re-sends history, so cache_read grows turn over turn. The
-      // gauge must track the LATEST turn (replacement), never the running sum.
+      // Gauge tracks the latest turn (replacement), never the running sum.
       const set = (cacheRead: number) =>
         fixture.componentRef.setInput('stats', {
           session_id: 'abc',
@@ -212,8 +207,7 @@ describe('SessionStatsComponent', () => {
     });
 
     it('handles a local model (no prompt cache): in: equals the whole prompt', () => {
-      // Local LLM has no prompt cache — cache fields are absent. `in:` then
-      // equals input_tokens (the whole prompt), and the gauge matches it.
+      // No prompt cache → `in:` equals input_tokens and the gauge matches it.
       fixture.componentRef.setInput('stats', {
         session_id: 'abc',
         total_cost: 0,
@@ -280,8 +274,7 @@ describe('SessionStatsComponent', () => {
     });
 
     it('renders in/out without cr/cw breakdown when cache tokens are absent', () => {
-      // The terminal-minimal layout collapses cr/cw into the `in:` total —
-      // cr/cw are no longer surfaced as their own segments.
+      // cr/cw collapse into the `in:` total, not surfaced as own segments.
       fixture.componentRef.setInput('stats', {
         session_id: 'abc',
         total_cost: 0.05,

--- a/desktop/src/src/app/chat/session-stats/session-stats.component.ts
+++ b/desktop/src/src/app/chat/session-stats/session-stats.component.ts
@@ -11,16 +11,7 @@ const BAR_INDICES: readonly number[] = [0, 1, 2, 3, 4];
 /** Shared number formatter for thousands separators (Intl instances are not free). */
 const NUMBER_FMT = new Intl.NumberFormat('en-US');
 
-/**
- * Terminal-minimal session stats strip — a single mono line shown below the
- * composer. Matches the mockup (lines 1143–1177):
- *
- *   `in: <n> · out: <n> · ctx [▮▮▮▯▯] N% · 116k/200k · limit [▮▮▮▯▯] N% · resets HH:MM · session: $0.018`
- *
- * Bars are 5 inline 6×6px segments coloured per-bucket (green ≤49% / amber
- * ≤76% / red). Optional segments (ctx + bar / limit + bar / cost) hide on
- * smaller breakpoints to preserve the single-line shape.
- */
+/** Terminal-minimal session stats strip — a single mono line below the composer. */
 @Component({
   selector: 'app-session-stats',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -122,9 +113,7 @@ const NUMBER_FMT = new Intl.NumberFormat('en-US');
         }
       </div>
     } @else {
-      <!-- Zero-state: same row, just with all counters at 0. Always visible
-           so the user sees the metric set even before the first turn — it
-           also preserves vertical rhythm so the composer never reflows. -->
+      <!-- Zero-state: same row with all counters at 0. -->
       <div
         data-testid="session-stats-placeholder"
         class="mono flex flex-wrap items-center gap-x-3 gap-y-1 px-1 py-3 text-[10px] text-[var(--ink-mute)]"
@@ -203,42 +192,20 @@ export class SessionStatsComponent {
   /** Stats input (signal). */
   readonly stats = input<SessionStats | null>(null);
 
-  /**
-   * Current git branch of the active project's working tree, or `null` when
-   * the project isn't a git repo. Renders as the branch-icon chip on the
-   * right side of the strip.
-   */
+  /** Current git branch of the active project's working tree, or `null` when not a git repo. */
   readonly branch = input<string | null>(null);
 
-  /**
-   * New input tokens the user sent this turn — `input_tokens` only, the
-   * uncached remainder after the last cache breakpoint. Excludes
-   * `cache_read` (the re-sent system prompt + tool catalog + history served
-   * from cache), which is what made a short chat read as 181k. For a local
-   * model (no prompt cache) the cache fields are 0, so this equals the whole
-   * prompt — correct in both cases. Drives the `in:` counter only.
-   */
+  /** New input tokens this turn — `input_tokens` only, excludes cached reads. */
   readonly inboundTokens = computed<number>(() => this.stats()?.usage?.input_tokens ?? 0);
 
-  /**
-   * Total tokens occupying the context window this turn (`input` +
-   * `cache_read` + `cache_write`) — the verified Anthropic formula
-   * (input_tokens is the uncached remainder; the three are additive).
-   * `output_tokens` are excluded because they don't occupy the prompt.
-   * Drives the ctx gauge (percentage + used/max), never the `in:` counter.
-   */
+  /** Total tokens occupying the context window: `input` + `cache_read` + `cache_write`. */
   readonly ctxTotal = computed<number>(() => {
     const usage = this.stats()?.usage;
     if (!usage) return 0;
     return usage.input_tokens + (usage.cache_read_tokens ?? 0) + (usage.cache_write_tokens ?? 0);
   });
 
-  /**
-   * Context window usage as an integer percentage (0–100), or `null` when
-   * the active provider didn't advertise a window (local LLM without
-   * inline metadata). Template hides the progress bar in that case rather
-   * than fabricating a default — ADR-041 "never guess".
-   */
+  /** Context window usage as integer percent (0–100), or `null` when window is unknown. */
   readonly ctxPct = computed<number | null>(() => {
     const total = this.ctxTotal();
     if (total <= 0) return 0;
@@ -259,10 +226,7 @@ export class SessionStatsComponent {
     return pct === null ? '' : barColor(pct);
   });
 
-  /**
-   * `used/max` label (e.g. `116k/200k`), or `null` when the context window
-   * is unknown — template hides the label.
-   */
+  /** `used/max` label (e.g. `116k/200k`), or `null` when the context window is unknown. */
   readonly ctxUsedMax = computed<string | null>(() => {
     const total = this.ctxTotal();
     if (total <= 0) return '';
@@ -312,7 +276,6 @@ function barColor(pct: number): string {
 
 /**
  * Converts a percentage (0–100) to the number of filled segments (0–5), rounded.
- * 30% → 1.5 → 2; 80% → 4.
  * @param pct - Percentage in the range 0–100.
  */
 function bucketFilled(pct: number): number {

--- a/desktop/src/src/app/chat/slash/slash-menu.component.spec.ts
+++ b/desktop/src/src/app/chat/slash/slash-menu.component.spec.ts
@@ -74,9 +74,7 @@ describe('SlashMenuComponent', () => {
   });
 
   /**
-   * Reads the protected `activeIndex` signal on a SlashMenuComponent without
-   * tunneling through `any` — the component exposes it as `protected` so we
-   * narrow it to its public shape (callable getter + `set()`).
+   * Reads the protected `activeIndex` signal on a SlashMenuComponent.
    * @param c - Component instance whose `activeIndex` signal to read.
    */
   const readActive = (c: SlashMenuComponent): number =>

--- a/desktop/src/src/app/chat/slash/slash-menu.component.ts
+++ b/desktop/src/src/app/chat/slash/slash-menu.component.ts
@@ -184,11 +184,7 @@ export class SlashMenuComponent {
   /** Index of the highlighted entry inside `filtered()`. Reset whenever the query changes. */
   protected readonly activeIndex = signal(0);
 
-  /**
-   * Sets up an effect that resets the highlighted index whenever the query
-   * changes — ensures the first match is always pre-selected so Enter/Tab
-   * pick the most relevant entry.
-   */
+  /** Resets the highlighted index whenever the query changes. */
   constructor() {
     effect(() => {
       this.query();
@@ -196,15 +192,7 @@ export class SlashMenuComponent {
     });
   }
 
-  /**
-   * Commands filtered by the current query, with startsWith ranked above
-   * substring matches.
-   *
-   * Subagents (`kind === 'Agent'`) are dropped here: Claude Code does not
-   * expose them as slash commands — they can only be invoked from inside an
-   * Agent tool call. Surfacing them in the slash menu lets the user pick a
-   * "/Plan" entry that the model then rejects with `Unknown skill: Plan`.
-   */
+  /** Commands filtered by query (startsWith ranked above substring); agents excluded. */
   readonly filtered = computed<readonly SlashCommand[]>(() => {
     const q = this.query().trim().toLowerCase();
     const all = this.service.commands().filter((c) => c.kind !== 'Agent');
@@ -226,12 +214,7 @@ export class SlashMenuComponent {
     return [...starts, ...contains];
   });
 
-  /**
-   * Buckets the filtered list into the mockup's three groups: skills, slash
-   * commands, and plugin commands. The flat-index is preserved on every
-   * entry so keyboard navigation (which addresses items by their position in
-   * `filtered()`) and group rendering stay in sync.
-   */
+  /** Buckets the filtered list into skills, commands, and plugin groups; preserves flat index. */
   readonly groups = computed<readonly SlashGroup[]>(() => {
     const list = this.filtered();
     const skills: GroupEntry[] = [];

--- a/desktop/src/src/app/chat/slash/slash.service.ts
+++ b/desktop/src/src/app/chat/slash/slash.service.ts
@@ -24,12 +24,8 @@ export interface SlashDiscovery {
 }
 
 /**
- * Bridges the slash-menu UI with the Tauri backend.
- *
- * Keeps the discovery result in signals so the menu component can re-render
- * automatically. Never throws — failures degrade to an empty list with
- * `source = null` so the UI can show a subtle error state without losing
- * any already-loaded commands.
+ * Bridges the slash-menu UI with the Tauri backend, holding discovery in signals.
+ * Never throws — failures degrade to an empty list with `source = null`.
  */
 @Injectable({ providedIn: 'root' })
 export class SlashService {
@@ -49,9 +45,7 @@ export class SlashService {
   readonly isLoadingEmpty = computed(() => this.discovering() && this.commands().length === 0);
 
   /**
-   * Fetches the slash-command list for the given project and updates the
-   * signals. Resolves on both success and failure; errors are surfaced
-   * via `this.error` / `this.source` without throwing.
+   * Fetches the slash-command list and updates the signals; never throws.
    * @param projectId - Project name used by Tauri to find the container.
    */
   async refresh(projectId: string): Promise<void> {
@@ -78,8 +72,7 @@ export class SlashService {
   }
 
   /**
-   * Invalidates the backend cache for a project. Call after installing or
-   * removing a plugin so the next `refresh` returns the new list.
+   * Invalidates the backend slash-command cache for a project.
    * @param projectId - Project name whose cache to invalidate.
    */
   async invalidate(projectId: string): Promise<void> {
@@ -87,8 +80,6 @@ export class SlashService {
     try {
       await this.tauri.invoke('invalidate_slash_cache', { projectId });
     } catch (err) {
-      // Invalidation errors are not user-actionable; log via the logging
-      // facade for diagnostics.
       this.log.warn(`[SlashService] invalidate_slash_cache failed: ${String(err)}`);
     }
   }

--- a/desktop/src/src/app/forbidden-patterns.spec.ts
+++ b/desktop/src/src/app/forbidden-patterns.spec.ts
@@ -1,8 +1,5 @@
 /**
  * Static guardrail — fails CI if any forbidden pattern reappears in src/.
- *
- * The patterns below represent legacy Angular or TypeScript idioms that
- * the project has phased out. Keeping this spec prevents regressions.
  */
 import { describe, it, expect } from 'vitest';
 import { readdirSync, readFileSync, statSync } from 'node:fs';
@@ -18,26 +15,9 @@ interface ForbiddenPattern {
 }
 
 /**
- * Locate the `desktop/src/src` source root.
- *
- * Using `__dirname + '..'` is unreliable: under `ng test --coverage` the
- * test bundle is rewritten such that `__dirname` resolves one or two
- * levels higher than expected (`desktop/src/` or even `desktop/`). A naive
- * walker then descends into `node_modules/@angular/`, `e2e/helpers/`, or
- * `src-tauri/build-context/mcp-servers/` which contain forbidden patterns
- * in their docstrings.
- *
- * The recovery walks upward until we find a directory containing both
- * this spec at the canonical relative path AND the `services/` directory
- * — the combination is unique to `desktop/src/src`. If no such directory
- * is found within ten levels we panic rather than scan a wrong tree.
+ * Locate the `desktop/src/src` source root, handling __dirname resolution variance under coverage.
  */
 function findSrcRoot(): string {
-  // Try several candidate roots starting from __dirname and walking upward.
-  // Under coverage, __dirname can resolve to `desktop/src/src/app`,
-  // `desktop/src/src`, or `desktop/src` depending on bundling. The
-  // canonical root is `desktop/src/src`, identified by containing both
-  // this spec under `app/` and the `app/services/` directory.
   const candidates: string[] = [];
   let dir = __dirname;
   for (let depth = 0; depth < 6; depth++) {
@@ -65,12 +45,7 @@ function findSrcRoot(): string {
 
 const SRC_ROOT = findSrcRoot();
 /**
- * Directory names skipped during the recursive scan. `node_modules` is the
- * obvious one; `e2e`, `src-tauri`, and `coverage` show up because some
- * `__dirname` resolutions under coverage walk land above the canonical
- * `src` root, and those siblings contain forbidden patterns in code we
- * don't own (Playwright fixtures, vendored MCP servers under
- * `build-context/`).
+ * Directory names skipped during the recursive scan.
  */
 const EXCLUDED_DIRS: readonly string[] = [
   'node_modules',

--- a/desktop/src/src/app/guards/beta-enabled.guard.ts
+++ b/desktop/src/src/app/guards/beta-enabled.guard.ts
@@ -5,9 +5,7 @@ import { TauriService } from '../services/tauri.service';
 
 /**
  * Guards beta-only routes (e.g. /meeting-transcription, ADR-058/056).
- * Queries `get_beta_enabled` directly rather than reading `BetaService`'s
- * signal, since that signal is seeded asynchronously and could still be
- * `false` on the first navigation. Redirects to /chat when beta is off.
+ * Redirects to /chat when beta is off.
  */
 export const betaEnabledGuard: CanActivateFn = async () => {
   const router = inject(Router);

--- a/desktop/src/src/app/integrations/integrations.component.spec.ts
+++ b/desktop/src/src/app/integrations/integrations.component.spec.ts
@@ -9,13 +9,7 @@ import { BetaService } from '../services/beta.service';
 import { MockTauriService } from '../testing/mock-tauri.service';
 import type { IntegrationStatusEntry } from '../models/integration';
 
-/**
- * Mock LoggerService for tests. Real LoggerService calls `@tauri-apps/plugin-log`
- * which has no Tauri context in unit tests; it would throw or no-op silently.
- * The mock lets us assert that the component logged the expected lifecycle
- * events (toggle clicks, validate outcomes, auto-disabled services) which is
- * what makes the user-supplied logs ZIP useful for support triage.
- */
+/** Mock LoggerService for unit tests (no Tauri context). */
 function makeMockLogger() {
   return {
     info: vi.fn(),
@@ -164,8 +158,7 @@ function setupMockTauri(mockTauri: MockTauriService): void {
       case 'get_selected_ide':
         return null;
       case 'validate_os_integrations_on_startup':
-        // Default: no auto-disabled integrations. Tests that exercise the
-        // migration banner override the handler explicitly.
+        // Default: no auto-disabled integrations.
         return [];
       default:
         return undefined;
@@ -188,9 +181,7 @@ describe('IntegrationsComponent', () => {
     setupMockTauri(mockTauri);
     mockLogger = makeMockLogger();
 
-    // Reset the static "already validated" map so each test starts clean —
-    // the production guard prevents re-validation when re-entering the route,
-    // but tests need to observe a fresh validate flow.
+    // Reset the static validation map so each test observes a fresh validate flow.
     (
       IntegrationsComponent as unknown as { validationByProject: Map<string, Promise<void>> }
     ).validationByProject.clear();
@@ -878,9 +869,7 @@ describe('IntegrationsComponent', () => {
       await component.ngOnInit();
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      // The "X services · Y running" counter was dropped — the integrations
-      // table itself already conveys per-row status, so the header counter
-      // was redundant noise.
+      // Counter was dropped; the table conveys per-row status.
       const count = fixture.nativeElement.querySelector('[data-testid="integrations-count"]');
       expect(count).toBeNull();
 
@@ -897,9 +886,7 @@ describe('IntegrationsComponent', () => {
         '[data-testid="integrations-table-wrapper"]'
       );
       expect(wrapper).not.toBeNull();
-      // Scope the row count to the integrations table — `<app-ide-bridge>`
-      // now also renders a tbody, so a global `tbody tr` selector picks up
-      // unrelated rows.
+      // Scope to the table wrapper; `<app-ide-bridge>` also renders a tbody.
       const rows = wrapper.querySelectorAll('tbody tr');
       expect(rows.length).toBe(component.services.length);
     });
@@ -922,8 +909,7 @@ describe('IntegrationsComponent', () => {
       fixture.detectChanges();
       const before = component.services[0].enabled;
       const svc = component.services[0];
-      // Use the parent click handler directly — the JSDOM click() does not
-      // bubble through stopPropagation reliably across the @if scope.
+      // Call the parent handler directly; JSDOM click() doesn't bubble reliably.
       await component.onRowToggle(svc, new MouseEvent('click'));
       expect(svc.enabled).toBe(!before);
       // Row click must NOT expand because onRowToggle calls stopPropagation.
@@ -1086,8 +1072,7 @@ describe('IntegrationsComponent', () => {
         credentials: { client_id: '550e8400-e29b-41d4-a716-446655440000', tenant_id: 'common' },
       });
 
-      // It was 'starting' when save_integration_credentials was called (before start_sharepoint_oauth)
-      // but by the time start_sharepoint_oauth runs it's still 'starting'
+      // Status is 'starting' when start_sharepoint_oauth is invoked.
       expect(statusDuringInvoke).toBe('starting');
     });
 
@@ -1118,8 +1103,7 @@ describe('IntegrationsComponent', () => {
   });
 
   describe('Slack OAuth flow (ADR-071)', () => {
-    // Slack is beta-gated; flip beta on so the row would be present. The
-    // flow itself only needs the service id + active project.
+    // Slack is beta-gated; flip beta on so the row is present.
     beforeEach(() => {
       betaEnabled.set(true);
     });
@@ -1251,9 +1235,7 @@ describe('IntegrationsComponent', () => {
   });
 
   describe('GitHub OAuth flow', () => {
-    // GitHub is in BETA_ONLY_SERVICES (ADR-058). The OAuth refactor doesn't
-    // change that — beta gating is an orthogonal product decision. Tests flip
-    // beta on so the GitHub row is present in `component.services`.
+    // GitHub is in BETA_ONLY_SERVICES (ADR-058); enable beta so its row is present.
     beforeEach(() => {
       betaEnabled.set(true);
     });
@@ -1283,8 +1265,7 @@ describe('IntegrationsComponent', () => {
 
       await component.handleStartOAuth({ svc: githubSvc, credentials: {} });
 
-      // GitHub uses bundled client_id (consts.rs::GITHUB_OAUTH_CLIENT_ID);
-      // the Tauri command takes only `project`.
+      // GitHub uses bundled client_id (consts.rs::GITHUB_OAUTH_CLIENT_ID).
       expect(invokeSpy).toHaveBeenCalledWith('start_github_oauth', {
         project: 'test-project',
       });
@@ -1322,8 +1303,7 @@ describe('IntegrationsComponent', () => {
         request_id: 'gh-rid-3',
       };
 
-      // Need a polling response for handleStartOAuth-style success path. Here
-      // we dispatch directly to the listener registered in ngOnInit.
+      // Dispatch directly to the listener registered in ngOnInit.
       mockTauri.dispatchEvent('github_oauth_progress', {
         status: 'success',
         message: 'Authentication successful',
@@ -1808,8 +1788,7 @@ describe('IntegrationsComponent', () => {
 
       expect(component.osIntegrationsAutoDisabled.length).toBe(2);
       expect(component.osIntegrationsAutoDisabled[0].service).toBe('calendar');
-      // Calendar reason must contain the calendar sub-identifier and the Calendar
-      // TCC service (not Mail/AppleEvents — that would be a regression).
+      // Calendar reason uses the Calendar TCC service, not Mail/AppleEvents.
       expect(component.osIntegrationsAutoDisabled[0].reason).toContain(
         'tccutil reset Calendar pl.speedwave.desktop.calendar'
       );
@@ -1907,8 +1886,7 @@ describe('IntegrationsComponent', () => {
     });
 
     it('handles validator errors non-fatally', async () => {
-      // Validator throws → component must continue loading integrations
-      // (UI cannot be blocked by a TCC validation failure).
+      // Validator throws → component must continue loading integrations.
       mockTauri.invokeHandler = async (cmd: string) => {
         if (cmd === 'validate_os_integrations_on_startup') {
           throw new Error('boom');
@@ -1935,9 +1913,7 @@ describe('IntegrationsComponent', () => {
   });
 
   describe('LoggerService — TCC validation + toggle observability', () => {
-    // These tests guarantee the logs ZIP a user sends with a support ticket
-    // contains enough breadcrumbs to reconstruct what happened. If a future
-    // PR drops a log line by accident, these tests catch it before merge.
+    // These tests verify the logs ZIP contains enough breadcrumbs for support triage.
 
     it('logs info on validateOsIntegrations start', async () => {
       await component.ngOnInit();
@@ -1993,9 +1969,7 @@ describe('IntegrationsComponent', () => {
       await component.ngOnInit();
       await component.runInitialOsValidation();
 
-      // One warn line per auto-disabled service, each carrying the recovery text
-      // (this is what makes a logs ZIP self-describing — support reads the warn,
-      // sees the exact tccutil command the user should run).
+      // One warn line per auto-disabled service, each carrying recovery text.
       expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('os.calendar'));
       expect(mockLogger.warn).toHaveBeenCalledWith(
         expect.stringContaining('tccutil reset Calendar pl.speedwave.desktop.calendar')
@@ -2110,9 +2084,7 @@ describe('IntegrationsComponent', () => {
     });
 
     it('renders the banner even when sharepoint reads as NOT configured (stale providerData)', async () => {
-      // Malformed/legacy providerData makes the service read as unconfigured,
-      // yet the backend now reports scope_mismatch regardless. The user must
-      // still be led to re-authorise — the banner must not hinge on configured.
+      // Banner must not hinge on `configured`: scope_mismatch alone shows it.
       const sharepointSvc = component.services.find((s) => s.service === 'sharepoint')!;
       sharepointSvc.configured = false;
       sharepointSvc.oauth_action_required = 'scope_mismatch';
@@ -2143,9 +2115,7 @@ describe('IntegrationsComponent', () => {
     });
 
     it('renders the banner for ANY service the backend flags (gate is flag-driven)', async () => {
-      // The backend only sets oauth_action_required for uses_oauth_refresh
-      // services (descriptor-gated); the template renders whatever is flagged
-      // so a new OAuth service (Slack, ADR-071) needs no template change.
+      // The template renders whatever oauth_action_required the backend flags.
       const gitlabSvc = component.services.find((s) => s.service === 'gitlab')!;
       gitlabSvc.configured = true;
       (gitlabSvc as { oauth_action_required?: string }).oauth_action_required = 'scope_mismatch';

--- a/desktop/src/src/app/integrations/integrations.component.ts
+++ b/desktop/src/src/app/integrations/integrations.component.ts
@@ -36,8 +36,7 @@ const SERVICE_DOT_COLOURS: readonly string[] = [
 ];
 
 /**
- * Returns the deterministic dot colour for a service row based on its name.
- * Configured + enabled services use the cycle palette; unconfigured stay muted.
+ * Returns the deterministic dot colour for a service row.
  * @param svc - the integration status entry
  * @param index - the row index in the rendered list
  */
@@ -346,23 +345,9 @@ export class IntegrationsComponent implements OnInit, OnDestroy {
   error = '';
   /** Name of the currently active project. */
   activeProject: string | null = null;
-  /**
-   * OS integrations auto-disabled at startup because macOS TCC denies the
-   * permission they previously had. Populated by validate_os_integrations_on_startup
-   * — non-empty after upgrades that change the binary identity (e.g. embedded
-   * Info.plist + sub-identifier change), where the prior TCC.db row no longer
-   * matches. Each entry carries a recovery reason from composeErrorMessage
-   * (typically a `tccutil reset` command). User clicks the toggle again to
-   * trigger a fresh permission prompt.
-   */
+  /** OS integrations auto-disabled at startup because macOS TCC denies their prior permission. */
   osIntegrationsAutoDisabled: OsIntegrationValidation[] = [];
-  /**
-   * In-flight or completed validation promises keyed by project. Static so
-   *  that route navigation (component remount) does NOT re-spawn 4 native
-   *  CLIs every time the user opens /integrations. The cached promise lets
-   *  later mounts await the original validate when they need its outcome
-   *  (tests do; production fire-and-forgets).
-   */
+  /** In-flight or completed validation promises keyed by project. */
   private static validationByProject = new Map<string, Promise<void>>();
 
   /** OAuth state */
@@ -401,18 +386,8 @@ export class IntegrationsComponent implements OnInit, OnDestroy {
   /** Loads the active project and integrations on init. */
   async ngOnInit(): Promise<void> {
     await this.loadActiveProject();
-    // Render the integrations table immediately. Validation runs in the
-    // background (see runInitialOsValidation) and only once per project —
-    // re-entering the view, project-settled events, etc. must NOT re-spawn
-    // 4 native CLIs each time, the cost is 400ms-1.4s of CPU + Mail.app
-    // launch attempts.
     await this.loadIntegrations();
     this.runInitialOsValidation();
-    // Subscribe to settled (not just ready) so we also reload after
-    // `auth_required` / `error` settle — the integrations table itself
-    // does not require Claude auth, so users still need to see and toggle
-    // services in those states. Without this, navigating to /integrations
-    // before the shell has fully initialized leaves the table empty.
     this.unsubProjectSettled = this.projectState.onProjectSettled(async () => {
       if (this.activeOAuthRequestId || this.oauthStatus === 'starting') {
         await this.handleCancelOAuth();
@@ -420,8 +395,7 @@ export class IntegrationsComponent implements OnInit, OnDestroy {
       await this.loadActiveProject();
       await this.loadIntegrations();
     });
-    // After a failed restart (build/compose), backend may have rolled the
-    // just-enabled service back to disabled — refresh the rows to match.
+    // Backend may roll a just-enabled service back on failed restart; refresh rows.
     this.unsubStatusRefresher = this.projectState.registerIntegrationStatusRefresher(() => {
       void this.loadIntegrations();
     });
@@ -436,9 +410,6 @@ export class IntegrationsComponent implements OnInit, OnDestroy {
 
   /**
    * Subscribe to an OAuth-progress event channel emitted by the Tauri side.
-   * Shared between SharePoint (`sharepoint_oauth_progress`) and GitHub
-   * (`github_oauth_progress`); the `service` arg drives autoEnableIfConfigured
-   * on success.
    * @param eventName - the Tauri event channel to listen on
    * @param service - the integration the events belong to
    */
@@ -580,9 +551,7 @@ export class IntegrationsComponent implements OnInit, OnDestroy {
         );
       }
     } catch (e: unknown) {
-      // Non-fatal: validation failure should not block the integrations view.
-      // The user can still toggle services manually; failures will surface
-      // through the existing error path on click.
+      // Non-fatal; validation failure does not block the integrations view.
       const msg = e instanceof Error ? e.message : String(e);
       this.logger.error(`[integrations] validateOsIntegrations failed (non-fatal): ${msg}`);
       this.osIntegrationsAutoDisabled = [];
@@ -603,8 +572,7 @@ export class IntegrationsComponent implements OnInit, OnDestroy {
       const response = await this.tauri.invoke<IntegrationsResponse>('get_integrations', {
         project: this.activeProject,
       });
-      // BETA_ONLY_SERVICES hidden unless beta is on (ADR-058); Slack is
-      // beta-gated for its first OAuth release (ADR-071).
+      // BETA_ONLY_SERVICES hidden unless beta is on (ADR-058, ADR-071).
       const betaOn = this.betaEnabled();
       this.services = response.services.filter(
         (s) => betaOn || !IntegrationsComponent.BETA_ONLY_SERVICES.has(s.service)
@@ -797,11 +765,9 @@ export class IntegrationsComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Per-service dispatcher for the `start_*_oauth` Tauri commands. Keeps the
-   * service-specific argument shape (SharePoint needs client_id/tenant_id;
-   * GitHub uses a bundled client_id in `consts.rs`) out of `handleStartOAuth`.
+   * Per-service dispatcher for the `start_*_oauth` Tauri commands.
    * @param service - the integration to start OAuth for
-   * @param credentials - non-oauth field values from the form (used by SharePoint)
+   * @param credentials - non-oauth field values from the form
    */
   private invokeOAuthStart(
     service: string,
@@ -813,8 +779,7 @@ export class IntegrationsComponent implements OnInit, OnDestroy {
       });
     }
     if (service === 'slack') {
-      // Loopback PKCE flow with a bundled client_id (ADR-071) — no typed
-      // prerequisites, no device code.
+      // Loopback PKCE flow with a bundled client_id (ADR-071).
       return this.tauri.invoke<LoopbackFlowStart>('start_slack_oauth', {
         project: this.activeProject,
       });
@@ -884,11 +849,9 @@ export class IntegrationsComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * SSOT for "user flipped an MCP service toggle".
-   * Persists the new value, marks `pendingJustEnabled` on enable so a failed
-   * restart can roll it back, and requests the container restart.
-   * @param svc - the integration being toggled.
-   * @param enabled - target enabled state.
+   * SSOT for user-toggled MCP service. Persists enabled state and requests restart.
+   * @param svc - the integration being toggled
+   * @param enabled - target enabled state
    */
   private async applyServiceToggle(svc: IntegrationStatusEntry, enabled: boolean): Promise<void> {
     await this.tauri.invoke('set_integration_enabled', {
@@ -924,8 +887,7 @@ export class IntegrationsComponent implements OnInit, OnDestroy {
         enabled: next,
       });
       this.logger.info(`[integrations] os toggle persisted service=${os.service} enabled=${next}`);
-      // Drop the auto-disabled banner entry for this service — the toggle
-      // succeeded so the banner's "Mail.app is not running" text is stale.
+      // Drop the auto-disabled banner entry for this service.
       if (this.osIntegrationsAutoDisabled.some((e) => e.service === os.service)) {
         this.osIntegrationsAutoDisabled = this.osIntegrationsAutoDisabled.filter(
           (e) => e.service !== os.service

--- a/desktop/src/src/app/integrations/redmine-config/redmine-config.component.ts
+++ b/desktop/src/src/app/integrations/redmine-config/redmine-config.component.ts
@@ -68,8 +68,7 @@ export const MAPPING_CATEGORIES: Record<string, string[]> = {
 };
 
 /**
- * Extracts the human-readable suffix from a mapping key by removing
- * the category prefix and normalizing underscores to spaces.
+ * Extracts the human-readable suffix from a mapping key.
  * @param key - e.g. "status_in_progress"
  * @returns e.g. "in progress"
  */
@@ -84,13 +83,6 @@ function extractSuffix(key: string): string {
 
 /**
  * Auto-matches predefined mapping keys against Redmine enum entries.
- *
- * Algorithm:
- * 1. Extract suffix after category prefix (e.g. `status_` -> `new`)
- * 2. Normalize: lowercase, replace underscores with spaces
- * 3. Case-insensitive comparison against Redmine enum entry names
- * 4. Exact match -> pre-select. Duplicate names -> first match wins
- * 5. No match -> null (= "Not mapped")
  * @param keys - predefined mapping keys for one category
  * @param entries - Redmine enum entries to match against
  * @returns mapping from key to matched entry id, or null if unmatched
@@ -402,11 +394,7 @@ export class RedmineConfigComponent implements OnDestroy {
   validating = false;
   validationError = '';
   loadingEnumerations = false;
-  /**
-   * Backing field for the {@link enumerations} accessor. Direct mutation goes
-   * through the setter so the OnPush template always re-renders without each
-   * caller having to remember `markForCheck`.
-   */
+  /** Backing field for the {@link enumerations} accessor. */
   private _enumerations: RedmineEnumerations | null = null;
   /** Currently loaded enumerations (projects, statuses, trackers, etc.). */
   get enumerations(): RedmineEnumerations | null {
@@ -436,7 +424,6 @@ export class RedmineConfigComponent implements OnDestroy {
 
   /**
    * Pre-populates form fields from the service's stored values and wizard state.
-   * Extracted from `ngOnChanges` so it can be triggered by the input effect.
    * @param svc - the integration entry to apply
    */
   private applyServiceState(svc: IntegrationStatusEntry | undefined): void {
@@ -539,9 +526,7 @@ export class RedmineConfigComponent implements OnDestroy {
   }
 
   /**
-   * Native `<select>` handler for the project picker. Empty string maps to
-   * `null` ("All projects"); anything else is parsed as the numeric Redmine
-   * project id.
+   * Native `<select>` handler for the project picker.
    * @param event - The native `change` event from the project `<select>`.
    */
   onProjectSelectChange(event: Event): void {
@@ -550,9 +535,7 @@ export class RedmineConfigComponent implements OnDestroy {
   }
 
   /**
-   * Native `<select>` handler for a mapping picker. Mirrors
-   * `onProjectSelectChange` but writes through `setMappingValue` so the
-   * edited-mappings dictionary stays the SSOT.
+   * Native `<select>` handler for a mapping picker.
    * @param key - The mapping key being edited.
    * @param event - The native `change` event from the mapping `<select>`.
    */

--- a/desktop/src/src/app/integrations/service-card/service-card.component.ts
+++ b/desktop/src/src/app/integrations/service-card/service-card.component.ts
@@ -151,13 +151,6 @@ export interface SaveCredentialsEvent {
             }
 
             <div class="flex gap-3 mt-4">
-              <!--
-                Save button only for classic-form services (no OAuth flow).
-                When an OAuth flow exists (SharePoint, GitHub), the Sign in /
-                Reconnect button persists every non-OAuth field via
-                save_integration_credentials before kicking off the flow,
-                so an explicit Save is redundant.
-              -->
               @if (hasNonOAuthFields() && !hasOAuthFields()) {
                 <button
                   type="submit"
@@ -206,10 +199,8 @@ export class ServiceCardComponent {
   editedValues: Record<string, string> = {};
 
   /**
-   * Provider label used in OAuth button copy — from the descriptor SSOT
-   * (`consts.rs::oauth_provider_label`; extracted when Slack became the
-   * third OAuth service, per the Rule of Three).
-   * @returns the IdP brand name shown to users (e.g. "Microsoft", "Slack")
+   * Provider label for the OAuth button.
+   * @returns the IdP brand name (e.g. "Microsoft", "Slack").
    */
   oauthProviderLabel(): string {
     return this.svc().oauth_provider_label ?? 'provider';
@@ -245,13 +236,7 @@ export class ServiceCardComponent {
     }
   }
 
-  /**
-   * Whether this service has anything the user can configure in the card body.
-   * Services with an empty `auth_fields` list (e.g. Playwright, which only
-   * reaches public URLs) have nothing to enter — the toggle header is the
-   * entire UI surface, so we hide the form, setup hint, and the Save / Remove
-   * Credentials buttons to avoid nonsensical empty prompts.
-   */
+  /** Whether this service has any configurable auth fields. */
   get hasConfigurableFields(): boolean {
     return this.svc().auth_fields.length > 0;
   }
@@ -282,12 +267,7 @@ export class ServiceCardComponent {
     return `Fill in ${missing.join(', ')} above to enable sign-in.`;
   }
 
-  /**
-   * Returns whether any auth fields are NOT OAuth-driven (i.e. need a Save
-   * button because the user types them into the form). For services where
-   * every field is `oauth_flow: true` (e.g. GitHub OAuth App), the Save
-   * button is suppressed — the token is persisted by the polling task.
-   */
+  /** Whether any auth fields are NOT OAuth-driven. */
   hasNonOAuthFields(): boolean {
     return this.svc().auth_fields.some((f) => !f.oauth_flow);
   }
@@ -310,9 +290,8 @@ export class ServiceCardComponent {
   }
 
   /**
-   * Emits the toggleService event with the service and DOM event.
-   * If the service is not configured, expands the form instead.
-   * @param event - the checkbox change event
+   * Toggles service on/off or expands form if not configured.
+   * @param event - checkbox change event
    */
   onToggle(event: Event): void {
     const svc = this.svc();
@@ -354,9 +333,7 @@ export class ServiceCardComponent {
       if (value !== undefined && value !== '') {
         credentials[field.key] = value;
       } else if (value === '' && field.optional) {
-        // Send empty string explicitly so the backend overwrites any
-        // previously-saved value in config.json (omitting the key would
-        // leave the stale value intact).
+        // Explicit empty string persists backend config change (omitting key leaves stale value).
         credentials[field.key] = '';
       }
     }

--- a/desktop/src/src/app/logs-view/logs-view.component.spec.ts
+++ b/desktop/src/src/app/logs-view/logs-view.component.spec.ts
@@ -70,9 +70,7 @@ describe('LogsViewComponent', () => {
     const times = Array.from(
       fixture.nativeElement.querySelectorAll('[data-testid="logs-time"]')
     ) as HTMLElement[];
-    // formatTime() prefixes bracketed `HH:MM:SS` stamps with today's date so
-    // the time column always carries a day. The raw bracketed value is kept
-    // in the `title` attribute for hover.
+    // formatTime() prefixes bracketed `HH:MM:SS` with today's date; raw value kept in `title`.
     expect(times[0].textContent?.trim()).toMatch(/^\d{4}-\d{2}-\d{2} 14:34:02$/);
     expect(times[0].getAttribute('title')).toBe('14:34:02.814');
 
@@ -99,11 +97,7 @@ describe('LogsViewComponent', () => {
   });
 
   it("prefixes today's date when the log line only carries HH:MM:SS", async () => {
-    // Reproduces the user-reported regression where the time column showed
-    // `11:32:56` with no day. Application-level logs inside the container
-    // emit `[HH:MM:SS]` and that often reaches the parser before any
-    // compose-level ISO stamp does. The fallback dates them with the host's
-    // current day so two entries from different days cannot collide.
+    // `[HH:MM:SS]`-only lines are dated with the host's current day.
     mockTauri.invokeHandler = async (cmd: string) =>
       cmd === 'get_all_logs' ? 'mcp_hub | [11:32:56] INFO  hello' : undefined;
     vi.spyOn(component as unknown as { todayIso(): string }, 'todayIso').mockReturnValue(
@@ -119,10 +113,7 @@ describe('LogsViewComponent', () => {
   });
 
   it('renders an ISO timestamp in the host local timezone, raw value in title', async () => {
-    // `nerdctl compose logs --timestamps` is UTC `Z`; Speedwave loggers carry
-    // an offset. Either way the column shows local time (`YYYY-MM-DD HH:MM:SS`)
-    // — so a UTC `Z` stamp and a `+02:00` stamp for the same instant render
-    // identically. `[title]` keeps the raw value (micros + offset).
+    // Column shows local time; UTC `Z` and `+02:00` for the same instant render identically.
     const raw = '2026-04-28T11:32:56.123456Z';
     mockTauri.invokeHandler = async (cmd: string) =>
       cmd === 'get_all_logs' ? `mcp_hub | ${raw} INFO  hello` : undefined;
@@ -130,8 +121,7 @@ describe('LogsViewComponent', () => {
     await component.ngOnInit();
     fixture.detectChanges();
 
-    // Expected = the same instant, formatted with the test process's local
-    // getters — `formatTime` must agree with a plain `new Date(...)`.
+    // `formatTime` must agree with a plain `new Date(...)`.
     const d = new Date(raw);
     const p2 = (n: number) => String(n).padStart(2, '0');
     const expected =
@@ -254,9 +244,7 @@ describe('LogsViewComponent', () => {
 
   it('shows "No active project" error when activeProject is null and the lifecycle has settled', async () => {
     projectState.activeProject = null;
-    // Mark the lifecycle as settled (any non-loading status works) so the
-    // banner is allowed to surface — during boot the view stays in a quiet
-    // loading state instead.
+    // Mark the lifecycle as settled (any non-loading status) so the banner can surface.
     projectState.status = 'error';
 
     await component.ngOnInit();
@@ -279,9 +267,7 @@ describe('LogsViewComponent', () => {
   });
 
   it('refetches logs once the project lifecycle settles after mount', async () => {
-    // Simulate the boot race: component mounts before the shell has had a
-    // chance to load `activeProject`. The view should pick up the project as
-    // soon as `onProjectSettled` fires and stop showing the loading state.
+    // Boot race: component mounts before `activeProject` loads; picks it up on `onProjectSettled`.
     projectState.activeProject = null;
     projectState.status = 'loading';
     await component.ngOnInit();
@@ -290,13 +276,11 @@ describe('LogsViewComponent', () => {
 
     projectState.activeProject = 'test';
     projectState.status = 'ready';
-    // The mock service exposes a notify hook through onProjectSettled
-    // listeners — emulate a settled event by calling all registered callbacks.
+    // Emulate a settled event by calling all registered onProjectSettled callbacks.
     (projectState as unknown as { settledListeners: Array<() => void> }).settledListeners.forEach(
       (cb) => cb()
     );
-    // The settled callback fires `void this.refresh()` — let the queued
-    // microtask resolve before asserting on the new state.
+    // The settled callback fires `void this.refresh()`; let the microtask resolve.
     await new Promise<void>((r) => setTimeout(r, 0));
     await fixture.whenStable();
     fixture.detectChanges();
@@ -1025,12 +1009,7 @@ describe('LogsViewComponent — status bar layout', () => {
   });
 
   it('schedules a scroll-to-bottom write after each successful fetch', async () => {
-    // Reproduces the user-visible bug where opening /logs landed on top of
-    // the stream. The component delegates the actual scroll to
-    // `afterNextRender({ write })` so the browser commits DOM first; that
-    // hook does not flush in the jsdom test runtime. We assert the contract
-    // instead — `scrollToBottom` is invoked after `lines.set(...)` so the
-    // render hook has work to do once Angular commits.
+    // `scrollToBottom` is invoked after `lines.set(...)`.
     const scrollSpy = vi.spyOn(
       component as unknown as { scrollToBottom(): void },
       'scrollToBottom'
@@ -1044,12 +1023,6 @@ describe('LogsViewComponent — status bar layout', () => {
   });
 
   // -- Unified logs view (get_all_logs) --
-  //
-  // The component now invokes `get_all_logs` instead of `get_compose_logs`
-  // so that the dropdown surfaces every host-side log source (tauri-plugin-log,
-  // mcp-os.log, claude-session.log) in addition to compose containers. These
-  // tests pin the new behaviour so a future refactor cannot silently revert
-  // to compose-only output.
 
   it('invokes get_all_logs (not get_compose_logs) on refresh', async () => {
     const invokeSpy = vi.spyOn(mockTauri, 'invoke');
@@ -1176,16 +1149,7 @@ describe('LogsViewComponent — status bar layout', () => {
   });
 
   it('renders desktop bracketed level as INFO/WARN level chip after Rust reformatting', async () => {
-    // Rust `prefix_lines` rewrites `[INFO]` → `INFO` so Angular `LEVEL_RE`
-    // (which expects unbracketed) hits and the line shows up in the level
-    // chip. Without that rewrite the line would default to `info` for every
-    // bracketed-level line — covering up real WARN/ERROR signals.
-    // The mock simulates what Rust `prefix_lines("desktop", …)` produces —
-    // the bracketed `[WARN]` from tauri-plugin-log is rewritten to `WARN ` (with
-    // trailing space, required by Angular `LEVEL_RE = /^LEVEL\s+/`) before
-    // the `desktop | ` prefix is added. The timestamp is now the colon-offset
-    // RFC-3339 form `log_ts::log_timestamp()` emits. If the Rust rewrite ever
-    // drops the trailing space, this test fails — which is the regression we want.
+    // Mock simulates Rust `prefix_lines("desktop", …)`: `[WARN]` rewritten to `WARN ` (trailing space required by `LEVEL_RE = /^LEVEL\s+/`).
     mockTauri.invokeHandler = async (cmd: string) => {
       if (cmd !== 'get_all_logs') return undefined;
       return 'desktop | 2026-05-12T14:34:02.814+02:00 WARN [speedwave_desktop::x] auto-disabled mail';

--- a/desktop/src/src/app/logs-view/logs-view.component.ts
+++ b/desktop/src/src/app/logs-view/logs-view.component.ts
@@ -62,9 +62,6 @@ const DRAIN_PREFIX_RE = /^(?:STDOUT|STDERR): (.*)$/;
 
 /**
  * Parse a single compose-log line into `LogLine`. Tolerant — never throws.
- * Backend (`container_logs_cmd::prefix_lines`) already strips the
- * `speedwave_<project>_` container prefix, so we render whatever source token
- * arrives — no client-side heuristic.
  * @param raw - A single log line as emitted by `get_all_logs`.
  */
 export function parseLogLine(raw: string): LogLine {
@@ -115,10 +112,6 @@ function normalizeLevel(raw: string): LogLevel {
 
 /**
  * Interleave per-source blocks into one chronological stream.
- * Lines without a parseable time inherit the *previous* line's instant; if
- * a line has no parseable time AND no prior line set one (file starts with
- * untimestamped content), it inherits the *next* line's instant so it sits
- * with its block rather than sinking to epoch zero.
  * @param lines - Parsed log lines in backend (block) order.
  */
 export function sortLogLinesByTime(lines: LogLine[]): LogLine[] {
@@ -138,10 +131,7 @@ export function sortLogLinesByTime(lines: LogLine[]): LogLine[] {
     }
   }
   const keyed = lines.map((line, i) => ({ line, key: keys[i] }));
-  // `Array.prototype.sort` is stable (ES2019+) — equal keys keep input order.
-  // Lines that remain NaN (no parseable timestamp anywhere in their block) sort
-  // BEFORE all timestamped lines — matches the historical epoch-zero placement
-  // so banner/header lines stay at the top of the view, not hidden at the bottom.
+  // Stable sort (ES2019+); NaN keys sort before timestamped lines.
   return keyed
     .sort((a, b) => {
       if (Number.isNaN(a.key) && Number.isNaN(b.key)) return 0;
@@ -726,18 +716,11 @@ export class LogsViewComponent implements OnInit, OnDestroy {
   private lastRaw = '';
 
   /**
-   * Kicks off the initial log fetch + health refresh + polling. Re-runs the
-   * fetch whenever the project lifecycle settles so the view recovers from
-   * the boot race where the shell loads `activeProject` after this component
-   * has already mounted (without this, the user sees a "No active project"
-   * banner even though the project pill in the header reads correctly).
+   * Kicks off the initial log fetch + health refresh + polling, re-running when the project settles.
    */
   async ngOnInit(): Promise<void> {
     await this.refresh();
-    // SystemHealthService owns the polling loop and the project-settled
-    // health refresh; we just kick it off and read its `health` signal.
-    // Await so the initial snapshot is committed before view tests assert
-    // on it.
+    // SystemHealthService owns polling and the project-settled refresh; we read its `health` signal.
     await this.systemHealth.ensurePolling();
     // Live-tail: silent refresh on the health cadence; sticky-scroll if at bottom.
     this.logsTimer = setInterval(() => void this.refresh(true), HEALTH_REFRESH_INTERVAL_MS);
@@ -864,11 +847,7 @@ export class LogsViewComponent implements OnInit, OnDestroy {
     }
   }
 
-  /**
-   * Copies the diagnostics path to the clipboard and flips the primary button
-   * label to `copied ✓` for a short moment. Falls back to the error banner if
-   * the clipboard API rejects (e.g. permission denied).
-   */
+  /** Copies the diagnostics path to the clipboard; on rejection surfaces the error banner. */
   protected async copyDiagnosticsPath(): Promise<void> {
     const path = this.diagnosticsPath();
     if (!path) return;
@@ -969,9 +948,7 @@ export class LogsViewComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * If the active source filter no longer appears in the latest log set
-   * (container stopped, name changed), fall back to `all` so the empty
-   * "no logs match" state can't be triggered by stale selection alone.
+   * Fall back to `all` if the active source filter no longer appears in the latest log set.
    * @param lines - Most recent parsed log batch.
    */
   private reconcileSourceFilter(lines: readonly LogLine[]): void {

--- a/desktop/src/src/app/meeting-transcription/live-transcript/live-transcript.component.ts
+++ b/desktop/src/src/app/meeting-transcription/live-transcript/live-transcript.component.ts
@@ -13,9 +13,8 @@ import { TranscriptionService } from '../../services/transcription.service';
 import type { Segment, TranscriptSession } from '../../models/transcript';
 
 /**
- * Seconds → `MM:SS`. (Segment timestamps are serde `Duration` `{secs,nanos}`;
- * the caller passes `.secs` — sub-second precision isn't shown.)
- * @param secs - whole seconds since the recording started.
+ * Seconds → `MM:SS`.
+ * @param secs - whole seconds since recording started.
  */
 function fmtTs(secs: number): string {
   return `${String(Math.floor(secs / 60)).padStart(2, '0')}:${String(secs % 60).padStart(2, '0')}`;
@@ -28,14 +27,7 @@ interface SpeakerRun {
   text: string;
 }
 
-/**
- * The live transcript view (right pane): renders the active session's segments
- * (the offline `final_segments` if the pass ran, else `live_segments`), groups
- * consecutive segments by speaker, lets the user rename a speaker (the chip is
- * marked "provisional" — labels can change after the offline pass), shows the
- * finalize progress bar, and has a "Send to Claude" button behind a confirm
- * dialog (the markdown leaves the machine).
- */
+/** Live transcript view: segments grouped by speaker, rename, finalize progress, Send-to-Claude. */
 @Component({
   selector: 'app-live-transcript',
   standalone: true,
@@ -147,8 +139,7 @@ export class LiveTranscriptComponent {
   private readonly cdr = inject(ChangeDetectorRef);
 
   /**
-   * Display label for a speaker id — the user-supplied name if any, else
-   * `Speaker N` (1-indexed), or `Speaker ?` when unassigned.
+   * Display label: user name, or `Speaker N` (1-indexed), or `Speaker ?` if unassigned.
    * @param id - speaker id or `null`.
    */
   speakerLabel(id: number | null): string {
@@ -158,8 +149,8 @@ export class LiveTranscriptComponent {
   }
 
   /**
-   * Prompts for a new name for a speaker and persists it.
-   * @param id - speaker id (`null` is ignored — can't rename "unknown").
+   * Prompt to rename speaker and persist.
+   * @param id - speaker id (`null` is ignored).
    */
   async rename(id: number | null): Promise<void> {
     const s = this.session();

--- a/desktop/src/src/app/meeting-transcription/model-manager/model-manager.component.ts
+++ b/desktop/src/src/app/meeting-transcription/model-manager/model-manager.component.ts
@@ -28,11 +28,7 @@ interface ProgressState {
   total: number | null;
 }
 
-/**
- * Whisper + diarization model list with download / delete. Downloads use the
- * network — the line at the bottom says so. The UI reads the catalogue from the
- * backend (`list_transcription_models`) and never hard-codes model names.
- */
+/** Whisper + diarization model list with download / delete. */
 @Component({
   selector: 'app-model-manager',
   standalone: true,
@@ -94,10 +90,7 @@ interface ProgressState {
 export class ModelManagerComponent implements OnInit {
   /** Forwards errors to the parent banner. */
   readonly errorOccurred = output<string>();
-  /**
-   * Emitted after the model list changes (download/delete) so the parent can
-   *  re-check whether recording is now possible.
-   */
+  /** Emitted after the model list changes (download/delete). */
   readonly changed = output<void>();
 
   /** Whisper catalogue entries + on-disk status. */
@@ -200,9 +193,7 @@ export class ModelManagerComponent implements OnInit {
   }
 
   /**
-   * Short text for the row's action cell. The template can't host complex
-   * controls per row in a one-liner, so this returns a status string and the
-   * actual download/delete are invoked from the (templated) buttons below.
+   * Action status text for a model row (downloading %, downloaded, or not downloaded).
    * @param m - the model row.
    */
   rowAction(m: ModelStatusEntry): string {

--- a/desktop/src/src/app/meeting-transcription/recording-controls/recording-controls.component.ts
+++ b/desktop/src/src/app/meeting-transcription/recording-controls/recording-controls.component.ts
@@ -32,8 +32,7 @@ function accelLabel(backends: Backend[]): string {
 /**
  * Recording controls: language toggle (PL/EN — never auto-detected), audio
  * source picker (per-app entries only when the host backend supports it), an
- * acceleration badge, and Start/Stop. Emits `started`/`stopped` so the parent
- * can subscribe to / detach from the session's live stream.
+ * acceleration badge, and Start/Stop. Emits `started`/`stopped`.
  */
 @Component({
   selector: 'app-recording-controls',
@@ -196,8 +195,7 @@ export class RecordingControlsComponent implements OnInit {
       this.backends.set(caps.backends);
       const list = await this.transcription.listAudioSources();
       this.sources.set(list);
-      // Default to "Whole meeting" (mixed) if offered, else "System
-      // (everything)", else the first entry.
+      // Prefer mixed, then system_wide, else first entry.
       const mixedIdx = list.findIndex((s) => s.source.kind === 'mixed');
       const sysIdx = list.findIndex((s) => s.source.kind === 'system_wide');
       this.sourceIndex.set(mixedIdx >= 0 ? mixedIdx : sysIdx >= 0 ? sysIdx : 0);
@@ -210,10 +208,7 @@ export class RecordingControlsComponent implements OnInit {
     this.cdr.markForCheck();
   }
 
-  /**
-   * Re-reads whether a Whisper model is downloaded. The parent calls this after
-   * a model download finishes so the Start button un-disables.
-   */
+  /** Re-reads whether a Whisper model is downloaded. */
   async refreshModelAvailability(): Promise<void> {
     try {
       const ack = await this.transcription.listModels();

--- a/desktop/src/src/app/meeting-transcription/session-list/session-list.component.ts
+++ b/desktop/src/src/app/meeting-transcription/session-list/session-list.component.ts
@@ -29,9 +29,7 @@ function statusLabel(s: TranscriptStatus): string {
 }
 
 /**
- * The recordings list (left pane of the Meeting transcription tab): open /
- * delete, status badge, and "discard audio" per session (frees disk; makes
- * re-transcription impossible). No auto-cleanup in v1 — the user manages it.
+ * Recordings list: open, delete, status badge, and discard audio per session.
  */
 @Component({
   selector: 'app-session-list',

--- a/desktop/src/src/app/models/integration.ts
+++ b/desktop/src/src/app/models/integration.ts
@@ -21,13 +21,7 @@ export interface IntegrationStatusEntry {
   current_values: Record<string, string>;
   mappings?: Record<string, unknown>;
   badge?: string;
-  /**
-   * Reason the integration needs the user's attention even though it is
-   * configured (OAuth-refresh services: SharePoint, Slack) — granted scopes
-   * are a strict subset of the required set, the state is stale, or the
-   * Slack refresh token aged out. The UI shows a "Re-authorize" banner.
-   * Undefined = no action required.
-   */
+  /** Re-authorize reason for OAuth-refresh services; undefined = no action. */
   oauth_action_required?: string;
   /** "Connected to <workspace>" hint (Slack: teamName · authedUserId). */
   oauth_identity?: string;
@@ -63,12 +57,8 @@ export interface DeviceCodeInfo {
 }
 
 /**
- * Progress event emitted by an OAuth flow. The host emits
- * awaiting_redirect/exchanging/success/error/cancelled/expired (Rust SSOT:
- * `ProgressStatus` in `desktop/src-tauri/src/oauth_flow.rs`, test-pinned);
- * `starting` and `polling` are frontend-local UI states never sent by the
- * host. `message` carries the redirect URI on `awaiting_redirect`, otherwise
- * a human-readable detail.
+ * OAuth flow progress event (Rust SSOT: `ProgressStatus` in
+ * `desktop/src-tauri/src/oauth_flow.rs`; `starting`/`polling` are UI-only).
  */
 export interface OAuthProgressEvent {
   status:
@@ -84,20 +74,12 @@ export interface OAuthProgressEvent {
   request_id: string;
 }
 
-/**
- * OAuth flow status — use this for component state/inputs so status string
- *  comparisons stay compiler-checked against the union above.
- */
+/** OAuth flow status union for compiler-checked comparisons. */
 export type OAuthFlowStatus = OAuthProgressEvent['status'];
 
 /**
- * Result of validating one OS integration against macOS TCC at startup.
- * Returned by `validate_os_integrations_on_startup` for each integration that
- * was previously `enabled=true` in config but whose live TCC state denies the
- * permission. The frontend renders a notice so users know the toggle was
- * auto-flipped to OFF and what to do next (re-click to trigger the prompt).
- *
- * Mirrors `OsIntegrationValidation` in `desktop/src-tauri/src/integrations_cmd.rs`.
+ * OS integration TCC validation result (mirrors `OsIntegrationValidation` in
+ * `desktop/src-tauri/src/integrations_cmd.rs`).
  */
 export interface OsIntegrationValidation {
   service: string;

--- a/desktop/src/src/app/models/llm.ts
+++ b/desktop/src/src/app/models/llm.ts
@@ -1,7 +1,6 @@
 /**
  * Frontend mirror of `speedwave_runtime::defaults::AnthropicModelInfo`,
- * returned by the `list_anthropic_models` Tauri command. Backend is the SSOT
- * — bumping a model means editing one const in `defaults.rs`.
+ * returned by the `list_anthropic_models` Tauri command. Backend is the SSOT.
  */
 export interface AnthropicModel {
   /** API alias passed to Claude Code via `ANTHROPIC_MODEL` (e.g. `claude-opus-4-7`). */
@@ -14,23 +13,12 @@ export interface AnthropicModel {
   latest: boolean;
 }
 
-/**
- * Default fallback context window. Used only when a chat session reports a
- * model the SSOT doesn't yet know about (e.g. running an old snapshot id
- * still accepted by the API). Aligns with the smallest supported window so
- * the percentage bar errs on the side of "your context is fuller than it
- * looks" rather than the other way round.
- */
+/** Default fallback context window for a model the SSOT doesn't know. */
 export const DEFAULT_CONTEXT_TOKENS = 200_000;
 
 /**
  * Frontend mirror of the Rust `DiscoveredModel` DTO returned by
- * `discover_llm_models` (Tauri command). Discovery talks to the local
- * provider's own API (Ollama `/api/tags` + `/api/show`, LM Studio
- * `/api/v0/models`, llama.cpp `/v1/models`) and surfaces the context
- * window directly from the server when it advertises one; otherwise
- * `context_tokens` stays `undefined` and the chat fallback chain takes
- * over.
+ * `discover_llm_models` (Tauri command).
  */
 export interface DiscoveredModel {
   /** Model id as advertised by the local server (e.g. `llama3.3`, `qwen2.5-coder`). */
@@ -39,13 +27,7 @@ export interface DiscoveredModel {
   context_tokens?: number;
 }
 
-/**
- * Result of a `provider="local"` discovery probe. Pairs the model list with
- * a chat-endpoint sanity flag — the UI shows a warning when the server has
- * `/v1/models` but does NOT implement `/v1/messages` (Anthropic Messages).
- * `messages_endpoint_ok === undefined` means "could not determine" (timeout
- * or transport error); treat as "unknown", not "failure".
- */
+/** Result of a `provider="local"` discovery probe. */
 export interface DiscoverResult {
   models: DiscoveredModel[];
   messages_endpoint_ok?: boolean;
@@ -54,20 +36,13 @@ export interface DiscoverResult {
 /** Local-provider names treated as "Local" in the UI (`isLocalProvider`). */
 export const LOCAL_PROVIDERS: ReadonlyArray<string> = ['ollama', 'lmstudio', 'llamacpp', 'local'];
 
-/**
- * Legacy local-provider names auto-migrated to `local` on Save. Derived
- * from {@link LOCAL_PROVIDERS} so a future rename of the canonical name
- * stays consistent without touching two arrays.
- */
+/** Legacy local-provider names auto-migrated to `local` on Save. */
 export const LEGACY_LOCAL_PROVIDERS: ReadonlyArray<string> = LOCAL_PROVIDERS.filter(
   (p) => p !== 'local'
 );
 
 /**
- * Mirror of `speedwave_runtime::config::is_local_provider`. Frontend uses
- * this to: (a) render the unified "Local" radio card for legacy configs,
- * (b) decide whether the honest context fallback applies (no `DEFAULT_CONTEXT_TOKENS`
- * fallback for local providers — ADR-041 "never guess").
+ * Mirror of `speedwave_runtime::config::is_local_provider`.
  * @param provider - Provider id from `get_llm_config().provider` (may be null).
  */
 export function isLocalProvider(provider: string | null | undefined): boolean {
@@ -76,11 +51,7 @@ export function isLocalProvider(provider: string | null | undefined): boolean {
 
 /**
  * Frontend mirror of the Rust `LlmConfigResponse` returned by the
- * `get_llm_config` Tauri command (`desktop/src-tauri/src/types.rs`). Fields
- * come from `claude.llm` (`speedwave_runtime::config::LlmConfig`) plus the
- * computed `default_base_url`. One-way: backend → frontend; the Rust struct
- * does not derive `Deserialize`.
- *
+ * `get_llm_config` Tauri command (`desktop/src-tauri/src/types.rs`).
  * Keep in sync with `LlmConfig` in `crates/speedwave-runtime/src/config.rs`.
  */
 export interface LlmConfigResponse {
@@ -88,12 +59,7 @@ export interface LlmConfigResponse {
   model: string | null;
   base_url: string | null;
   default_base_url: string | null;
-  /**
-   * Persisted context window for the active model (in tokens). For Anthropic
-   * the frontend sets this from the SSOT catalog; for local providers it
-   * comes from the discovery probe. The chat footer falls back to this
-   * value when the stream-level `context_window_size` is missing.
-   */
+  /** Persisted context window for the active model (in tokens). */
   context_tokens?: number | null;
   /** True when an api_key file exists for this project. */
   has_api_key?: boolean;
@@ -109,8 +75,7 @@ export interface LlmConfigResponse {
 
 /**
  * Provider kind discriminator (ADR-073). Mirror of the Rust
- * `speedwave_runtime::config::LlmProviderKind` serde representation
- * (snake_case strings). Drift guarded by `llm_provider_kind_matches_ts_union`.
+ * `LlmProviderKind` serde rep; drift guarded by `llm_provider_kind_matches_ts_union`.
  */
 export type LlmProviderKind =
   | 'anthropic_oauth'
@@ -121,8 +86,7 @@ export type LlmProviderKind =
 
 /**
  * One configured LLM provider (ADR-073 schema v2). Mirror of the Rust
- * `LlmProviderEntry`. Key VALUES never reach the frontend — only the
- * `has_api_key` presence flag.
+ * `LlmProviderEntry`. Key VALUES never reach the frontend, only `has_api_key`.
  */
 export interface LlmProviderEntry {
   /** Slug id (`^[a-z][a-z0-9-]{0,63}$`); becomes file/env names backend-side. */
@@ -160,11 +124,7 @@ export interface UsageBucket {
   throughput_latency_ms_sum: number;
 }
 
-/**
- * Usage dashboard payload from `get_llm_usage` (ADR-073). The single
- * source is the litellm callback JSONL; per-session chat statistics come
- * from the stream and are deliberately NOT part of this payload.
- */
+/** Usage dashboard payload from `get_llm_usage` (ADR-073). */
 export interface UsageSummary {
   /** `YYYY-MM-DD` → model → bucket (sorted by the backend's BTreeMap). */
   days: Record<string, Record<string, UsageBucket>>;

--- a/desktop/src/src/app/models/plugin.ts
+++ b/desktop/src/src/app/models/plugin.ts
@@ -1,8 +1,7 @@
 /**
  * Allowed `auth_fields[].field_type` values. Mirrors `ALLOWED_AUTH_FIELD_TYPES`
- * in `crates/speedwave-runtime/src/plugin.rs` — kept in sync by the Rust test
- * `allowed_auth_field_types_match_ts_union`. As a literal union, the compiler
- * flags any unhandled case in the credentials form's render switch.
+ * in `crates/speedwave-runtime/src/plugin.rs`; kept in sync by the Rust test
+ * `allowed_auth_field_types_match_ts_union`.
  */
 export type PluginAuthFieldType = 'text' | 'password' | 'textarea';
 
@@ -21,14 +20,12 @@ export interface PluginAuthField {
   description?: string;
   /**
    * Optional regex format constraint. Mirrors the Rust `AuthFieldValidation`
-   * (`plugin.rs`). `pattern` is treated as anchored (full-match) to agree
-   * with the HTML `<input pattern>` attribute and the host-side check in
-   * `save_plugin_credentials`; `message` is shown on mismatch.
+   * (`plugin.rs`). `pattern` is anchored (full-match); `message` shown on mismatch.
    */
   validation?: PluginAuthFieldValidation;
   /**
-   * Marks an OAuth credential filled by the host-driven Authorize flow, not a
-   * text input. Stored off-mount. Mirrors Rust `AuthFieldDef.oauth_flow`.
+   * Marks an OAuth credential filled by the host-driven Authorize flow.
+   * Mirrors Rust `AuthFieldDef.oauth_flow`.
    */
   oauth_flow?: boolean;
 }
@@ -41,38 +38,22 @@ export interface PluginAuthFieldValidation {
 
 /**
  * Maximum byte length of a single plugin credential value.
- *
- * Mirrors `MAX_CREDENTIAL_BYTES` in
- * `desktop/src-tauri/src/types.rs` — the Rust `save_plugin_credentials`
- * command rejects anything longer. Surfaced here so the credentials form
- * can cap input via `maxlength` and fail in the UI before a round-trip.
+ * Mirrors `MAX_CREDENTIAL_BYTES` in `desktop/src-tauri/src/types.rs`.
  */
 export const MAX_PLUGIN_CREDENTIAL_BYTES = 4096;
 
 /**
- * Payload emitted by `PluginCredentialsFormComponent` when the user
- * submits filled credential fields. Only non-empty (post-trim) fields
- * appear in `credentials`.
- *
- * Named `Plugin…` to avoid collision with the `SaveCredentialsEvent`
- * in `integrations/service-card/service-card.component.ts`, which has a
- * different shape (service + credentials + mappings).
+ * Payload emitted by `PluginCredentialsFormComponent` on submit.
+ * Only non-empty (post-trim) fields appear in `credentials`.
  */
 export interface PluginSaveCredentialsEvent {
   credentials: Record<string, string>;
 }
 
 /**
- * Outcome of `runtime::plugin::list_for_ui` for a single plugin.
- * `'verified'` is the only state that allows the user to enable the
- * plugin or save credentials; every other state surfaces in
- * `verification_error` so users can see what went wrong and how to
- * recover (the remove button stays available regardless).
- *
- * Mirrors the `VerificationStatus` enum in
- * `crates/speedwave-runtime/src/plugin.rs`, which derives
- * `#[serde(rename_all = "snake_case")]` — the literals here must
- * stay in sync with that derive.
+ * Verification outcome for a plugin; `'verified'` is the only usable state.
+ * Mirrors `VerificationStatus` in `crates/speedwave-runtime/src/plugin.rs`
+ * (`#[serde(rename_all = "snake_case")]`).
  */
 export type PluginVerificationStatus =
   | 'verified'
@@ -88,10 +69,7 @@ export interface PluginStatusEntry {
   service_id: string | null;
   version: string;
   description: string;
-  /**
-   * Optional long-form Markdown setup/usage guide from the manifest,
-   * rendered on the Dashboard tab. Absent when the manifest omits it.
-   */
+  /** Optional long-form Markdown setup/usage guide from the manifest. */
   instructions?: string;
   enabled: boolean;
   configured: boolean;
@@ -99,8 +77,7 @@ export interface PluginStatusEntry {
   current_values: Record<string, string>;
   /**
    * Keys of `auth_fields` that have a non-empty value stored on disk.
-   * Metadata-only — secret contents are never exposed. Drives the
-   * per-field "configured" indicator in the credentials form.
+   * Metadata-only — secret contents are never exposed.
    */
   configured_fields: string[];
   token_mount: PluginTokenMount;
@@ -156,11 +133,8 @@ export interface PluginsResponse {
 
 /**
  * Phase strings emitted by the `plugin_install_status` event.
- *
  * Mirror of `ALL_PLUGIN_INSTALL_PHASES` in
- * `crates/speedwave-runtime/src/plugin.rs`. Adding/removing/renaming a phase
- * here requires the same change there (no codegen — small, rarely-changing
- * list).
+ * `crates/speedwave-runtime/src/plugin.rs`.
  */
 export const PLUGIN_INSTALL_PHASES = [
   'verifying',

--- a/desktop/src/src/app/models/state-tree.ts
+++ b/desktop/src/src/app/models/state-tree.ts
@@ -1,10 +1,5 @@
 /**
- * State-tree types mirroring `crates/speedwave-runtime/src/stream/state_tree.rs`.
- *
- * The Rust side serialises these via serde with `rename_all = "snake_case"`
- * for tagged enums and default field names otherwise. The tree is rebuilt
- * locally by `ChatStateService.rebuildStateTree()` after every mutation.
- * @see docs/adr/ADR-042-json-patch-stream-protocol.md
+ * State-tree types mirroring `crates/speedwave-runtime/src/stream/state_tree.rs` (ADR-042).
  */
 
 /** Conversation role. */
@@ -62,11 +57,7 @@ export interface EntryMetaState {
 import type { AskUserQuestionItem } from './chat';
 
 /**
- * One question inside an `ask_user` block — mirrors
- * `speedwave_runtime::stream::AskUserQuestionItem`. Same shape as
- * {@link AskUserQuestionItem}; this alias exposes a `Readonly` view for
- * persistence-layer consumers, but the underlying type lives in
- * `models/chat.ts` (single source of truth).
+ * One question inside an `ask_user` block; mirrors Rust `AskUserQuestionItem` (SSOT in `models/chat.ts`).
  */
 export type AskUserQuestionStateItem = Readonly<AskUserQuestionItem>;
 

--- a/desktop/src/src/app/models/transcript.ts
+++ b/desktop/src/src/app/models/transcript.ts
@@ -81,13 +81,7 @@ export interface TranscriptSession {
   last_seq: number;
 }
 
-/**
- * `speaker_names` on the wire inside a `TranscriptEvent` — a list of
- * `[speaker_id, name]` pairs. (The Rust side serializes the map this way for
- * events because serde_json's "numeric map key from string" shortcut doesn't
- * fire through the internally-tagged enum's `Content` buffer. The reducer
- * converts it to the `Record<number, string>` shape used on `TranscriptSession`.)
- */
+/** `speaker_names` on the wire inside a `TranscriptEvent` — `[speaker_id, name]` pairs. */
 export type SpeakerNamePairs = readonly (readonly [number, string])[];
 
 /** Live event on a `transcript_event::<id>` channel. `seq` is monotonic per session. */
@@ -148,9 +142,8 @@ export interface DownloadProgress {
 }
 
 /**
- * Meeting-transcription preferences (top-level user config, ADR-056 §13 —
- * repo `.speedwave.json` cannot set these). All fields optional; `null`/absent
- * means "use the default".
+ * Meeting-transcription preferences (top-level user config only, ADR-056 §13).
+ * All fields optional; `null`/absent means "use the default".
  */
 export interface TranscriptionConfig {
   enabled: boolean | null;

--- a/desktop/src/src/app/models/update.ts
+++ b/desktop/src/src/app/models/update.ts
@@ -6,10 +6,7 @@ export interface UpdateInfo {
   is_critical: boolean;
 }
 
-/**
- * Tagged result of `check_for_update`. Mirrors the Rust enum
- * `updater::UpdateCheckOutcome` (serde tag = "kind", snake_case).
- */
+/** Tagged result of `check_for_update`; mirrors Rust `updater::UpdateCheckOutcome` (serde tag "kind", snake_case). */
 export type UpdateCheckOutcome =
   | { kind: 'up_to_date' }
   | ({ kind: 'update_available' } & UpdateInfo);
@@ -57,11 +54,7 @@ export interface BundleReconcileStatus {
   applied_bundle_id: string | null;
 }
 
-/**
- * Payload emitted with the `project_switch_failed` Tauri event.
- * Extends the basic error with optional CloudStorage failure context
- * so the frontend can route to the CloudStorage remediation modal.
- */
+/** Payload emitted with the `project_switch_failed` Tauri event, with optional CloudStorage failure context. */
 export interface ProjectSwitchFailedPayload {
   /** The project name that was active before the failed switch (may be null). */
   project: string | null;

--- a/desktop/src/src/app/plugins/plugin-credentials-form/plugin-credentials-form.component.spec.ts
+++ b/desktop/src/src/app/plugins/plugin-credentials-form/plugin-credentials-form.component.spec.ts
@@ -168,8 +168,7 @@ describe('PluginCredentialsFormComponent', () => {
   });
 
   it('per-field clear is confirm-gated (first click stages, Yes emits)', () => {
-    // H9 — per-field clear is destructive, so it requires a confirm. First
-    // click shows inline Yes/Cancel; only Yes emits the clearField event.
+    // First click stages confirm; only Yes emits clearField.
     fixture.componentRef.setInput('authFields', makeAuthFields());
     fixture.componentRef.setInput('configuredFields', ['example_pat']);
     fixture.detectChanges();
@@ -267,8 +266,7 @@ describe('PluginCredentialsFormComponent', () => {
   });
 
   it('renders a typed input for oauth_flow client fields and emits their value on save', () => {
-    // An oauth_flow:true client field (e.g. client_id) must be typeable AND be
-    // submitted, so save_plugin_credentials can route it to the off-mount seed.
+    // An oauth_flow:true client field must be typeable and submitted.
     fixture.componentRef.setInput('authFields', [
       {
         key: 'client_id',
@@ -520,8 +518,7 @@ describe('PluginCredentialsFormComponent', () => {
     fixture.componentRef.setInput('authFields', makeAuthFields());
     fixture.detectChanges();
 
-    // Synthetic event with a non-input target (e.g. a div). Must not
-    // write undefined into the buffer or hasAnyValue() would throw on trim.
+    // Synthetic event with a non-input target (e.g. a div).
     const fakeEvent = { target: document.createElement('div') } as unknown as Event;
     component.onFieldInput('example_pat', fakeEvent);
 
@@ -663,8 +660,7 @@ describe('PluginCredentialsFormComponent', () => {
   });
 
   it('rejects a partial match — the pattern is anchored full-match', () => {
-    // Author pattern is intentionally un-anchored; the component wraps it in
-    // ^(?:…)$ so a value that merely contains a match is still rejected.
+    // Author pattern is un-anchored; component wraps it in ^(?:…)$.
     fixture.componentRef.setInput('authFields', [
       {
         key: 'example_pat',

--- a/desktop/src/src/app/plugins/plugin-credentials-form/plugin-credentials-form.component.ts
+++ b/desktop/src/src/app/plugins/plugin-credentials-form/plugin-credentials-form.component.ts
@@ -12,16 +12,7 @@ import { OAuthFlowStatus } from '../../models/integration';
 /**
  * Renders a form for a plugin's `auth_fields[]`. Emits the filled subset
  * on submit; emits a separate event when the user requests a full reset.
- *
- * Existing stored token values are **never read back** (the backend treats
- * them as secrets — files are not exposed via any tauri command). The form
- * is always rendered with empty inputs; the placeholder hints at the
- * expected token format. Leaving a field empty preserves whatever is
- * currently on disk; entering a value overwrites it.
- *
- * Per-field byte cap mirrors the Rust-side `MAX_CREDENTIAL_BYTES = 4096`
- * via the `maxlength` attribute, surfaced in the UI before the user hits
- * Save instead of as a backend error response.
+ * Stored token values are never read back; inputs render empty.
  */
 @Component({
   selector: 'app-plugin-credentials-form',
@@ -89,11 +80,7 @@ import { OAuthFlowStatus } from '../../models/integration';
               </p>
             }
             @if (field.field_type === 'textarea') {
-              <!-- Multi-line secret (PEM, service-account JSON). The HTML
-                   pattern attribute is invalid on textarea, so the regex is
-                   checked by JS at submit + the backend. Masked with
-                   -webkit-text-security when is_secret (Tauri webviews are
-                   Chromium/WebKit). -->
+              <!-- Multi-line secret; regex checked by JS at submit + backend (pattern invalid on textarea). -->
               <textarea
                 [id]="'cred-' + field.key"
                 rows="3"
@@ -189,9 +176,7 @@ import { OAuthFlowStatus } from '../../models/integration';
     }
   `,
   styles: [
-    // Mask multi-line secrets the way <input type=password> masks single-line.
-    // Tauri webviews are Chromium (Windows/WebView2) / WebKit (macOS), both
-    // support the vendor-prefixed property.
+    // Mask multi-line secrets via -webkit-text-security (Chromium/WebKit webviews).
     `
       .cred-secret-mask {
         -webkit-text-security: disc;
@@ -203,18 +188,14 @@ export class PluginCredentialsFormComponent {
   private readonly log = inject(LoggerService);
   readonly authFields = input.required<PluginAuthField[]>();
   /**
-   * Keys of fields that currently have a value stored on disk (from
-   * `PluginStatusEntry.configured_fields`). Drives the per-field "✓ set"
-   * badge + "clear" button. Secrets are never read back, so this is the
-   * only signal the form has that a value already exists.
+   * Keys of fields with a value stored on disk (from
+   * `PluginStatusEntry.configured_fields`); drives the "✓ set" badge + clear button.
    */
   readonly configuredFields = input<string[]>([]);
   readonly save = output<PluginSaveCredentialsEvent>();
   /**
-   * Renamed from `reset` (which collides with the DOM-native form
-   * `reset` event — `@angular-eslint/no-output-native` flags it).
-   * Semantics unchanged: the host component should call
-   * `delete_plugin_credentials` (clear ALL) when this fires.
+   * Fires when the user requests a full reset; host clears ALL credentials.
+   * Named `clear` (not `reset`) to avoid the DOM-native `reset` event collision.
    */
   readonly clear = output<void>();
   /**
@@ -223,9 +204,7 @@ export class PluginCredentialsFormComponent {
    */
   readonly clearField = output<string>();
   /**
-   * True while a save/clear is in flight upstream. When true the Save button
-   * is disabled to block double-submit (each click would re-trigger the
-   * `save_plugin_credentials` Tauri call + container restart).
+   * True while a save/clear is in flight upstream; disables Save to block double-submit.
    */
   readonly inFlight = input<boolean>(false);
 
@@ -256,9 +235,7 @@ export class PluginCredentialsFormComponent {
   }
 
   /**
-   * Whether every typed prerequisite is SAVED. Authorize reads credentials from
-   * the host-side seed (written by Save), so freshly-typed-but-unsaved values
-   * do not count — the user must Save first, then Authorize.
+   * Whether every prerequisite is SAVED (Authorize reads only saved credentials).
    */
   oauthPrerequisitesMet(): boolean {
     return this.oauthPrerequisiteFields().every((f) => this.isConfigured(f.key));
@@ -301,10 +278,8 @@ export class PluginCredentialsFormComponent {
   }
 
   /**
-   * Space-joined list of `id`s the field is described by, for screen
-   * readers — the help text `<p>` and/or the validation error `<p>`. Returns
-   * `null` (not empty string) when neither is present so Angular drops the
-   * attribute entirely instead of binding an empty `aria-describedby`.
+   * Space-joined `id`s for `aria-describedby` (help and/or error `<p>`);
+   * `null` when neither is present so Angular drops the attribute.
    * @param key the field key
    * @returns the attribute value, or `null`
    */
@@ -348,10 +323,8 @@ export class PluginCredentialsFormComponent {
   }
 
   /**
-   * Local edit buffer. Never seeded from server — secrets are write-only.
-   * Cleared after a successful save so the next render shows empty inputs
-   * (otherwise the password field would still hold the just-typed token
-   * in memory).
+   * Local edit buffer. Never seeded from server (secrets are write-only);
+   * cleared after a successful save.
    */
   private values: Record<string, string> = {};
 
@@ -367,22 +340,16 @@ export class PluginCredentialsFormComponent {
   }
 
   /**
-   * Captures a single input event into the local edit buffer. Does not
-   * trim — the trim happens at submit time so the user can still see
-   * trailing spaces as they type.
+   * Captures an input event into the edit buffer; trims only at submit.
    * @param key the field key being edited
    * @param event the DOM input event from the bound `<input>` or `<textarea>`
    */
   onFieldInput(key: string, event: Event): void {
-    // Guard the cast — a synthetic event (e.g. dispatched in a test or
-    // by an extension) with a non-field target would otherwise write
-    // `undefined` into the buffer and break `hasAnyValue()`'s `.trim()`.
-    // Both <input> (text/password) and <textarea> (multi-line) are accepted.
+    // Guard the cast against a non-field event target.
     const target = event.target;
     if (!(target instanceof HTMLInputElement) && !(target instanceof HTMLTextAreaElement)) return;
     this.values[key] = target.value;
-    // Clear a stale validation error as soon as the user edits the field —
-    // it's re-evaluated on the next submit.
+    // Clear a stale validation error on edit; re-evaluated on next submit.
     delete this.validationErrors[key];
   }
 
@@ -403,11 +370,8 @@ export class PluginCredentialsFormComponent {
   }
 
   /**
-   * Tests a trimmed value against a field's optional regex constraint,
-   * anchored full-match to mirror both the HTML `pattern` attribute and the
-   * Rust host-side check. A field with no `validation`, or a compile error
-   * in the (manifest-validated) pattern, is treated as valid here — the
-   * backend remains the authority.
+   * Tests a trimmed value against a field's optional regex (anchored full-match).
+   * No `validation` or an uncompilable pattern is treated as valid here.
    * @param field the auth field whose constraint to apply
    * @param value the trimmed candidate value
    * @returns the error message on mismatch, or `null` when acceptable
@@ -419,9 +383,7 @@ export class PluginCredentialsFormComponent {
     try {
       re = new RegExp(`^(?:${validation.pattern})$`);
     } catch (err) {
-      // Pattern compiled in Rust (RE2) but not in JS (e.g. a construct the
-      // JS engine rejects). The backend still enforces it on save, so we
-      // pass the client check — but log rather than swallow silently.
+      // Pattern compiles in Rust (RE2) but not JS; backend still enforces on save.
       this.log.warn(
         `auth_field "${field.key}" pattern not compilable in JS; skipping client check: ${String(err)}`
       );
@@ -432,10 +394,8 @@ export class PluginCredentialsFormComponent {
   }
 
   /**
-   * True if at least one field has a non-empty, non-whitespace value in
-   * the edit buffer. Drives the Save button's `disabled` state — a
-   * submit with only whitespace would emit `{ credentials: {} }` which
-   * the host component drops anyway, so we block the click earlier.
+   * True if any field has a non-whitespace value in the edit buffer;
+   * drives the Save button's `disabled` state.
    * @returns whether any input has typed content worth saving
    */
   hasAnyValue(): boolean {
@@ -443,10 +403,8 @@ export class PluginCredentialsFormComponent {
   }
 
   /**
-   * Handles `<form>` submit. Trims every value, drops whitespace-only
-   * entries, and emits `save` with the filtered map. Whitespace-only or
-   * fully-empty submits are no-ops (the host component would also
-   * filter, but blocking earlier avoids a flash of "saving…" state).
+   * Handles `<form>` submit: trims values, drops empty entries, emits `save`.
+   * Whitespace-only or fully-empty submits are no-ops.
    * @param event the form submit event (preventDefault called immediately)
    */
   onSubmit(event: Event): void {
@@ -458,10 +416,7 @@ export class PluginCredentialsFormComponent {
     }
     if (Object.keys(credentials).length === 0) return;
 
-    // Validate each filled field against its regex constraint before
-    // emitting. Collect every error (not just the first) so the user sees
-    // all problems at once. Any error blocks the save; the buffer is kept
-    // so the user can correct it.
+    // Validate each filled field against its regex, collecting all errors.
     const errors: Record<string, string> = {};
     const fields = this.authFields();
     for (const [key, value] of Object.entries(credentials)) {

--- a/desktop/src/src/app/plugins/plugin-detail/plugin-detail.component.spec.ts
+++ b/desktop/src/src/app/plugins/plugin-detail/plugin-detail.component.spec.ts
@@ -167,10 +167,7 @@ describe('PluginDetailComponent', () => {
   }
 
   /**
-   * setup() variant whose get_plugins returns the default plugin carrying an
-   * `instructions` value (and an optional verification_status override).
-   * Collapses the repeated mockTauri + JSON-clone boilerplate the instruction
-   * tests would otherwise duplicate.
+   * setup() variant whose get_plugins returns a plugin with `instructions`.
    * @param instructions - Markdown to put on the plugin's `instructions` field
    * @param verificationStatus - wire `verification_status` (defaults to 'verified')
    * @returns the component + fixture, ready for `initAndDetect`
@@ -589,8 +586,7 @@ describe('PluginDetailComponent', () => {
 
   describe('terminal-minimal tabs + master toggle', () => {
     it('renders three tabs: dashboard / settings / logs', async () => {
-      // `tools` tab was removed (YAGNI — backend never exposed per-plugin
-      // tool stats, so `exposedTools` was always `[]`).
+      // `tools` tab was removed.
       const { component, fixture } = setup();
       await initAndDetect(component, fixture);
       expect(fixture.nativeElement.querySelector('[data-testid="tab-bar"]')).not.toBeNull();
@@ -713,8 +709,7 @@ describe('PluginDetailComponent', () => {
       await initAndDetect(component, fixture);
       mockTauri.invokeHandler = async (cmd: string) => {
         if (cmd === 'start_plugin_oauth') {
-          // The host's spawned task can emit before the IPC return resolves —
-          // such an event must be buffered and replayed, not dropped.
+          // Event can arrive before the IPC return resolves; must be buffered.
           mockTauri.dispatchEvent('plugin_oauth_progress', {
             status: 'awaiting_redirect',
             message: 'http://127.0.0.1:6001/callback',
@@ -746,8 +741,7 @@ describe('PluginDetailComponent', () => {
         message: '',
         request_id: 'rid',
       });
-      // The success handler awaits loadPlugin (an async invoke) before
-      // requestRestart — let the macrotask queue drain.
+      // Success handler awaits loadPlugin before requestRestart; drain macrotasks.
       await new Promise((r) => setTimeout(r, 0));
       expect(restartSpy).toHaveBeenCalled();
       expect(component.oauthRedirectUri).toBeNull();
@@ -836,8 +830,7 @@ describe('PluginDetailComponent', () => {
       const { component, fixture } = setup();
       await initAndDetect(component, fixture);
 
-      // Open confirm prompt by clicking the uninstall button (UI-driven path
-      // — keeps OnPush change detection consistent with real user interaction).
+      // Open confirm prompt by clicking the uninstall button.
       const uninstallBtn = fixture.nativeElement.querySelector(
         '[data-testid="uninstall-btn"]'
       ) as HTMLButtonElement;
@@ -911,8 +904,7 @@ describe('PluginDetailComponent', () => {
       const { component, fixture } = setup();
       await initAndDetect(component, fixture);
 
-      // Hold remove_plugin pending so we observe the buttons in their
-      // mid-flight (`removing = true`) state before the invoke resolves.
+      // Hold remove_plugin pending to observe the mid-flight button state.
       let resolveFn!: () => void;
       mockTauri.invokeHandler = (cmd: string) => {
         if (cmd === 'remove_plugin') {
@@ -930,11 +922,9 @@ describe('PluginDetailComponent', () => {
       uninstallBtn.click();
       fixture.detectChanges();
 
-      // Kick off uninstall but do not await — we want to observe the UI
-      // while the invoke is still pending.
+      // Kick off uninstall without await; observe UI while invoke pending.
       const promise = component.onConfirmUninstall();
-      // Yield once so onConfirmUninstall sets `removing = true` and calls
-      // markForCheck before we re-render.
+      // Yield so onConfirmUninstall sets `removing = true` before re-render.
       await new Promise((r) => setTimeout(r, 0));
       fixture.detectChanges();
 
@@ -1169,10 +1159,7 @@ describe('PluginDetailComponent', () => {
     });
 
     it('save refreshes the plugin entry so the configured badge can flip', async () => {
-      // PLUGIN_WITH_AUTH starts configured:false. After a successful save,
-      // loadPlugin re-fetches; if the backend now reports configured:true,
-      // the component reflects it. We simulate that by switching the
-      // get_plugins response post-save.
+      // Simulate backend reporting configured:true after save.
       const { component, fixture, mockTauri } = setupWithAuth();
       await initAndDetect(component, fixture);
       expect(component.plugin?.configured).toBe(false);
@@ -1191,8 +1178,7 @@ describe('PluginDetailComponent', () => {
     });
 
     it('save success message survives a post-save refresh failure', async () => {
-      // Invariant (2) from runPluginMutation: a loadPlugin failure must not
-      // clobber the success message — the credentials were already saved.
+      // Credentials already saved; loadPlugin failure must not clobber success message.
       const { component, fixture, mockTauri } = setupWithAuth();
       await initAndDetect(component, fixture);
       mockTauri.invokeHandler = (cmd: string) => {

--- a/desktop/src/src/app/plugins/plugin-detail/plugin-detail.component.ts
+++ b/desktop/src/src/app/plugins/plugin-detail/plugin-detail.component.ts
@@ -34,19 +34,9 @@ export type PluginDetailTab = 'dashboard' | 'settings' | 'logs';
 /** Shown when a mutation is attempted with no active project / loaded plugin. */
 const NO_ACTIVE_PROJECT_MSG = 'No active project — open or create a project first.';
 
+/** Scoped `marked` for the Dashboard `instructions` block; forces `<a>` to open in a new tab with `rel="noopener noreferrer"`. */
 /**
- * Scoped `marked` instance for the Dashboard `instructions` block. Forces
- * every rendered `<a>` to open in a new tab with `rel="noopener noreferrer"`
- * so a click inside the Tauri webview can't navigate the SPA away (state
- * loss) nor leak `window.opener` to the linked page. Scoped — does not
- * touch other markdown call sites (e.g. chat text-block).
- */
-/**
- * Escape user-supplied strings before interpolating into an HTML attribute
- * value. Angular's `DomSanitizer` still applies at bind time (so this is
- * defence-in-depth, not the primary XSS gate), but a manifest author writing
- * `[x](url "It's a \"quote\"")` would otherwise produce structurally
- * malformed HTML that breaks subsequent attributes on the same `<a>`.
+ * Escape a string for interpolation into an HTML attribute value.
  * @param s the string to escape
  * @returns `s` with `&` → `&amp;` and `"` → `&quot;`
  */
@@ -479,11 +469,7 @@ export class PluginDetailComponent implements OnInit, OnDestroy {
   /** True while `delete_plugin_credentials` is in flight; disables confirm/cancel. */
   resetting = false;
 
-  /**
-   * True while any credential/settings mutation is in flight via
-   * `runPluginMutation`. Bound to the credentials form's `inFlight` input so
-   * Save disables + flips to "Saving…" — blocks double-submit + signals work.
-   */
+  /** True while any credential/settings mutation is in flight; disables Save. */
   saving = false;
 
   // -- OAuth (authorization_code) flow state --
@@ -494,10 +480,7 @@ export class PluginDetailComponent implements OnInit, OnDestroy {
   oauthRedirectUri: string | null = null;
   /** Correlates progress events to the in-flight flow. */
   private activeOAuthRequestId: string | null = null;
-  /**
-   * Latest event per request that arrived before `start_plugin_oauth`
-   *  returned its request_id (the emit can outrun the IPC return).
-   */
+  /** Latest event per request that arrived before `start_plugin_oauth` returned its request_id. */
   private pendingOAuthEvents = new Map<string, OAuthProgressEvent>();
   private unlistenOAuth: (() => void) | null = null;
 
@@ -523,10 +506,7 @@ export class PluginDetailComponent implements OnInit, OnDestroy {
   private instructionsCache: { src: string; html: string } | null = null;
 
   /**
-   * Renders the manifest's `instructions` Markdown. Result is bound via
-   * `[innerHTML]`, sanitised at bind-time by Angular's default `SecurityContext.HTML`
-   * (only holds while the binding is NOT wrapped in `bypassSecurityTrustHtml`).
-   * Memoised on the source string so OnPush ticks don't re-parse.
+   * Renders the manifest's `instructions` Markdown, memoised on the source string.
    * @returns HTML string (sanitised at bind time), or `''`
    */
   renderedInstructions(): string {
@@ -663,11 +643,7 @@ export class PluginDetailComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Shared skeleton for credentials/settings mutations: guard → clear status
-   * → invoke → set success → reload. Captures slug/project before the first
-   * await (project-switch mid-flight would otherwise null `this.plugin`). On
-   * reload failure the success message survives (the mutation already won)
-   * with a "view may be stale" caveat.
+   * Shared skeleton for credentials/settings mutations; captures slug/project before the first await.
    * @param command - Tauri command name to invoke
    * @param buildPayload - given validated (slug, project), returns the payload
    * @param successMsg - message to show on success
@@ -747,14 +723,7 @@ export class PluginDetailComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Persists filled credential fields to disk via the Rust-side
-   * `save_plugin_credentials` Tauri command. The command writes each
-   * accepted key as `~/.speedwave/tokens/<project>/<service_id>/<key>`
-   * with chmod 600, having first verified the plugin's Ed25519 signature
-   * and validated that every key is in the manifest's `auth_fields`
-   * allow-list. On success, requests a container restart so workers pick
-   * up the new tokens, then reloads the plugin entry to refresh the
-   * `configured` status badge.
+   * Persists filled credential fields to disk via `save_plugin_credentials`.
    * @param event - filled credentials emitted by PluginCredentialsFormComponent
    */
   async onSaveCredentials(event: PluginSaveCredentialsEvent): Promise<void> {
@@ -766,11 +735,7 @@ export class PluginDetailComponent implements OnInit, OnDestroy {
     );
   }
 
-  /**
-   * Starts the plugin's authorization_code OAuth flow. Client credentials must
-   * already be saved (the host reads them from the seed; the Authorize button is
-   * gated on the configured badge). Opens the browser and awaits the callback.
-   */
+  /** Starts the plugin's authorization_code OAuth flow; client credentials must be pre-saved. */
   async handleStartPluginOAuth(): Promise<void> {
     const slug = this.plugin?.service_id ?? this.plugin?.slug;
     if (!slug || !this.activeProject) return;
@@ -784,8 +749,7 @@ export class PluginDetailComponent implements OnInit, OnDestroy {
         slug,
       });
       this.activeOAuthRequestId = result.request_id;
-      // The host may have emitted (e.g. awaiting_redirect with the redirect
-      // URI) before the invoke resolved — replay the buffered event now.
+      // Replay any event buffered before the invoke resolved.
       const buffered = this.pendingOAuthEvents.get(result.request_id);
       this.pendingOAuthEvents.clear();
       if (buffered) await this.applyOAuthProgress(buffered, slug);
@@ -821,8 +785,7 @@ export class PluginDetailComponent implements OnInit, OnDestroy {
       .listen<OAuthProgressEvent>('plugin_oauth_progress', async (event) => {
         const payload = (event as { payload: OAuthProgressEvent }).payload;
         if (payload.request_id !== this.activeOAuthRequestId) {
-          // start_plugin_oauth may still be awaiting its IPC return — buffer
-          // the newest event per request so awaiting_redirect is not lost.
+          // Buffer the newest event per request until the request_id is correlated.
           this.pendingOAuthEvents.set(payload.request_id, payload);
           return;
         }
@@ -863,12 +826,8 @@ export class PluginDetailComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Clears a SINGLE stored credential field via `delete_plugin_credential_field`.
-   * Unlike the full reset, this is not gated behind a confirm prompt — it
-   * removes just one token (trivially re-entered) and leaves the rest plus
-   * the plugin's enabled state intact.
-   * @param key - the auth_field key to clear (emitted by the form's per-field
-   *   "clear" button)
+   * Clears a single stored credential field via `delete_plugin_credential_field`; not gated by confirm.
+   * @param key - the auth_field key to clear
    */
   async onClearField(key: string): Promise<void> {
     await this.runPluginMutation(
@@ -878,17 +837,8 @@ export class PluginDetailComponent implements OnInit, OnDestroy {
     );
   }
 
-  /**
-   * Deletes every stored credential for this plugin via the Rust-side
-   * `delete_plugin_credentials` Tauri command (which removes the per-plugin
-   * tokens directory). The destructive confirm is handled in the template
-   * via `confirmingReset` (mirrors the uninstall confirm pattern), so this
-   * method is only reached after the user clicked "yes, reset".
-   */
+  /** Deletes every stored credential for this plugin via `delete_plugin_credentials`; reached only after confirm. */
   async onResetCredentials(): Promise<void> {
-    // `resetting` is set unconditionally and always cleared after the call
-    // (runPluginMutation returns rather than throwing on a guard failure), so
-    // the flag can never stick on an early exit.
     this.resetting = true;
     this.cdr.markForCheck();
     await this.runPluginMutation(
@@ -941,9 +891,7 @@ export class PluginDetailComponent implements OnInit, OnDestroy {
         this.integrationStatuses.set(integration, svc?.configured ?? false);
       }
     } catch (e: unknown) {
-      // Non-fatal: the integration badges fall back to "not configured". Log
-      // so the failure isn't invisible — a swallowed get_integrations error
-      // would otherwise masquerade as genuinely unconfigured integrations.
+      // Non-fatal: badges fall back to "not configured"; log so the error isn't invisible.
       this.log.warn(`loadIntegrationStatuses: get_integrations failed: ${String(e)}`);
     }
   }

--- a/desktop/src/src/app/plugins/plugins.component.spec.ts
+++ b/desktop/src/src/app/plugins/plugins.component.spec.ts
@@ -86,15 +86,7 @@ describe('PluginsComponent', () => {
   let projectState: ProjectStateService;
 
   beforeEach(async () => {
-    // The Angular `unit-test` builder configures Vitest with
-    // `isolate: false` (see @angular/build/.../vitest/executor.js), which
-    // means module mocks live across spec files in the same run. Without
-    // an explicit reset here, `openMock` retains whatever mockResolvedValue
-    // the previous spec configured — most visibly,
-    // `create-project-modal.component.spec.ts` resolves `open` to a path
-    // string, and the next plugins-spec test that calls `open` without
-    // setting its own resolved value gets that stale path back. Reset
-    // first thing in every beforeEach to keep specs self-contained.
+    // Reset openMock to clear stale mock values from previous specs (isolate: false).
     openMock.mockReset();
 
     mockTauri = new MockTauriService();
@@ -370,11 +362,7 @@ describe('PluginsComponent', () => {
   });
 
   describe('installPlugin()', () => {
-    /**
-     * Default install handler used by these tests: peeks an MCP plugin
-     * (with `service_id`) and installs successfully. Override per-test for
-     * other scenarios.
-     */
+    /** Peeks an MCP plugin (with `service_id`) and installs successfully. */
     function defaultInstallHandler(): (cmd: string) => Promise<unknown> {
       return async (cmd: string) => {
         if (cmd === 'peek_plugin_manifest')
@@ -459,9 +447,7 @@ describe('PluginsComponent', () => {
         return undefined;
       };
       await component.installPlugin();
-      // After install completes, the steps signal still holds the last list
-      // used during the run — we can assert resource-only plugins never get
-      // a `building` step.
+      // Resource-only plugins never get a `building` step.
       const steps = component.installSteps();
       expect(steps.map((s) => s.id)).toEqual(['verifying', 'extracting']);
     });
@@ -509,8 +495,7 @@ describe('PluginsComponent', () => {
     it('marks the active step as error and sets installError on phase=failed', async () => {
       await component.ngOnInit();
       openMock.mockResolvedValue('/tmp/bad.zip');
-      // Hold install_plugin pending so the dispatched phase events are
-      // delivered while the listener is still registered.
+      // Hold install_plugin pending so phase events arrive while the listener is registered.
       let rejectFn!: (e: Error) => void;
       mockTauri.invokeHandler = (cmd: string) => {
         if (cmd === 'peek_plugin_manifest')
@@ -754,9 +739,7 @@ describe('PluginsComponent', () => {
       const target = component.plugins[0];
       const before = target.enabled;
       await component.onRowToggle(target, new MouseEvent('click'));
-      // Hold a direct reference because ngOnInit's project-ready listener
-      // can re-fetch and replace the plugins array between the await and
-      // the assertion in some Angular zone flushes.
+      // Hold a direct reference: the project-ready listener may replace the plugins array.
       expect(target.enabled).toBe(!before);
       expect(navSpy).not.toHaveBeenCalled();
     });

--- a/desktop/src/src/app/plugins/plugins.component.ts
+++ b/desktop/src/src/app/plugins/plugins.component.ts
@@ -358,16 +358,12 @@ export class PluginsComponent implements OnInit, OnDestroy {
    */
   toolsLabelFor(plugin: PluginStatusEntry): string {
     if (!plugin.service_id) return '—';
-    // We don't currently expose tool counts via get_plugins, so render a stable
-    // "—" placeholder and let plugin-detail report the real number per worker.
+    // Placeholder; actual tool count reported per-worker.
     return '—';
   }
 
   /**
-   * True iff the plugin's signature and manifest both passed the runtime
-   * audit. Drives whether the enable toggle is interactive and which
-   * pill (green/red) renders. The remove action is intentionally
-   * available regardless — that's the recovery path.
+   * Signature and manifest audit result; gates toggle interactivity.
    * @param plugin - the plugin status entry to inspect
    */
   isVerified(plugin: PluginStatusEntry): boolean {
@@ -375,9 +371,7 @@ export class PluginsComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Short label for the pill / aria text when a plugin is unverified.
-   * Backend always supplies `verification_status` so we don't need a
-   * "missing field" fallback here.
+   * Verification result label for pill display.
    * @param plugin - the plugin status entry whose status string to render
    */
   verificationStatusLabel(plugin: PluginStatusEntry): string {
@@ -414,9 +408,7 @@ export class PluginsComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Opens a native file dialog to select a plugin ZIP, then installs it.
-   * The flow is: peek manifest → render the right step list → register the
-   * progress listener → invoke install. Progress phases drive the overlay.
+   * Opens file dialog, then invokes backend install with progress tracking.
    */
   async installPlugin(): Promise<void> {
     let selected: string | null;
@@ -440,11 +432,7 @@ export class PluginsComponent implements OnInit, OnDestroy {
    * button inside the overlay's error banner.
    */
   async retryInstall(): Promise<void> {
-    // Guard against concurrent runs: a `failed` phase event arrives while
-    // the original `invoke('install_plugin')` Promise is still pending,
-    // and the overlay's retry button is reachable in that window. Without
-    // this check, clicking retry would spawn a second runInstall whose
-    // `finally` collides with the first.
+    // Guard against concurrent runs during a failed event.
     if (this.installing || !this.currentZipPath) return;
     await this.runInstall(this.currentZipPath);
   }
@@ -455,8 +443,7 @@ export class PluginsComponent implements OnInit, OnDestroy {
     this.success = '';
     this.installError.set(null);
     this.installing = true;
-    // Render an empty list while the peek is in flight; we'll populate it
-    // before the first progress event arrives.
+    // Render empty steps; populated before first progress event.
     this.installSteps.set([]);
     this.cdr.markForCheck();
 
@@ -522,14 +509,11 @@ export class PluginsComponent implements OnInit, OnDestroy {
         this.setStepStatus(STEP_EXTRACTING, 'active', p.message);
         break;
       case 'building':
-        // STEP_VERIFYING is already 'done' from the prior 'extracting' event;
-        // we only need to advance the immediately preceding step here.
         this.setStepStatus(STEP_EXTRACTING, 'done');
         this.setStepStatus(STEP_BUILDING, 'active', p.message);
         break;
       case 'done':
-        // Mark every step in the current list as done. The overlay closes
-        // after `install_plugin` resolves (in the finally block).
+        // Mark steps done; overlay closes after invoke resolves.
         this.installSteps.update((list) => list.map((s) => ({ ...s, status: 'done' as const })));
         break;
       case 'failed': {
@@ -541,9 +525,6 @@ export class PluginsComponent implements OnInit, OnDestroy {
         break;
       }
       case 'done_with_pending_build':
-        // Terminal informational state. After `failed` no steps remain
-        // pending, so there is nothing to mutate here — the overlay closes
-        // through the caller's `finally` block which clears `installing`.
         break;
     }
   }

--- a/desktop/src/src/app/project-switcher/project-pill.component.ts
+++ b/desktop/src/src/app/project-switcher/project-pill.component.ts
@@ -11,17 +11,7 @@ import { ProjectStateService } from '../services/project-state.service';
 import { UiStateService } from '../services/ui-state.service';
 import { swatchFor } from './project-swatch';
 
-/**
- * Project switcher trigger — the small monogram + name pill rendered in the
- * right slot of every view header (chat, settings, logs, plugins, etc.).
- *
- * Single source of truth for the pill so all views look and behave identically.
- * Reads the active project from {@link ProjectStateService} and toggles the
- * dropdown via {@link UiStateService.toggleProjectSwitcher}.
- *
- * Mockup reference: header right-cluster across all views (lines 488-506,
- * 1481-1492, 1636-1660).
- */
+/** Header pill showing the active project; opens the project switcher on click. */
 @Component({
   selector: 'app-project-pill',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -49,7 +39,7 @@ export class ProjectPillComponent implements OnInit, OnDestroy {
   readonly ui = inject(UiStateService);
   private readonly projectState = inject(ProjectStateService);
 
-  /** Active project name — kept in a signal so OnPush re-renders on change. */
+  /** Active project name. */
   protected readonly projectName = signal<string>('');
 
   /** Position of the active project in the list — drives the swatch. -1 when no project. */
@@ -67,7 +57,7 @@ export class ProjectPillComponent implements OnInit, OnDestroy {
 
   private unsubscribe: (() => void) | null = null;
 
-  /** Subscribes to project state changes so the pill label stays current. */
+  /** Subscribes to project state changes. */
   ngOnInit(): void {
     this.refresh();
     this.unsubscribe = this.projectState.onChange(() => this.refresh());

--- a/desktop/src/src/app/project-switcher/project-switcher.component.ts
+++ b/desktop/src/src/app/project-switcher/project-switcher.component.ts
@@ -49,8 +49,7 @@ export function cleanRemoveErrorMessage(msg: string): string {
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     @if (ui.projectSwitcherOpen()) {
-      <!-- Click-outside backdrop — closes the dropdown when clicking anywhere
-           outside it (mockup behaviour). Sits below the dropdown z-index. -->
+      <!-- Click-outside backdrop — closes the dropdown. -->
       <div
         class="fixed inset-0 z-[1000]"
         data-testid="project-switcher-backdrop"
@@ -193,11 +192,7 @@ export function cleanRemoveErrorMessage(msg: string): string {
   `,
 })
 export class ProjectSwitcherComponent implements OnInit, OnDestroy {
-  /**
-   * Backend-loaded list of projects, refreshed on settled events. Must be a
-   * signal — `visibleProjects` is a computed and would not recompute on a
-   * plain field reassignment, leaving the dropdown stale after `add_project`.
-   */
+  /** Backend-loaded list of projects, refreshed on settled events. */
   readonly projects = signal<ProjectEntry[]>([]);
   /** Slug of the currently active project — drives the "current" pill. */
   readonly activeProject = signal<string | null>(null);
@@ -229,9 +224,7 @@ export class ProjectSwitcherComponent implements OnInit, OnDestroy {
 
   /** Registers reactive cleanup of transient pending/error state. */
   constructor() {
-    // Reset transient pending/error state when the dropdown closes or when
-    // the row disappears from the list — otherwise reopening would render
-    // a stale "Sure?" confirm prompt or an error for a missing project.
+    // Reset transient pending/error state when the dropdown closes or the row disappears.
     effect(() => {
       if (!this.ui.projectSwitcherOpen()) {
         this.pendingDeleteName.set(null);

--- a/desktop/src/src/app/services/anthropic-models.service.spec.ts
+++ b/desktop/src/src/app/services/anthropic-models.service.spec.ts
@@ -35,11 +35,7 @@ const FIXTURE: AnthropicModel[] = [
   },
 ];
 
-// Pricing fields the real `list_anthropic_models` payload carries (the Rust
-// SSOT serialized). The mock returns them so the service can seed the pricing
-// index; the `AnthropicModel` type omits them, so cast on assignment. Rates
-// are deliberately off-catalog so the "seeds the pricing index" test proves
-// the backend numbers overrode the bootstrap seed.
+// Payload carries pricing fields the `AnthropicModel` type omits (cast on assignment); rates off-catalog.
 const PRICED_FIXTURE = FIXTURE.map((m) => ({
   ...m,
   pricing: { input: 9, cachedInput: 0.9, cacheWrite: 11.25, output: 45 },
@@ -113,14 +109,12 @@ describe('AnthropicModelsService', () => {
         cache_read_tokens: 0,
         cache_write_tokens: 0,
       };
-      // 1M input @ the off-catalog fixture rate ($9) — proves pricing.ts was
-      // populated from the backend payload, overriding the bootstrap seed ($5).
+      // 1M input @ the off-catalog fixture rate ($9), not the bootstrap seed ($5).
       expect(calculateCost('claude-opus-4-8', usage)).toBeCloseTo(9, 6);
     });
 
     afterEach(() => {
-      // Restore the bootstrap seed so off-catalog fixture rates don't leak
-      // into other specs that read pricing.ts.
+      // Restore the bootstrap seed so fixture rates don't leak into other specs.
       _resetPricingToSeedForTest();
     });
 
@@ -135,9 +129,7 @@ describe('AnthropicModelsService', () => {
     });
 
     it('does NOT cache on failure — the next call retries the backend', async () => {
-      // Regression: a transient failure used to cache `[]`, permanently
-      // emptying the model list. The cache must stay null so a recovered
-      // backend repopulates on the next call.
+      // Regression: a transient failure must not cache `[]`; cache stays null.
       let calls = 0;
       mockTauri.invokeHandler = async () => {
         calls++;
@@ -197,8 +189,7 @@ describe('AnthropicModelsService', () => {
     });
 
     it('skips Fable (premium tier) when picking the everyday placeholder', async () => {
-      // Fable 5 leads the catalog but costs 2x Opus — the placeholder must
-      // keep nudging users toward the balanced Sonnet tier.
+      // Fable 5 leads the catalog but is premium — placeholder must pick Sonnet.
       const withFable = [
         { id: 'claude-fable-5', family: 'Fable 5', context_tokens: 1_000_000, latest: true },
         { id: 'claude-opus-4-8', family: 'Opus 4.8', context_tokens: 1_000_000, latest: true },
@@ -213,8 +204,6 @@ describe('AnthropicModelsService', () => {
 
   describe('contextTokensFor()', () => {
     it('returns null before the catalog has loaded', () => {
-      // Pre-list() — cache empty by design so consumers can fall back without
-      // forcing a synchronous fetch.
       expect(service.contextTokensFor('claude-opus-4-7')).toBeNull();
     });
 
@@ -226,9 +215,7 @@ describe('AnthropicModelsService', () => {
     });
 
     it('resolves the short alias Claude Code emits in session metadata', async () => {
-      // Claude Code sometimes reports `opus-4.7` instead of `claude-opus-4-7`
-      // in the modelUsage chunk — the alias path replaces `.` with `-` and
-      // re-prepends `claude-`.
+      // Alias `opus-4.7`: `.` becomes `-`, `claude-` re-prepended.
       await service.list();
       expect(service.contextTokensFor('opus-4.7')).toBe(1_000_000);
       expect(service.contextTokensFor('haiku-4.5')).toBe(200_000);

--- a/desktop/src/src/app/services/anthropic-models.service.ts
+++ b/desktop/src/src/app/services/anthropic-models.service.ts
@@ -4,25 +4,12 @@ import { LoggerService } from './logger.service';
 import { AnthropicModel, DEFAULT_CONTEXT_TOKENS } from '../models/llm';
 import { setPricingCatalog, type PricedAnthropicModel } from '../chat/pricing';
 
-/**
- * Model-id prefixes for the premium tiers the everyday-placeholder hint skips
- * (Opus and Fable cost noticeably more than the balanced Sonnet tier). Add a
- * prefix here when a new premium family ships.
- */
+/** Model-id prefixes for the premium tiers the everyday-placeholder hint skips. */
 const PREMIUM_MODEL_ID_PREFIXES = ['claude-opus-', 'claude-fable-'] as const;
 
 /**
  * Frontend cache of the SSOT Anthropic model catalog served by the Rust
- * backend (`list_anthropic_models` Tauri command, sourced from
- * `speedwave_runtime::defaults::ANTHROPIC_MODELS`).
- *
- * The list never changes within a session, so we fetch it once and reuse the
- * cached promise — every call to `list()` returns the same in-memory array,
- * and `contextTokensFor()` is synchronous after the first call settles.
- *
- * On a transient backend failure the cache is left `null` (not `[]`) so the
- * next call retries — caching an empty list would permanently empty the model
- * dropdown and cost meter after one flaky invoke.
+ * backend (`list_anthropic_models`, from `defaults::ANTHROPIC_MODELS`).
  */
 @Injectable({ providedIn: 'root' })
 export class AnthropicModelsService {
@@ -32,10 +19,8 @@ export class AnthropicModelsService {
   private inflight: Promise<AnthropicModel[]> | null = null;
 
   /**
-   * Returns the model catalog. Fetches from the backend on first call;
-   * subsequent successful calls reuse the cached result. On failure (browser
-   * dev mode, transient IPC error) returns an empty list WITHOUT caching it,
-   * so a later call retries rather than being stuck with an empty catalog.
+   * Returns the model catalog, caching the first successful fetch. On failure
+   * returns an empty list WITHOUT caching, so a later call retries.
    */
   async list(): Promise<AnthropicModel[]> {
     if (this.cache) return this.cache;
@@ -45,13 +30,11 @@ export class AnthropicModelsService {
         const result = await this.tauri.invoke<AnthropicModel[]>('list_anthropic_models');
         if (Array.isArray(result)) {
           this.cache = result;
-          // Feed the cost meter's pricing index from the same SSOT payload —
-          // no model rates are hard-coded in the frontend.
+          // Feed the cost meter's pricing index from the same SSOT payload.
           setPricingCatalog(result as unknown as PricedAnthropicModel[]);
           return result;
         }
-        // Non-array payload is a contract violation — log and retry next call
-        // rather than poisoning the cache with a bad value.
+        // Non-array payload is a contract violation; not caching.
         this.logger.warn(
           `list_anthropic_models returned a non-array payload (${typeof result}); not caching`
         );
@@ -82,9 +65,7 @@ export class AnthropicModelsService {
     if (!trimmed) return null;
     const direct = this.cache.find((m) => m.id === trimmed);
     if (direct) return direct.context_tokens;
-    // Claude Code's session metadata sometimes carries the short form
-    // (`opus-4.7` instead of `claude-opus-4-7`). Try both shapes before
-    // giving up.
+    // Session metadata may carry the short form (`opus-4.7`); try prefixed too.
     const candidate = trimmed.startsWith('claude-')
       ? trimmed
       : `claude-${trimmed.replace('.', '-')}`;
@@ -104,13 +85,9 @@ export class AnthropicModelsService {
   }
 
   /**
-   * The model id the Settings free-text placeholder should hint at for the
-   * Anthropic provider: the latest non-premium entry (a Sonnet, the everyday
-   * balanced default) so we don't nudge users toward the costly premium tiers
-   * (`PREMIUM_MODEL_ID_PREFIXES`). Falls back to the first `latest` entry,
-   * then the first entry. Returns `null` while the catalog is loading (or
-   * empty) so the caller renders a blank placeholder rather than a stale
-   * hard-coded string.
+   * The Settings placeholder hint: the latest non-premium entry
+   * (`PREMIUM_MODEL_ID_PREFIXES`), falling back to the first `latest` then the
+   * first entry. Returns `null` while the catalog is loading or empty.
    */
   latestEverydayModelId(): string | null {
     if (!this.cache || this.cache.length === 0) return null;

--- a/desktop/src/src/app/services/chat-state.service.spec.ts
+++ b/desktop/src/src/app/services/chat-state.service.spec.ts
@@ -82,8 +82,7 @@ describe('ChatStateService', () => {
       // startChatSession is fire-and-forget — flush microtask queue
       await new Promise((r) => setTimeout(r, 0));
 
-      // A non-auth start_chat failure used to be silent (console.error only).
-      // It must now surface in the UI so the chat is not a dead surface.
+      // A non-auth start_chat failure surfaces in the UI.
       expect(projectState.status).toBe('error');
       expect(projectState.error).toContain('chat backend crashed');
       expect(mockLogger.error).toHaveBeenCalledWith(
@@ -185,8 +184,7 @@ describe('ChatStateService', () => {
         ],
       });
 
-      // Wire format: pure text with the `@…` reference — no `image`
-      // content block ever crosses stdin (avoids the OOM-killing path).
+      // Wire format: pure text with the `@…` reference, no `image` block on stdin.
       expect(spy).toHaveBeenCalledWith('send_message', {
         blocks: [
           {
@@ -1217,8 +1215,7 @@ describe('ChatStateService', () => {
 
   describe('session startup timeout', () => {
     it('shows error when startingSession does not clear within deadline', async () => {
-      // Directly invoke sendMessage without full init — we only need the
-      // retry path and the startingSession flag.
+      // Invoke sendMessage without full init.
       mockTauri.invokeHandler = async (cmd: string) => {
         if (cmd === 'send_message') throw new Error('no active session');
         return undefined;
@@ -1227,15 +1224,7 @@ describe('ChatStateService', () => {
       // Simulate startingSession permanently stuck true
       (service as unknown as { startingSession: boolean }).startingSession = true;
 
-      // Mock Date.now to make the deadline expire immediately.
-      // sendMessage calls: (1) user-msg timestamp, (2) deadline = Date.now() + 30_000,
-      // (3+) while-loop condition Date.now() < deadline.
-      // Track Date.now() calls.  We need the deadline setup call to
-      // return `base` and all subsequent calls to return past the
-      // deadline.  Use a generous threshold: the first 5 calls return
-      // base (covers user-msg timestamp, notifyChange(), deadline setup,
-      // plus any framework overhead).  After that, jump past the
-      // deadline so the while loop exits on the next iteration.
+      // First 5 Date.now() calls return base, the rest return past the deadline.
       const base = 1000000;
       let nowCall = 0;
       const spy = vi.spyOn(Date, 'now').mockImplementation(() => {
@@ -2279,9 +2268,7 @@ describe('ChatStateService', () => {
   });
 
   describe('resolveContextWindow priority chain', () => {
-    // resolveContextWindow is private; the chain is exercised through the
-    // public surface (Result-chunk handler / seedResumedSession). We hit it
-    // here through a controlled cast for direct assertions on each tier.
+    // resolveContextWindow is private; cast to assert on each tier directly.
     type Internal = {
       resolveContextWindow: (live: number | undefined, model: string | undefined) => number;
       _persistedContextTokens: number | null;

--- a/desktop/src/src/app/services/chat-state.service.ts
+++ b/desktop/src/src/app/services/chat-state.service.ts
@@ -86,39 +86,15 @@ export class ChatStateService {
   private _model = '';
   private _rateLimit: RateLimitInfo | null = null;
   private _totalOutputTokens = 0;
-  /**
-   * Context window for the active model. `null` until populated from a
-   * stream value, SSOT lookup, persisted config, or the Anthropic default
-   * fallback. ADR-041 forbids guessing a value for local providers, so
-   * `null` propagates to the UI and the footer hides the `used / max` ratio
-   * rather than showing 200K.
-   */
+  /** Context window for the active model; `null` until populated or if unknown. */
   private _contextWindowSize: number | null = null;
-  /**
-   * Active LLM provider id from `get_llm_config().provider`. Drives the
-   * "is local?" check in `resolveContextWindow` — Anthropic gets the
-   * DEFAULT_CONTEXT_TOKENS bottom fallback; local providers do not.
-   */
+  /** Active LLM provider id from `get_llm_config().provider`. */
   private _currentProvider: string | null = null;
 
-  /**
-   * Last-known persisted context window from `claude.llm.context_tokens`
-   * (`get_llm_config`). Refreshed on init / project change / explicit
-   * `refreshLlmConfigCache()` calls (Settings invokes that after save).
-   * Populated from the real provider API for local providers
-   * (Ollama / LM Studio / llama.cpp) and from the SSOT for Anthropic, so
-   * the chat footer can show an accurate `used / max` ratio before any
-   * stream-level value lands.
-   */
+  /** Last-known persisted context window from `claude.llm.context_tokens`. */
   private _persistedContextTokens: number | null = null;
 
-  /**
-   * Monotonically increasing turn id. Bumped by both `sendMessage` (new turn
-   * starts) and `stopConversation` (turn cancelled). Used across awaits by
-   * `submitAnswer` to detect whether the turn it was answering has since
-   * been superseded, so late backend errors from the dying turn can be
-   * suppressed.
-   */
+  /** Monotonically increasing turn id; bumped on `sendMessage` and `stopConversation`. */
   private _turnId = 0;
   /** Test-only read access. */
   get turnId(): number {
@@ -136,22 +112,12 @@ export class ChatStateService {
   private log = inject(LoggerService);
   private unsubProjectChange: (() => void) | null = null;
 
-  /**
-   * ADR-042 — full state-tree signal. Rebuilt from the legacy
-   * `_messages`/`_currentBlocks` fields by `rebuildStateTree()` after
-   * every mutation — the single pipeline feeding the signal projections.
-   */
+  /** ADR-042 — full state-tree signal, rebuilt after every mutation. */
   private readonly _state = signal<ConversationStateTree>({ ...DEFAULT_STATE_TREE });
   /** Public read-only signal exposed to components. */
   readonly state: Signal<ConversationStateTree> = this._state.asReadonly();
 
-  /**
-   * ADR-042 — Project the state-tree's committed entries onto the legacy
-   * `ChatMessage[]` shape so components can read state-tree as their
-   * source of truth without changing their templates. The trailing
-   * "live streaming" entry (no committed UUID, no meta) is excluded —
-   * `currentBlocksFromState` exposes it separately for the streaming view.
-   */
+  /** ADR-042 — committed state-tree entries projected onto `ChatMessage[]`. */
   readonly messagesFromState: Signal<readonly ChatMessage[]> = computed(() =>
     stateEntriesToChatMessages(this._state().entries)
   );
@@ -159,25 +125,14 @@ export class ChatStateService {
   /** ADR-042 — projection of `state().is_streaming` onto a signal. */
   readonly isStreamingFromState: Signal<boolean> = computed(() => this._state().is_streaming);
 
-  /**
-   * Signal mirror of {@link canRetryLastAssistant}. Backed by the same
-   * `_state` projection that drives `messagesFromState`, so OnPush
-   * components binding `[disabled]="!retryEnabled()"` re-evaluate without
-   * a manual `markForCheck` whenever the retry anchor flips.
-   */
+  /** Signal mirror of {@link canRetryLastAssistant}. */
   readonly retryEnabled: Signal<boolean> = computed(() => {
     const tree = this._state();
     if (tree.is_streaming || !tree.session_id) return false;
     return findRetryAnchorIn(tree.entries, 'committed') !== null;
   });
 
-  /**
-   * ADR-042 — projection of the live (uncommitted) trailing entry's blocks.
-   * "Live" means: the trailing entry is an assistant turn that has no
-   * meta yet (Result hasn't fired) AND no committed UUID. Once Result
-   * settles meta or commits the UUID the entry is no longer live and
-   * its blocks belong on `messagesFromState` instead.
-   */
+  /** ADR-042 — projection of the live (uncommitted) trailing entry's blocks. */
   readonly currentBlocksFromState: Signal<readonly MessageBlock[]> = computed(() => {
     const entries = this._state().entries;
     const last = entries[entries.length - 1];
@@ -210,22 +165,12 @@ export class ChatStateService {
     if (state.pendingQueue !== undefined) this._pendingQueue = state.pendingQueue;
   }
 
-  /**
-   * Rebuilds the state-tree signal from the post-mutation legacy fields so
-   * the `state()` projections (`messagesFromState`, `currentBlocksFromState`,
-   * `isStreamingFromState`, `pendingQueueFromState`) stay in lockstep with
-   * the legacy mutation methods (ADR-042/043). Components read the signal
-   * projections; OnPush picks up the change automatically.
-   */
+  /** Rebuilds the state-tree signal from legacy fields after a mutation. */
   private notifyChange(): void {
     this.rebuildStateTree();
   }
 
-  /**
-   * Project the legacy fields onto a fresh `ConversationStateTree` and
-   * write it to `_state`. Called from `notifyChange()` so the signal
-   * always reflects the latest mutation.
-   */
+  /** Project legacy fields onto a fresh `ConversationStateTree` and write `_state`. */
   private rebuildStateTree(): void {
     this._state.set(
       buildStateTreeFromLegacy({
@@ -455,14 +400,10 @@ export class ChatStateService {
   }
 
   /**
-   * Records one slot's answer for a multi-question AskUserQuestion block
-   * Optimistically advances the block's `current_index` to the
-   * next unanswered slot, then forwards to the host. On error, reverts the
-   * slot and appends an error block.
+   * Records one slot's answer for a multi-question AskUserQuestion block.
    * @param toolUseId   tool_use_id of the AskUserQuestion control_request.
    * @param questionIdx slot index being answered (0-based).
-   * @param value       chosen value (single string; multi-select labels are
-   *                    pre-joined with `", "` by the renderer).
+   * @param value       chosen value (multi-select labels pre-joined with `", "`).
    */
   async submitAnswer(toolUseId: string, questionIdx: number, value: string): Promise<void> {
     const capturedTurn = this._turnId;
@@ -533,16 +474,10 @@ export class ChatStateService {
     // 1. Invalidate any in-flight / buffered stream events from the dying turn.
     this._turnId += 1;
 
-    // 2. Synchronous UI reset — must precede any await so re-entrant calls see
-    //    isStreaming=false and early-return (prevents double invoke of stop_chat).
+    // 2. Synchronous UI reset, before any await, so re-entrant calls early-return.
     this.isStreaming = false;
 
-    // 3. Preserve the partial assistant reply but drop ask_user blocks and
-    //    finalize running tool_use blocks. The interrupt aborts the in-flight
-    //    turn; Claude will not answer any rendered question (the matching
-    //    tool_use_id is abandoned), so ask_user is unanswerable. Running tools
-    //    would otherwise render a permanent "running" spinner inside a closed
-    //    message — flip them to status: 'error' with an "Interrupted" marker.
+    // 3. Keep the partial reply; drop ask_user blocks; mark running tools errored.
     const keptBlocks = this._currentBlocks
       .filter((b) => b.type !== 'ask_user')
       .map((b) => {
@@ -672,10 +607,7 @@ export class ChatStateService {
 
       case 'Result': {
         if (chunk.data.result_text) {
-          // Only append result_text when no streamed text blocks exist yet.
-          // Claude Code always copies the full response into `result`, so for
-          // normal turns the text was already streamed via Text deltas.  Slash
-          // commands (e.g. /cost) produce *only* a result — no text deltas.
+          // Append result_text only when no streamed text blocks exist (e.g. slash commands).
           const hasStreamedText = this._currentBlocks.some((b) => b.type === 'text');
           if (!hasStreamedText) {
             this._currentBlocks = [
@@ -722,10 +654,7 @@ export class ChatStateService {
       }
 
       case 'UserMessageCommit': {
-        // ADR-046: the parser has seen `user.message.id` for the most recent
-        // user prompt. Commit it onto the last user entry that still lacks a
-        // UUID — walking from the end handles out-of-order arrivals where the
-        // commit chunk lands after several intermediate events.
+        // ADR-046: commit the parsed UUID onto the last user entry missing one.
         const uuid = chunk.data.uuid;
         const idx = findLastUserIndexMissingUuid(this._messages);
         if (idx >= 0) {
@@ -758,10 +687,7 @@ export class ChatStateService {
         break;
 
       case 'QueueDrained': {
-        // ADR-045: backend sent the queued payload to stdin as the next
-        // turn. Mirror that into local state so the composer's "queued: …"
-        // line clears, and synthesise the user entry so the streamed
-        // response below has its retry anchor in place.
+        // ADR-045: backend sent the queued payload to stdin; mirror to local state.
         this._pendingQueue = null;
         this._messages = [
           ...this._messages,
@@ -810,10 +736,7 @@ export class ChatStateService {
   }
 
   /**
-   * Seeds the session id immediately after a resume so retry / queue can run
-   * without waiting for the first `Result` event. Stamps a minimal stats
-   * object — token counters / cost stay zero until the next live turn fills
-   * them in.
+   * Seeds the session id after a resume so retry / queue can run before the first `Result`.
    * @param sessionId - Resumed JSONL session uuid.
    */
   seedResumedSession(sessionId: string): void {
@@ -833,15 +756,9 @@ export class ChatStateService {
   }
 
   /**
-   * Queue a message to be sent as the next turn (ADR-045). Replace
-   * semantics — calling this while a slot is already occupied displaces the
-   * previous queued message and returns its preview text. Returns `null`
-   * when the slot was empty before this call.
-   *
-   * The composer calls this when the user hits send while
-   * `isStreaming === true`. Backend drains the slot when the running turn
-   * emits its `Result` event.
+   * Queue a message as the next turn (ADR-045); replace semantics.
    * @param text - The message to queue.
+   * @returns the displaced queued text, or `null` if the slot was empty.
    */
   async queueMessage(text: string): Promise<string | null> {
     const sessionId = this._sessionStats?.session_id;
@@ -860,16 +777,11 @@ export class ChatStateService {
     }
   }
 
-  /**
-   * Cancel the queued message for the active session. No-op when no slot
-   * is occupied or no session is active. Composer wires this to the X
-   * button on the "queued: …" preview line.
-   */
+  /** Cancel the queued message for the active session; no-op when empty. */
   async cancelQueuedMessage(): Promise<void> {
     const sessionId = this._sessionStats?.session_id;
     if (!sessionId) {
-      // No session yet — but local slot may still be set if we got ahead
-      // of the first Result. Clear locally either way.
+      // No session yet — clear the local slot anyway.
       this._pendingQueue = null;
       this.notifyChange();
       return;
@@ -884,16 +796,9 @@ export class ChatStateService {
   }
 
   /**
-   * Copies the textual content of the message at `index` to the system
-   * clipboard via Angular CDK's `Clipboard` service. Returns `true` on
-   * success, `false` on failure (out-of-range index, empty content, write
-   * rejection). Block kinds that carry no user-facing prose — `tool_use`,
-   * `thinking`, `ask_user` — are elided; `text` and `error` blocks are
-   * joined with a blank line.
-   *
-   * The component layer owns the "copied" indicator timing so this method can
-   * stay pure and testable.
+   * Copies the message at `index` to the clipboard; elides tool/thinking/ask_user blocks.
    * @param index - Index into `messages` of the entry to copy.
+   * @returns `true` on success, `false` on out-of-range / empty / write failure.
    */
   copyMessage(index: number): boolean {
     const msg = this._messages[index];
@@ -907,26 +812,12 @@ export class ChatStateService {
     return ok;
   }
 
-  /**
-   * Returns whether the last assistant turn can be retried (ADR-046).
-   * Requires:
-   *   - not streaming (would race with the live turn),
-   *   - a session id from the most recent Result chunk,
-   *   - a user entry preceding the last assistant entry whose UUID is committed.
-   *
-   * The component layer reads this on every change-detection cycle to gate
-   * the retry button — it must be cheap and side-effect free.
-   */
+  /** Returns whether the last assistant turn can be retried (ADR-046). */
   canRetryLastAssistant(): boolean {
     return this.findRetryAnchor() !== null;
   }
 
-  /**
-   * Walks the message list from the end to find the retry anchor: the user
-   * entry immediately preceding the last committed assistant entry. Returns
-   * `null` when no such pair exists, when streaming, or when the session id
-   * is missing.
-   */
+  /** Finds the retry anchor: user entry before the last committed assistant entry. */
   private findRetryAnchor(): {
     sessionId: string;
     userUuid: string;
@@ -940,16 +831,7 @@ export class ChatStateService {
     return anchor === null ? null : { sessionId, ...anchor };
   }
 
-  /**
-   * Retries the last assistant turn via the backend `retry_last_turn` Tauri
-   * command (ADR-046). Trims the last assistant entry from local state,
-   * stamps `edited_at` on the anchor user entry, flips `isStreaming` so the
-   * input bar disables and the next stream chunks are accepted, and asks the
-   * backend to relaunch Claude Code with `--resume-session-at`.
-   *
-   * On backend failure the optimistic state changes are reverted and an error
-   * block is appended so the user sees what went wrong.
-   */
+  /** Retries the last assistant turn via the backend `retry_last_turn` command (ADR-046). */
   async retryLastAssistant(): Promise<void> {
     const anchor = this.findRetryAnchor();
     if (!anchor) return;
@@ -1012,11 +894,7 @@ export class ChatStateService {
   }
 
   /**
-   * Fallback chain for the chat footer's context-window value.
-   * Order: live stream value → Anthropic SSOT lookup → persisted
-   * `claude.llm.context_tokens` → previous `_contextWindowSize` → for
-   * Anthropic only: {@link DEFAULT_CONTEXT_TOKENS}. Local providers
-   * propagate `null` instead — ADR-041 "never guess".
+   * Context-window fallback: live → SSOT → persisted → previous → Anthropic default; local stays `null`.
    * @param liveValue - Authoritative value carried by the stream (highest priority).
    * @param model - Resolved model id used for the SSOT lookup.
    */
@@ -1032,28 +910,19 @@ export class ChatStateService {
     return isLocalProvider(this._currentProvider) ? null : DEFAULT_CONTEXT_TOKENS;
   }
 
-  /**
-   * Re-reads `get_llm_config().context_tokens` from the backend and updates
-   * the cache used by the chat fallback chain. Public so Settings can call
-   * it after `update_llm_config` settles — without that, the chat footer
-   * would keep showing the previous model's window until the next session.
-   */
+  /** Re-reads `get_llm_config()` and updates the chat fallback-chain cache. */
   async refreshLlmConfigCache(): Promise<void> {
     try {
       const config = await this.tauri.invoke<LlmConfigResponse>('get_llm_config');
       this._persistedContextTokens = config.context_tokens ?? null;
       this._currentProvider = config.provider;
-      // If we have no live stream value yet, surface the persisted one
-      // through `_contextWindowSize` so the next `notifyChange` rebuilds
-      // session stats with the right `used / max`.
+      // With no live stream value, surface the persisted one.
       if (this._persistedContextTokens && !this._sessionStats?.usage) {
         this._contextWindowSize = this._persistedContextTokens;
       }
       this.notifyChange();
     } catch (err) {
-      // Browser dev mode or backend unavailable — log so backend renames /
-      // serialisation regressions surface during development without
-      // disrupting the UI.
+      // Browser dev mode or backend unavailable.
       this.log.debug(`[chat-state] refreshLlmConfigCache failed: ${String(err)}`);
     }
   }
@@ -1069,12 +938,7 @@ export class ChatStateService {
           this.handleStreamChunk(chunk);
           return;
         }
-        // Content-bearing chunks belong to a specific turn. If isStreaming is
-        // false (stopConversation already ran, or the turn already finished),
-        // drop the chunk so it cannot write into _messages or flip isStreaming
-        // back on. That single check is sufficient in single-threaded JS:
-        // stopConversation sets isStreaming = false synchronously before any
-        // await, so every subsequent event-loop tick observes the reset.
+        // Drop content-bearing chunks when not streaming.
         if (!this.isStreaming) return;
         this.handleStreamChunk(chunk);
       });
@@ -1099,13 +963,7 @@ function appendOrCreateTextBlock(blocks: MessageBlock[], content: string): Messa
 }
 
 function appendOrCreateThinkingBlock(blocks: MessageBlock[], content: string): MessageBlock[] {
-  // Anthropic returns redacted thinking blocks by default for Opus 4.7
-  // (and others when summaries are not requested) — the model still does
-  // the reasoning, but the streamed `thinking` text is empty and only the
-  // signature (encrypted thinking, used for multi-turn continuity) is sent.
-  // Skip empty deltas so we don't render an empty collapsible. If the API
-  // ever sends a non-empty delta later in the same turn, we still attach
-  // it to a fresh thinking block.
+  // Anthropic returns redacted thinking blocks by default; skip empty deltas.
   if (!content) return blocks;
   const last = blocks[blocks.length - 1];
   if (last && last.type === 'thinking') {
@@ -1125,11 +983,7 @@ function updateToolInput(blocks: MessageBlock[], toolId: string, delta: string):
 }
 
 /**
- * Builds per-turn metadata for the assistant entry just finalized by a
- * `Result` chunk. Prefers the backend's authoritative `turn_cost`; falls
- * back to `calculateCost()` against the per-model pricing table when the
- * backend didn't provide it. Returns `undefined` when the chunk carries
- * no usage or model information.
+ * Builds per-turn metadata for the assistant entry finalized by a `Result` chunk.
  * @param data - Relevant fields copied from the `Result` chunk payload.
  * @param data.turn_usage - Per-turn token usage (required for fallback cost).
  * @param data.turn_cost - Authoritative per-turn cost from the backend.
@@ -1137,14 +991,7 @@ function updateToolInput(blocks: MessageBlock[], toolId: string, delta: string):
  * @param resolvedModel - Model id already resolved by the reducer.
  */
 /**
- * Locates the retry anchor — the (assistant, user) pair at the tail of
- * `entries` whose user entry can be replayed via `retry_last_turn`
- * (ADR-046). Returns the matched indices and the user uuid, or `null`.
- *
- * `committedTag` is parametrised because the legacy ChatMessage shape
- * uses 'Committed' while the state-tree shape uses 'committed'. An
- * `undefined` `uuid_status` is treated as committed for backward
- * compatibility with pre-ADR-046 transcript entries.
+ * Locates the retry anchor: the (assistant, user) pair replayable via `retry_last_turn` (ADR-046).
  * @param entries - Conversation entries in order, oldest first.
  * @param committedTag - The literal value that means "uuid is durable".
  */
@@ -1225,10 +1072,7 @@ function completeToolBlock(
 }
 
 /**
- * Returns the index of the most recent user entry that has not yet had a UUID
- * committed onto it (ADR-046). Returns -1 when no such entry exists. Walking
- * from the end is correct because `UserMessageCommit` chunks always belong to
- * the latest pending user prompt — earlier prompts already carry their UUIDs.
+ * Index of the most recent user entry missing a UUID, or -1 if none (ADR-046).
  * @param msgs - Snapshot of `_messages` at the time the commit chunk arrives.
  */
 function findLastUserIndexMissingUuid(msgs: readonly ChatMessage[]): number {
@@ -1250,11 +1094,7 @@ export interface LegacyStateSnapshot {
 }
 
 /**
- * Project legacy ChatStateService fields onto a `ConversationStateTree`.
- *
- * This projection is the single pipeline feeding the `state()` signal
- * (ADR-042 status note): it rebuilds the tree from the legacy fields
- * after every mutation so the projections never drift.
+ * Project legacy ChatStateService fields onto a `ConversationStateTree` (ADR-042).
  * @param src - Snapshot of legacy backing fields.
  */
 export function buildStateTreeFromLegacy(src: LegacyStateSnapshot): ConversationStateTree {
@@ -1390,10 +1230,7 @@ export function stateBlocksToMessageBlocks(blocks: readonly MessageBlockState[])
         out.push({ type: 'image', media_type: b.media_type, alt: b.alt ?? undefined });
         break;
       default: {
-        // A new Rust MessageBlock variant landed without a TS arm here
-        // (ADR-042 SSOT-alignment drift). Surface a placeholder instead of
-        // silently dropping it, and forward to the log pipeline so the gap
-        // is visible in a diagnostics ZIP.
+        // Unknown Rust MessageBlock variant with no TS arm (ADR-042 drift).
         const unknownKind = (b as { kind: string }).kind;
         pluginLogWarn(
           `[chat-state] stateBlocksToMessageBlocks: dropping unknown block kind "${unknownKind}"`
@@ -1466,11 +1303,7 @@ export function messageBlocksToState(blocks: readonly MessageBlock[]): MessageBl
 }
 
 /**
- * Flattens a message's blocks into a copy-friendly plain-text string. Tool
- * inputs and outputs are intentionally elided — the user wants the assistant's
- * prose, not the JSON of every Bash command. Thinking blocks, ask_user, and
- * tool_use are dropped; text and error contents are concatenated with a blank
- * line between blocks for readability.
+ * Flatten blocks into plain text; elides tool inputs/outputs, thinking, and ask_user.
  * @param blocks - The message blocks to flatten.
  */
 export function blocksToPlainText(blocks: readonly MessageBlock[]): string {

--- a/desktop/src/src/app/services/health-store.service.ts
+++ b/desktop/src/src/app/services/health-store.service.ts
@@ -1,11 +1,7 @@
 import { Injectable, signal } from '@angular/core';
 import type { HealthReport } from '../models/health';
 
-/**
- * SSOT for the latest health snapshot. Written by the startup health gate
- * (ProjectStateService) and the polling loop (SystemHealthService), so views
- * render real data immediately instead of a "checking…" placeholder.
- */
+/** SSOT for the latest health snapshot. */
 @Injectable({ providedIn: 'root' })
 export class HealthStoreService {
   /** Latest health report; `null` until the first fetch lands. */

--- a/desktop/src/src/app/services/image-preprocessor.service.spec.ts
+++ b/desktop/src/src/app/services/image-preprocessor.service.spec.ts
@@ -16,9 +16,6 @@ describe('NATIVE_LONG_EDGE', () => {
 
 describe('limit constants', () => {
   it('per-image binary cap is 3 MiB (tidy + fast file read; ADR-065)', () => {
-    // Images go to disk under `<project>/.speedwave/pastes/` and Claude
-    // lazy-reads them through `@/workspace/...`. The cap is about keeping
-    // the project tidy and the file read fast — not about API limits.
     expect(MAX_IMAGE_BYTES).toBe(3 * 1024 * 1024);
   });
 });

--- a/desktop/src/src/app/services/image-preprocessor.service.ts
+++ b/desktop/src/src/app/services/image-preprocessor.service.ts
@@ -67,9 +67,7 @@ export class ImagePreprocessorService {
     const mediaType = file.type as SupportedMediaType;
 
     if (file.type === 'image/gif') {
-      // GIFs are not resampled (would lose animation). Size guard before
-      // hitting the host-side `MAX_PASTE_BYTES` so the user sees
-      // ERROR_TOO_LARGE instead of a raw backend error.
+      // GIFs are not resampled; size guard before host `MAX_PASTE_BYTES`.
       if (file.size > MAX_IMAGE_BYTES) {
         throw new Error(ERROR_TOO_LARGE);
       }
@@ -86,8 +84,6 @@ export class ImagePreprocessorService {
     const targetLongEdge = Math.min(longEdge, MAX_DIMENSION);
     let blob = await this.resample(file, dims, targetLongEdge);
     if (blob.size > MAX_IMAGE_BYTES && targetLongEdge !== NATIVE_LONG_EDGE.sonnet) {
-      // Second attempt only helps when the first pass used a larger edge
-      // (Opus → 2576 → 1568). Sonnet/Haiku already hit 1568 on attempt 1.
       blob = await this.resample(file, dims, NATIVE_LONG_EDGE.sonnet);
     }
     if (blob.size > MAX_IMAGE_BYTES) {

--- a/desktop/src/src/app/services/logger.service.spec.ts
+++ b/desktop/src/src/app/services/logger.service.spec.ts
@@ -3,15 +3,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
 import { LoggerService } from './logger.service';
 
-/**
- * The service is a thin wrapper around `@tauri-apps/plugin-log#error`.
- * `vi.mock` of that module is unreliable under `@angular/build:unit-test`
- * (the warning "is not at the top level of the module" surfaces and the
- * factory is occasionally applied AFTER the SUT's static imports), so the
- * test exercises the production code path that the runtime executes by
- * stubbing `__TAURI_INTERNALS__.invoke` — `pluginLogError` ultimately
- * forwards to `invoke('plugin:log|log', …)`.
- */
+/** Stubs `__TAURI_INTERNALS__.invoke`, which the wrapper forwards to via `invoke('plugin:log|log', …)`. */
 describe('LoggerService', () => {
   let service: LoggerService;
   let invokeSpy: ReturnType<typeof vi.fn>;
@@ -33,8 +25,7 @@ describe('LoggerService', () => {
   it('forwards the message to the Rust log pipeline as an error-level entry', async () => {
     service.error('boom');
 
-    // The plugin sends a microtask through `invoke` — yield once so the
-    // wrapper's `.catch(() => {})` chain can settle.
+    // Yield so the wrapper's `.catch(() => {})` chain can settle.
     await Promise.resolve();
     await Promise.resolve();
 
@@ -68,11 +59,7 @@ describe('LoggerService', () => {
   });
 
   // -- info / warn / debug levels --
-  // Each level forwards to the same `invoke('plugin:log|log', { message, level })`
-  // pipeline as `error` but with a different `level` integer. The plugin defines
-  // levels as Trace=1, Debug=2, Info=3, Warn=4, Error=5 (see @tauri-apps/plugin-log
-  // LogLevel enum). These tests pin the level integers so a future plugin
-  // version bump or accidental refactor (e.g. swapping info<>warn) is caught.
+  // LogLevel: Trace=1, Debug=2, Info=3, Warn=4, Error=5.
 
   it('forwards info-level messages with level=3', async () => {
     service.info('hello');

--- a/desktop/src/src/app/services/logger.service.ts
+++ b/desktop/src/src/app/services/logger.service.ts
@@ -8,28 +8,11 @@ import {
 
 /**
  * Thin wrapper around `@tauri-apps/plugin-log` for Angular dependency injection.
- *
- * Components inject this service rather than calling the plugin import directly so
- * tests can `useValue: { info, warn, error, debug: vi.fn() }` instead of trying
- * to mock the underlying ESM module — `vi.mock` hoisting is unreliable under
- * `@angular/build:unit-test`.
- *
- * All four levels forward to the same tauri-plugin-log pipeline configured in
- * `desktop/src-tauri/src/main.rs` (file + stdout + webview targets), so logs
- * written via this service show up in:
- *   - the Logs view inside the running app (webview target),
- *   - the rotated log file under `~/Library/Logs/pl.speedwave.desktop/` (file target),
- *   - the dev-mode terminal (stdout target).
- *
- * That makes a user-supplied logs ZIP a single source of truth when triaging
- * support tickets — UI events, Tauri command boundaries, and Swift CLI traces
- * all converge into one timeline.
  */
 @Injectable({ providedIn: 'root' })
 export class LoggerService {
   /**
-   * Forwards an error-level message to the Rust log pipeline. Logging failure
-   * must never crash the UI — the underlying promise rejection is swallowed.
+   * Forwards an error-level message to the Rust log pipeline.
    * @param message - The message to log.
    */
   error(message: string): void {
@@ -37,9 +20,7 @@ export class LoggerService {
   }
 
   /**
-   * Forwards a warn-level message — used for non-fatal anomalies the user
-   * (or future support reader) needs to see, e.g. an integration auto-disabled
-   * because TCC denied permission.
+   * Forwards a warn-level message to the Rust log pipeline.
    * @param message - The message to log.
    */
   warn(message: string): void {
@@ -47,9 +28,7 @@ export class LoggerService {
   }
 
   /**
-   * Forwards an info-level message — used for normal lifecycle events the
-   * support reader needs to reconstruct what the user did, e.g. a toggle
-   * click that succeeded.
+   * Forwards an info-level message to the Rust log pipeline.
    * @param message - The message to log.
    */
   info(message: string): void {
@@ -57,10 +36,7 @@ export class LoggerService {
   }
 
   /**
-   * Forwards a debug-level message — used for verbose diagnostic context that
-   * is too chatty for `info` but still helpful in a logs ZIP. The Rust log
-   * level filter (Trace by default — see `main.rs`) decides whether these
-   * land in the file.
+   * Forwards a debug-level message to the Rust log pipeline.
    * @param message - The message to log.
    */
   debug(message: string): void {

--- a/desktop/src/src/app/services/native-theme-adapter.spec.ts
+++ b/desktop/src/src/app/services/native-theme-adapter.spec.ts
@@ -30,8 +30,7 @@ describe('NativeThemeAdapter', () => {
   });
 
   it('attempts the native call when running inside Tauri', () => {
-    // Presence of the internals object flips the guard; the dynamic import of
-    // the window API then rejects under jsdom and is swallowed via .catch.
+    // Internals object flips the guard; dynamic import rejects under jsdom, swallowed via .catch.
     (window as unknown as Record<string, unknown>)['__TAURI_INTERNALS__'] = { invoke: vi.fn() };
     expect(() => adapter.syncWindowTheme('light')).not.toThrow();
   });

--- a/desktop/src/src/app/services/native-theme-adapter.ts
+++ b/desktop/src/src/app/services/native-theme-adapter.ts
@@ -4,22 +4,13 @@ import { LoggerService } from './logger.service';
 /** Effective (resolved) appearance — `auto` has already been collapsed to one of these. */
 export type EffectiveMode = 'light' | 'dark';
 
-/**
- * Bridges the resolved appearance mode to the native window chrome.
- *
- * Isolated from {@link ThemeService} so the service owns only signal state and
- * DOM/localStorage writes — the Tauri platform call lives here and can be
- * swapped or stubbed in tests. On macOS this drives the traffic-light glyph
- * appearance; on non-Tauri hosts (web preview, jsdom) it is a no-op.
- */
+/** Bridges the resolved appearance mode to the native window chrome (no-op on non-Tauri hosts). */
 @Injectable({ providedIn: 'root' })
 export class NativeThemeAdapter {
   private log = inject(LoggerService);
 
   /**
-   * Pushes the effective mode to the native window. Dynamically imports the
-   * Tauri window API so test runners without the runtime don't load the module.
-   * Best-effort: failures are logged, never thrown.
+   * Pushes the effective mode to the native window; best-effort, never throws.
    * @param effective Resolved light/dark mode to apply to the native window.
    */
   syncWindowTheme(effective: EffectiveMode): void {

--- a/desktop/src/src/app/services/plugin-bridge.service.ts
+++ b/desktop/src/src/app/services/plugin-bridge.service.ts
@@ -15,11 +15,7 @@ interface BridgeEventPayload {
     | 'pending_timeout';
 }
 
-/**
- * Tracks each host-bridge plugin's status via a `plugin_bridge_get_status`
- * snapshot plus live `plugin_bridge_event` updates so the UI sees `paired` /
- * `partner_connected` flip without polling. Other fields reflect the snapshot.
- */
+/** Tracks host-bridge plugin status via snapshot plus live `plugin_bridge_event` updates. */
 @Injectable({ providedIn: 'root' })
 export class PluginBridgeService implements OnDestroy {
   private readonly tauri = inject(TauriService);

--- a/desktop/src/src/app/services/project-state.service.spec.ts
+++ b/desktop/src/src/app/services/project-state.service.spec.ts
@@ -923,8 +923,7 @@ describe('ProjectStateService', () => {
 
       await service.restartContainers();
 
-      // justEnabled is null when no integration was just toggled — backend
-      // accepts an Option<String> and rolls back only the named service.
+      // justEnabled is null when no integration was just toggled.
       expect(spy).toHaveBeenCalledWith('restart_integration_containers', {
         project: 'test',
         justEnabled: null,
@@ -969,9 +968,7 @@ describe('ProjectStateService', () => {
       };
 
       const promise = service.restartContainers();
-      // restartContainers preloads worker-image estimates and registers an
-      // event listener before invoking the restart command; allow those
-      // microtasks to settle so resolveInvoke is bound.
+      // Allow microtasks to settle so resolveInvoke is bound.
       await new Promise((r) => setTimeout(r, 0));
       await new Promise((r) => setTimeout(r, 0));
 
@@ -1051,15 +1048,10 @@ describe('ProjectStateService', () => {
 
       await service.restartContainers();
 
-      // Slash cache must be invalidated so the next slash-menu open
-      // re-runs discovery — otherwise the chat composer keeps the
-      // pre-restart skill list (10-min cache).
+      // Slash cache must be invalidated before the next slash-menu open.
       expect(spy).toHaveBeenCalledWith('invalidate_slash_cache', { projectId: 'test' });
-      // onProjectReady must fire so the composer + chat re-fetch their
-      // per-project state with the new container set.
+      // onProjectReady/onProjectSettled fire so consumers re-fetch per-project state.
       expect(readyCallback).toHaveBeenCalled();
-      // onProjectSettled must fire too — integrations.component and
-      // project-switcher refresh through this listener path, not ready.
       expect(settledCallback).toHaveBeenCalled();
     });
 
@@ -1080,20 +1072,14 @@ describe('ProjectStateService', () => {
       await service.restartContainers();
 
       expect(service.restartError).toBe('boom');
-      // The post-success steps (cache invalidate + ready/settled fanout)
-      // MUST NOT run when the restart itself failed: state has not
-      // advanced, and firing ready could mask the error or trigger
-      // consumers to refetch stale data.
+      // Post-success steps must not run when restart fails — state has not advanced.
       expect(spy).not.toHaveBeenCalledWith('invalidate_slash_cache', expect.anything());
       expect(readyCallback).not.toHaveBeenCalled();
       expect(settledCallback).not.toHaveBeenCalled();
     });
 
     it('restartContainers still fires onProjectReady when invalidate_slash_cache itself fails', async () => {
-      // Regression guard: a future refactor that moves `restartedOk = true`
-      // inside the inner try would silently break the "ready fires even
-      // when invalidation fails" guarantee. The cache eventually expires,
-      // so the invalidate call is best-effort.
+      // Regression guard: ensures ready fires even when invalidation fails.
       service.requestRestart();
       mockTauri.invokeHandler = (cmd: string) => {
         if (cmd === 'invalidate_slash_cache') {

--- a/desktop/src/src/app/services/project-state.service.ts
+++ b/desktop/src/src/app/services/project-state.service.ts
@@ -49,21 +49,12 @@ export interface AuthStatusResponse {
   oauth_authenticated: boolean;
 }
 
-/**
- * SSOT for project lifecycle state. All project switching, adding,
- * container lifecycle, and reconcile status goes through this service.
- * Components subscribe to state changes instead of listening to Tauri
- * events directly.
- */
+/** SSOT for project lifecycle state (switching, adding, container lifecycle, reconcile). */
 @Injectable({ providedIn: 'root' })
 export class ProjectStateService {
   activeProject: string | null = null;
   targetProject: string | null = null;
-  /**
-   * All configured projects from `~/.speedwave/config.json`. Exposed so views
-   * can resolve the directory of the active project (e.g. for the
-   * project-pill tooltip) without re-invoking `list_projects` themselves.
-   */
+  /** All configured projects from `~/.speedwave/config.json`. */
   projects: ProjectEntry[] = [];
   status: ProjectStatus = 'loading';
   error = '';
@@ -71,16 +62,12 @@ export class ProjectStateService {
   restarting = false;
   restartError = '';
 
-  /**
-   * Service just toggled on, forwarded to backend for rollback on build fail.
-   * Tracks the most recent toggle only; rapid A→B enables overwrite to B.
-   */
+  /** Service just toggled on, forwarded to backend for rollback on build fail. */
   pendingJustEnabled: string | null = null;
 
   /**
    * Structured error kind set when a CloudStorage TCC failure is detected.
    * `'cloudstorage_tcc_required'` routes the shell to `<app-cloudstorage-modal>`.
-   * Reset to `undefined` at the start of every new project switch attempt.
    */
   errorKind?: 'cloudstorage_tcc_required';
   /** CloudStorage provider display name (e.g. "OneDrive") when errorKind is set. */
@@ -92,10 +79,7 @@ export class ProjectStateService {
   private tauri = inject(TauriService);
   private log = inject(LoggerService);
   private healthStore = inject(HealthStoreService);
-  /**
-   * Set of integration status re-fetchers registered by the integrations component;
-   * called after a failed restart so the toggled-on row reverts to reality.
-   */
+  /** Set of integration status re-fetchers, called after a failed restart. */
   private statusRefreshers: Array<() => void> = [];
   private changeListeners: Array<() => void> = [];
   private readyListeners: Array<() => void> = [];
@@ -181,12 +165,7 @@ export class ProjectStateService {
     }
   }
 
-  /**
-   * Re-fetch the configured project list so cached metadata
-   * (e.g. directories used by the project-pill tooltip) stays in sync after
-   * the user adds, renames, or switches projects. Fire-and-forget; failures
-   * leave the previous snapshot in place.
-   */
+  /** Re-fetch configured projects so cached metadata stays in sync after adds/renames/switches. */
   private async refreshProjectList(): Promise<void> {
     try {
       const refreshed = await this.tauri.invoke<ProjectList>('list_projects');

--- a/desktop/src/src/app/services/system-health.service.ts
+++ b/desktop/src/src/app/services/system-health.service.ts
@@ -8,18 +8,7 @@ import type { HealthReport } from '../models/health';
 /** How often the polling loop refreshes the health snapshot. */
 export const HEALTH_REFRESH_INTERVAL_MS = 5000;
 
-/**
- * Polls `get_health` and exposes the latest `HealthReport` as a signal so
- * any component can subscribe without managing the polling timer or
- * project-settled subscription itself.
- *
- * Lifetime is `'root'` — there is exactly one polling loop per app instance.
- * The loop starts on first `ensurePolling()` call and stops on `OnDestroy`.
- *
- * Extracted from `LogsViewComponent` so the SRP load on that component is
- * reduced and the same data is reusable from other views (system tray,
- * setup wizard) without duplicating polling logic.
- */
+/** Polls `get_health` and exposes the latest `HealthReport` as a signal. */
 @Injectable({ providedIn: 'root' })
 export class SystemHealthService implements OnDestroy {
   private readonly tauri = inject(TauriService);
@@ -35,12 +24,7 @@ export class SystemHealthService implements OnDestroy {
   private lastSerialised = '';
   private started = false;
 
-  /**
-   * Starts the polling loop on first call and returns the initial fetch
-   * promise so callers can `await` the first snapshot. Subsequent calls
-   * still return a promise that resolves immediately; they don't multiply
-   * the fetch rate or restart the timer.
-   */
+  /** Starts the polling loop on first call; returns the initial fetch promise. */
   ensurePolling(): Promise<void> {
     if (this.started) return Promise.resolve();
     this.started = true;
@@ -61,16 +45,13 @@ export class SystemHealthService implements OnDestroy {
       if (!report || typeof report !== 'object' || !('vm' in report) || !('ide_bridge' in report)) {
         return;
       }
-      // Skip the signal write when the snapshot is byte-identical to the
-      // previous one — OnPush descendants stay quiet between real changes.
+      // Skip the signal write when the snapshot is byte-identical to the previous one.
       const serialised = JSON.stringify(report);
       if (serialised === this.lastSerialised) return;
       this.lastSerialised = serialised;
       this.health.set(report);
     } catch (err) {
-      // Health is non-critical; keep the previous snapshot. Log at debug so the
-      // failure is visible in a diagnostics ZIP without spamming during the
-      // expected container-startup window (only when actually inside Tauri).
+      // Health is non-critical; keep the previous snapshot and log at debug level.
       if (this.tauri.isRunningInTauri()) {
         this.log.debug(`[SystemHealth] get_health failed: ${String(err)}`);
       }

--- a/desktop/src/src/app/services/tauri.service.spec.ts
+++ b/desktop/src/src/app/services/tauri.service.spec.ts
@@ -3,13 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { TauriService } from './tauri.service';
 
 /**
- * Verifies the thin wrapper around `@tauri-apps/api/*` by simulating the
- * Tauri runtime via a stubbed `__TAURI_INTERNALS__` object on `window`.
- * `vi.mock` of `@tauri-apps/api/core` is unreliable under
- * `@angular/build:unit-test` (the warning "is not at the top level of the
- * module" surfaces and the mock factory is occasionally applied AFTER the
- * SUT has imported the real module), so the test exercises the
- * production code path that the runtime actually executes.
+ * Simulates Tauri runtime via stubbed __TAURI_INTERNALS__ object on window.
  */
 describe('TauriService', () => {
   let service: TauriService;
@@ -46,8 +40,6 @@ describe('TauriService', () => {
 
       const result = await service.invoke('simple_cmd');
 
-      // Tauri's runtime normalises a missing args object to `{}` before
-      // forwarding to `__TAURI_INTERNALS__.invoke`.
       expect(mockInternals.invoke).toHaveBeenCalledWith('simple_cmd', {}, undefined);
       expect(result).toBe('result');
     });
@@ -61,9 +53,6 @@ describe('TauriService', () => {
 
   describe('listen()', () => {
     it('delegates to event listen and returns unlisten function', async () => {
-      // The event channel is registered through plugin:event|listen which
-      // resolves via the stubbed __TAURI_INTERNALS__.invoke. The first
-      // resolved value is the event id used to build the unlisten callback.
       mockInternals.invoke.mockResolvedValue(42);
       const handler = vi.fn();
 
@@ -84,8 +73,6 @@ describe('TauriService', () => {
 
       const result = await service.getVersion();
 
-      // `@tauri-apps/api/app` calls the plugin command with no args; the
-      // Tauri runtime normalises that to `{}`.
       expect(mockInternals.invoke).toHaveBeenCalledWith('plugin:app|version', {}, undefined);
       expect(result).toBe('1.2.3');
     });
@@ -98,7 +85,6 @@ describe('TauriService', () => {
     });
 
     it('returns true when __TAURI_INTERNALS__ is present', () => {
-      // beforeEach already installs the stub; assert the detection picks it up.
       expect(service.isRunningInTauri()).toBe(true);
     });
   });

--- a/desktop/src/src/app/services/theme.service.spec.ts
+++ b/desktop/src/src/app/services/theme.service.spec.ts
@@ -23,8 +23,7 @@ function mockMatchMedia(prefersDark: boolean): {
     matches: prefersDark,
     media: '(prefers-color-scheme: dark)',
     onchange: null,
-    // Honour `options.signal` like a real EventTarget so AbortController-based
-    // teardown is exercised faithfully by the tests.
+    // Honour `options.signal` like a real EventTarget.
     addEventListener: (
       _: string,
       fn: (e: MediaQueryListEvent) => void,
@@ -58,14 +57,7 @@ function mockMatchMedia(prefersDark: boolean): {
   };
 }
 
-/**
- * Build a fresh in-memory `Storage`-shaped object for each test. Some test
- * runner / Node combinations (notably odd-numbered Node releases under the
- * `--localstorage-file` experimental flag) leave the global `localStorage`
- * accessor with an unusable shape — `getItem` / `setItem` may be missing or
- * throw. Installing our own implementation per-test removes that variance
- * and gives us deterministic state regardless of jsdom version.
- */
+/** Build a fresh in-memory `Storage`-shaped object for each test. */
 function makeMemoryStorage(): Storage {
   const data = new Map<string, string>();
   return {
@@ -363,8 +355,7 @@ describe('ThemeService', () => {
       expect(THEME_MODES).toEqual(['light', 'dark', 'auto']);
     });
 
-    // Pins the literal the anti-FOUC script in index.html depends on — a rename
-    // of MODE_STORAGE_KEY without updating index.html would flash on every boot.
+    // Pins the literal the anti-FOUC script in index.html depends on.
     it('MODE_STORAGE_KEY matches the literal used by the anti-FOUC script', () => {
       expect(MODE_STORAGE_KEY).toBe('speedwave-theme-mode');
     });

--- a/desktop/src/src/app/services/theme.service.ts
+++ b/desktop/src/src/app/services/theme.service.ts
@@ -152,10 +152,7 @@ export class ThemeService implements OnDestroy {
           signal: this.abortController.signal,
         });
       } else if (typeof this.mediaQuery.addListener === 'function') {
-        // Legacy WebView fallback — addListener is deprecated but still required
-        // on older WebKit builds shipped in some Tauri targets. Cleaned up by
-        // the matching removeListener in ngOnDestroy (the AbortController only
-        // unregisters the addEventListener path).
+        // Legacy WebView fallback; cleaned up in ngOnDestroy
         this.mediaQuery.addListener(this.mediaListener);
       }
     }
@@ -164,8 +161,7 @@ export class ThemeService implements OnDestroy {
   /** Removes the matchMedia listener when the root service is torn down. */
   ngOnDestroy(): void {
     this.abortController.abort();
-    // Legacy fallback teardown — only needed when addEventListener was unavailable
-    // (otherwise the AbortController above already removed the listener).
+    // Legacy fallback teardown (only when addEventListener unavailable)
     if (this.mediaQuery && typeof this.mediaQuery.addEventListener !== 'function') {
       try {
         this.mediaQuery.removeListener?.(this.mediaListener);
@@ -197,10 +193,8 @@ export class ThemeService implements OnDestroy {
   }
 
   /**
-   * Resolves the effective mode, applies the DOM class, and syncs native chrome.
-   * Does NOT persist — the OS-driven `auto` listener calls this on every system
-   * theme change, and re-writing the unchanged `'auto'` value would be storage
-   * noise. Persistence lives in {@link setMode} (explicit user intent only).
+   * Resolves effective mode, applies DOM class, syncs native chrome.
+   * Does NOT persist; persistence is in {@link setMode} (explicit user intent only).
    * @param mode Mode to apply (light/dark/auto).
    */
   private applyMode(mode: ThemeMode): void {

--- a/desktop/src/src/app/services/transcription.service.ts
+++ b/desktop/src/src/app/services/transcription.service.ts
@@ -185,9 +185,7 @@ export class TranscriptionService {
   }
 
   /**
-   * Renders the transcript as markdown and sends it to Claude via the existing
-   * chat path. The UI should show a confirm dialog before calling this — the
-   * markdown leaves the machine.
+   * Renders the transcript as markdown and sends it to Claude via the chat path.
    * @param sessionId - the session to send.
    */
   async sendToChat(sessionId: string): Promise<void> {
@@ -293,7 +291,6 @@ export class TranscriptionService {
         break;
       case 'final_segments_ready':
         // The offline pass produced a higher-quality transcript; swap it in.
-        // Speaker IDs were already remapped server-side to keep user relabels.
         next.final_segments = ev.segments;
         next.speaker_names = pairsToRecord(ev.speaker_names);
         break;

--- a/desktop/src/src/app/services/ui-state.service.ts
+++ b/desktop/src/src/app/services/ui-state.service.ts
@@ -1,17 +1,6 @@
 import { Injectable, signal, type Signal } from '@angular/core';
 
-/**
- * SSOT for transient UI state shared across shell/chat views.
- *
- * Holds view-state signals that span components (conversations sidebar, memory
- * panel). Per terminal-minimal implementation prompt (Signals architecture):
- * view toggles live in a dedicated UI-state service with `providedIn: 'root'`.
- *
- * Consumers:
- * - `ShellComponent` binds the ⌘B / Ctrl+B keyboard shortcut to `toggleSidebar()`.
- * - `ChatComponent` renders `<app-memory-panel>` and `<app-conversations-sidebar>`
- *   driven by `memoryOpen()` / `sidebarOpen()`.
- */
+/** SSOT for transient UI state shared across shell/chat views (sidebar, memory, palette, project switcher toggles). */
 @Injectable({ providedIn: 'root' })
 export class UiStateService {
   private readonly sidebarOpenSignal = signal<boolean>(false);
@@ -31,11 +20,7 @@ export class UiStateService {
   /** Read-only signal reflecting the project switcher dropdown's open state. */
   readonly projectSwitcherOpen: Signal<boolean> = this.projectSwitcherOpenSignal.asReadonly();
 
-  /**
-   * Flips the conversations sidebar drawer between open and closed.
-   * Closes the memory drawer first — both share the left-edge anchor and
-   * cannot be open simultaneously without overlapping.
-   */
+  /** Flips the conversations sidebar drawer; closes the memory drawer first (shared left-edge anchor). */
   toggleSidebar(): void {
     this.sidebarOpenSignal.update((open) => {
       const next = !open;
@@ -44,10 +29,7 @@ export class UiStateService {
     });
   }
 
-  /**
-   * Flips the memory panel drawer between open and closed.
-   * Closes the conversations drawer first — both share the left-edge anchor.
-   */
+  /** Flips the memory panel drawer; closes the conversations drawer first (shared left-edge anchor). */
   toggleMemory(): void {
     this.memoryOpenSignal.update((open) => {
       const next = !open;

--- a/desktop/src/src/app/settings/advanced-section/advanced-section.component.ts
+++ b/desktop/src/src/app/settings/advanced-section/advanced-section.component.ts
@@ -8,11 +8,7 @@ import {
 import { CommonModule } from '@angular/common';
 import { TauriService } from '../../services/tauri.service';
 
-/**
- * Settings → Danger Zone. Diagnostics export and forced trace-level logging
- * live in the System health view (`/logs`); Settings only owns the
- * destructive factory-reset action now.
- */
+/** Settings → Danger Zone. Owns the factory-reset action. */
 @Component({
   selector: 'app-advanced-section',
   imports: [CommonModule],
@@ -77,12 +73,7 @@ export class AdvancedSectionComponent {
   private cdr = inject(ChangeDetectorRef);
   private tauri = inject(TauriService);
 
-  /**
-   * Performs a factory reset, destroying containers and VM.
-   * The backend calls app.restart() and never returns a response,
-   * so the lines after invoke() are unreachable in practice —
-   * they exist only as a safety net if restart behaviour changes.
-   */
+  /** Performs a factory reset, destroying containers and VM. */
   async resetEnvironment(): Promise<void> {
     this.resetting = true;
     try {

--- a/desktop/src/src/app/settings/auth-terminal.component.ts
+++ b/desktop/src/src/app/settings/auth-terminal.component.ts
@@ -14,8 +14,7 @@ import { LoggerService } from '../services/logger.service';
 
 /**
  * OAuth login instructions card.
- * Displays a copyable CLI command for the user to paste into their terminal,
- * then polls auth status to detect when login completes.
+ * Displays a copyable CLI command and polls auth status for completion.
  */
 @Component({
   selector: 'app-auth-terminal',
@@ -120,17 +119,15 @@ export class AuthTerminalComponent implements OnInit, OnDestroy {
         this.cdr.markForCheck();
       })
       .catch((err: unknown) => {
-        // Non-fatal: the Windows PowerShell hint just won't show. Login still
-        // works. Log so the failure isn't completely invisible.
+        // Non-fatal: the Windows PowerShell hint just won't show.
         this.log.warn(`auth-terminal: get_platform failed: ${String(err)}`);
       });
     this.startPolling();
   }
 
   /**
-   * Spawns the host's system terminal running `speedwave login` for the
-   *  active project. Does NOT cancel polling — `get_auth_status` still
-   *  detects when the user finishes the OAuth flow.
+   * Spawns the host terminal running `speedwave login`.
+   * Polling continues to detect login completion.
    */
   openTerminal(): void {
     this.opening = true;
@@ -189,9 +186,7 @@ export class AuthTerminalComponent implements OnInit, OnDestroy {
           this.done.emit(true);
         }
       } catch (err: unknown) {
-        // Expected while the container is still starting; log anything that
-        // doesn't look like that so a real regression (e.g. the command
-        // disappearing) leaves a trace instead of an infinite silent poll.
+        // Expected while the container is still starting; log anything else.
         const msg = typeof err === 'string' ? err : String(err);
         if (!/container|not running|starting/i.test(msg)) {
           this.log.debug(`auth-terminal: get_auth_status poll error: ${msg}`);

--- a/desktop/src/src/app/settings/llm-provider/llm-provider.component.spec.ts
+++ b/desktop/src/src/app/settings/llm-provider/llm-provider.component.spec.ts
@@ -20,11 +20,7 @@ const DEFAULT_BASE_URLS: Record<string, string> = {
 };
 
 /**
- * Drains pending microtasks. After triggering `ngOnInit`, the component fires
- * `loadConfig` as fire-and-forget; chained awaits inside it (auto-probe via
- * `discoverModels`) require multiple microtask cycles before the discovery
- * state settles. `whenStable` only flushes Zone tasks — these promises live
- * outside Zone in vitest, so we drain them explicitly.
+ * Drains pending non-Zone microtasks.
  * @param cycles - How many `await Promise.resolve()` ticks to drain.
  */
 async function flushMicrotasks(cycles = 10): Promise<void> {
@@ -218,8 +214,7 @@ describe('LlmProviderComponent', () => {
   });
 
   it('returns an empty Anthropic placeholder while the SSOT catalog is loading', () => {
-    // No catalog yet (reset in beforeEach) — must not flash a stale hard-coded
-    // model id; the hint is derived from the backend SSOT, blank until loaded.
+    // No catalog yet (reset in beforeEach) — placeholder is blank until the SSOT loads.
     component.provider = 'anthropic';
     expect(component.modelPlaceholder()).toBe('');
   });
@@ -339,9 +334,7 @@ describe('LlmProviderComponent', () => {
   });
 
   it('hot-reloads the proxy with the input-signal project, not projectState', async () => {
-    // T10 regression: saveConfig must read the active project from the
-    // activeProject() input, not ProjectStateService. When the active
-    // selection is unchanged, it hot-reloads litellm for that project.
+    // T10 regression: saveConfig reads the active project from the activeProject() input, not ProjectStateService.
     fixture.componentRef.setInput('activeProject', 'proj-from-input');
     const projectState = TestBed.inject(ProjectStateService);
     projectState.activeProject = 'wrong-project';
@@ -367,8 +360,7 @@ describe('LlmProviderComponent', () => {
   });
 
   it('writes provider keys before the config and aborts the config on key failure', async () => {
-    // T11 regression: a per-provider key write must precede update_llm_config,
-    // so a key failure leaves config and keys consistent (neither applied).
+    // T11 regression: a per-provider key write must precede update_llm_config.
     const errorSpy = vi.fn();
     component.errorOccurred.subscribe(errorSpy);
 
@@ -539,8 +531,7 @@ describe('LlmProviderComponent', () => {
     fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
 
-    // The unified-list redesign (ADR-073) drops the read-only base_url
-    // field for anthropic — routing is the proxy's concern, not the user's.
+    // The unified-list redesign (ADR-073) drops the read-only base_url field for anthropic.
     const baseUrlInput = fixture.nativeElement.querySelector(
       '[data-testid="settings-llm-base-url"]'
     );
@@ -552,10 +543,7 @@ describe('LlmProviderComponent', () => {
     const options = Array.from(modelEl.querySelectorAll('option')).map(
       (o) => (o as HTMLOptionElement).value
     );
-    // Default option (empty value, "let Claude Code choose") plus every
-    // catalog id served by the backend SSOT — the component must not add
-    // or drop entries on its own. Order mirrors the catalog: latest first,
-    // legacy after.
+    // Default option plus every backend-SSOT catalog id, latest first then legacy.
     expect(options).toEqual([
       '',
       'claude-fable-5',
@@ -568,13 +556,10 @@ describe('LlmProviderComponent', () => {
     const defaultLabel = (
       modelEl.querySelector('option[value=""]') as HTMLOptionElement
     )?.textContent?.trim();
-    // Default option carries the SSOT-resolved Opus family label so the
-    // user knows which model the alias-mode actually steers toward. The
-    // exact string is verified by the dedicated tests below.
+    // Default option carries the SSOT-resolved Opus family label (exact string verified below).
     expect(defaultLabel?.toLowerCase()).toContain('default');
 
-    // Latest entries land in an optgroup labelled "Latest" so users see
-    // the recommended families at the top.
+    // Latest entries land in an optgroup labelled "Latest".
     const latestGroup = modelEl.querySelector('optgroup[label="Latest"]') as HTMLOptGroupElement;
     expect(latestGroup).not.toBeNull();
     const latestIds = Array.from(latestGroup.querySelectorAll('option')).map(
@@ -595,8 +580,7 @@ describe('LlmProviderComponent', () => {
     );
     expect(legacyIds).toEqual(['claude-opus-4-7', 'claude-opus-4-6']);
 
-    // Labels carry the family + context window so users see the same
-    // ctx value the chat footer reports (1M for Opus 4.8, 200k for Haiku).
+    // Labels carry family + context window (1M for Opus 4.8, 200k for Haiku).
     const opus48Label = (
       modelEl.querySelector('option[value="claude-opus-4-8"]') as HTMLOptionElement
     )?.textContent?.trim();
@@ -609,10 +593,7 @@ describe('LlmProviderComponent', () => {
   });
 
   it('preserves a previously-saved model id that is no longer in the SSOT catalog', async () => {
-    // A user might have persisted a model id that has since been pulled
-    // from the catalog (deprecated, retired). Surface it as a stand-alone
-    // option marked "(not in catalog)" instead of silently resetting the
-    // selection — the UI must reflect what is actually in their config.
+    // A persisted-but-retired model id is surfaced as a "(not in catalog)" option, not reset.
     mockTauri.invokeHandler = async (cmd: string, args?: Record<string, unknown>) => {
       switch (cmd) {
         case 'get_llm_config':
@@ -649,10 +630,7 @@ describe('LlmProviderComponent', () => {
   });
 
   it('renders dynamic Default — <family> label when backend returns a label', async () => {
-    // Backend SSOT returns the Opus family label so the dropdown surfaces
-    // what `(default)` actually steers toward (alias mode → Opus 4.8 today).
-    // Anything but the dynamic form would hide the resolved model from the
-    // user — exactly the regression this PR fixes.
+    // Backend SSOT returns the Opus family label that `(default)` resolves to.
     component.ngOnInit();
     await fixture.whenStable();
     await flushMicrotasks();
@@ -669,9 +647,7 @@ describe('LlmProviderComponent', () => {
   });
 
   it('falls back to the generic placeholder when backend returns null', async () => {
-    // Older backends (or backends in dev mode without the new command)
-    // may return null. The component must keep the generic placeholder
-    // wording rather than render a broken half-string.
+    // When the backend returns null, the generic placeholder wording is kept.
     mockTauri.invokeHandler = async (cmd: string, args?: Record<string, unknown>) => {
       switch (cmd) {
         case 'get_llm_config':
@@ -910,9 +886,7 @@ describe('LlmProviderComponent', () => {
   });
 
   it('dedupes_provider_change_and_blur_on_same_url', async () => {
-    // While a probe is in-flight against URL X, a second trigger with the
-    // same URL must be deduped (return without invoking). Use a hanging
-    // promise so we can issue the second trigger before the first resolves.
+    // While a probe is in-flight against URL X, a second same-URL trigger is deduped.
     let resolveFirst: (v: string[]) => void = () => {};
     const hanging = new Promise<string[]>((resolve) => {
       resolveFirst = resolve;
@@ -933,8 +907,7 @@ describe('LlmProviderComponent', () => {
   });
 
   it('discards_stale_response_on_rapid_blur', async () => {
-    // First blur is slow; change URL; second blur returns fast. Final state
-    // must reflect the second URL, not the first.
+    // On rapid URL change, final state reflects the latest URL, not the stale slow response.
     let resolveFirst: (v: string[]) => void = () => {};
     const slow = new Promise<string[]>((r) => {
       resolveFirst = r;

--- a/desktop/src/src/app/settings/llm-provider/llm-provider.component.ts
+++ b/desktop/src/src/app/settings/llm-provider/llm-provider.component.ts
@@ -521,9 +521,7 @@ type DiscoveryState =
               }
               @if (entry.kind === 'open_router' && entry.models && entry.models.length > 0) {
                 <div class="flex items-center gap-2">
-                  <!-- Selection lives on the options: a [value] binding on the
-                       select applies before the async catalog options exist
-                       and the browser silently falls back to the first row. -->
+                  <!-- Selection lives on the options, not a [value] binding: catalog options load async. -->
                   <select
                     (change)="onExtraModelSelect(entry, $any($event.target).value)"
                     class="mono w-full rounded border border-[var(--line)] bg-[var(--bg-1)] px-2 py-1.5 text-[12px] text-[var(--ink)]"
@@ -1096,28 +1094,21 @@ export class LlmProviderComponent implements OnInit {
    */
   async onProviderChange(): Promise<void> {
     if (this.provider === this.lastKnownProvider) {
-      // Guard against redundant ngModelChange fires (HMR reinit, identical
-      // selection etc.) — don't wipe state on no-op.
+      // Guard against redundant ngModelChange fires — no-op.
       return;
     }
-    // Stash the URL we were just on so the user gets it back if they switch
-    // back to this provider during the same session (e.g. they typed :8001
-    // for llama.cpp, switched to Ollama to check something, came back — we
-    // restore :8001 instead of the hardcoded :8080 default).
+    // Cache the URL per provider to restore on switch back in the same session.
     const previousProvider = this.lastKnownProvider;
     if (previousProvider !== 'anthropic' && this.baseUrl) {
       this.baseUrlByProvider[previousProvider] = this.baseUrl;
     }
-    // Snapshot the anthropic model when leaving the card so it survives the
-    // round-trip and is restored below (symmetric with loadedLocalEntry).
+    // Snapshot the anthropic model when leaving the card so it is restored below.
     if (previousProvider === 'anthropic' && this.model) {
       this.loadedAnthropicModel = this.model;
     }
     this.lastKnownProvider = this.provider;
     this.discoveryCounter++;
-    // Clear stale state synchronously so the UI reflects the provider change
-    // immediately — even while the async default-URL fetch is in-flight.
-    // Model is provider-specific; restore the target's persisted one, else clear.
+    // Clear state now; model is provider-specific and restored from snapshot.
     this.model =
       this.provider === 'anthropic'
         ? (this.loadedAnthropicModel ?? '')
@@ -1125,9 +1116,7 @@ export class LlmProviderComponent implements OnInit {
     this.discoveryState = { kind: 'idle' };
     this.providerChange.emit(this.provider);
     this.cdr.markForCheck();
-    // Fetch the backend-authoritative default for the new provider if not yet cached.
-    // This keeps compose.rs as the SSOT and avoids duplicating URL strings here.
-    // Done AFTER the synchronous state reset above so the UI is consistent.
+    // Fetch backend-authoritative default if not cached (compose.rs is SSOT).
     if (this.provider !== 'anthropic' && !this.defaultBaseUrlsByProvider[this.provider]) {
       try {
         const freshDefault = await this.tauri.invoke<string | null>('get_default_base_url', {
@@ -1344,11 +1333,7 @@ export class LlmProviderComponent implements OnInit {
       }
     }
     for (const extra of this.extraProviders) {
-      // The rows are permanent UI; only configured ones are persisted (a
-      // bare compat row would also fail the backend's base-URL validation).
-      // hasKey reflects the post-save truth: an edited-then-cleared field
-      // drops the key, so the entry must record has_api_key:false (otherwise
-      // the rendered config keeps an os.environ ref the entrypoint can't fill).
+      // Only configured rows persist; hasKey drops when the field is cleared.
       const hasKey = extra.keyTouched ? extra.keyInput.trim() !== '' : extra.hasKey;
       const configured =
         extra.kind === 'open_ai_compat'
@@ -1432,22 +1417,14 @@ export class LlmProviderComponent implements OnInit {
     this.saved = false;
     try {
       const active = this.buildActive();
-      // If the user left baseUrl blank for the active local card, fall back to
-      // the provider default so compose can inject ANTHROPIC_BASE_URL. Anthropic
-      // and remote rows ignore the flat baseUrl, so null is correct there.
+      // Fall back to provider default if baseUrl blank; compose injects ANTHROPIC_BASE_URL.
       const effectiveBaseUrl =
         active.provider_id === 'local' ? this.baseUrl || this.defaultBaseUrl || null : null;
       // Input signal — the single project source (drives the restart below).
       const project = this.activeProject();
       // Reuse the cached auth state (loadAuthStatus) — no redundant round-trip.
       const anthropicHasApiKey = this.apiKeyConfigured;
-      // The flat provider/model/base_url fields are the legacy (kill-switch
-      // direct path) mirror and drive the backend's model-required gate. When
-      // a card is active they keep the card's provider verbatim (preserving a
-      // legacy alias like `ollama` the user hasn't migrated). When a REMOTE row
-      // is active they must NOT describe the local card's leftover state — send
-      // the remote id (neither 'local' nor 'anthropic', so the model-required
-      // gate doesn't fire); the v2 providers/active blocks carry routing.
+      // Flat fields mirror v2 providers/active for backend routing; remote row active = remote id.
       const activeIsRemote = this.extraProviders.some((p) => p.id === active.provider_id);
       const flatProvider = activeIsRemote ? active.provider_id : this.provider;
       const update: {
@@ -1473,10 +1450,7 @@ export class LlmProviderComponent implements OnInit {
       if (this.customHeadersTouched) {
         update.custom_headers = nullIfEmpty(this.customHeaders);
       }
-      // Write per-provider keys BEFORE persisting config (ADR-073: values
-      // bypass config.json). A key-write failure throws here, before the
-      // config commit, so the two never end up out of sync. State resets are
-      // deferred until every write + the config save succeed.
+      // Write keys before config so a failure prevents the config commit (ADR-073).
       const touchedExtras = this.extraProviders.filter((e) => e.keyTouched);
       for (const extra of touchedExtras) {
         await this.tauri.invoke('set_llm_provider_key', {
@@ -1486,11 +1460,7 @@ export class LlmProviderComponent implements OnInit {
       }
       await this.tauri.invoke('update_llm_config', { update });
 
-      // Everything persisted — now reset UI state to mirror what was saved.
-      // Mirror exactly what was persisted: if the save dropped the local entry
-      // (e.g. base_url cleared), forget the snapshot too — otherwise the stale
-      // entry would be re-pushed verbatim on the next save and resurrect a
-      // provider the user removed.
+      // Reset to mirror the save; a stale local entry would resurrect on the next save.
       const savedLocal = update.providers.find((p) => p.id === 'local');
       this.loadedLocalEntry = savedLocal ? { ...savedLocal } : null;
       for (const extra of touchedExtras) {
@@ -1499,9 +1469,7 @@ export class LlmProviderComponent implements OnInit {
         extra.keyTouched = false;
       }
       this.saved = true;
-      // Reset touched flags so subsequent saves don't re-send the credentials
-      // unless the user edits the fields again. Update the `has_*` flags
-      // optimistically based on what we just persisted.
+      // Reset touched flags; update the has_* flags from persisted values.
       if (this.apiKeyTouched) {
         this.hasApiKey = !!update.api_key;
         this.apiKey = '';
@@ -1512,15 +1480,10 @@ export class LlmProviderComponent implements OnInit {
         this.customHeaders = '';
         this.customHeadersTouched = false;
       }
-      // Push the freshly-persisted context_tokens into ChatStateService so
-      // the chat footer's `used / max` reflects the new model immediately,
-      // not after the next session start.
+      // Push context tokens so the chat footer updates immediately.
       void this.chatState.refreshLlmConfigCache();
       this.providerChange.emit(this.provider);
-      // Restart scope (ADR-073): the active provider/model lives in the
-      // claude env — changing it needs the full project restart. Anything
-      // else (keys, added/removed remote providers) only changes the litellm
-      // config: hot-reload the proxy and keep the claude session running.
+      // Provider/model change needs full restart; other changes = proxy reload (ADR-073).
       const activeKey = `${active.provider_id}|${active.model ?? ''}`;
       if (activeKey === this.loadedActiveKey && project) {
         try {
@@ -1581,38 +1544,27 @@ export class LlmProviderComponent implements OnInit {
       this.model = config.model || '';
       this.baseUrl = config.base_url || '';
       this.defaultBaseUrl = config.default_base_url || '';
-      // Seed the local-model context cache so a Save right after load
-      // (without re-running discovery) preserves the persisted value
-      // instead of nulling it out.
+      // Seed the context cache so a save preserves the persisted value without discovery.
       this.loadedLocalContextTokens =
         this.provider !== 'anthropic' ? (config.context_tokens ?? null) : null;
       this.hasApiKey = !!config.has_api_key;
       this.hasCustomHeaders = !!config.has_custom_headers;
       this.lastKnownProvider = this.provider;
-      // Seed the per-provider cache with the backend-authoritative default for
-      // the persisted provider so `isDefaultBaseUrl` can compare without a
-      // round-trip (backend is SSOT via get_default_base_url / compose.rs).
+      // Seed the cache with the backend-authoritative default for isDefaultBaseUrl.
       if (this.provider !== 'anthropic' && this.defaultBaseUrl) {
         this.defaultBaseUrlsByProvider[this.provider] = this.defaultBaseUrl;
       }
-      // Seed the per-provider URL cache with the persisted URL so switching away
-      // and back doesn't lose it.
+      // Seed the URL cache so switching away and back preserves the user's URL.
       if (this.provider !== 'anthropic' && this.baseUrl) {
         this.baseUrlByProvider[this.provider] = this.baseUrl;
       }
 
-      // v2 provider list (ADR-073): anthropic/local entries map onto the
-      // cards (already seeded from the legacy flat fields above, which
-      // sync_llm_legacy_fields keeps coherent); everything else becomes a
-      // remote row.
+      // v2 provider list: anthropic/local on cards, the rest become remote rows (ADR-073).
       this.loadedLocalEntry = (config.providers ?? []).find((p) => p.id === 'local') ?? null;
       if (this.loadedLocalEntry?.base_url && !this.baseUrlByProvider['local']) {
         this.baseUrlByProvider['local'] = this.loadedLocalEntry.base_url;
       }
-      // Anthropic model snapshot: prefer the v2 entry / active selection, then
-      // fall back to the flat field already seeded into this.model above (the
-      // v1 shape carries the model only there). Never clobber a model the flat
-      // path loaded.
+      // Anthropic model snapshot: prefer v2 entry / active, fall back to the flat field.
       const anthropicEntry = (config.providers ?? []).find((p) => p.id === 'anthropic');
       this.loadedAnthropicModel =
         anthropicEntry?.model ??
@@ -1636,9 +1588,7 @@ export class LlmProviderComponent implements OnInit {
           row.contextTokens = p.context_tokens ?? null;
         }
       }
-      // Resolve the active remote row, tolerating legacy generated ids
-      // (`openrouter-2`, suffixed compat): match by exact id first, then by
-      // the active entry's kind — the fixed rows absorbed that entry above.
+      // Resolve the active row by id first, then by kind for legacy generated ids.
       const activeId = config.active?.provider_id;
       const activeEntry = (config.providers ?? []).find((p) => p.id === activeId);
       const activeRow = activeId ? this.findExtraRow(activeId, activeEntry?.kind) : undefined;
@@ -1665,12 +1615,7 @@ export class LlmProviderComponent implements OnInit {
       }
     }
     this.cdr.markForCheck();
-    // Auto-probe only when the effective URL is a known-safe default. Any
-    // user-supplied URL (even one persisted in config) must NOT be probed
-    // silently — a cloned malicious repo could set base_url to an internal
-    // RFC1918 host, turning Settings open into an SSRF probe. The user must
-    // explicitly click Refresh or blur the Base URL field to trigger a probe
-    // against a non-default URL.
+    // Auto-probe only defaults; user-supplied URLs need an explicit trigger (SSRF mitigation).
     const effectiveUrl = this.baseUrl || this.defaultBaseUrl;
     const isSafeToAutoProbe =
       this.provider !== 'anthropic' &&

--- a/desktop/src/src/app/settings/llm-usage/llm-usage.component.spec.ts
+++ b/desktop/src/src/app/settings/llm-usage/llm-usage.component.spec.ts
@@ -199,8 +199,7 @@ describe('LlmUsageComponent metrics', () => {
 
   it('clamps cache hit rate to 100% when cache_read exceeds reported prompt tokens', async () => {
     const c = await makeComponent();
-    // Anthropic streamed records: prompt_tokens excludes cached → ratio could
-    // exceed 1 without the prompt+cache denominator and the clamp.
+    // Anthropic streamed records: prompt_tokens excludes cached.
     expect(c.cacheHitRate(bucket({ prompt_tokens: 100, cache_read: 20_000 }))).toBeLessThanOrEqual(
       1
     );

--- a/desktop/src/src/app/settings/llm-usage/llm-usage.component.ts
+++ b/desktop/src/src/app/settings/llm-usage/llm-usage.component.ts
@@ -56,15 +56,7 @@ const SHARE_COLORS = [
 /** Bars shown in the daily chart — the most recent month of activity. */
 export const DAILY_CHART_DAYS = 30;
 
-/**
- * LLM usage dashboard (ADR-073). Renders the aggregate returned by the
- * `get_llm_usage` Tauri command — the litellm callback JSONL is the single
- * source of truth here; per-session chat statistics (the stream-derived
- * numbers in `session-stats`) are intentionally NOT mixed in, the same
- * request would be counted twice.
- *
- * All charts are plain div/grid constructs — no chart library.
- */
+/** LLM usage dashboard (ADR-073). Renders the aggregate returned by the `get_llm_usage` Tauri command. */
 @Component({
   selector: 'app-llm-usage',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -320,11 +312,7 @@ export class LlmUsageComponent {
   /** Row labels of the heatmap, Monday-first. */
   readonly weekdayLabels = ['mo', 'tu', 'we', 'th', 'fr', 'sa', 'su'] as const;
 
-  /**
-   * Refetches whenever the bound project changes — covers the first render and
-   * an in-place project switch via the page's own project pill (the host keeps
-   * this instance alive, so a one-shot init would show stale data).
-   */
+  /** Refetches on project changes; covers initial render and in-place project switches. */
   constructor() {
     effect(() => {
       const project = this.project();
@@ -394,11 +382,7 @@ export class LlmUsageComponent {
   }
 
   /**
-   * Share of input tokens served from the provider's prompt cache, clamped to
-   * [0,1]. Anthropic-format streamed records report `prompt_tokens` EXCLUDING
-   * cached tokens, so cache_read can exceed it — the true denominator is then
-   * prompt + cache_read. Clamp guards against any remaining provider skew so
-   * the card never shows a nonsensical >100%.
+   * Share of input tokens from prompt cache, clamped to [0,1].
    * @param bucket - Aggregate bucket (totals or a table row).
    */
   cacheHitRate(bucket: UsageBucket): number {
@@ -411,9 +395,7 @@ export class LlmUsageComponent {
   }
 
   /**
-   * Mean output throughput (tok/s) over successful timed records, or null when
-   * none exist. Numerator and denominator come from the same record subset
-   * (backend excludes failures and untimed records), so the rate is honest.
+   * Mean output throughput (tok/s) over timed records, null when none.
    * @param bucket - Aggregate bucket (totals or a table row).
    */
   tokensPerSec(bucket: UsageBucket): number | null {

--- a/desktop/src/src/app/settings/settings-update.spec.ts
+++ b/desktop/src/src/app/settings/settings-update.spec.ts
@@ -36,10 +36,7 @@ describe('UpdateSectionComponent — update settings (compat)', () => {
     component = fixture.componentInstance;
   });
 
-  // toggleAutoCheck/setCheckInterval were removed alongside the UI controls.
-  // Auto-check is now hard-coded to true with a 12 h interval; the component
-  // self-rewrites persisted state on init when it drifts (covered by the
-  // dedicated update-section.component.spec.ts).
+  // Auto-check state is self-rewritten by the component per update-section.component.spec.ts
 
   describe('installUpdate()', () => {
     it('calls install_update_and_reconcile with expectedVersion', async () => {

--- a/desktop/src/src/app/settings/settings.component.spec.ts
+++ b/desktop/src/src/app/settings/settings.component.spec.ts
@@ -35,8 +35,7 @@ describe('SettingsComponent', () => {
   let component: SettingsComponent;
   let fixture: ComponentFixture<SettingsComponent>;
   let mockTauri: MockTauriService;
-  // Stub the root BetaService; default "on" so the transcription section
-  // renders as before. The beta-off case flips it.
+  // Stub the root BetaService; default "on".
   const betaEnabled = signal(true);
 
   beforeEach(async () => {
@@ -147,9 +146,7 @@ describe('SettingsComponent', () => {
     };
 
     mockTauri.dispatchEvent('project_switch_succeeded', { project: 'other-project' });
-    // dispatchEvent kicks off an async loadProjectInfo() via the onProjectReady
-    // callback; whenStable alone resolves before that nested promise settles,
-    // so we yield a macrotask first to let the chained await fall through.
+    // Yield a macrotask so the nested loadProjectInfo() promise settles before whenStable.
     await new Promise<void>((r) => setTimeout(r, 0));
     await fixture.whenStable();
     expect(component.activeProject).toBe('other-project');

--- a/desktop/src/src/app/settings/settings.component.ts
+++ b/desktop/src/src/app/settings/settings.component.ts
@@ -19,11 +19,7 @@ import { UpdateSectionComponent } from './update-section/update-section.componen
 import { ProjectPillComponent } from '../project-switcher/project-pill.component';
 import { ProjectList } from '../models/update';
 
-/**
- * One theme card in the Appearance accent grid. The preview swatch reads the
- * live `--accent` value per theme via `data-theme`, so it stays correct in
- * both light and dark mode without duplicating CSS hex values here.
- */
+/** One theme card in the Appearance accent grid; swatch reads live `--accent` via `data-theme`. */
 interface ThemeCard {
   /** Theme identifier — drives `ThemeService.setTheme()` and the active-state binding. */
   readonly id: ThemeId;

--- a/desktop/src/src/app/settings/update-section/update-section.component.spec.ts
+++ b/desktop/src/src/app/settings/update-section/update-section.component.spec.ts
@@ -47,9 +47,6 @@ describe('UpdateSectionComponent', () => {
   });
 
   describe('auto-check defaults (no UI)', () => {
-    // The toggle + frequency dropdown were removed — auto-check is always on
-    // with a fixed 12 h interval. The component rewrites persisted settings
-    // on init when they drift from those defaults.
     it('rewrites backend settings when persisted state has auto_check=false', async () => {
       const calls: { cmd: string; args?: Record<string, unknown> }[] = [];
       mockTauri.invokeHandler = async (cmd: string, args?: Record<string, unknown>) => {

--- a/desktop/src/src/app/settings/update-section/update-section.component.ts
+++ b/desktop/src/src/app/settings/update-section/update-section.component.ts
@@ -62,10 +62,6 @@ import { UpdateCheckOutcome, UpdateSettings } from '../../models/update';
           {{ updateInstallError }}
         </p>
       }
-
-      <!-- Auto-check is always on with a fixed 12h interval — there is no
-           user-facing control. The values are persisted on init by the
-           component so the backend stays in sync. -->
     </section>
   `,
 })
@@ -74,17 +70,11 @@ export class UpdateSectionComponent implements OnInit {
 
   readonly errorOccurred = output<string>();
 
-  /**
-   * Hard-coded auto-check interval in hours — every user is opted in to a
-   *  12 h check, the UI no longer exposes a toggle or frequency dropdown.
-   */
+  /** Hard-coded auto-check interval in hours; the UI exposes no toggle or frequency control. */
   private static readonly DEFAULT_INTERVAL_HOURS = 12;
 
   currentVersion = '';
-  /**
-   * Always true — auto-check is non-negotiable, kept as a field so the
-   *  existing backend-sync helper (`saveUpdateSettings`) compiles unchanged.
-   */
+  /** Always true; auto-check is non-negotiable. */
   updateAutoCheck = true;
   updateIntervalHours = UpdateSectionComponent.DEFAULT_INTERVAL_HOURS;
   updateChecking = false;
@@ -103,11 +93,7 @@ export class UpdateSectionComponent implements OnInit {
     this.loadUpdateSettings();
   }
 
-  /**
-   * Human-readable status line shown under the version label.
-   * Maps the four UI states (idle, checking, up-to-date, available) to the
-   * mockup's status copy so the status row mirrors the design.
-   */
+  /** Human-readable status line shown under the version label. Maps the four UI states to the mockup's status copy. */
   updateStatusText(): string {
     if (this.updateChecking) return 'checking for updates...';
     if (this.updateResult === 'up-to-date') return '✓ up to date';
@@ -117,11 +103,7 @@ export class UpdateSectionComponent implements OnInit {
     return 'tap "check now" to look for updates';
   }
 
-  /**
-   * Tailwind class applied to the status line. Green for "up to date", amber
-   * for "available", muted for the idle/checking states. Returned as a single
-   * string so the template uses `[class]="..."` rather than `ngClass`.
-   */
+  /** Tailwind class for the status line: green for up-to-date, amber for available, muted for idle/checking. Returned as single string for [class]="..." binding. */
   updateStatusClass(): string {
     if (this.updateResult === 'up-to-date') return 'text-[var(--green)]';
     if (this.updateResult === 'available') return 'text-[var(--amber)]';
@@ -137,13 +119,6 @@ export class UpdateSectionComponent implements OnInit {
     this.cdr.markForCheck();
   }
 
-  /**
-   * Backend-sync on init. Auto-check + 12 h interval are non-negotiable in
-   * the UI, so on first read we *force* the persisted settings to those
-   * defaults if they drift (e.g. from an older version that exposed the
-   * dropdown). The frontend never reads `settings.check_interval_hours` for
-   * display — it just keeps the backend in sync.
-   */
   private async loadUpdateSettings(): Promise<void> {
     try {
       const settings = await this.tauri.invoke<UpdateSettings>('get_update_settings');

--- a/desktop/src/src/app/setup/setup-wizard.component.ts
+++ b/desktop/src/src/app/setup/setup-wizard.component.ts
@@ -165,9 +165,7 @@ export class SetupWizardComponent {
   get steps(): SetupStep[] {
     return this.stepsSig();
   }
-  /**
-   * Replaces the step list — kept as a setter for tests that mutate it directly.
-   */
+  /** Replaces the step list. */
   set steps(next: SetupStep[]) {
     this.stepsSig.set(next);
   }
@@ -248,10 +246,7 @@ export class SetupWizardComponent {
   }
 
   /**
-   * Resumes the setup pipeline after `<app-create-project-modal>` has
-   * successfully created the project on the backend. The modal owns the
-   * `create_project` invocation + inline error handling; this handler only
-   * marks step 3 as done and continues with the remaining auto-steps.
+   * Marks step 3 done and continues auto-steps after the project is created.
    * @param payload - Name and directory of the freshly created project.
    */
   async onProjectCreated(payload: CreatedProject): Promise<void> {

--- a/desktop/src/src/app/shared/create-project-modal/create-project-modal.component.spec.ts
+++ b/desktop/src/src/app/shared/create-project-modal/create-project-modal.component.spec.ts
@@ -167,9 +167,7 @@ describe('CreateProjectModalComponent', () => {
     });
 
     it('preserves multi-line backend error formatting via whitespace-pre-wrap', async () => {
-      // Backend errors like `wsl_other_distro_msg` are multi-line with \n separating
-      // numbered options. The error pane must render them as multiple visible lines,
-      // not collapse them into a wall of text.
+      // Backend errors use \n; error pane must preserve via whitespace-pre-wrap.
       const multiLineError =
         "Project is in WSL distribution 'Ubuntu'.\n\n" +
         '1. Copy the project into Speedwave\n' +
@@ -190,8 +188,7 @@ describe('CreateProjectModalComponent', () => {
       expect(err?.textContent).toContain('1. Copy the project');
       expect(err?.textContent).toContain('2. Move to /mnt/c/');
       expect(err?.textContent).toContain('3. Use Claude Code');
-      // The whitespace-pre-wrap class must be on the error pane so the browser
-      // honours `\n` in textContent at render time.
+      // whitespace-pre-wrap on the error pane makes the browser honour \n.
       const classes = (err as HTMLElement | null)?.className ?? '';
       expect(classes).toContain('whitespace-pre-wrap');
     });

--- a/desktop/src/src/app/shared/create-project-modal/create-project-modal.component.ts
+++ b/desktop/src/src/app/shared/create-project-modal/create-project-modal.component.ts
@@ -23,16 +23,8 @@ export interface CreatedProject {
 
 /**
  * Modal dialog for creating a new Speedwave project. Opens the OS folder
- * picker, derives a default project name from the chosen directory's basename
- * (editable), and invokes `create_project` on the Rust backend on submit.
- *
- * Reused by the setup-wizard (where it is non-dismissible — user must create
- * a project to finish setup) and the project-switcher dropdown (dismissible).
- *
- * Uses Angular Signal Forms (`@angular/forms/signals`) for the editable
- * project-name field. Signal Forms are signal-driven and OnPush-safe — they
- * avoid the second change-detection pass that the legacy `NgModel` directive
- * schedules, which Angular 21.2.x crashes on inside embedded views.
+ * picker, derives a default project name from the dir basename (editable),
+ * and invokes the configured command on the Rust backend on submit.
  */
 @Component({
   selector: 'app-create-project-modal',
@@ -166,18 +158,9 @@ export interface CreatedProject {
 export class CreateProjectModalComponent {
   /** Whether the modal is visible. */
   readonly open = input.required<boolean>();
-  /**
-   * Whether the user is allowed to close the modal without creating a project.
-   * Setup-wizard sets this to `false` (project creation is mandatory there);
-   * the project-switcher sets it to `true`.
-   */
+  /** Whether the user is allowed to close the modal without creating a project. */
   readonly dismissible = input<boolean>(true);
-  /**
-   * Tauri command to invoke on submit. Defaults to `create_project` (setup
-   * pipeline — config-only registration). The project-switcher should pass
-   * `add_project` instead, which also boots containers and switches active
-   * project as part of the same transaction.
-   */
+  /** Tauri command to invoke on submit (defaults to `create_project`). */
   readonly command = input<'create_project' | 'add_project'>('create_project');
 
   /** Emitted with the chosen `name` + `dir` after `create_project` succeeds. */
@@ -188,17 +171,9 @@ export class CreateProjectModalComponent {
   private readonly tauri = inject(TauriService);
   private readonly cdr = inject(ChangeDetectorRef);
 
-  /**
-   * Reactive model backing the Signal Forms tree. `dir` is set programmatically
-   * by `browse()`; `name` is auto-filled from the dir basename then editable.
-   */
+  /** Reactive model backing the Signal Forms tree. */
   protected readonly model = signal<CreatedProject>({ name: '', dir: '' });
-  /**
-   * Signal Forms field tree. The name input binds via `[formField]` — this
-   * routes user input directly through the model and tracks dirty state for
-   * us, replacing the legacy `[value]+(input)` workaround and the manual
-   * `nameTouched` flag.
-   */
+  /** Signal Forms field tree backing the name input. */
   protected readonly projectForm = form(this.model, (path) => {
     required(path.name, { message: 'Project name is required' });
   });
@@ -224,10 +199,7 @@ export class CreateProjectModalComponent {
     this.error.set(null);
     let selected: string | string[] | null;
     try {
-      // E2E test seam: WebDriver cannot drive the OS folder picker, so the
-      // suite plants `window.__E2E_DIALOG_PATH__` to short-circuit the
-      // native call. `string` resolves the picker, `null` simulates cancel.
-      // Anything else (`undefined`, missing) falls through to the real API.
+      // E2E seam: `window.__E2E_DIALOG_PATH__` overrides the picker (string=path, null=cancel).
       const e2eOverride = (window as unknown as { __E2E_DIALOG_PATH__?: string | null })
         .__E2E_DIALOG_PATH__;
       selected =
@@ -240,9 +212,7 @@ export class CreateProjectModalComponent {
     if (typeof selected !== 'string' || selected.length === 0) {
       return;
     }
-    // Auto-fill name only when the user has not yet edited it. Signal Forms
-    // marks the `name` field as dirty whenever its value flows through the
-    // `[formField]` binding, so `dirty()` is the SSOT for "user touched it".
+    // Auto-fill name only when the user has not yet edited it.
     const nameDirty = this.projectForm.name().dirty();
     this.model.update((m) => ({
       ...m,
@@ -250,8 +220,7 @@ export class CreateProjectModalComponent {
       name: nameDirty ? m.name : slugify(basename(selected as string)),
     }));
     this.cloudstorageWarning.set(null);
-    // Non-blocking: fire-and-forget CloudStorage detection; ignore errors so a
-    // missing Tauri context (tests, browser preview) doesn't break the picker.
+    // Fire-and-forget CloudStorage detection; errors ignored.
     void this.detectCloudstorage(selected as string);
     this.cdr.markForCheck();
   }
@@ -276,11 +245,6 @@ export class CreateProjectModalComponent {
 
   /**
    * Handles manual edits to the project-name input.
-   *
-   * In production the `[formField]` directive owns the input event and writes
-   * directly to the form's control value. This method exists so unit tests can
-   * simulate user typing without spinning up a full DOM event — it routes
-   * through the same control-value setter, which keeps `dirty()` honest.
    * @param event - Native `input` event (or test stand-in) from the name field.
    */
   onNameInput(event: Event): void {
@@ -331,8 +295,7 @@ export class CreateProjectModalComponent {
 
   private reset(): void {
     this.model.set({ name: '', dir: '' });
-    // Clear the form's dirty/touched flags so the next `browse()` is treated
-    // as a fresh selection rather than a continuation of the previous edit.
+    // Clear the form's dirty/touched flags.
     this.projectForm().reset();
     this.error.set(null);
     this.cloudstorageWarning.set(null);

--- a/desktop/src/src/app/shared/progress-steps/progress-steps.component.ts
+++ b/desktop/src/src/app/shared/progress-steps/progress-steps.component.ts
@@ -17,12 +17,8 @@ export interface SetupStep {
 }
 
 /**
- * Presentational component that renders a list of progress steps with status
- * circles, pills, an optional progress bar, an error banner with retry/back
- * controls, and an optional footer.
- *
- * Used by both the first-run setup wizard and the plugin install overlay.
- * The caller owns the step list and drives status transitions.
+ * Presentational multi-step progress: status circles, pills, progress bar,
+ * error banner with retry/back, optional footer. Caller owns the step list.
  */
 @Component({
   selector: 'app-progress-steps',
@@ -168,8 +164,8 @@ export class ProgressStepsComponent {
   });
 
   /**
-   * Status circle — border colour.
-   * @param step Step whose status drives the colour.
+   * Status circle — border colour for the step's status.
+   * @param step - Step whose status drives the colour.
    */
   protected circleBorder(step: SetupStep): string {
     if (step.status === 'done') return 'rgba(52, 211, 153, 0.3)';
@@ -179,8 +175,8 @@ export class ProgressStepsComponent {
   }
 
   /**
-   * Status circle — background fill.
-   * @param step Step whose status drives the fill colour.
+   * Status circle — background fill for the step's status.
+   * @param step - Step whose status drives the fill.
    */
   protected circleBg(step: SetupStep): string {
     if (step.status === 'done') return 'rgba(52, 211, 153, 0.1)';
@@ -190,8 +186,8 @@ export class ProgressStepsComponent {
   }
 
   /**
-   * Status circle — text/icon colour.
-   * @param step Step whose status drives the foreground colour.
+   * Status circle — text/icon colour for the step's status.
+   * @param step - Step whose status drives the colour.
    */
   protected circleColor(step: SetupStep): string {
     if (step.status === 'done') return 'var(--green)';

--- a/desktop/src/src/app/shared/spin-icon.component.ts
+++ b/desktop/src/src/app/shared/spin-icon.component.ts
@@ -1,13 +1,8 @@
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 
 /**
- * Seamless Material-style SVG spinner. Two rotations layered with
- * mismatched periods (root SVG: 2s, dash growth: 1.4s) so the seam
- * where the dash pattern wraps never lines up with the same frame
- * twice — eliminating the visible "jump" of a single-rotation
- * dashoffset spinner. Pattern from Glenn McComb's article on pure-CSS
- * SVG spinners. Stroke colour follows `currentColor`, sizing follows
- * the host Tailwind classes.
+ * Seamless Material-style SVG spinner. Stroke colour follows `currentColor`,
+ * sizing follows the host Tailwind classes.
  */
 @Component({
   selector: 'app-spin-icon',

--- a/desktop/src/src/app/shared/tooltip.directive.spec.ts
+++ b/desktop/src/src/app/shared/tooltip.directive.spec.ts
@@ -149,9 +149,7 @@ describe('TooltipDirective', () => {
   });
 
   it('removes native title attribute from host on init', () => {
-    // Re-create with a host that has a native title attribute via initial input
-    // The directive strips `title` even if browser default is empty, but more
-    // importantly verify the host element does not carry it after init.
+    // Host element does not carry `title` after init.
     const btn = getButton(fixture!);
     expect(btn.hasAttribute('title')).toBe(false);
   });

--- a/desktop/src/src/app/shared/tooltip.directive.ts
+++ b/desktop/src/src/app/shared/tooltip.directive.ts
@@ -25,12 +25,7 @@ export type TooltipPlacement = 'top' | 'right' | 'bottom' | 'left';
 /** Pixels offset between the host edge and the tooltip body. */
 const OFFSET_PX = 8;
 
-/**
- * Internal panel component rendered inside the CDK overlay. Carries the
- * `.app-tooltip` class so the global stylesheet (in `styles.css`) controls
- * its appearance, and adds a `data-state` attribute that drives the fade-in
- * opacity transition.
- */
+/** Internal CDK-overlay panel; `.app-tooltip` class + `data-state` fade attr. */
 @Component({
   selector: 'app-tooltip-panel',
   standalone: true,
@@ -127,27 +122,7 @@ const POSITIONS: Record<TooltipPlacement, ConnectedPosition[]> = {
   ],
 };
 
-/**
- * Custom tooltip directive — single source of truth for hover/focus tooltips
- * across the app. Replaces the native `title=""` attribute so every tooltip
- * is styled identically and matches the terminal-minimal mockup
- * (`design-proposals/06-terminal-minimal.html`, `.tooltip` class).
- *
- * Behaviour:
- * - The tooltip element is rendered through the **CDK Overlay** so it always
- *   floats above any ancestor regardless of `overflow` clipping or stacking
- *   contexts (drawers, dropdowns, modals).
- * - Position is managed by `FlexibleConnectedPositionStrategy` connected to
- *   the host element, with one fallback side if the requested placement
- *   would push the panel off-screen.
- * - Strips the native `title=""` so the browser tooltip never double-appears.
- *
- * Usage:
- * ```html
- * <button appTooltip="Conversations" tooltipKbd="⌘B" placement="bottom">…</button>
- * <button [appTooltip]="dynamicLabel()" placement="left">…</button>
- * ```
- */
+/** Custom tooltip directive — SSOT for hover/focus tooltips; renders via CDK Overlay, strips native `title`. */
 @Directive({
   selector: '[appTooltip]',
   standalone: true,
@@ -173,15 +148,13 @@ export class TooltipDirective implements OnDestroy {
 
   /** Wires the effects that strip the native `title` and sync panel inputs. */
   constructor() {
-    // Strip the native `title` so the browser tooltip never stacks on top
-    // of ours. Effect re-runs when `label()` changes (dynamic tooltips).
+    // Strip native `title`; effect re-runs on label change.
     effect(() => {
       this.label();
       this.host.nativeElement.removeAttribute('title');
     });
 
-    // Keep the live panel inputs (label/kbd/placement) in sync with the
-    // directive inputs while the tooltip is visible.
+    // Sync live panel inputs (label/kbd/placement) while visible.
     effect(() => {
       const ref = this.panelRef;
       if (!ref) return;
@@ -223,13 +196,7 @@ export class TooltipDirective implements OnDestroy {
     this.hide();
   }
 
-  /**
-   * Click on the host should also dismiss the tooltip — the user has
-   * committed to the action, and a click usually triggers a layout change
-   * (drawer open, navigation, modal open) that can hide the host element
-   * without firing `mouseleave`. Without this, the tooltip lingers as a
-   * stale floating chip over the new view.
-   */
+  /** Click dismisses the tooltip; prevents a stale chip when host layout changes. */
   @HostListener('click') onClick(): void {
     this.hide();
   }
@@ -256,8 +223,7 @@ export class TooltipDirective implements OnDestroy {
       this.overlayRef = this.overlay.create({
         positionStrategy,
         scrollStrategy: this.scrollStrategies.close(),
-        // The panel itself is not interactive; pointer-events: none in CSS
-        // keeps the host hover state stable.
+        // Non-interactive panel; CSS pointer-events:none keeps host hover stable.
         hasBackdrop: false,
         disposeOnNavigation: true,
       });
@@ -272,8 +238,7 @@ export class TooltipDirective implements OnDestroy {
 
     this.panelRef = componentRef;
 
-    // Force a reflow then flip `data-state` to trigger the opacity transition
-    // defined in `styles.css`.
+    // Force reflow, then flip data-state to trigger the opacity transition.
     const overlayEl = this.overlayRef.overlayElement;
     void overlayEl.offsetWidth;
     componentRef.setInput('visible', true);

--- a/desktop/src/src/app/shell/command-palette/command-palette.component.spec.ts
+++ b/desktop/src/src/app/shell/command-palette/command-palette.component.spec.ts
@@ -8,9 +8,7 @@ import { UiStateService } from '../../services/ui-state.service';
 import { MockTauriService } from '../../testing/mock-tauri.service';
 
 /**
- * The palette renders through CDK Dialog into the document-level overlay
- * container, so tests must query the global `document` rather than the
- * fixture's native element.
+ * Query the document-level CDK overlay container.
  * @param selector CSS selector to look up in the document root.
  */
 function q(selector: string): HTMLElement | null {
@@ -18,9 +16,7 @@ function q(selector: string): HTMLElement | null {
 }
 
 describe('CommandPaletteComponent', () => {
-  // CdkListbox calls `Element.scrollIntoView()` in `setActiveStyles()` when an
-  // option is clicked — jsdom does not implement it, which surfaces as an
-  // unhandled exception that pollutes the test report. Stub it for this suite.
+  // jsdom does not implement Element.scrollIntoView; stub it for this suite.
   beforeAll(() => {
     const proto = Element.prototype as unknown as { scrollIntoView?: () => void };
     if (typeof proto.scrollIntoView !== 'function') {
@@ -76,8 +72,7 @@ describe('CommandPaletteComponent', () => {
   });
 
   afterEach(() => {
-    // CDK Dialog leaves its overlay container attached to the document body.
-    // Closing via the signal lets the next test start with a clean DOM.
+    // Close the CDK Dialog overlay so the next test starts with a clean DOM.
     ui.closePalette();
     fixture.detectChanges();
   });

--- a/desktop/src/src/app/shell/command-palette/command-palette.component.ts
+++ b/desktop/src/src/app/shell/command-palette/command-palette.component.ts
@@ -53,18 +53,7 @@ interface DecoratedItem extends PaletteItem {
   readonly index: number;
 }
 
-/**
- * Command palette modal — ⌘K.
- *
- * Visibility is wired to {@link UiStateService.paletteOpen} via an effect
- * that opens/closes a CDK Dialog instance. CDK Dialog gives us focus trap,
- * backdrop, scroll lock, and Escape handling for free. The list itself is a
- * `cdkListbox` with `cdkListboxUseActiveDescendant`, so arrow keys, Home/End,
- * and Enter are handled natively without manual `(document:keydown.*)`
- * bindings — we mirror the slash-menu pattern by forwarding the same keys
- * from the search input (which retains focus) into the active-descendant
- * signal.
- */
+/** Command palette modal (⌘K) wired to {@link UiStateService.paletteOpen}. */
 @Component({
   selector: 'app-command-palette',
   imports: [A11yModule, CdkListbox, CdkOption],
@@ -160,12 +149,7 @@ export class CommandPaletteComponent implements OnInit, OnDestroy {
   /** Current search query. */
   readonly query = signal<string>('');
 
-  /**
-   * Index of the highlighted item in `filteredItems()`. Driven by the search
-   * input via {@link onSearchKeydown} — the input keeps focus, so the
-   * `cdkListbox` keyboard manager never owns the keystrokes itself; we mirror
-   * the active-descendant pattern with this signal instead.
-   */
+  /** Index of the highlighted item in `filteredItems()`. */
   readonly activeIndex = signal<number>(0);
 
   /** Live list of projects fetched on init and refreshed on settled events. */
@@ -184,11 +168,7 @@ export class CommandPaletteComponent implements OnInit, OnDestroy {
   private readonly positionBuilder = inject(OverlayPositionBuilder);
 
   private dialogRef: DialogRef<unknown, unknown> | null = null;
-  /**
-       True while we are programmatically closing the dialog (signal flipped to
-      false). Prevents the `closed` subscription from re-calling
-      `closePalette()` and looping.
-   */
+  /** True while programmatically closing the dialog, to prevent re-entry. */
   private closingProgrammatically = false;
 
   private unsubProjectSettled: (() => void) | null = null;
@@ -299,12 +279,7 @@ export class CommandPaletteComponent implements OnInit, OnDestroy {
     });
   });
 
-  /**
-   * Wires three effects:
-   *  1. open/close the CDK Dialog in response to `paletteOpen()` flipping;
-   *  2. reset the query and active index on each fresh open;
-   *  3. clamp the active index when the filtered list shrinks.
-   */
+  /** Wires effects for dialog visibility, query/index reset, and index clamping. */
   constructor() {
     effect(() => {
       if (this.ui.paletteOpen()) {
@@ -357,9 +332,7 @@ export class CommandPaletteComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Forwards arrow / Home / End / Enter keystrokes from the search input
-   * down to the active-descendant signal so the user can navigate the list
-   * while keeping focus on the input.
+   * Forwards arrow/Home/End/Enter keys from the search input to the active-descendant signal.
    * @param event - Keydown from the search input.
    */
   onSearchKeydown(event: KeyboardEvent): void {
@@ -394,9 +367,7 @@ export class CommandPaletteComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Escape closes the palette. CDK Dialog already handles Escape by default,
-   * but we keep this explicit handler so the signal flips first — preventing
-   * a brief render of an "empty" dialog before the effect catches up.
+   * Escape closes the palette.
    * @param event - Keyboard event for the Escape press.
    */
   onEscape(event: Event): void {
@@ -405,9 +376,7 @@ export class CommandPaletteComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * CdkListbox value-change handler. Single-select listbox, so `event.value`
-   * is a 0- or 1-length array; treat any non-empty value as "user picked
-   * this item".
+   * CdkListbox value-change handler; invokes the picked item.
    * @param event - CdkListbox change event.
    */
   onListboxChange(event: ListboxValueChangeEvent<unknown>): void {
@@ -468,8 +437,7 @@ export class CommandPaletteComponent implements OnInit, OnDestroy {
     });
     this.dialogRef.closed.subscribe(() => {
       this.dialogRef = null;
-      // CDK Dialog closed via Escape, backdrop click, or programmatic close.
-      // If we did not initiate it, sync the signal back so the next ⌘K reopens.
+      // Sync signal back if closed externally (Escape, backdrop, or dialog.close).
       if (!this.closingProgrammatically && this.ui.paletteOpen()) {
         this.ui.closePalette();
       }
@@ -497,8 +465,7 @@ export class CommandPaletteComponent implements OnInit, OnDestroy {
     try {
       await this.tauri.invoke('check_for_update');
     } catch {
-      // Outside Tauri or backend rejected — silent fail; the dedicated
-      // settings/Update panel surfaces the error path.
+      // Silent fail — error surfaces in the settings/Update panel.
     }
   }
 

--- a/desktop/src/src/app/shell/modal-overlay/modal-overlay.component.spec.ts
+++ b/desktop/src/src/app/shell/modal-overlay/modal-overlay.component.spec.ts
@@ -50,8 +50,6 @@ class TestHostComponent {
 
 /**
  * Query the dialog content rendered into the CDK overlay container.
- * CDK Dialog renders the template into a portal attached to `document.body`,
- * not inside the host fixture, so we query the global document.
  * @param sel CSS selector to locate the element under document.
  */
 function q(sel: string): HTMLElement | null {

--- a/desktop/src/src/app/shell/modal-overlay/modal-overlay.component.ts
+++ b/desktop/src/src/app/shell/modal-overlay/modal-overlay.component.ts
@@ -20,12 +20,7 @@ export type ModalBorderColor = 'default' | 'red';
 
 /**
  * Generic modal-overlay shell — backdrop + centered card + title/body/actions.
- *
- * Used by the shell to surface the restart-required, update-available, and
- * system-check-failed dialogs from the mockup (lines 1904-1952). All copy and
- * action handlers come from the parent via inputs/outputs; this component
- * delegates positioning, backdrop, focus trap, and Esc handling to the CDK
- * `Dialog` service so we never re-implement those primitives ourselves.
+ * Delegates positioning, backdrop, focus trap, and Esc handling to CDK `Dialog`.
  */
 @Component({
   selector: 'app-modal-overlay',
@@ -106,11 +101,7 @@ export class ModalOverlayComponent {
   readonly kicker = input.required<string>();
   /** Color family applied to the kicker — picks one of the semantic palette tokens. */
   readonly kickerColor = input<ModalKickerColor>('accent');
-  /**
-   * Title rendered with the view-title font/spacing. Renamed from `title` to
-   * avoid the HTML `title` attribute collision (which would surface as a
-   * native browser tooltip on the host element).
-   */
+  /** Title text; named `modalTitle` to avoid the HTML `title` attribute collision. */
   readonly modalTitle = input.required<string>();
   /** Body paragraph; pass an empty string to hide the paragraph entirely. */
   readonly body = input<string>('');
@@ -147,12 +138,7 @@ export class ModalOverlayComponent {
   private readonly dialog = inject(Dialog);
   private dialogRef: DialogRef<unknown, unknown> | null = null;
 
-  /**
-   * True while the host is closing the dialog because `open()` flipped
-   * to false. Used to suppress the `closed` output that the dialog's own
-   * `closed` subscription would otherwise fire (which would echo right back
-   * to the parent that already knows).
-   */
+  /** True while the host closes the dialog because `open()` flipped to false. */
   private closingProgrammatically = false;
 
   /** CSS classes for the kicker text — picks a semantic color from the palette. */
@@ -195,16 +181,14 @@ export class ModalOverlayComponent {
    * CDK dialog as the input toggles, and tears down on host destroy.
    */
   constructor() {
-    // Sync dialog open/closed state with the `open()` input. CDK Dialog handles
-    // the backdrop click, Esc key, and focus trap entirely on its own.
+    // Sync dialog open/closed state with the `open()` input.
     effect(() => {
       const isOpen = this.open();
       if (isOpen) this.openDialog();
       else this.closeDialog();
     });
 
-    // Ensure the dialog is torn down if the host component is destroyed
-    // mid-flight (e.g. parent collapses the surrounding `@if`).
+    // Tear down the dialog if the host component is destroyed mid-flight.
     inject(DestroyRef).onDestroy(() => this.closeDialog());
   }
 

--- a/desktop/src/src/app/shell/nav-rail/nav-rail.component.spec.ts
+++ b/desktop/src/src/app/shell/nav-rail/nav-rail.component.spec.ts
@@ -74,9 +74,6 @@ describe('NavRailComponent', () => {
   });
 
   it('does not render hover tooltips on rail entries', () => {
-    // The hover tooltip with the shortcut hint was removed — the rail
-    // surface is intentionally minimal (mockup-aligned) and the keyboard
-    // shortcuts live in the command palette.
     const tip = fixture.nativeElement.querySelector('[data-testid="nav-chat"] .tooltip');
     expect(tip).toBeNull();
     const tipKbd = fixture.nativeElement.querySelector('[data-testid="nav-integrations"] .tooltip');

--- a/desktop/src/src/app/shell/nav-rail/nav-rail.component.ts
+++ b/desktop/src/src/app/shell/nav-rail/nav-rail.component.ts
@@ -17,15 +17,7 @@ export interface NavRailEntry {
   shortcut?: string;
 }
 
-/**
- * Vertical icon rail that lives on the left edge of the shell.
- *
- * Replaces the legacy top-bar segmented switcher. Each entry renders as a
- * 36×36 button with an inline SVG icon and a tooltip on hover; the active
- * entry gets a 2px accent bar drawn via `.rail-btn.active::before`.
- *
- * Active state is derived from the current router URL by the parent shell.
- */
+/** Vertical icon rail with 36×36 icon buttons; active entry gets a 2px accent bar. */
 @Component({
   selector: 'app-nav-rail',
   imports: [RouterLink, IconComponent, LogoComponent],

--- a/desktop/src/src/app/shell/shell.component.spec.ts
+++ b/desktop/src/src/app/shell/shell.component.spec.ts
@@ -15,8 +15,7 @@ describe('ShellComponent', () => {
   let fixture: ComponentFixture<ShellComponent>;
   let mockTauri: MockTauriService;
   let projectState: ProjectStateService;
-  // Stub the root BetaService so specs control beta state directly; default
-  // "on" so the meeting-transcription nav entry behaves as before.
+  // Beta on by default so the meeting-transcription nav entry is present.
   const betaEnabled = signal(true);
 
   beforeEach(async () => {
@@ -241,9 +240,7 @@ describe('ShellComponent', () => {
   });
 
   it('keeps the Chat nav link visible when status is auth_required', async () => {
-    // Mockup-aligned behaviour: the chat icon is always present in the rail.
-    // When auth is missing the chat view itself surfaces an inline
-    // "auth required" block with a link to Settings instead of disappearing.
+    // Chat icon persists in nav even when auth is required; auth surfaces inline.
     await component.ngOnInit();
     projectState.status = 'auth_required';
     component['cdr'].markForCheck();
@@ -315,9 +312,7 @@ describe('ShellComponent', () => {
   });
 
   describe('restart overlay', () => {
-    // Modal contents render through CDK Dialog (a portal attached to
-    // document.body), not inside the host fixture, so we query the global
-    // document for any element underneath the overlay.
+    // CDK Dialog renders into document.body, outside the host fixture.
     function q(sel: string): HTMLElement | null {
       return document.querySelector(sel) as HTMLElement | null;
     }
@@ -343,8 +338,7 @@ describe('ShellComponent', () => {
     });
 
     it('shows overlay when needsRestart is true and status is auth_required', () => {
-      // Toggling an integration is valid before Anthropic login; the restart
-      // prompt must still surface in auth_required, not only in ready.
+      // Restart prompt must surface in auth_required, not only in ready.
       projectState.status = 'auth_required';
       projectState.needsRestart = true;
       component['cdr'].markForCheck();
@@ -426,8 +420,7 @@ describe('ShellComponent', () => {
       component['cdr'].markForCheck();
       fixture.detectChanges();
 
-      // The spinner branch lives inside the host template (not the modal),
-      // so it stays in the fixture DOM.
+      // Spinner branch lives in the host template, so it stays in the fixture DOM.
       const overlay = fixture.nativeElement.querySelector('[data-testid="restart-overlay"]');
       expect(overlay).not.toBeNull();
       expect(overlay.textContent).toContain('Restarting containers...');

--- a/desktop/src/src/app/shell/shell.component.ts
+++ b/desktop/src/src/app/shell/shell.component.ts
@@ -23,12 +23,8 @@ import { SpinIconComponent } from '../shared/spin-icon.component';
 import { CloudStorageModalComponent } from '../shared/cloudstorage-modal/cloudstorage-modal.component';
 
 /**
- * Application shell — hosts the left icon rail, the routed main content, and
- * the global keyboard shortcuts (⌘1/⌘2/⌘3/⌘L for view nav, ⌘B for the
- * conversations drawer, ⌘K for the command palette).
- *
- * Blocking overlays (loading / check-failed / restart-required / error banner)
- * live here because they must cover the rail and the routed content alike.
+ * Application shell — hosts the icon rail, routed content, global keyboard
+ * shortcuts, and the blocking overlays (loading / check-failed / restart / error).
  */
 @Component({
   selector: 'app-shell',
@@ -238,14 +234,7 @@ export class ShellComponent implements OnInit, OnDestroy {
   private readonly currentUrlSignal = signal<string>(this.router.url);
   private readonly statusSignal = signal(this.projectState.status);
 
-  /**
-   * Catalog of nav entries to render. The chat icon stays visible regardless
-   * of project status — when the user lands on `/chat` while authentication
-   * is missing, the view itself surfaces the `auth required` block + a link
-   * back to Settings instead of silently disappearing from the rail.
-   * Meeting transcription is a beta-gated surface: hidden until the user
-   * enables beta features in the tray (ADR-058/056).
-   */
+  /** Nav entries to render: chat always visible; meeting-transcription beta-gated (ADR-058/056). */
   readonly visibleEntries = computed(() =>
     this.beta.enabled()
       ? this.entryCatalog
@@ -294,11 +283,8 @@ export class ShellComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Global keyboard shortcuts. Wired via `host: { '(document:keydown)': … }` —
-   * the `HostListener` decorator is forbidden by the project's best-practices
-   * rules.
-   * @param event - keyboard event from the document; consumed (preventDefault)
-   *   on every match so the platform doesn't apply the default action.
+   * Global keyboard shortcuts.
+   * @param event - keyboard event; consumed via preventDefault on every match.
    */
   onKeydown(event: KeyboardEvent): void {
     const cmd = event.metaKey || event.ctrlKey;

--- a/desktop/src/src/app/system-view/system-view.component.spec.ts
+++ b/desktop/src/src/app/system-view/system-view.component.spec.ts
@@ -8,8 +8,7 @@ import type { HealthReport } from '../models/health';
 
 const MOCK_HEALTHY_REPORT: HealthReport = {
   containers: [
-    // Backend (parse_container_entries) strips the compose prefix; mocks
-    // reflect the post-strip wire format the component actually receives.
+    // Post-strip wire format: parse_container_entries removes the compose prefix.
     { name: 'claude', status: 'running', healthy: true },
     { name: 'mcp_hub', status: 'running', healthy: true },
     { name: 'mcp_redmine', status: 'starting', healthy: false },
@@ -158,8 +157,7 @@ describe('SystemViewComponent', () => {
   });
 
   it('adds an aria-label communicating the actual restart-all scope', async () => {
-    // The Tauri command recreates ALL project containers, not just the one
-    // whose row was clicked. The label must communicate the actual scope.
+    // recreate_project_containers recreates all project containers, not just the clicked row.
     await component.ngOnInit();
     fixture.detectChanges();
 

--- a/desktop/src/src/app/update-notification/update-notification.component.ts
+++ b/desktop/src/src/app/update-notification/update-notification.component.ts
@@ -104,9 +104,7 @@ export class UpdateNotificationComponent implements OnDestroy {
         this.cdr.markForCheck();
       });
 
-      // Proactive check in case the event fired before the listener was
-      // registered. The backend returns a tagged outcome — only the
-      // `update_available` variant should surface the banner.
+      // Proactive check: backend returns tagged outcome, only 'update_available' surfaces.
       const outcome = await this.tauri.invoke<UpdateCheckOutcome>('check_for_update');
       if (outcome.kind === 'update_available') {
         const { kind: _kind, ...info } = outcome;

--- a/desktop/src/vitest.config.ts
+++ b/desktop/src/vitest.config.ts
@@ -2,12 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 /**
  * Vitest configuration consumed via `ng test --runner-config vitest.config.ts`.
- *
- * `isolate: true` gives every spec file a fresh module graph. Without
- * isolation, a `vi.fn()` defined under a `vi.mock(...)` factory leaks
- * across sibling specs that import the same module — under
- * concurrency, an assertion in one spec sees mock state set by another.
- * Isolation makes per-spec mocks deterministic on every runner.
+ * `isolate: true` gives every spec file a fresh module graph (no mock leakage between specs).
  */
 export default defineConfig({
   test: {

--- a/mcp-servers/atlassian/src/auth.test.ts
+++ b/mcp-servers/atlassian/src/auth.test.ts
@@ -1,9 +1,5 @@
 /**
  * Tests for Atlassian credential loading and the auth-token wiring.
- *
- * `normalizeSiteUrl` and `readCredentials` are unit-tested with a mocked `fs`.
- * The `MCP_ATLASSIAN_AUTH_TOKEN` exit-1 contract and `createMCPServer` middleware
- * wiring follow the same shape as the other workers (see `redmine/src/auth.test.ts`).
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';

--- a/mcp-servers/atlassian/src/client.test.ts
+++ b/mcp-servers/atlassian/src/client.test.ts
@@ -1,17 +1,13 @@
 /**
- * Tests for AtlassianClient — auth header, per-request retry policy, error
- * formatting (secret-safe), connectivity, and `initializeAtlassianClient`.
- *
- * `axios` is mocked: `axios.create()` returns a fake instance whose `request`
- * is a `vi.fn()` we script per test. `axios.isAxiosError` is preserved.
+ * Tests for AtlassianClient — auth header, retry policy, error formatting,
+ * connectivity, and `initializeAtlassianClient`. `axios` is mocked.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { AxiosRequestConfig } from 'axios';
 
 // ── axios mock ─────────────────────────────────────────────────────────────
-// `vi.mock` factories are hoisted above module-level `const`s, so the mock
-// functions must come from `vi.hoisted()` to be referenceable inside them.
+// `vi.mock` factories are hoisted; mocks come from `vi.hoisted()`.
 const { requestMock, createMock, readCredentialsMock } = vi.hoisted(() => ({
   requestMock: vi.fn(),
   createMock: vi.fn(),
@@ -85,8 +81,7 @@ beforeEach(() => {
   readCredentialsMock.mockReset();
   vi.spyOn(console, 'warn').mockImplementation(() => {});
   vi.spyOn(console, 'log').mockImplementation(() => {});
-  // Make jitter deterministic-ish: backoff() uses Math.random — pin to 0 so
-  // retries don't actually sleep long. We still advance timers manually.
+  // Pin Math.random to 0 to make backoff jitter deterministic.
   vi.spyOn(Math, 'random').mockReturnValue(0);
 });
 
@@ -398,8 +393,7 @@ describe('formatError', () => {
   });
 
   it('a short ATATT-prefixed string (under 20 chars after the prefix) is not redacted', () => {
-    // The scrub() regex requires {20,} to match log_sanitizer.rs — short
-    // strings are not real Atlassian tokens and pass through unchanged.
+    // scrub() regex requires {20,} chars; short strings pass through.
     expect(AtlassianClient.formatError('value: ATATTshort')).toMatch(/ATATTshort/);
   });
 
@@ -416,9 +410,6 @@ describe('initializeAtlassianClient', () => {
   });
 
   it('returns client + schedules background test when testConnection fails', async () => {
-    // Init no longer blocks on testConnection — it kicks the check into the
-    // background. The client is returned immediately; healthCheck reads the
-    // tracker to surface the failure.
     readCredentialsMock.mockResolvedValueOnce(CONFIG);
     requestMock.mockRejectedValueOnce(httpError(401));
     const client = await initializeAtlassianClient();

--- a/mcp-servers/atlassian/src/client.ts
+++ b/mcp-servers/atlassian/src/client.ts
@@ -119,8 +119,7 @@ export class AtlassianClient {
         'Content-Type': 'application/json',
         Accept: 'application/json',
       },
-      // Never follow redirects automatically; Atlassian Cloud doesn't need it
-      // and it avoids leaking the Authorization header cross-host.
+      // No redirects; avoids leaking the Authorization header cross-host.
       maxRedirects: 0,
     });
   }
@@ -161,8 +160,7 @@ export class AtlassianClient {
         const status = axios.isAxiosError(error) ? error.response?.status : undefined;
         const isRateLimited = status === 429;
         const isTransient5xx = typeof status === 'number' && status >= 500 && status <= 599;
-        // 429 is always safe to retry (the request was rejected, not processed).
-        // 5xx is only retried for explicitly-idempotent requests.
+        // 429 always retried; 5xx only when retryable (idempotent).
         if (!isRateLimited && !(retryable && isTransient5xx)) break;
 
         const retryAfter =
@@ -287,8 +285,7 @@ export class AtlassianClient {
       if (typeof status === 'number' && status >= 500) {
         return 'Atlassian server error. Try again later.';
       }
-      // No response (network/timeout) — use the code, never the config (it
-      // carries the Authorization header).
+      // No response: use the code, never the config (carries Authorization).
       const code = error.code ? ` (${error.code})` : '';
       return `Atlassian request failed${code}: unable to reach ${this.safeHost(error.config?.baseURL)}`;
     }

--- a/mcp-servers/atlassian/src/domains/confluence-content.ts
+++ b/mcp-servers/atlassian/src/domains/confluence-content.ts
@@ -47,9 +47,7 @@ export function createConfluenceContentClient(client: AtlassianClient): Confluen
         );
         key = sp.key ? String(sp.key) : undefined;
       } catch (error) {
-        // A 404 just means the space isn't visible; any other error
-        // (401/403/429/timeout) is surfaced so a transient failure doesn't
-        // masquerade as a "space not allowed" configuration error.
+        // 404 means the space isn't visible; other statuses are warned, not swallowed.
         const status = (error as { response?: { status?: number } })?.response?.status;
         if (status !== 404) {
           console.warn(

--- a/mcp-servers/atlassian/src/domains/confluence-pages.ts
+++ b/mcp-servers/atlassian/src/domains/confluence-pages.ts
@@ -1,7 +1,5 @@
 /**
- * Confluence pages — CQL search (v1), and page CRUD via the v2 API. `update`
- * needs the current `version.number` (+1), which this client fetches
- * automatically so callers never have to.
+ * Confluence pages — CQL search (v1), and page CRUD via the v2 API.
  * @module mcp-atlassian/domains/confluence-pages
  */
 
@@ -17,9 +15,8 @@ type FullPage = ConfluencePage & { version: number };
 /** Client for Confluence page operations. */
 export interface ConfluencePagesClient {
   /**
-   * Search content with CQL (Confluence Query Language) via the v1 search API
-   * (v2 has no CQL equivalent). Returns matched pages, normalised to v2 shape
-   * where possible (best-effort — search results omit version/body).
+   * Search content with CQL via the v1 search API. Returns matched pages
+   * normalised to v2 shape (best-effort — search results omit version/body).
    */
   search(params: { cql: string; limit?: number }): Promise<ConfluencePage[]>;
   /** Get a page by ID (v2), optionally including the storage-format body. */
@@ -68,9 +65,7 @@ export function createConfluencePagesClient(client: AtlassianClient): Confluence
       if (key) spaceKeyCache.set(spaceId, key);
       return key;
     } catch (error) {
-      // A 404 just means the space isn't visible (treat as unresolvable). Any
-      // other error (401/403/429/timeout) is surfaced via the log so a flaky
-      // network doesn't masquerade as a "space not allowed" configuration error.
+      // 404 means the space isn't visible (unresolvable); other errors are logged.
       const status = (error as { response?: { status?: number } })?.response?.status;
       if (status !== 404) {
         console.warn(
@@ -113,8 +108,7 @@ export function createConfluencePagesClient(client: AtlassianClient): Confluence
       const pages = (res.results ?? [])
         .map(mapV1SearchResult)
         .filter((p): p is ConfluencePage => p !== null);
-      // Best-effort space-key enforcement: v1 search results carry a space key,
-      // so drop any whose space is outside the allowlist.
+      // Best-effort space-key enforcement on v1 search results.
       return filterByAllowlist(pages, (p) => p.space_key, client.confluenceSpaceKeys);
     },
 
@@ -175,8 +169,7 @@ export function createConfluencePagesClient(client: AtlassianClient): Confluence
     },
 
     async getChildren(pageId, options = {}) {
-      // Enforce the space allowlist before listing children: this is a pageId
-      // read like every other Confluence pageId op, so it must be scoped too.
+      // Enforce the space allowlist before listing children.
       if (client.confluenceSpaceKeys.length > 0) {
         await enrich(
           mapV2Page(await client.get<unknown>(`/wiki/api/v2/pages/${encodeURIComponent(pageId)}`))

--- a/mcp-servers/atlassian/src/domains/jira-agile.ts
+++ b/mcp-servers/atlassian/src/domains/jira-agile.ts
@@ -54,9 +54,6 @@ export function createJiraAgileClient(client: AtlassianClient): JiraAgileClient 
 
   /**
    * Enforce the project allowlist for a sprint whose board ID may be absent.
-   * The Agile API can omit `originBoardId` (e.g. for some closed/cross-board
-   * sprints); when that happens and an allowlist is configured we cannot prove
-   * the sprint is in scope, so we fail closed rather than leak it.
    * @param sprintId - The sprint ID (for the error message only).
    * @param boardId - The sprint's `originBoardId`, or `undefined` if absent.
    */
@@ -125,8 +122,7 @@ export function createJiraAgileClient(client: AtlassianClient): JiraAgileClient 
         sprintId,
         typeof sprint.originBoardId === 'number' ? sprint.originBoardId : undefined
       );
-      // The board check covers the sprint's project; each issue can still belong
-      // to a different project, so validate every key against the allowlist too.
+      // Each issue may belong to a different project than the sprint's board.
       const issues = issueKeysOrIds.slice(0, 50);
       for (const ref of issues) assertJiraIssueKeyAllowed(ref, client.jiraProjectKeys);
       await client.post<void>(`/rest/agile/1.0/sprint/${sprintId}/issue`, { issues });

--- a/mcp-servers/atlassian/src/domains/jira-issues.ts
+++ b/mcp-servers/atlassian/src/domains/jira-issues.ts
@@ -1,9 +1,5 @@
 /**
- * Jira issues domain — search (enhanced JQL), CRUD, transitions, assignment,
- * and the current account. Wraps {@link AtlassianClient}'s low-level helpers;
- * the enhanced search endpoint (`POST /rest/api/3/search/jql`) is paginated by
- * an opaque `nextPageToken` rather than `startAt` (the old `/search` endpoint
- * is being removed by Atlassian).
+ * Jira issues domain — search (enhanced JQL), CRUD, transitions, assignment, account.
  * @module mcp-atlassian/domains/jira-issues
  */
 
@@ -123,9 +119,7 @@ export function createJiraIssuesClient(client: AtlassianClient): JiraIssuesClien
         nextPageToken?: string | null;
         isLast?: boolean;
       }>('/rest/api/3/search/jql', body, { retryable: true });
-      // Enforce the project allowlist on the result set: arbitrary JQL can match
-      // issues outside the configured projects, so filter rather than trust the
-      // query (same approach as confluence-pages.ts `search`).
+      // Filter the result set by the project allowlist.
       const issues = filterByAllowlist(
         (res.issues ?? []).map(mapIssue),
         (i) => i.project_key,

--- a/mcp-servers/atlassian/src/domains/jira-projects.ts
+++ b/mcp-servers/atlassian/src/domains/jira-projects.ts
@@ -49,7 +49,7 @@ export function createJiraProjectsClient(client: AtlassianClient): JiraProjectsC
     },
 
     async listIssueTypes(projectIdOrKey) {
-      // Enforce scope first (cheap: parse a project key, or fetch the project).
+      // Enforce scope first.
       const project = await this.get(projectIdOrKey);
       const res = await client.get<unknown[]>(`/rest/api/3/issuetype/project`, {
         projectId: project.id,

--- a/mcp-servers/atlassian/src/index.ts
+++ b/mcp-servers/atlassian/src/index.ts
@@ -1,11 +1,5 @@
 /**
- * MCP Atlassian Worker
- *
- * Isolated Jira & Confluence (Atlassian Cloud) MCP server with per-service token
- * isolation. Built on a thin `axios` HTTP client (no external Atlassian SDK —
- * see `docs/guides/integrations.md` for the rationale). Exposes 33 tools across
- * Jira (issues, comments, projects, Agile boards/sprints) and Confluence
- * (spaces, pages, comments, labels, attachments).
+ * MCP Atlassian Worker — isolated Jira & Confluence (Atlassian Cloud) server with per-service token isolation.
  * @module mcp-atlassian
  */
 

--- a/mcp-servers/atlassian/src/scope.ts
+++ b/mcp-servers/atlassian/src/scope.ts
@@ -1,12 +1,5 @@
 /**
- * Project/space scope enforcement for the Atlassian worker.
- *
- * The worker authenticates as a real Atlassian account, so by default it can
- * reach everything that account can. The optional `jira_project_keys` /
- * `confluence_space_keys` allowlists narrow that surface: when configured, any
- * operation whose project/space is not in the list — or whose project/space
- * cannot be determined — is rejected with {@link ScopeError}. An empty allowlist
- * means "unrestricted".
+ * Project/space scope enforcement. Optional allowlists narrow surface; empty = unrestricted.
  * @module mcp-atlassian/scope
  */
 
@@ -14,7 +7,7 @@
 export class ScopeError extends Error {
   /**
    * Create a scope-violation error.
-   * @param message - Human-readable explanation of the violation.
+   * @param message - Human-readable violation detail.
    */
   constructor(message: string) {
     super(message);
@@ -23,10 +16,7 @@ export class ScopeError extends Error {
 }
 
 /**
- * Throw {@link ScopeError} if `allowlist` is non-empty and `key` is not in it.
- * Comparison is case-insensitive (Atlassian keys are upper-case). A missing/empty
- * `key` with a configured allowlist is also rejected — callers must resolve the
- * key before the check.
+ * Check if key is in allowlist (case-insensitive). Reject if missing or not in allowlist.
  * @param key - Project/space key to check (may be `undefined`).
  * @param allowlist - Configured allowed keys (empty = unrestricted).
  * @param kind - `'Jira project'` or `'Confluence space'`, for the error message.
@@ -76,12 +66,7 @@ export function assertConfluenceSpaceAllowed(
 }
 
 /**
- * Enforce the Jira project allowlist for an issue ref. When `issueIdOrKey` is a
- * `PROJ-123`-style key the project is parsed directly; when it is a bare numeric
- * ID the key cannot be derived from the string, so — if an allowlist is
- * configured — the operation is rejected with {@link ScopeError} (callers that
- * need numeric-ID support with an allowlist must resolve the issue key first).
- * No-op when no allowlist is configured.
+ * Enforce allowlist for issue key. Numeric IDs rejected if allowlist is configured; callers must resolve key first.
  * @param issueIdOrKey - The Jira issue key (e.g. `PROJ-123`) or numeric ID.
  * @param allowlist - Configured allowed project keys (empty = unrestricted).
  */
@@ -95,8 +80,7 @@ export function assertJiraIssueKeyAllowed(
 }
 
 /**
- * Filter a list of items to those whose key is in the allowlist. When the
- * allowlist is empty the list passes through unchanged.
+ * Filter items by allowlist keys (case-insensitive). Empty allowlist = no filtering.
  * @param items - Items to filter.
  * @param keyOf - Extracts the project/space key from an item.
  * @param allowlist - Configured allowed keys (empty = unrestricted).

--- a/mcp-servers/atlassian/src/tools/validation.ts
+++ b/mcp-servers/atlassian/src/tools/validation.ts
@@ -1,8 +1,5 @@
 /**
- * Tool-handler wrapper for the Atlassian worker: short-circuits to a
- * "not configured" error when the client is absent, and turns any thrown error
- * into a sanitized {@link errorResult} via {@link AtlassianClient.formatError}.
- * Named `withValidation` for consistency with the other workers.
+ * Tool-handler wrapper for the Atlassian worker.
  * @module mcp-atlassian/tools/validation
  */
 
@@ -16,8 +13,7 @@ import { AtlassianClient } from '../client.js';
 import type { StorageBodyInput } from '../adf.js';
 
 /**
- * Wrap a tool handler with client-presence and error handling (shared Family-B
- * wrapper {@link withClientValidation}).
+ * Wrap a tool handler with client-presence and error handling.
  * @template T - The tool's parsed input params type.
  * @param client - The Atlassian client (or `null` when the service is unconfigured).
  * @param handler - The handler, invoked only when `client` is non-null.
@@ -37,10 +33,7 @@ export function withValidation<T>(
 }
 
 /**
- * Map a Confluence body tool input (`{ bodyStorage?, bodyText? }`) to the domain
- * {@link StorageBodyInput} shape (`{ storage?, text? }`). `bodyStorage` (raw
- * storage-representation XHTML) takes precedence; otherwise `bodyText` is used
- * (an absent text body becomes the empty string).
+ * Map a Confluence body tool input to the domain {@link StorageBodyInput} shape.
  * @param p - The tool input fragment.
  * @param p.bodyStorage - Body as raw storage-representation XHTML (takes precedence).
  * @param p.bodyText - Body as plain text (used when `bodyStorage` is absent).

--- a/mcp-servers/atlassian/src/url.ts
+++ b/mcp-servers/atlassian/src/url.ts
@@ -6,13 +6,10 @@
 import { ts } from '@speedwave/mcp-shared';
 
 /**
- * Build the human `/browse/<key>` URL for a Jira issue or project from its `self`
- * API URL. Returns `undefined` if `selfUrl` isn't a parseable URL (the API
- * unexpectedly changed its `self` format) — logged at warn level so the change
- * is visible.
+ * Build the human `/browse/<key>` URL for a Jira issue or project from its `self` API URL.
  * @param selfUrl - The resource's `self` API URL.
  * @param key - The Jira issue or project key.
- * @returns The `https://<host>/browse/<key>` URL, or `undefined` on failure.
+ * @returns The `https://<host>/browse/<key>` URL, or `undefined` if `selfUrl` is not parseable (logged at warn).
  */
 export function deriveBrowseUrl(selfUrl: string, key: string): string | undefined {
   try {

--- a/mcp-servers/context7/src/client.test.ts
+++ b/mcp-servers/context7/src/client.test.ts
@@ -1,9 +1,5 @@
 /**
- * Tests for Context7 REST client.
- *
- * Uses undici's built-in MockAgent — same approach as official undici docs,
- * no extra dependency on msw/nock. Each test creates a fresh mock and pins
- * it as the client's dispatcher so global state never leaks between tests.
+ * Tests for Context7 REST client. Uses undici's built-in MockAgent.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -72,8 +68,7 @@ describe('Context7Client.searchLibraries', () => {
       })
       .reply(200, JSON.stringify({ results: [] }));
 
-    // If the header was missing, the intercept would not match and undici
-    // would throw "no matching interceptor" — assertion via behaviour.
+    // Assertion via intercept — if header missing, undici throws.
     await client.searchLibraries('react', 'h');
   });
 
@@ -468,8 +463,7 @@ describe('Context7Client misc', () => {
 
   it('aborts when response body exceeds MAX_RESPONSE_BYTES — OOM regression guard', async () => {
     const { client, mock } = makeClient();
-    // 6 MiB of payload — over the 5 MiB cap. The mock streams it as one chunk;
-    // readBodyLimited must reject before buffering the whole thing.
+    // 6 MiB payload — over the 5 MiB cap.
     const oversized = 'x'.repeat(6 * 1024 * 1024);
     mock
       .intercept({ path: '/api/v2/libs/search?libraryName=react&query=q', method: 'GET' })

--- a/mcp-servers/context7/src/client.ts
+++ b/mcp-servers/context7/src/client.ts
@@ -1,11 +1,6 @@
 /**
- * Context7 REST API client.
- *
- * Talks directly to `https://context7.com/api/v2/*` — same backend the
- * upstream `@upstash/context7-mcp` server proxies to.
- *
- * Anonymous mode (no API key): per-IP rate limit (~200 req/day on
- * `ratelimit-limit` header), see docs/architecture/security.md.
+ * Context7 REST API client for `https://context7.com/api/v2/*`.
+ * Anonymous mode (no API key): per-IP rate limit, see docs/architecture/security.md.
  * @module mcp-context7/client
  */
 
@@ -67,8 +62,6 @@ const RETRY_BASE_DELAY_MS = 1_000;
 
 /**
  * REST client wrapping Context7's search and context endpoints.
- *
- * Stateless aside from the options bag — safe to share across tool calls.
  */
 export class Context7Client {
   private readonly apiKey: string | undefined;
@@ -180,9 +173,7 @@ export class Context7Client {
     let lastError: Context7Error | undefined;
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
       try {
-        // undici v7/v8: redirects opt-in via the `redirect` interceptor —
-        // we never set it, so 3xx surfaces as a status we treat as an error
-        // in mapErrorStatus (defence-in-depth, mirrors ADR-041 host policy).
+        // No `redirect` interceptor set, so 3xx surfaces as an error status.
         const response = await request(url, {
           method: 'GET',
           headers,
@@ -224,8 +215,6 @@ export class Context7Client {
 
 /**
  * Map a Context7 HTTP status to a {@link Context7Error}.
- *
- * Centralised so handlers and tests share the same vocabulary.
  * @param status - HTTP status from Context7
  * @param body - Response body (already read)
  * @param headers - Response headers (used for `ratelimit-reset`)
@@ -377,11 +366,6 @@ function sleep(ms: number): Promise<void> {
 
 /**
  * Drain a response body to a string, throwing if it would exceed `maxBytes`.
- *
- * Undici's `.text()` has no byte ceiling — a 500 MB upstream response would
- * be buffered in full, bounded only by the 128 MiB container cap (OOM kill,
- * not a clean error). This iterates chunks with a running byte counter and
- * aborts cleanly before memory pressure becomes a problem.
  * @param body - Undici response body (AsyncIterable of Buffer chunks)
  * @param maxBytes - Upper bound on total bytes
  * @param tier - Quota tier to attach to the error

--- a/mcp-servers/context7/src/index.test.ts
+++ b/mcp-servers/context7/src/index.test.ts
@@ -1,9 +1,6 @@
 /**
  * Tests for the worker entry point.
- *
- * Regression-guards the rule that the local /health probe MUST NOT call
- * Context7 — at 30 s intervals it would burn the ~200/day anonymous quota
- * in under 2 h, breaking every other user on the same source IP.
+ * Guards that the local /health probe never calls Context7.
  */
 
 import { describe, expect, it, vi } from 'vitest';
@@ -11,9 +8,7 @@ import { createMCPServer } from '@speedwave/mcp-shared';
 
 describe('context7 worker healthcheck', () => {
   it('healthCheck does NOT make outbound HTTP — anonymous quota regression guard', async () => {
-    // The worker installs a local readiness probe. If anyone "improves" it
-    // by probing Context7 (`fetch(BASE_URL + '/libs/search?...')`), this
-    // assertion fires.
+    // Local readiness probe must not call Context7.
     const fetchSpy = vi.fn(() => {
       throw new Error('healthCheck must NOT make HTTP calls');
     });
@@ -26,9 +21,7 @@ describe('context7 worker healthcheck', () => {
         version: '0.0.0',
         port: 0,
         auth: { token: 'test-token' },
-        // No healthCheck callback — local readiness only. Mirrors the
-        // production worker (`src/index.ts`): an external probe here
-        // would burn anonymous quota.
+        // Local readiness only; mirrors production src/index.ts.
         healthCheck: async () => {},
       });
       const actualPort = await server.start();

--- a/mcp-servers/context7/src/index.ts
+++ b/mcp-servers/context7/src/index.ts
@@ -1,10 +1,6 @@
 #!/usr/bin/env node
 /**
- * MCP Context7 Worker
- *
- * Wraps the Context7 REST API (`https://context7.com/api/v2/*`) as an MCP
- * worker discoverable by the hub. Anonymous mode supported — see
- * docs/architecture/security.md for the privacy and rate-limit caveats.
+ * MCP Context7 Worker: wraps the Context7 REST API as an MCP worker, anonymous mode supported.
  * @module mcp-context7
  */
 
@@ -12,21 +8,13 @@ import { bootWorker, loadTokenFile, ts } from '@speedwave/mcp-shared';
 import { Context7Client } from './client.js';
 import { createToolDefinitions } from './tools/index.js';
 
-/**
- * Try to load the optional Context7 API key from `/tokens/api_key`.
- *
- * Returns `undefined` (anonymous mode) when the file is missing or empty;
- * propagates other errors so genuine misconfigurations (EACCES on a present
- * file) surface in startup logs rather than being silently swallowed.
- */
+/** Load optional Context7 API key from `/tokens/api_key`; returns undefined (anonymous) if missing/empty. */
 async function loadOptionalApiKey(): Promise<string | undefined> {
   try {
     const key = await loadTokenFile('api_key');
     return key.length > 0 ? key : undefined;
   } catch (e) {
-    // `loadToken` re-throws with `{ cause: originalErrnoException }`, so the fs
-    // errno is reachable as `e.cause.code` — anything other than ENOENT
-    // (EACCES, EISDIR, …) propagates so real misconfigs surface.
+    // fs errno is at `e.cause.code`; non-ENOENT propagates.
     const cause = (e as { cause?: NodeJS.ErrnoException }).cause;
     if (cause?.code === 'ENOENT') {
       return undefined;
@@ -35,9 +23,7 @@ async function loadOptionalApiKey(): Promise<string | undefined> {
   }
 }
 
-// context7 always constructs a client (anonymous mode is valid, not "not
-// configured"), so initClient never returns null. No healthCheck: probing
-// Context7 here would burn the anonymous quota (index.test.ts guards this).
+// Anonymous mode is valid; no healthCheck (would burn anonymous quota).
 bootWorker<Context7Client>({
   serverName: 'mcp-context7',
   version: '0.1.0',

--- a/mcp-servers/github/src/auth.test.ts
+++ b/mcp-servers/github/src/auth.test.ts
@@ -1,8 +1,6 @@
 /**
- * GitHub worker auth wiring tests (SEC-035)
- *
- * Verifies that mcp-github reads MCP_GITHUB_AUTH_TOKEN and passes it to createMCPServer.
- * Middleware correctness is covered by shared/src/server.test.ts — here we test wiring only.
+ * GitHub worker auth wiring tests (SEC-035): mcp-github reads
+ * MCP_GITHUB_AUTH_TOKEN and passes it to createMCPServer.
  */
 
 import { describe, it, expect, afterEach } from 'vitest';

--- a/mcp-servers/github/src/client.test.ts
+++ b/mcp-servers/github/src/client.test.ts
@@ -1945,9 +1945,7 @@ describe('initializeGitHubClient', () => {
   });
 
   it('returns client + schedules background test when testConnection fails', async () => {
-    // Init no longer blocks on testConnection — it kicks the check into the
-    // background. The client is returned immediately; healthCheck reads the
-    // tracker to surface the failure.
+    // testConnection runs in the background; the client is returned immediately.
     mockLoadTokenFile.mockResolvedValue('test-token');
     octokitHolder.instance = {
       rest: {
@@ -2027,8 +2025,7 @@ describe('initializeGitHubClient', () => {
     mockLoadTokenFile.mockRejectedValue(new Error('EACCES: permission denied, open /tokens/token'));
     const result = await initializeGitHubClient();
     expect(result).toBeNull();
-    // The warning must carry the underlying error (a permissions failure must be
-    // distinguishable from a plain "token not found").
+    // The warning must carry the underlying error detail.
     const warned = (console.warn as unknown as { mock: { calls: unknown[][] } }).mock.calls
       .map((c) => c.join(' '))
       .join('\n');

--- a/mcp-servers/github/src/client.ts
+++ b/mcp-servers/github/src/client.ts
@@ -77,11 +77,7 @@ const DEFAULT_LIMIT = 100;
 const MAX_PER_PAGE = 100;
 
 /**
- * `true` if `url` is a syntactically valid absolute `https://` URL. Used to keep
- * GitHub-supplied download URLs (`Location` headers, `archive_download_url`) from
- * carrying a `file://`, `http://`, or metadata-service address to the model — see
- * `.claude/rules/security.md`. (Inert in v1 since the API base is github.com, but
- * preemptively closes the vector if GHES / a config-driven base URL is ever added.)
+ * `true` if `url` is a syntactically valid absolute `https://` URL.
  * @param url - Candidate URL string
  * @returns Whether the string parses as an `https:` URL
  */
@@ -94,15 +90,9 @@ function isHttpsUrl(url: string): boolean {
 }
 
 /**
- * Extracts the redirect target URL from an Octokit response fetched with
- * `request: { redirect: 'manual' }` (logs/artifact download endpoints). The URL
- * is in the `Location` header; older Octokit versions also exposed it as `res.url`.
- * Throws if neither is present, or if it isn't an `https://` URL — better a clear
- * error than handing Claude an empty or unsafe `download_url` it can't act on
- * (would only happen if GitHub changes the redirect behaviour, a future Octokit
- * version stops exposing it, or a GHES/config-driven base URL is added later).
+ * Extracts the redirect target URL from an Octokit response (status 302).
  * @param res - Octokit response object (status 302)
- * @param what - What was being downloaded, for the error message (e.g. "workflow run logs")
+ * @param what - What was being downloaded, for the error message
  * @returns The non-empty `https://` redirect URL
  */
 function extractRedirectUrl(res: unknown, what: string): string {
@@ -119,9 +109,6 @@ function extractRedirectUrl(res: unknown, what: string): string {
 
 /**
  * Decodes the body of a `mediaType: { format: 'diff' }` response to a string.
- * Octokit returns a `string` when the response carries a textual content-type, but
- * falls back to an `ArrayBuffer`/`Buffer` otherwise — guard against that so we never
- * return the literal `"[object ArrayBuffer]"`.
  * @param data - The `response.data` from a diff-format request
  * @returns The diff as a UTF-8 string
  */
@@ -153,10 +140,7 @@ type ErrorCategory =
   | 'unknown';
 
 /**
- * Classifies an Octokit-style error into a coarse {@link ErrorCategory}, the single place
- * that knows which HTTP status / message substring means what. `formatError` turns the
- * category (plus the raw error) into a user-facing string; `testConnection` exposes it
- * directly so callers can branch on `auth` vs `network` etc.
+ * Classifies an Octokit-style error into a coarse {@link ErrorCategory}.
  * @param error - The thrown value (an Octokit RequestError or anything else)
  * @returns The matched error category
  */
@@ -458,8 +442,7 @@ export class GitHubClient {
       id: Number(a.id),
       name: String(a.name || ''),
       size_in_bytes: Number(a.size_in_bytes || 0),
-      // Drop anything that isn't a plain https:// URL — never hand a file://, http://,
-      // or metadata-service address to the model (see isHttpsUrl).
+      // Drop any non-https:// URL (see isHttpsUrl).
       archive_download_url: isHttpsUrl(downloadUrl) ? downloadUrl : '',
       expired: Boolean(a.expired),
     };
@@ -601,8 +584,7 @@ export class GitHubClient {
       console.error(`${ts()} GitHub connection test failed:`, errorMessage);
 
       const category = classifyOctokitError(error);
-      // `validation` / `server` aren't expected for getAuthenticated() and aren't part of
-      // ConnectionTestResult's narrower set — fold them into 'unknown'.
+      // Fold `validation` / `server` into 'unknown' (not in ConnectionTestResult's set).
       const errorType: ConnectionTestResult['errorType'] =
         category === 'validation' || category === 'server' ? 'unknown' : category;
 
@@ -1396,8 +1378,7 @@ export class GitHubClient {
         });
         sha = existing.sha;
       } catch (error) {
-        // Only "file does not exist yet" (404) is expected — re-throw anything else
-        // (permission errors, network failures, "path is a directory", etc.).
+        // 404 means the file does not exist yet; re-throw anything else.
         if ((error as OctokitErrorLike)?.status !== 404) {
           throw error;
         }
@@ -1895,19 +1876,8 @@ export class GitHubClient {
 //═══════════════════════════════════════════════════════════════════════════════
 
 /**
- * Initializes the GitHub client with a token from the mounted token path.
- * Reads the authentication token from /tokens/token (or TOKENS_DIR env var) and tests
- * connectivity before returning the client. github.com only in v1 — there is no
- * host_url file (unlike GitLab); the API base URL stays at its default
- * (https://api.github.com). If a future version adds GHES support, read base_url here.
- *
- * IMPORTANT: Returns null (not throws) when the token is missing or invalid.
- * This enables "graceful degradation" - the server starts even without config:
- * - User can run `speedwave` (no subcommand) without configuring all integrations
- * - Healthcheck reports the service as unconfigured
- * - Tools return a clear "not configured" error when called
- *
- * DO NOT change this to throw - it breaks container startup for unconfigured services.
+ * Initializes the GitHub client with a token from /tokens/token.
+ * Returns null (not throws) when token is missing or invalid (graceful degradation).
  * @returns Configured GitHubClient instance, or null if the token is not found / invalid
  */
 export async function initializeGitHubClient(): Promise<GitHubClient | null> {
@@ -1934,8 +1904,6 @@ export async function initializeGitHubClient(): Promise<GitHubClient | null> {
     console.log(`${ts()} ✅ GitHub client initialized, connection test scheduled`);
     return client;
   } catch (error) {
-    // Broad catch is intentional (graceful degradation), but surface the full error —
-    // a permissions error on /tokens/token must be distinguishable from a missing token.
     const detail = error instanceof Error ? (error.stack ?? error.message) : String(error);
     console.warn(`${ts()} Failed to initialize GitHub client: ${detail}`);
     return null;

--- a/mcp-servers/github/src/tools/index.ts
+++ b/mcp-servers/github/src/tools/index.ts
@@ -1,17 +1,5 @@
 /**
- * GitHub Tools Aggregator
- *
- * Exports all 45 tools (camelCase names) organized by domain:
- * - Repos: 3 tools (listRepos, getRepo, searchCode)
- * - Pull Requests: 7 tools (listPullRequests, getPullRequest, createPullRequest, mergePullRequest, updatePullRequest, getPrDiff, getPrFiles)
- * - PR Review: 6 tools (listPrCommits, listPrReviews, createPrReview, listPrComments, createPrComment, createPrReviewComment)
- * - Branches: 5 tools (listBranches, getBranch, createBranch, deleteBranch, compareBranches)
- * - Commits: 4 tools (listCommits, listBranchCommits, searchCommits, getCommitDiff)
- * - Repository content: 3 tools (getTree, getFileContents, createOrUpdateFile)
- * - Actions: 7 tools (listWorkflowRuns, getWorkflowRun, getRunLogs, rerunWorkflow, triggerWorkflow, listWorkflowRunArtifacts, downloadArtifact)
- * - Issues: 5 tools (listIssues, getIssue, createIssue, updateIssue, closeIssue)
- * - Labels: 2 tools (listLabels, createLabel)
- * - Releases: 3 tools (createTag, deleteTag, createRelease)
+ * GitHub Tools Aggregator — exports 45 tools across 10 domains via factory functions.
  */
 
 import { ToolDefinition } from '@speedwave/mcp-shared';

--- a/mcp-servers/github/src/tools/pr.test.ts
+++ b/mcp-servers/github/src/tools/pr.test.ts
@@ -1,9 +1,4 @@
-/**
- * Tests for GitHub Pull Request Tools
- *
- * Coverage: listPullRequests, getPullRequest, createPullRequest, mergePullRequest,
- *           updatePullRequest, getPrDiff, getPrFiles (7 tools)
- */
+/** Tests for GitHub Pull Request Tools. */
 
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { notConfiguredMessage } from '@speedwave/mcp-shared';

--- a/mcp-servers/github/src/tools/validation.ts
+++ b/mcp-servers/github/src/tools/validation.ts
@@ -1,11 +1,4 @@
-/**
- * Validation Helpers for GitHub Tool Parameters
- *
- * `withValidation` delegates to the shared Family-B wrapper
- * ({@link withClientValidation}): not-configured gate + error mapping. The
- * unexpected-error hook logs anything that isn't an Octokit-style error (a
- * programming bug in a handler) so it doesn't masquerade as a "GitHub API error".
- */
+/** Validation helpers for GitHub tool parameters (via shared {@link withClientValidation}). */
 
 import {
   withClientValidation,

--- a/mcp-servers/github/src/types.ts
+++ b/mcp-servers/github/src/types.ts
@@ -1,14 +1,9 @@
 /**
- * GitHub MCP Server Type Definitions
- *
- * Extracted from client.ts for better modularity.
- * Field names mirror the GitHub REST API (mostly snake_case); the client
- * mappers normalize raw responses to these shapes defensively.
+ * GitHub MCP Server type definitions; field names mirror the GitHub REST API.
  */
 
 /**
  * GitHub API client configuration.
- * Contains the authentication token and an optional API base URL.
  * @interface GitHubConfig
  */
 export interface GitHubConfig {

--- a/mcp-servers/gitlab/src/client.test.ts
+++ b/mcp-servers/gitlab/src/client.test.ts
@@ -2461,9 +2461,6 @@ describe('initializeGitLabClient', () => {
   });
 
   it('returns client + schedules background test when testConnection fails', async () => {
-    // Init no longer blocks on testConnection — it kicks the check into the
-    // background. The client is returned immediately; healthCheck reads the
-    // tracker to surface the failure.
     mockLoadTokenFile.mockResolvedValue('test-token');
     mockReadFile.mockRejectedValue(new Error('ENOENT'));
 
@@ -3669,8 +3666,7 @@ describe('initializeGitLabClient — additional branches', () => {
 
     await initializeGitLabClient();
 
-    // When host_url file has empty content, should use default gitlab.com
-    // (because trimmed is empty string, falls through to default)
+    // Empty host_url content falls through to default gitlab.com
     expect(mockGitlabConstructor).toHaveBeenCalledWith({
       token: 'test-token',
       host: 'https://gitlab.com',

--- a/mcp-servers/gitlab/src/client.ts
+++ b/mcp-servers/gitlab/src/client.ts
@@ -1434,18 +1434,7 @@ export class GitLabClient {
 //═══════════════════════════════════════════════════════════════════════════════
 
 /**
- * Initializes GitLab client with token from mounted path and host from /tokens/host_url.
- * Reads authentication token from /tokens/token (or TOKENS_DIR env var) and GitLab host URL
- * from /tokens/host_url file. Falls back to GITLAB_URL env var, then https://gitlab.com.
- * Tests connection before returning client instance.
- *
- * IMPORTANT: Returns null (not throws) when tokens are missing or invalid.
- * This enables "graceful degradation" - server starts even without config:
- * - User can run `speedwave` (no subcommand) without configuring all integrations
- * - Healthcheck reports `configured: false` for unconfigured services
- * - Tools return clear "not configured" error when called
- *
- * DO NOT change this to throw - it breaks container startup for unconfigured services.
+ * Initializes GitLab client from /tokens/token and /tokens/host_url (or GITLAB_URL, then https://gitlab.com).
  * @returns Configured GitLabClient instance, or null if token not found/invalid
  */
 export async function initializeGitLabClient(): Promise<GitLabClient | null> {
@@ -1455,8 +1444,7 @@ export async function initializeGitLabClient(): Promise<GitLabClient | null> {
     const token = await loadTokenFile('token');
 
     if (!token) {
-      // Graceful degradation: log warning, return null, let server start
-      // DO NOT throw here - see JSDoc above for rationale
+      // Graceful degradation: return null, let server start
       console.warn(`${ts()} ${withSetupGuidance('GitLab token is empty or not found.')}`);
       return null;
     }
@@ -1484,9 +1472,7 @@ export async function initializeGitLabClient(): Promise<GitLabClient | null> {
       }
     }
 
-    // Create client. Connection test runs in the background — see comment
-    // on backgroundConnectionTest. The HTTP listener no longer waits on a
-    // slow or unreachable GitLab.
+    // Connection test runs async; see backgroundConnectionTest
     const client = new GitLabClient({ token, host });
     backgroundConnectionTest(
       client.statusTracker,

--- a/mcp-servers/gitlab/src/tools/label-tools.ts
+++ b/mcp-servers/gitlab/src/tools/label-tools.ts
@@ -112,7 +112,7 @@ const createLabelTool: Tool = {
 };
 
 /**
- * Tool handler function
+ * Builds the GitLab label tool definitions.
  * @param client - GitLab client instance
  */
 export function createLabelTools(client: GitLabClient | null): ToolDefinition[] {

--- a/mcp-servers/gitlab/src/tools/mr-notes.test.ts
+++ b/mcp-servers/gitlab/src/tools/mr-notes.test.ts
@@ -1,12 +1,4 @@
-/**
- * Tests for MR Notes Tools
- *
- * Tests 4 tools:
- * - list_mr_commits: List commits in a merge request
- * - list_mr_pipelines: List pipelines associated with a merge request
- * - list_mr_notes: List notes/comments on a merge request
- * - create_mr_note: Add a comment/note to a merge request
- */
+/** Tests for MR Notes Tools: list_mr_commits, list_mr_pipelines, list_mr_notes, create_mr_note. */
 
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { notConfiguredMessage, withSetupGuidance } from '@speedwave/mcp-shared';

--- a/mcp-servers/gitlab/src/tools/release-tools.ts
+++ b/mcp-servers/gitlab/src/tools/release-tools.ts
@@ -161,7 +161,7 @@ const createReleaseTool: Tool = {
 };
 
 /**
- * Tool handler function
+ * Builds the GitLab release tool definitions.
  * @param client - GitLab client instance
  */
 export function createReleaseTools(client: GitLabClient | null): ToolDefinition[] {

--- a/mcp-servers/gitlab/src/tools/validation.ts
+++ b/mcp-servers/gitlab/src/tools/validation.ts
@@ -1,10 +1,5 @@
 /**
- * Validation Helpers for GitLab Tool Parameters
- *
- * `withValidation` delegates to the shared Family-B wrapper
- * ({@link withClientValidation}): not-configured gate + error mapping. The
- * unexpected-error hook logs anything that isn't a GitBeaker-style error (a
- * programming bug in a handler) so it doesn't masquerade as a "GitLab API error".
+ * Validation helpers for GitLab tool parameters; delegates to {@link withClientValidation}.
  */
 
 import {

--- a/mcp-servers/hub/src/auto-return.test.ts
+++ b/mcp-servers/hub/src/auto-return.test.ts
@@ -37,9 +37,6 @@ describe('addAutoReturn (AST-based)', () => {
   });
 
   it('parses top-level return without error (sourceType: script)', () => {
-    // This test verifies the fix for 'return' outside of function error
-    // With sourceType: 'module', this would fail parsing
-    // With sourceType: 'script', this parses correctly
     const result = addAutoReturn('return 42');
     expect(result.code).toBe('return 42');
     expect(result.parseError).toBeUndefined();
@@ -157,8 +154,6 @@ describe('addAutoReturn (AST-based)', () => {
 
   // AST body length === 0: a comment-only string parses to an empty body
   it('returns original code unchanged when AST body is empty (comment only)', () => {
-    // Acorn parses a comment-only string to ast.body === [] — no statements.
-    // addAutoReturn should detect this and return { code } unchanged.
     const input = '/* just a comment */';
     const result = addAutoReturn(input);
     expect(result.code).toBe(input);

--- a/mcp-servers/hub/src/auto-return.ts
+++ b/mcp-servers/hub/src/auto-return.ts
@@ -12,17 +12,7 @@ export interface AutoReturnResult {
 }
 
 /**
- * Dodaje 'return' do ostatniego wyrażenia w kodzie, jeśli nie ma explicit return.
- * Używa AST parsera dla 100% poprawności.
- *
- * Parser configuration:
- * - sourceType: 'script' - allows parsing without ES module restrictions
- * - allowAwaitOutsideFunction: true - allows top-level await
- * - allowReturnOutsideFunction: true - allows top-level return
- *
- * Note: ES module syntax (import/export statements) will cause parse errors.
- * This is intentional - the code is executed inside an AsyncFunction wrapper,
- * where static ES module syntax is not supported anyway.
+ * Adds implicit 'return' to the last expression if no explicit return exists.
  * @param code - JavaScript code to process
  * @returns Result with code and optional parse error
  */

--- a/mcp-servers/hub/src/bridge-executor-parity.test.ts
+++ b/mcp-servers/hub/src/bridge-executor-parity.test.ts
@@ -1,15 +1,5 @@
 /**
- * Bridge-Executor Parity Tests (SSOT Architecture)
- *
- * With the Single Source of Truth (SSOT) refactoring:
- * - Both http-bridge and executor are generated from TOOL_REGISTRY
- * - Parity is GUARANTEED BY DESIGN
- * - No more manual sync needed between files
- *
- * These tests verify:
- * 1. Registry contains all expected methods
- * 2. Bridges are correctly generated from registry
- * 3. Registry consistency with tool files
+ * Bridge-Executor Parity Tests: bridges and registry stay consistent.
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';

--- a/mcp-servers/hub/src/executor.test.ts
+++ b/mcp-servers/hub/src/executor.test.ts
@@ -18,15 +18,7 @@ import {
 } from './test-helpers.js';
 
 //═══════════════════════════════════════════════════════════════════════════════
-// Tests for Code Executor
-//
-// Purpose: Test sandbox execution (security and basic functionality)
-// - Verify security restrictions (forbidden patterns)
-// - Verify basic code execution without tool dependencies
-//
-// Note: These tests focus on code validation and security.
-// Full integration tests with tool availability, audit logging, and PII tokenization
-// are tested separately with proper mocking/fixtures to avoid bridge initialization issues.
+// Tests for Code Executor (sandbox security and basic validation)
 //═══════════════════════════════════════════════════════════════════════════════
 
 describe('executor', () => {
@@ -160,8 +152,6 @@ describe('executor', () => {
     it('should enforce timeout on async operations', async () => {
       _setBridgesForTesting(createMockBridges());
 
-      // Note: Synchronous infinite loops cannot be interrupted by Promise.race timeout
-      // This tests async timeout which is the realistic scenario
       const code = `
         await new Promise(resolve => setTimeout(resolve, 5000));
         return { done: true };
@@ -475,9 +465,7 @@ describe('executor', () => {
     });
   });
 
-  // Note: sanitizeParamsForLogging tests removed - functionality moved to PII Tokenizer
-  // Sensitive data protection for Claude is handled by pii-tokenizer.ts (SENSITIVE_FIELD type)
-  // Local Docker logs are not sanitized as they don't leave the container
+  // sanitizeParamsForLogging tests moved to pii-tokenizer.ts
 
   describe('batch helper (through executeCode)', () => {
     beforeEach(() => {
@@ -596,13 +584,7 @@ describe('executor', () => {
   });
 
   describe('auto-return transformation', () => {
-    // These tests verify that the auto-return transformation correctly prepends
-    // 'return' to expressions without causing syntax errors.
-    // We test using pure JavaScript that doesn't require HTTP bridges.
-
     it('should handle multiline expression with object parameter', async () => {
-      // Simulates: await sharepoint.sync({ local_path: "/path", mode: "pull" });
-      // The multiline object literal should not break the auto-return transformation
       const code = `({
         local_path: "/path",
         mode: "pull"
@@ -893,16 +875,12 @@ describe('executor', () => {
 
   describe('auto-return parse error path (syntax warning)', () => {
     it('warns and continues execution when addAutoReturn returns a parseError', async () => {
-      // Code with a syntax error — addAutoReturn will fail to parse and
-      // return { code, parseError: '...' }, which triggers the syntaxWarning branch.
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-      // Deliberately malformed code (unclosed brace) — addAutoReturn cannot parse it
-      // but the execution attempt will fail with a runtime error, which is fine.
+      // Malformed code (unclosed brace) — addAutoReturn cannot parse it
       const code = `const x = {`;
       const result = await executeCode({ code, timeoutMs: 5000 });
 
-      // Whether success or failure, the warn branch was reached
       const warnMessages = warnSpy.mock.calls.map((args) => String(args[0]));
       const syntaxWarnEmitted = warnMessages.some((m) => m.includes('[executor]'));
       expect(syntaxWarnEmitted).toBe(true);
@@ -1053,8 +1031,7 @@ describe('executor', () => {
     });
 
     it('skips a service in SERVICE_NAMES that is not in ENABLED_SERVICES', async () => {
-      // Service 'os' is in SERVICE_NAMES (via _setServiceNamesForTesting) but NOT in ENABLED_SERVICES.
-      // createToolWrappers must hit the `if (!enabled.has(service)) continue` branch for 'os'.
+      // 'os' is in SERVICE_NAMES but not ENABLED_SERVICES — hits the skip branch
       resetServiceCaches();
       process.env.ENABLED_SERVICES = 'slack';
       // Add 'os' to SERVICE_NAMES even though it is not enabled
@@ -1108,8 +1085,7 @@ describe('executor', () => {
     });
 
     it('uses "Unknown execution error" when caught value is not an Error', async () => {
-      // Line 569 branch: `error instanceof Error ? error.message : 'Unknown execution error'`
-      // Throw a plain string from the sandbox to exercise the non-Error path.
+      // Throw a plain string to exercise the non-Error catch path
       const code = `throw 'a plain string error';`;
       const result = await executeCode({ code, timeoutMs: 5000 });
 
@@ -1134,9 +1110,7 @@ describe('executor', () => {
     });
 
     it('falls through to generic error when the identified service is not in sandbox', async () => {
-      // `someService.nonExistent is not a function` — `someService` is not a known service
-      // in the sandbox, so the `if (serviceTools && typeof serviceTools === 'object')` branch
-      // evaluates to false (serviceTools is undefined). Lines 587-592 are the falsy path.
+      // unknown service → serviceTools undefined → falsy branch
       resetServiceCaches();
       process.env.ENABLED_SERVICES = 'slack';
       _setBridgesForTesting(createMockBridges());
@@ -1167,14 +1141,11 @@ describe('executor', () => {
     });
 
     it('falls through when underscore-split service is not in sandbox', async () => {
-      // Line 608: underscoreMatch found, but sandboxContext[serviceName] is undefined/falsy.
-      // Use a name like `ghost_method` where `ghost` is not a service in the sandbox.
+      // `ghost_method` → `ghost` not in sandbox → underscore handler falls through
       resetServiceCaches();
       process.env.ENABLED_SERVICES = 'slack';
       _setBridgesForTesting(createMockBridges());
 
-      // `ghost_method` → serviceName='ghost', methodName='method'
-      // sandboxContext['ghost'] is undefined → the `if (serviceTools && ...)` is false
       const code = `ghost_method()`;
       const result = await executeCode({ code, timeoutMs: 5000 });
 
@@ -1222,8 +1193,7 @@ describe('executor', () => {
     });
 
     it('audit log uses empty object fallback when params is undefined', async () => {
-      // Call a tool WITHOUT arguments so params is undefined in the wrapWithAudit callback.
-      // This exercises the `params ?? {}` branches at lines 199 and 204.
+      // No-arg call → params undefined → exercises the `params ?? {}` fallback
       globalThis.fetch = vi.fn().mockResolvedValue({
         ok: true,
         status: 200,
@@ -1281,8 +1251,7 @@ describe('executor', () => {
     });
 
     it('iterates serviceName parts to find the real service when it contains underscores', async () => {
-      // Register a service with an underscore in the name so that the while loop
-      // inside the underscore error handler has to iterate to find the right split.
+      // Service name with underscore forces the split-iteration while loop
       const mutableRegistry = TOOL_REGISTRY as Record<
         string,
         Record<string, Record<string, unknown>>
@@ -1299,22 +1268,15 @@ describe('executor', () => {
         },
       };
 
-      // Add my_service to SERVICE_NAMES so createToolWrappers includes it in the sandbox context.
-      // buildServiceBridge needs _registry['my_service'] to exist (set above).
+      // my_service must be in SERVICE_NAMES for createToolWrappers to include it
       _setServiceNamesForTesting(['slack', 'sharepoint', 'redmine', 'gitlab', 'os', 'my_service']);
 
-      // Set a worker URL so callWorker doesn't throw "Unknown service: my_service".
-      // (The URL doesn't need to be reachable — the code under test never actually calls
-      // my_service.doThing(); it only produces a ReferenceError for my_service_doThing.)
+      // Worker URL so callWorker doesn't throw "Unknown service: my_service"
       process.env.WORKER_MY_SERVICE_URL = 'http://mcp-my-service:9999';
       process.env.ENABLED_SERVICES = 'slack,my_service';
       resetServiceCaches();
 
-      // This triggers the `XXX_YYY is not defined` handler.
-      // The greedy regex first captures `my` as serviceName and `service_doThing` as methodName.
-      // The while loop iterates: serviceName+='_service', methodName='doThing' — now found in
-      // sandboxContext because my_service is in SERVICE_NAMES and enabled.
-      // Because `doThing` is a camelCase match in `my_service`, it hits the camelMethod branch.
+      // Triggers the `XXX_YYY is not defined` handler; while loop resolves my_service.doThing
       const code = `my_service_doThing()`;
       const result = await executeCode({ code, timeoutMs: 5000 });
 

--- a/mcp-servers/hub/src/executor.ts
+++ b/mcp-servers/hub/src/executor.ts
@@ -122,7 +122,6 @@ type AuditCategory = 'READ' | 'WRITE' | 'DELETE';
 
 /**
  * Derive audit category from a tool's annotations in the registry.
- * Falls back to 'WRITE' when annotations are unavailable (safe default).
  * @param service - Service name (e.g., 'redmine', 'gitlab')
  * @param tool - camelCase tool method name (e.g., 'createIssue')
  */
@@ -269,14 +268,7 @@ function logErrorDebug(context: string, error: unknown): void {
 }
 
 /**
- * Create tool wrappers for sandbox execution
- * These wrap HTTP bridge calls with PII tokenization and audit logging.
- *
- * ARCHITECTURE: Uses buildExecutorWrappers from tool-registry.ts
- * - Tool metadata (name, service) is Single Source of Truth
- * - Wrappers are generated dynamically from registry
- * - No manual duplication of method definitions
- * - Timeout propagation: remaining time budget passed to each worker call
+ * Create tool wrappers for sandbox execution (PII tokenization, audit logging).
  * @param piiContext - PII tokenization context for this execution
  * @param auditContext - Audit logging context for tracking tool calls
  * @param executionStartTime - Start time of execution (Date.now())
@@ -573,10 +565,7 @@ export async function executeCode(params: ExecuteCodeParams): Promise<IToolResul
       }
     }
 
-    // Smart error enhancement: detect underscore notation "service_method is not defined"
-    // Claude sometimes generates service_method instead of service.method
-    // The greedy regex splits at the last underscore so serviceName = everything before the last _
-    // and methodName = the part after. This directly gives the longest possible service prefix.
+    // Detect underscore notation: "service_method is not defined"
     const underscoreMatch = message.match(/^([\w]+)_([\w_]+) is not defined$/);
     if (underscoreMatch) {
       const [, serviceName, methodName] = underscoreMatch;

--- a/mcp-servers/hub/src/handlers.test.ts
+++ b/mcp-servers/hub/src/handlers.test.ts
@@ -448,7 +448,6 @@ describe('createCodeExecutorHandlers', () => {
       });
 
       // undefined is converted to "null" to avoid MCP validation errors
-      // (JSON.stringify(undefined) returns undefined, not a string!)
       expect(result.content[0].text).toBe('null');
     });
 
@@ -800,8 +799,7 @@ describe('createCodeExecutorHandlers', () => {
     });
 
     it('should use timeout from registry SSOT (tool metadata declares timeoutClass)', async () => {
-      // This test verifies the SOLID refactoring: timeout class comes from tool metadata
-      // not from hardcoded regex patterns in handlers.ts
+      // timeout class comes from tool metadata, not hardcoded regex patterns
       vi.mocked(executorModule.executeCode).mockResolvedValue(
         createMockExecuteResult({ result: 'ok' })
       );

--- a/mcp-servers/hub/src/handlers.ts
+++ b/mcp-servers/hub/src/handlers.ts
@@ -18,8 +18,7 @@ interface HandlerConfig {
 }
 
 /**
- * Convert data to JSON text for MCP response
- * Handles undefined/null: JSON.stringify(undefined) returns undefined, not a string!
+ * Convert data to JSON text for MCP response. Coerces undefined/null → null.
  * @param data - Data to convert to JSON string
  * @returns JSON string representation
  */
@@ -87,15 +86,13 @@ function validateTimeout(paramValue: unknown, configDefault: number, maxTimeout:
 }
 
 /**
- * Factory function to create code executor handlers
- * Uses dependency injection pattern for testability
+ * Factory to create code executor handlers.
  * @param config - Handler configuration including default timeout
- * @returns Object containing handler functions for all three meta-tools
+ * @returns Object containing handler functions
  */
 export function createCodeExecutorHandlers(config: HandlerConfig) {
   /**
-   * search_tools - Progressive discovery handler
-   * Searches available tools by keyword with configurable detail levels
+   * search_tools - searches available tools by keyword with detail levels.
    * @param params - Search parameters
    * @returns MCP tool call result
    */
@@ -148,8 +145,7 @@ export function createCodeExecutorHandlers(config: HandlerConfig) {
   };
 
   /**
-   * execute_code - JavaScript execution in sandbox
-   * Executes user code with access to tool imports
+   * execute_code - executes user JavaScript in sandbox with tool imports.
    * @param params - Code execution parameters
    * @returns MCP tool call result
    */

--- a/mcp-servers/hub/src/http-bridge.test.ts
+++ b/mcp-servers/hub/src/http-bridge.test.ts
@@ -30,12 +30,7 @@ import { populateRegistryWithMockTools, _resetRegistryForTesting } from './test-
 import * as authTokens from './auth-tokens.js';
 
 //═══════════════════════════════════════════════════════════════════════════════
-// Tests for HTTP Bridge
-//
-// Purpose: Test bridge creation and method delegation to workers
-// - Verify all methods exist on bridges
-// - Verify correct method names (camelCase) are passed to workers
-// - Verify parameters are passed correctly
+// Tests for HTTP Bridge (method delegation to workers, auth, session handling, errors)
 //═══════════════════════════════════════════════════════════════════════════════
 
 describe('http-bridge', () => {
@@ -2077,8 +2072,7 @@ describe('http-bridge', () => {
     });
 
     it('classifies ENOTFOUND errors (DNS_ERROR) from ping failures', async () => {
-      // Throw an error with code=ENOTFOUND so classifyHealthError returns DNS_ERROR.
-      // postPing's catch block calls classifyHealthError; the /health fallback also fails.
+      // DNS error classification from ping failure
       const dnsError = Object.assign(new Error('getaddrinfo ENOTFOUND mcp-slack'), {
         code: 'ENOTFOUND',
       });
@@ -2110,7 +2104,7 @@ describe('http-bridge', () => {
     });
 
     it('returns error code as-is for unknown error codes', async () => {
-      // An error with a code that is not ENOTFOUND or ECONNREFUSED hits line 214 (return code)
+      // Unknown error code returned as-is
       const customError = Object.assign(new Error('custom error'), { code: 'ECUSTOM' });
       fetchMock.mockRejectedValue(customError);
 
@@ -2312,8 +2306,7 @@ describe('http-bridge', () => {
     });
 
     it('classifies a thrown non-Error value as UNKNOWN', async () => {
-      // Throwing a string (not an Error instance) hits line 208:
-      //   if (!(error instanceof Error)) return 'UNKNOWN'
+      // Non-Error values classified as UNKNOWN
       fetchMock.mockRejectedValue('plain string error');
 
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -2327,8 +2320,7 @@ describe('http-bridge', () => {
     });
 
     it('classifies AbortError (name=AbortError) as TIMEOUT', async () => {
-      // Throwing an error with name=AbortError hits line 209:
-      //   if (error.name === 'AbortError') return 'TIMEOUT'
+      // AbortError classified as TIMEOUT
       const abortError = new Error('The operation was aborted');
       abortError.name = 'AbortError';
       fetchMock.mockRejectedValue(abortError);
@@ -2343,8 +2335,7 @@ describe('http-bridge', () => {
     });
 
     it('classifies TLS error messages as TLS_ERROR', async () => {
-      // Throwing an error with "TLS" in the message hits line 216:
-      //   if (error.message.includes('TLS') || error.message.includes('SSL')) return 'TLS_ERROR'
+      // TLS/SSL error messages classified as TLS_ERROR
       const tlsError = new Error('TLS handshake failed');
       fetchMock.mockRejectedValue(tlsError);
 

--- a/mcp-servers/hub/src/http-bridge.ts
+++ b/mcp-servers/hub/src/http-bridge.ts
@@ -85,14 +85,7 @@ export interface JSONRPCResponse {
   id: string | number;
   /** Result object containing MCP response */
   result?: {
-    /**
-     * Array of content items. MCP spec 2025-11-25 §Tool Result defines
-     * several `type` values: `"text"`, `"image"` (base64 + mimeType),
-     * `"audio"`, `"resource_link"`, and `"resource"`. Our hub keeps the
-     * shape open so third-party servers (e.g. `@playwright/mcp` returns
-     * a text summary followed by a base64 PNG in the same array) don't
-     * lose structured output.
-     */
+    /** Array of content items (MCP 2025-11-25: text, image, audio, resource_link, resource). */
     content: Array<{
       type: string;
       text?: string;
@@ -118,8 +111,7 @@ export interface JSONRPCResponse {
  * @param authToken - Optional bearer token for authentication
  */
 export function buildWorkerHeaders(authToken?: string): Record<string, string> {
-  // Accept must include both application/json and text/event-stream
-  // per MCP spec — worker servers validate this header (transport.ts)
+  // Accept must include both application/json and text/event-stream per MCP spec.
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
     Accept: 'application/json, text/event-stream',
@@ -132,10 +124,7 @@ export function buildWorkerHeaders(authToken?: string): Record<string, string> {
 }
 
 /**
- * Parse a worker HTTP response, handling both JSON and SSE content types.
- * MCP spec allows servers to respond with either application/json or
- * text/event-stream. For SSE responses, extracts the first `data:` line
- * that contains valid JSON.
+ * Parse a worker HTTP response (JSON or SSE) into a JSONRPCResponse.
  * @param response - HTTP Response from a worker
  * @returns Parsed JSON-RPC response
  */
@@ -158,10 +147,6 @@ export async function parseResponse(response: Response): Promise<JSONRPCResponse
         }
       }
     }
-    // Fail hard with the full body so we can see what the worker actually
-    // sent. This happens in practice when third-party MCP servers emit
-    // progress frames (`event: progress`, `event: ping`, ...) before the
-    // final `data:` line and the stream gets cut off mid-flight.
     const bodyDump = text.length > 4000 ? text.slice(0, 4000) + '...[truncated]' : text;
     throw new Error(
       `No JSON-RPC response in SSE stream (status ${response.status}, ${text.length} bytes). Body:\n${bodyDump}`
@@ -219,21 +204,8 @@ function classifyHealthError(error: unknown): string {
 }
 
 /**
- * Attempt an `initialize` handshake against a worker.
- *
- * Strict MCP servers (e.g. `@playwright/mcp`) reject every request with
- * `Bad Request: Server not initialized` until `initialize` completes AND the
- * returned `Mcp-Session-Id` header is sent on every subsequent request.
- * In-house workers are more permissive and answer `ping` without any of
- * this.
- *
- * This helper is called both by `checkWorkerHealth` (startup health path)
- * and by `ensureWorkerSession` (per-call session management) when
- * initialization is required.
- *
- * Returns the `Mcp-Session-Id` assigned by the worker (or an empty string if
- * the worker does not use sessions) on success, and `null` on failure.
- * @param url - Worker base URL (same URL the ping POST is issued against)
+ * Perform MCP initialize handshake; returns Mcp-Session-Id (empty if stateless), null on failure.
+ * @param url - Worker base URL
  * @param authToken - Optional bearer token
  */
 async function performMcpInitialize(url: string, authToken?: string): Promise<string | null> {
@@ -254,26 +226,12 @@ async function performMcpInitialize(url: string, authToken?: string): Promise<st
       signal: AbortSignal.timeout(TIMEOUTS.HEALTH_CHECK_MS),
       redirect: 'error',
     });
-    // MCP spec 2025-11-25 §Session Management:
-    //   "A server … MAY assign a session ID at initialization time, by
-    //    including it in an `MCP-Session-Id` header on the HTTP response
-    //    containing the InitializeResult."
-    // HTTP headers are case-insensitive per RFC 7230, so `Mcp-Session-Id`
-    // reads the same header the server wrote, but we keep the canonical
-    // capitalisation when echoing it back on subsequent requests to make
-    // trace logs line up with the spec.
+    // Per MCP spec, Mcp-Session-Id header must be echoed on subsequent requests.
     const sessionId = response.headers.get('Mcp-Session-Id') ?? '';
     const result = await parseResponse(response);
     if (result.error) return null;
 
-    // MCP spec 2025-11-25 §Lifecycle + §Streamable HTTP:
-    //   After InitializeResult the client MUST send
-    //   `notifications/initialized`. Strict servers (e.g. `@playwright/mcp`)
-    //   refuse every subsequent request with 400 "Server not initialized"
-    //   until this notification has been POSTed and ACK'd with 202 Accepted.
-    // Critically, this must complete BEFORE we return — the caller
-    // immediately issues `tools/call` on the session we just built, and any
-    // race with the notification makes the tool call fail.
+    // Per MCP spec, notifications/initialized must complete before subsequent requests on this session.
     const notifHeaders = buildWorkerHeaders(authToken);
     if (sessionId) notifHeaders['Mcp-Session-Id'] = sessionId;
     const notifResponse = await fetch(url, {
@@ -283,9 +241,7 @@ async function performMcpInitialize(url: string, authToken?: string): Promise<st
       signal: AbortSignal.timeout(TIMEOUTS.HEALTH_CHECK_MS),
       redirect: 'error',
     });
-    // Spec says notifications return 202 Accepted; permissive servers may
-    // return 200. Anything in the 2xx range is fine. Drain the body so the
-    // underlying socket can be reused for the next request.
+    // Spec says 202; permissive servers return 200. Accept 2xx, drain body for socket reuse.
     await notifResponse.text().catch(() => undefined);
     if (!notifResponse.ok) {
       console.error(
@@ -305,20 +261,7 @@ async function performMcpInitialize(url: string, authToken?: string): Promise<st
 }
 
 /**
- * Single health-check using MCP `ping` method with `/health` endpoint fallback.
- *
- * Flow:
- *   1. Plain MCP `ping` — fast path for our in-house workers that respond to
- *      `ping` on a fresh connection.
- *   2. `initialize` handshake followed by `ping` — required by strict MCP
- *      servers like `@playwright/mcp` that refuse every request with
- *      `Bad Request: Server not initialized` until the session is
- *      initialised. This is the spec-compliant flow and the only way to
- *      talk to most third-party MCP servers.
- *   3. Legacy `/health` GET — backwards compatibility with any remaining
- *      worker that predates MCP-over-HTTP.
- *
- * Returns `true` when any of the three attempts succeeds.
+ * Single health-check via MCP ping with /health fallback (plain ping, then initialize+ping, then legacy GET).
  * @param service - Service name to check
  */
 async function checkWorkerHealth(service: string): Promise<boolean> {
@@ -362,14 +305,11 @@ async function checkWorkerHealth(service: string): Promise<boolean> {
     }
   };
 
-  // Attempt 1: plain ping (fast path for permissive workers).
+  // Attempt 1: plain ping.
   const first = await postPing();
   if (first.ok) return true;
 
-  // Attempt 2: if the server told us it needed initialisation, do it and
-  // retry the ping on the same session. Strict MCP servers assign a
-  // session ID via the Mcp-Session-Id response header on initialize and
-  // reject subsequent requests that do not echo it back.
+  // Attempt 2: if not initialised, run initialize + retry ping on the session.
   if (first.notInitialised) {
     const sessionId = await performMcpInitialize(url, authToken);
     if (sessionId !== null) {
@@ -419,13 +359,7 @@ export const STARTUP_HEALTH_RETRIES = 3;
 export const STARTUP_RETRY_DELAYS_MS = [1_000, 2_000, 4_000];
 
 /**
- * Delays for tool-registry discovery retries. Wider than `STARTUP_RETRY_DELAYS_MS`
- * because some workers do real I/O on first boot (SharePoint resolves site_id
- * via Graph and may have to refresh an expired OAuth token, which routes
- * through the host-side oauth worker — total cold-start can run 5–15 s).
- * Hub's 7 s budget left those workers with an empty registry until the
- * 5-minute background refresh, blocking the Claude session for that whole
- * window. Total budget here: 1+2+4+8+15 = 30 s.
+ * Delays for tool-registry discovery retries; longer for cold-start I/O workers. Total budget: 30s.
  */
 export const DISCOVERY_RETRY_DELAYS_MS = [1_000, 2_000, 4_000, 8_000, 15_000];
 
@@ -580,27 +514,13 @@ export function parseServiceError(error: unknown, serviceName: string): string {
 //═══════════════════════════════════════════════════════════════════════════════
 
 /**
- * Per-service cache of `Mcp-Session-Id` values issued by workers.
- *
- * Strict MCP servers (`@playwright/mcp`) reject every JSON-RPC request with
- * `Bad Request: Server not initialized` unless the caller both completed
- * `initialize` and echoes back the `Mcp-Session-Id` header the worker set in
- * the initialize response. We remember that header per service and replay it
- * on subsequent `tools/call` requests. An empty string means the worker
- * issued no session header (stateless worker) — we still store it so we
- * don't re-initialize on every call.
- *
- * On a `400 Bad Request` with "not initialized" (worker restarted, session
- * expired) the entry is invalidated and `ensureWorkerSession` re-runs
- * `initialize`.
+ * Per-service cache of Mcp-Session-Id values; empty string means stateless.
+ * Invalidated on 400/404 'not initialized'.
  */
 const workerSessionCache: Map<string, string> = new Map();
 
 /**
- * Ensures a worker has been initialised for the current hub process and
- * returns the `Mcp-Session-Id` to echo on subsequent requests (empty string
- * if the worker is stateless). Caches per service; subsequent callers hit
- * the cache.
+ * Ensure a worker is initialised; returns cached Mcp-Session-Id (empty if stateless).
  * @param service - Service name
  * @param url - Worker base URL
  * @param authToken - Optional bearer token
@@ -641,7 +561,7 @@ export function _clearWorkerSessionCacheForTesting(): void {
 }
 
 /**
- * Call a worker tool via HTTP bridge
+ * Call a worker tool via HTTP bridge.
  * @param service Service name (slack, sharepoint, redmine, gitlab)
  * @param toolName Tool name to call
  * @param params Tool parameters
@@ -664,9 +584,7 @@ export async function callWorker<T = unknown>(
   const timeout = options?.timeoutMs ?? TIMEOUTS.WORKER_REQUEST_MS;
   const authToken = getAuthToken(service);
 
-  // Helper: performs the actual tools/call request with an optional cached
-  // session id. Separate so we can retry once after session invalidation
-  // without duplicating the request body / error handling.
+  // Performs tools/call with an optional cached session id.
   const attemptCall = async (sessionId: string | undefined): Promise<Response> => {
     const headers = buildWorkerHeaders(authToken);
     if (sessionId) {
@@ -690,22 +608,11 @@ export async function callWorker<T = unknown>(
   };
 
   try {
-    // Fast path: try the call with whatever session is cached (or none, for
-    // permissive workers that never required `initialize`). This keeps the
-    // round-trip count at 1 for the common case — only strict MCP servers
-    // (`@playwright/mcp`) that reject with 400 "not initialized" pay the
-    // cost of an extra initialize handshake.
+    // Fast path: use the cached session (or none for permissive workers).
     const cachedSid = workerSessionCache.get(service);
     let response = await attemptCall(cachedSid);
 
-    // Strict MCP servers signal session trouble in two ways:
-    //   * 400 "Server not initialized" — no session on this request at all.
-    //   * 404 Not Found               — the Mcp-Session-Id we just sent has
-    //                                    expired or refers to a worker
-    //                                    instance that has since restarted.
-    // Both cases are recoverable by invalidating the cached session and
-    // running `initialize` (+ `notifications/initialized`) again before
-    // retrying the call exactly once.
+    // On 400/404 'not initialized': invalidate the session, re-init, retry once.
     if (response.status === 400 || response.status === 404) {
       const body = await response.text();
       const bodyLower = body.toLowerCase();
@@ -738,34 +645,20 @@ export async function callWorker<T = unknown>(
     // Extract content from MCP response.
     const content = result.result?.content;
     if (content && content.length > 0) {
-      // Check if worker returned an error (e.g., notConfiguredMessage('Redmine'))
-      // errorResult() sets isError: true and wraps message in "Error: " prefix.
+      // errorResult() sets isError: true and wraps the message in an "Error: " prefix.
       if (result.result?.isError) {
         const firstText = content.find((c) => c.type === 'text')?.text ?? 'Unknown error';
         throw new Error(firstText);
       }
 
-      // Multi-item responses are spec-compliant (MCP 2025-11-25 §Tool Result:
-      // "can contain multiple content items of different types"). A strict
-      // server like `@playwright/mcp` returns a text summary followed by a
-      // base64 `image` item on `browser_take_screenshot`. Pass the whole
-      // array through so the executor / caller can forward every item — the
-      // image is useless without its sibling text describing the screenshot,
-      // and vice versa.
+      // Multi-item responses (e.g. text + base64 image): pass the whole array through.
       const textItems = content.filter((c) => c.type === 'text' && c.text !== undefined);
       const hasNonTextItems = content.some((c) => c.type !== 'text');
       if (hasNonTextItems) {
         return content as T;
       }
 
-      // Single text item — legacy shape used by all in-house workers.
-      // MCP spec 2025-11-25 §Tool Result → Text Content defines the content
-      // item as `{ "type": "text", "text": "Tool result text" }` — any
-      // string is valid, no JSON requirement. Our workers happen to wrap
-      // JSON because their bridge API returns structured data. Try JSON
-      // first so existing workers keep their typed shape; fall back to
-      // the raw string when parsing fails. Multiple text items are joined
-      // with newlines before the JSON attempt.
+      // Single/joined text item: try JSON parse first, fall back to the raw string.
       const text = textItems.map((c) => c.text).join('\n');
       try {
         return JSON.parse(text) as T;
@@ -831,13 +724,7 @@ export function createOsBridge() {
 export type AllBridges = Record<string, ReturnType<typeof buildServiceBridge> | null>;
 
 /**
- * Initialize all service bridges
- *
- * IMPORTANT: Bridges are always created regardless of worker availability.
- * Each bridge call checks worker health lazily - if a worker becomes available
- * after Hub startup, it will work on the next call.
- *
- * This fixes the race condition where Hub starts before workers are ready.
+ * Initialize all service bridges (lazy mode: created regardless of worker availability, health checked at startup).
  * @returns All initialized bridges
  */
 export async function initializeAllBridges(): Promise<AllBridges> {

--- a/mcp-servers/hub/src/hub-types.ts
+++ b/mcp-servers/hub/src/hub-types.ts
@@ -120,17 +120,7 @@ export type TimeoutClass = 'standard' | 'long';
 export interface ToolMetadata {
   /** Tool name as exposed by the hub (camelCase, used by JS bridge API). */
   name: string;
-  /**
-   * Tool name as exposed by the worker itself (often snake_case, especially
-   * for third-party MCP servers that follow the MCP spec literally, e.g.
-   * `@playwright/mcp`'s `browser_navigate`). Hub uses this verbatim when
-   * issuing `tools/call` so the worker recognises the method; the hub-side
-   * `name` above is only the JS bridge alias.
-   *
-   * Optional for backward compatibility with tests that build metadata
-   * without going through `mergeToolWithMeta`; when absent, callers fall
-   * back to `name`.
-   */
+  /** Tool name as exposed by the worker (often snake_case); falls back to `name` if absent. */
   workerToolName?: string;
   /** Tool description */
   description: string;

--- a/mcp-servers/hub/src/index.ts
+++ b/mcp-servers/hub/src/index.ts
@@ -258,8 +258,7 @@ async function main() {
     console.log(`${ts()}    2. execute_code     - JavaScript execution in sandbox`);
   });
 
-  // Graceful shutdown handler — only reachable via OS signals at runtime, not in unit tests.
-  // The lambdas registered with process.on() are also only invoked by OS signals, never in tests.
+  // Graceful shutdown handler.
   /* c8 ignore start */
   const gracefulShutdown = (signal: string) => {
     console.log(`${ts()} \n📴 Received ${signal}, shutting down gracefully...`);
@@ -314,8 +313,6 @@ export function createSessionRateLimiter() {
 
 /**
  * Create the Hub Express app with MCP transport endpoints.
- * Extracted for testability — callers can exercise routes without starting
- * the full server (health check, bridges, registry).
  * @param rpcHandler - JSON-RPC handler to process incoming requests
  * @returns Configured Express app
  */

--- a/mcp-servers/hub/src/paginate.test.ts
+++ b/mcp-servers/hub/src/paginate.test.ts
@@ -136,9 +136,7 @@ describe('paginate', () => {
     });
 
     it('extracts items when fetcher returns a plain array (no wrapper object)', async () => {
-      // When the fetched response is itself an array (none of the known keys match),
-      // extractItems falls through all key checks and returns the array directly
-      // via the `if (Array.isArray(result))` branch.
+      // A plain-array response is returned by the Array.isArray fallback.
       const mockFetcher = vi
         .fn()
         .mockResolvedValueOnce([{ id: 1 }, { id: 2 }] as unknown as {

--- a/mcp-servers/hub/src/paginate.ts
+++ b/mcp-servers/hub/src/paginate.ts
@@ -1,6 +1,5 @@
 /**
- * Sandbox pagination helpers — async generators that iterate large datasets
- * page-by-page to minimize memory and token use. Used by execute_code globals.
+ * Sandbox pagination helpers — async generators that iterate large datasets.
  * @module paginate
  */
 
@@ -77,13 +76,7 @@ type PaginatedResponse<T> = {
 //═══════════════════════════════════════════════════════════════════════════════
 
 /**
- * Create async generator for paginated API calls
- *
- * Automatically extracts items from common response shapes:
- * - Redmine: { issues: [], total_count: N }
- * - GitLab: { projects: [], merge_requests: [] }
- * - Slack: { messages: [], channels: [] }
- * - Generic: { items: [], results: [] }
+ * Create async generator for paginated API calls.
  * @param fetcher - Function that fetches a page given offset and limit
  * @param config - Pagination configuration
  * @yields {PageResult<T>} PageResult for each page
@@ -179,9 +172,7 @@ function extractItems<T>(result: PaginatedResponse<T>): T[] {
 //═══════════════════════════════════════════════════════════════════════════════
 
 /**
- * Collect all pages into a single array
- *
- * WARNING: Use maxItems config to prevent memory issues with large datasets
+ * Collect all pages into a single array.
  * @param generator - Pagination generator
  * @returns All items from all pages
  */
@@ -194,9 +185,7 @@ export async function collectPages<T>(generator: AsyncGenerator<PageResult<T>>):
 }
 
 /**
- * Find first item matching predicate across all pages
- *
- * Stops fetching as soon as a match is found (efficient for large datasets)
+ * Find first item matching predicate across all pages.
  * @param generator - Pagination generator
  * @param predicate - Function to test each item
  * @returns First matching item or undefined
@@ -270,9 +259,7 @@ export async function mapPages<T, U>(
 }
 
 /**
- * Take first N items across pages
- *
- * Stops fetching once N items are collected
+ * Take first N items across pages.
  * @param generator - Pagination generator
  * @param n - Number of items to take
  * @returns First N items

--- a/mcp-servers/hub/src/pii-tokenizer.test.ts
+++ b/mcp-servers/hub/src/pii-tokenizer.test.ts
@@ -301,7 +301,6 @@ describe('pii-tokenizer', () => {
     it('tokenizes a valid Polish IBAN', () => {
       const context = createPIIContext();
       // Valid Polish IBAN (mod-97 check digit = 1)
-      // PL61109010140000071219812874 is a well-known valid test IBAN
       const data = { account: 'PL61109010140000071219812874' };
       const result = tokenizePII(data, context) as Record<string, string>;
 

--- a/mcp-servers/hub/src/pii-tokenizer.ts
+++ b/mcp-servers/hub/src/pii-tokenizer.ts
@@ -1,6 +1,5 @@
 /**
- * Replaces PII (email, phone, PESEL, NIP, IBAN, card, API key, sensitive fields) with tokens
- * before data reaches the model, and resolves tokens back to real values for MCP-to-MCP calls.
+ * Tokenizes PII before data reaches the model and resolves tokens back for MCP-to-MCP calls.
  * @module pii-tokenizer
  */
 
@@ -25,8 +24,7 @@ export interface PIIContext {
 }
 
 /**
- * PII detection patterns (for value-based detection)
- * Note: EMAIL pattern has length limits to prevent ReDoS attacks
+ * PII detection patterns (value-based). EMAIL has length limits to prevent ReDoS.
  */
 const PII_PATTERNS: Partial<Record<PIIType, RegExp>> = {
   [PIIType.EMAIL]: /[a-zA-Z0-9._%+-]{1,64}@[a-zA-Z0-9.-]{1,255}\.[a-zA-Z]{2,10}/g,
@@ -41,11 +39,7 @@ const PII_PATTERNS: Partial<Record<PIIType, RegExp>> = {
 };
 
 /**
- * Sensitive field key names (case-insensitive, partial match)
- * Used for key-based detection in objects
- *
- * Note: Partial matching (includes) catches variants like:
- * session_token, jwt_token, encryption_key, etc.
+ * Sensitive field key names (case-insensitive, partial match via includes).
  */
 const SENSITIVE_KEYS = [
   // Authentication & Authorization
@@ -205,10 +199,7 @@ function generateToken(type: PIIType): string {
 }
 
 /**
- * `author`/`authors` as a complete word segment is prose metadata (message
- * author, document author), not authentication — without this carve-out the
- * partial `auth` match redacts every sender name. `authorization` stays
- * caught: its `author` is followed by a letter, so the regex does not match.
+ * Matches `author`/`authors` as a complete word segment (excludes `authorization`).
  */
 const AUTHOR_SEGMENT = /(^|[^a-z])authors?(?=[^a-z]|$)/g;
 
@@ -267,11 +258,7 @@ function tokenizeSensitiveValue(value: string, context: PIIContext): string {
 }
 
 /**
- * Tokenize PII in data
- * Recursively processes objects and arrays
- * Detects PII by:
- * 1. Value patterns (email, phone, PESEL, etc.)
- * 2. Key names (password, token, secret, etc.)
+ * Recursively tokenize PII in data by value patterns and key names.
  * @param data - Data to tokenize
  * @param context - PII context for this execution
  * @returns Tokenized data
@@ -308,8 +295,7 @@ export function tokenizePII(data: unknown, context: PIIContext): unknown {
 }
 
 /**
- * Tokenize PII in a string
- * Uses O(1) lookup via valueToToken cache and replaceAll for multiple occurrences
+ * Tokenize PII in a string.
  * @param text - String to tokenize
  * @param context - PII context for this execution
  * @returns Tokenized string
@@ -412,9 +398,7 @@ export function detokenizePII(data: unknown, context: PIIContext): unknown {
 }
 
 /**
- * Detokenize PII in a string
- * Uses reverse-order replacement to handle cases where token values
- * might contain token-like patterns
+ * Detokenize PII in a string using reverse-order replacement.
  * @param text - String containing tokens
  * @param context - PII context with token mappings
  * @returns Detokenized string

--- a/mcp-servers/hub/src/search-tools.test.ts
+++ b/mcp-servers/hub/src/search-tools.test.ts
@@ -1,12 +1,4 @@
-/**
- * Comprehensive tests for search-tools.ts
- * Baseline tests to ensure behavior is preserved during refactoring
- *
- * Tests cover:
- * - searchTools: query matching, service filtering, detail levels, deferred loading
- * - getServiceTools: retrieving all tools for a service
- * - getToolMetadata: retrieving specific tool metadata
- */
+/** Tests for searchTools, getServiceTools, getToolMetadata in search-tools.ts. */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { searchTools, getServiceTools, getToolMetadata } from './search-tools.js';
@@ -329,8 +321,7 @@ describe('searchTools edge cases', () => {
   });
 
   it('skips a service that has an empty tool list', async () => {
-    // Add an enabled service with zero tools — searchTools should skip it (line 84 continue)
-    // without returning any matches from it.
+    // Add an enabled service with zero tools — searchTools should skip it.
     const mutableRegistry = TOOL_REGISTRY as Record<string, Record<string, unknown>>;
     mutableRegistry['emptysvc'] = {};
     // Must also add to SERVICE_NAMES so the service appears in servicesToSearch
@@ -350,8 +341,6 @@ describe('searchTools edge cases', () => {
 
   it('matches a tool by keyword when name and description do not match', async () => {
     // Insert a tool whose name/description don't contain 'xkeyword', but keywords does.
-    // This exercises the `keywords.some((k) => k.toLowerCase().includes(queryLower))` branch
-    // and the arrow-function body inside it.
     const mutableRegistry = TOOL_REGISTRY as Record<
       string,
       Record<

--- a/mcp-servers/hub/src/search-tools.ts
+++ b/mcp-servers/hub/src/search-tools.ts
@@ -1,16 +1,7 @@
 /**
- * Progressive Discovery - search_tools implementation
+ * Progressive discovery — lazy tool definitions (names_only/with_descriptions/full_schema).
+ * Tool metadata from tool-registry.ts (SSOT).
  * @module search-tools
- *
- * Implements lazy loading of tool definitions:
- * - names_only: ~50 tokens (just tool paths)
- * - with_descriptions: ~200 tokens (paths + descriptions)
- * - full_schema: ~500 tokens (complete schema for specific tool)
- *
- * This reduces token usage from ~25K (all tools upfront) to ~50-500 per query
- *
- * Tool metadata is dynamically loaded from tools/{service}/index.ts files
- * to maintain a single source of truth and avoid duplication.
  */
 
 import { ToolSearchResult, ToolMetadata } from './hub-types.js';

--- a/mcp-servers/hub/src/service-list.ts
+++ b/mcp-servers/hub/src/service-list.ts
@@ -1,16 +1,10 @@
 /**
- * Service List - Dynamic service enumeration
- * @module service-list
- *
- * Parses ENABLED_SERVICES env var to build a service list.
- *
- * IMPORTANT: This module has ZERO imports from other hub modules
- * to prevent import cycles. It reads process.env directly.
+ * Service List - Dynamic service enumeration.
+ * Parses ENABLED_SERVICES env var; zero hub-module imports.
  */
 
 /**
- * Get all service names from ENABLED_SERVICES env var.
- * Returns only services that are explicitly enabled.
+ * Get explicitly enabled service names from ENABLED_SERVICES env var.
  * @returns Array of enabled service names
  */
 export function getAllServiceNames(): string[] {

--- a/mcp-servers/hub/src/test-helpers.ts
+++ b/mcp-servers/hub/src/test-helpers.ts
@@ -298,11 +298,7 @@ function buildMockToolMetadata(
 }
 
 /**
- * Populate registry with mock tool data inline.
- * Replaces the old populateRegistryFromPolicies() that depended on TOOL_POLICIES.
- * Must be called after _resetRegistryForTesting().
- *
- * Also sets SERVICE_NAMES so tests that iterate SERVICE_NAMES see all 5 built-in services.
+ * Populate registry with mock tool data and set SERVICE_NAMES. Call after _resetRegistryForTesting().
  */
 export function populateRegistryWithMockTools(): void {
   const mutableRegistry = TOOL_REGISTRY as Record<string, Record<string, ToolMetadata>>;
@@ -321,7 +317,6 @@ export function populateRegistryWithMockTools(): void {
 
 /**
  * Create a full mock AllBridges object with all service methods as vi.fn().
- * Eliminates ~425 lines of duplicated mock definitions across test files.
  */
 export function createMockBridges(): AllBridges {
   return {

--- a/mcp-servers/hub/src/tool-discovery.test.ts
+++ b/mcp-servers/hub/src/tool-discovery.test.ts
@@ -45,10 +45,7 @@ function mockJsonResponse(
 }
 
 /**
- * Create a mock fetch function that handles the 3-call sequence:
- * 1. initialize -> success
- * 2. notifications/initialized -> 204
- * 3. tools/list -> tools response
+ * Mock fetch for the initialize / notifications/initialized / tools/list sequence.
  * @param tools - Tools to return from tools/list
  * @param sessionId - Optional session ID to return from initialize
  */
@@ -131,8 +128,7 @@ describe('tool-discovery', () => {
     });
 
     it('resolves WORKER_*_URL for hyphenated slug via deriveWorkerEnv normalization', async () => {
-      // PR0 fix: a plugin slug like `my-plugin` must look up `WORKER_MY_PLUGIN_URL`
-      // (the form compose injects), not the broken `WORKER_MY-PLUGIN_URL`.
+      // slug `my-plugin` looks up `WORKER_MY_PLUGIN_URL` (hyphens normalized to underscores)
       process.env.WORKER_MY_PLUGIN_URL = 'http://mcp-my-plugin:4040';
 
       const mockTools: Tool[] = [

--- a/mcp-servers/hub/src/tool-discovery.ts
+++ b/mcp-servers/hub/src/tool-discovery.ts
@@ -196,12 +196,7 @@ export function mergeToolWithMeta(tool: Tool, service: string, methodName: strin
   const rawOsCategory = typeof meta.osCategory === 'string' ? meta.osCategory : undefined;
   return {
     name: methodName,
-    // Preserve the worker's original tool name (often snake_case for strict
-    // MCP servers like `@playwright/mcp` which expose `browser_navigate`
-    // rather than the camelCase `browserNavigate` used in our JS bridge
-    // API). Without this the hub discovers the tool, rewrites the name to
-    // camelCase, and then fails `tools/call` because the worker has never
-    // heard of `browserNavigate`.
+    // Worker's original tool name (often snake_case); used verbatim for tools/call
     workerToolName: tool.name,
     description: tool.description,
     keywords: tool.keywords ?? [],

--- a/mcp-servers/hub/src/tool-registry.test.ts
+++ b/mcp-servers/hub/src/tool-registry.test.ts
@@ -42,9 +42,7 @@ describe('tool-registry', () => {
   beforeEach(() => {
     _resetRegistryForTesting();
     populateRegistryWithMockTools();
-    // Skip the up-to-7 s production backoff (1+2+4 s delays) so tests don't wait
-    // every time discovery returns zero tools. The retry logic itself is
-    // covered by a dedicated test in this file.
+    // Skip production backoff (1+2+4 s) so tests run fast.
     _setDiscoveryRetryDelaysForTesting([0, 0, 0]);
   });
 
@@ -740,29 +738,22 @@ describe('tool-registry', () => {
         .mockImplementationOnce(() => firstRefreshPromise) // first interval (slow)
         .mockResolvedValue({}); // any further calls
 
-      // Switch to fake timers BEFORE initializeRegistry so the setInterval created by
-      // _startBackgroundRefresh() is registered with fake timers. The startup discovery
-      // mock resolves immediately (non-empty result → no retry delays), so the await
-      // completes without needing to advance fake timers.
+      // Fake timers before initializeRegistry so the refresh setInterval uses them.
       vi.useFakeTimers();
       await initializeRegistry();
 
-      // Advance to trigger the first interval callback (sets _refreshInProgress = true).
-      // advanceTimersByTimeAsync also flushes pending microtasks after advancing.
+      // First interval callback sets _refreshInProgress = true.
       await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 1);
-      // Advance again to fire the interval a second time — should hit the early return
-      // because _refreshInProgress is still true (firstRefreshPromise not yet resolved).
+      // Second interval fire hits the early return (_refreshInProgress still true).
       await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 1);
 
-      // Resolve the first refresh and flush remaining microtasks.
       resolveFirstRefresh!();
       // Drain microtask queue so _refreshInProgress is reset to false.
       await Promise.resolve();
 
-      // Registry remains intact — the overlapping refresh was skipped without error
+      // Overlapping refresh was skipped without error.
       expect(TOOL_REGISTRY['slack']).toBeDefined();
-      // discoverAndMergeService was called once for startup + once for the first refresh
-      // (the second interval call was skipped via the _refreshInProgress guard)
+      // Called once for startup + once for the first refresh (second skipped).
       expect(mockDiscover).toHaveBeenCalledTimes(2);
     });
 
@@ -775,9 +766,7 @@ describe('tool-registry', () => {
       const mockDiscover = vi.mocked(discoverAndMergeService);
       mockDiscover.mockClear();
 
-      // Return a non-empty tool set on the first call so discoverWithStartupRetry exits
-      // immediately without waiting for retry delays. The background refresh itself
-      // (the second call) can return anything — we just want the interval to fire.
+      // Non-empty first call so discoverWithStartupRetry exits immediately.
       const slackTool: ToolMetadata = {
         name: 'sendChannel',
         description: 'Send a channel message',

--- a/mcp-servers/hub/src/tool-registry.ts
+++ b/mcp-servers/hub/src/tool-registry.ts
@@ -73,15 +73,8 @@ export let SERVICE_NAMES: readonly string[] = [];
 //═══════════════════════════════════════════════════════════════════════════════
 
 /**
- * Retry backoff for initial tool discovery. Uses the longer
- * `DISCOVERY_RETRY_DELAYS_MS` schedule (~30 s total) because some workers
- * do real I/O on cold start: SharePoint resolves site_id through Graph
- * and may have to refresh an expired OAuth token via the host-side oauth
- * worker — that whole chain can run 5–15 s and the previous 7 s budget
- * left the registry empty until the 5-minute background refresh.
- *
- * Tests can override with `[0, 0, 0]` via `_setDiscoveryRetryDelaysForTesting`
- * so the suite doesn't pay the 30 s real wall-clock of the production schedule.
+ * Retry schedule for cold-start workers (SharePoint OAuth can take 5–15s).
+ * Tests override via _setDiscoveryRetryDelaysForTesting.
  */
 let discoveryRetryDelays: readonly number[] = DISCOVERY_RETRY_DELAYS_MS;
 
@@ -128,19 +121,8 @@ async function discoverWithStartupRetry(service: string): Promise<Record<string,
 }
 
 /**
- * Initialize the registry from workers.
- * Called once at startup before initializeBridges().
- *
- * For each service:
- * 1. Try to discover tools from worker (JSON-RPC tools/list)
- * 2. Retry with backoff if the first attempt returns zero tools — a
- *    slow-starting worker (e.g. `mcp-playwright` spinning up Chromium)
- *    may not be ready when the hub boots, and without the retry the
- *    service's registry stays empty until the next background refresh
- *    five minutes later.
- * 3. Merge tool data including `_meta` fields.
- * 4. If the worker is still unavailable after retries, the service gets
- *    an empty registry entry; background refresh will populate it later.
+ * Initialize the registry from workers. Called once at startup before initializeBridges().
+ * Discovers each service with startup retry; unavailable services get empty entries.
  */
 export async function initializeRegistry(): Promise<void> {
   if (_initialized) return;
@@ -191,17 +173,8 @@ export async function refreshServiceTools(service: string): Promise<void> {
 let _refreshInProgress = false;
 
 /**
- * Per-service exponential backoff for empty-registry catch-up.
- *
- * Replaces the legacy single `setInterval(10s)` that polled every empty
- * service on a fixed cadence. Now each service runs its own timer with
- * 10s → 20s → 40s → 60s (cap) backoff, reset to 10s on every successful
- * discovery. A perpetually broken worker no longer spams Graph every 10 s.
- *
- * - BASE: first retry delay (10 s).
- * - MAX: cap on backoff (60 s) — chosen so that recovery from a real
- *   restart never waits more than a minute, while a flapping worker is
- *   not retried multiple times per second.
+ * Per-service exponential backoff (10s → 60s cap) for empty-registry catch-up.
+ * Replaces legacy fixed 10s poll.
  */
 let EMPTY_REGISTRY_RECHECK_BASE_MS = 10 * 1000;
 const EMPTY_REGISTRY_RECHECK_MAX_MS = 60 * 1000;
@@ -246,16 +219,12 @@ function _startBackgroundRefresh(): void {
   }, REFRESH_MS);
 
   // Don't prevent process from exiting
-  /* c8 ignore next 3 — in Node.js setInterval always returns a Timeout with .unref();
-   * the false branch only fires in browser-like environments (setInterval returns a number) */
+  /* c8 ignore next 3 — Node.js setInterval returns Timeout with .unref(), browser returns number */
   if (_refreshInterval && typeof _refreshInterval === 'object' && 'unref' in _refreshInterval) {
     _refreshInterval.unref();
   }
 
-  // Per-service catch-up timers for services that started with empty
-  // registries. Each service has its own setTimeout chain with exponential
-  // backoff (10s → 20s → 40s → 60s cap). On successful discovery the timer
-  // is dropped; on failure the next retry is rescheduled with a larger delay.
+  // Start catch-up timers for initially-empty services with exponential backoff.
   for (const service of SERVICE_NAMES) {
     if (Object.keys(_registry[service] ?? {}).length === 0) {
       _scheduleEmptyServiceRecheck(service, 0);
@@ -265,9 +234,6 @@ function _startBackgroundRefresh(): void {
 
 /**
  * Compute backoff delay for the n-th consecutive empty-discovery failure.
- *
- * Exported with the `_` prefix so unit tests can assert the formula without
- * the indirection of `setTimeout` mocking. Not part of the public API.
  * @param failures - 0-based count of consecutive empty discoveries.
  * @internal
  */
@@ -276,12 +242,7 @@ export function _emptyRecheckDelayMs(failures: number): number {
 }
 
 /**
- * Schedule the next catch-up discovery for an empty service.
- *
- * Idempotent: if a timer is already scheduled it is cleared first. After the
- * timer fires we call {@link refreshServiceTools} and inspect the registry —
- * non-empty drops the timer, empty schedules the next attempt with
- * `failures + 1` so the backoff grows.
+ * Schedule the next catch-up discovery for an empty service. Idempotent.
  * @param service - Service name to recheck.
  * @param failures - Number of preceding failed rechecks (drives backoff).
  */
@@ -292,13 +253,7 @@ function _scheduleEmptyServiceRecheck(service: string, failures: number): void {
   }
   const delay = _emptyRecheckDelayMs(failures);
   const timer = setTimeout(async () => {
-    // Don't run if another refresh is in flight — let it settle, then we
-    // re-check below whether we still need to schedule.
-    /* c8 ignore next 4 — race between this 1–60 s timer and the 5-min
-     * setInterval refresh that also sets _refreshInProgress. Reproducing
-     * in unit tests would require coordinating both schedulers across the
-     * same exact tick; fake-timer plumbing is disproportionate for the
-     * one-line defer-and-reschedule guard. */
+    /* c8 ignore next 4 — race with 5-min refresh; testing requires coordinating both schedulers */
     if (_refreshInProgress) {
       _scheduleEmptyServiceRecheck(service, failures);
       return;
@@ -310,8 +265,7 @@ function _scheduleEmptyServiceRecheck(service: string, failures: number): void {
       _refreshInProgress = false;
     }
     if (Object.keys(_registry[service] ?? {}).length > 0) {
-      // Success — drop the timer entirely. The 5-min background refresh
-      // covers ongoing maintenance.
+      // Success — drop timer; 5-min refresh handles maintenance.
       _emptyServiceTimers.delete(service);
       return;
     }

--- a/mcp-servers/oauth/src/audit-log.test.ts
+++ b/mcp-servers/oauth/src/audit-log.test.ts
@@ -126,9 +126,7 @@ describe('audit-log rotation', () => {
   it.runIf(process.platform !== 'win32')(
     'rotateIfNeeded swallows rename errors (best-effort, covers audit-log.ts:55)',
     async () => {
-      // Make rotation fail: `${logPath}.1` is a non-empty directory →
-      // `rename` cannot replace it. The function must log the error and
-      // continue, not throw, so the calling append still gets a chance.
+      // Make rotation fail: `${logPath}.1` is a non-empty directory.
       const { mkdir } = await import('node:fs/promises');
       await writeFile(logPath, 'a'.repeat(20));
       await mkdir(`${logPath}.1`);

--- a/mcp-servers/oauth/src/audit-log.ts
+++ b/mcp-servers/oauth/src/audit-log.ts
@@ -2,12 +2,7 @@
  * Append-only audit log for OAuth refresh/forget events (ADR-060 §"Threat model").
  *
  * One line per event, ISO-8601 timestamp, no token contents. Log file mode 0o600.
- *
- * Rotation: when the live file exceeds {@link DEFAULT_MAX_BYTES} we rename it
- * to `<logPath>.1` (overwriting any older `.1`) and start a fresh file. KISS —
- * only one historical copy is kept; we are not building a logging framework.
- * The cost is one extra `stat` per append, which dominates nothing compared to
- * the refresh HTTP round-trip these events accompany.
+ * Rotates to `<logPath>.1` when it exceeds {@link DEFAULT_MAX_BYTES}.
  */
 import { appendFile, chmod, rename, stat } from 'node:fs/promises';
 
@@ -25,17 +20,11 @@ export interface AuditEvent {
   outcome: AuditOutcome;
 }
 
-/**
- * Rotation threshold. 1 MiB ≈ tens of thousands of audit lines — enough to
- * see the cadence of a noisy worker without growing unbounded across months
- * of background refreshes. The previous file is kept as `<logPath>.1`.
- */
+/** Rotation threshold in bytes; one historical copy kept as `<logPath>.1`. */
 export const DEFAULT_MAX_BYTES = 1 * 1024 * 1024;
 
 /**
- * Rotate `<logPath>` to `<logPath>.1` when it grows past `maxBytes`. Best
- * effort: any error (missing file, EACCES) leaves the live log in place and
- * the next append continues into it.
+ * Rotate `<logPath>` to `<logPath>.1` when it grows past `maxBytes`. Best-effort.
  * @param logPath - the live log path
  * @param maxBytes - rotate when current size strictly exceeds this value
  */
@@ -59,9 +48,7 @@ export async function rotateIfNeeded(logPath: string, maxBytes: number): Promise
 }
 
 /**
- * Append a single event to the audit log. Best-effort: a write failure is
- * logged to stderr but does not block the refresh/forget operation itself
- * (the caller has already mutated state by then).
+ * Append a single event to the audit log. Best-effort: write failures go to stderr.
  * @param logPath - absolute path to the audit log file
  * @param event - the event to record (timestamps generated at call site)
  * @param maxBytes - optional rotation threshold (override for tests)
@@ -76,8 +63,7 @@ export async function appendAuditEvent(
   await rotateIfNeeded(logPath, maxBytes);
   try {
     await appendFile(logPath, line, { mode: 0o600 });
-    // chmod again — appendFile mode only applies on file creation. Any
-    // chmod failure falls through to the outer catch (logged best-effort).
+    // chmod again — appendFile mode only applies on file creation.
     await chmod(logPath, 0o600);
   } catch (err) {
     console.error(

--- a/mcp-servers/oauth/src/index.ts
+++ b/mcp-servers/oauth/src/index.ts
@@ -1,11 +1,6 @@
 /**
  * `oauth` MCP worker — host-side, per-project (ADR-060).
- *
- * Holds per-service OAuth state (refresh token + provider-specific data such
- * as Microsoft `clientId` / `tenantId` in `providerData`) for each configured
- * OAuth-using service in the project. Exposes `refresh` and `forget` tools to
- * authenticated consumers (today: SharePoint). NOT visible to Claude — not in
- * ENABLED_SERVICES, the hub has no bearer for it.
+ * Exposes `refresh` and `forget` tools to authenticated consumers.
  *
  * Env inputs (set by the Rust supervisor `oauth_process.rs`):
  *   PORT             — listening port (0 = OS picks)
@@ -52,16 +47,12 @@ async function main(): Promise<void> {
   const auditLogPath = process.env.OAUTH_LOG_FILE ?? join(stateDir, 'audit.log');
   const project = requireEnv('OAUTH_PROJECT');
   const supervisorToken = requireEnv('OAUTH_SUPERVISOR_TOKEN');
-  // Fail-fast: the Rust supervisor always sets OAUTH_TOKENS_BASE; a missing
-  // value would have access tokens land in a relative `<project>/<service>/
-  // access_token` path that nothing else reads.
   const tokensBase = requireEnv('OAUTH_TOKENS_BASE');
 
   // Load consumer bearers — bearer → service id.
   const bearerMap = await loadBearerMap(stateDir);
 
-  // ADR-060 §"Threat model" claims the refresh rate limit is configurable
-  // via OAUTH_REFRESH_RATE_LIMIT_SECONDS. Honour that contract here.
+  // Refresh rate limit configurable via OAUTH_REFRESH_RATE_LIMIT_SECONDS (ADR-060).
   const rateLimitOverride = process.env.OAUTH_REFRESH_RATE_LIMIT_SECONDS;
   const rateLimitSeconds = rateLimitOverride ? Number.parseInt(rateLimitOverride, 10) : undefined;
   if (

--- a/mcp-servers/oauth/src/oauth-state.test.ts
+++ b/mcp-servers/oauth/src/oauth-state.test.ts
@@ -336,8 +336,7 @@ describe('oauth-state', () => {
     });
 
     it('rejects empty bearer key', async () => {
-      // An empty key in the JSON object would map ambiguously inside the auth
-      // map; the loader must reject it. This covers oauth-state.ts:104.
+      // Covers oauth-state.ts:104.
       await writeFile(join(dir, '.bearer-map.json'), JSON.stringify({ '': 'sharepoint' }), {
         mode: 0o600,
       });

--- a/mcp-servers/oauth/src/providers/generic.test.ts
+++ b/mcp-servers/oauth/src/providers/generic.test.ts
@@ -112,8 +112,6 @@ describe('refreshGenericToken', () => {
   });
 
   it('actually fires the AbortController callback on the refresh timeout', async () => {
-    // Cover the `() => controller.abort()` arrow passed to setTimeout —
-    // production timer is TIMEOUTS.TOKEN_REFRESH_MS; fake timers fire it in ms.
     vi.useFakeTimers();
     try {
       let observedSignal: AbortSignal | undefined;

--- a/mcp-servers/oauth/src/providers/generic.ts
+++ b/mcp-servers/oauth/src/providers/generic.ts
@@ -1,9 +1,5 @@
 /**
- * Data-driven OAuth2 provider for plugins (ADR-069).
- *
- * `token_url`, client id/secret, grant type, and auth style all come from the
- * stored state (host-validated at manifest install + start_plugin_oauth), so
- * this provider re-validates the URL and hardens the HTTP call on every refresh.
+ * Data-driven OAuth2 provider for plugins; re-validates token_url and grant on every refresh (ADR-069).
  */
 
 import { TIMEOUTS, ts } from '@speedwave/mcp-shared';
@@ -26,9 +22,7 @@ interface GenericProviderData {
 }
 
 /**
- * Narrows untyped `providerData` to the generic shape. An unknown
- * `authStyle`/`grantType` literal (tampered or future-version state file) is
- * rejected rather than silently falling through to a default branch.
+ * Narrows untyped `providerData` to the generic shape; rejects unknown authStyle/grantType.
  * @param raw - the stored providerData map
  */
 function parseGenericProviderData(
@@ -59,10 +53,7 @@ const RFC6749_ERROR_CODES = new Set([
 ]);
 
 /**
- * Keeps the `error` code only if it is a known RFC 6749 §5.2 value; a
- * data-driven IdP could otherwise stuff secrets into a free-form `error`.
- * The raw value stays diagnosable via a capped worker-stderr breadcrumb —
- * a bare `http: redacted` is unsupportable on its own.
+ * Returns the `error` code only if it is a known RFC 6749 §5.2 value, else 'redacted'.
  * @param errorCode - the IdP `error` field (or empty)
  */
 export function redactGenericError(errorCode: string): string {
@@ -86,13 +77,10 @@ function validateTokenUrl(raw: string): URL | null {
   }
   if (url.protocol !== 'https:') return null;
   if (url.username || url.password) return null;
-  // Strip the brackets URL keeps on IPv6 literals (URL also lower-cases +
-  // normalizes ::ffff:10.0.0.1 to its hex form ::ffff:a00:1).
+  // Strip brackets URL keeps on IPv6 literals.
   const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, '');
   if (host === 'localhost' || host.endsWith('.localhost')) return null;
-  // Block private/loopback/link-local/CGNAT literals; the host-side Rust
-  // validator is authoritative at install — this is defense-in-depth against a
-  // tampered state file, not a complete reserved-range implementation.
+  // Block private/loopback/link-local/CGNAT literals.
   if (
     /^127\./.test(host) ||
     /^0\./.test(host) ||
@@ -173,8 +161,7 @@ export async function refreshGenericToken(req: RefreshRequest): Promise<RefreshR
     clearTimeout(timeoutId);
   }
 
-  // A 3xx (redirect: 'manual' yields an opaqueredirect/non-ok) is not a valid
-  // token response — refuse rather than follow an attacker-influenced Location.
+  // A 3xx is not a valid token response.
   if (response.status >= 300 && response.status < 400) {
     return {
       ok: false,

--- a/mcp-servers/oauth/src/providers/http-body.ts
+++ b/mcp-servers/oauth/src/providers/http-body.ts
@@ -7,17 +7,14 @@
 export const MAX_BODY_BYTES = 256 * 1024;
 
 /**
- * Reads at most `MAX_BODY_BYTES` of the response (streaming, never buffering a
- * larger body), then parses JSON. A hostile token endpoint cannot OOM the
- * worker — the read aborts once the cap is crossed.
+ * Reads at most `MAX_BODY_BYTES` of the response (streaming), then parses JSON.
  * @param response - the token endpoint response
  */
 export async function readJsonCapped(
   response: Response
 ): Promise<{ ok: true; json: Record<string, unknown> } | { ok: false; message: string }> {
   const ctype = response.headers.get('content-type') ?? '';
-  // application/json or a +json suffix type (e.g. application/problem+json) —
-  // a bare /json/ substring match would pass crafted types like text/jsonx.
+  // application/json or a +json suffix type (e.g. application/problem+json).
   if (!/^application\/(?:[^;]+\+)?json\b/i.test(ctype)) {
     return { ok: false, message: `unexpected content-type '${ctype}'` };
   }
@@ -42,9 +39,7 @@ export async function readJsonCapped(
 }
 
 /**
- * Streams the response body, returning its text or `null` once `maxBytes` is
- * crossed (aborting the read). Context7 has an undici-specific counterpart; the
- * body types differ (WHATWG stream vs undici), so they stay separate.
+ * Streams the response body, returning its text or `null` once `maxBytes` is crossed.
  * @param response - the response whose body to read
  * @param maxBytes - upper bound on total bytes
  */

--- a/mcp-servers/oauth/src/providers/microsoft.ts
+++ b/mcp-servers/oauth/src/providers/microsoft.ts
@@ -64,8 +64,7 @@ export async function refreshMicrosoftToken(
     scope: req.scopes.join(' '),
   });
 
-  // Upper bound on the Microsoft token endpoint round-trip — a hang here
-  // would block every SharePoint tool call (refresh fires on 401).
+  // Upper bound on the Microsoft token endpoint round-trip.
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), TIMEOUTS.TOKEN_REFRESH_MS);
   let response: Response;
@@ -89,8 +88,7 @@ export async function refreshMicrosoftToken(
     clearTimeout(timeoutId);
   }
 
-  // A 3xx is not a valid token response — refuse rather than follow a
-  // Location header (mirrors the generic provider's hardening).
+  // A 3xx is not a valid token response; refuse rather than follow it.
   if (response.status >= 300 && response.status < 400) {
     return {
       ok: false,
@@ -141,15 +139,8 @@ export async function refreshMicrosoftToken(
   const grantedScopes =
     typeof grantedScope === 'string' && grantedScope.trim() ? grantedScope.trim().split(/\s+/) : [];
 
-  // Scope mismatch (granted ⊊ requested) — Microsoft returns 200 in this case.
-  // Exception: `offline_access` is an OIDC scope, not an API permission. Even
-  // when granted (and a `refresh_token` is returned), Microsoft does NOT echo
-  // it back in the `scope` field of the token response. Treat its presence in
-  // `req.scopes` as satisfied iff the response carries a refresh_token on the
-  // initial exchange, or — for refresh calls — implicitly (we got here at all).
-  // The Desktop banner check applies the same skip in
-  // `desktop/src-tauri/src/integrations_cmd.rs` (`OFFLINE_ACCESS_SCOPE`) — keep
-  // both in sync.
+  // `offline_access` is never echoed in the token response; treat as satisfied.
+  // Keep in sync with integrations_cmd.rs::OFFLINE_ACCESS_SCOPE.
   const missing = req.scopes.filter((s) => {
     if (s.toLowerCase() === 'offline_access') return false;
     return !grantedScopes.some((g) => g.toLowerCase() === s.toLowerCase());

--- a/mcp-servers/oauth/src/providers/types.ts
+++ b/mcp-servers/oauth/src/providers/types.ts
@@ -1,11 +1,5 @@
 /**
  * Generic OAuth provider contract used by the host-side `oauth` worker.
- *
- * Each IdP (Microsoft, Atlassian, …) implements one `OAuthProvider`. The
- * worker reads `state.provider` from `oauth/<project>/<service>.json`, looks
- * the implementation up in the registry, and calls `refresh()` with the
- * stored `providerData` (IdP-specific fields like Microsoft `clientId` /
- * `tenantId`).
  */
 
 /** SSOT — widen this union when adding an IdP. */
@@ -51,16 +45,9 @@ export type RefreshResult =
 /** One IdP implementation registered in the provider registry. */
 export interface OAuthProvider {
   readonly id: ProviderId;
-  /**
-   * Required keys of `providerData`; dispatcher validates pre-call. Used
-   * when the provider does not supply its own {@link validateRequest}.
-   */
+  /** Required keys of `providerData`; dispatcher validates pre-call. */
   readonly requiredFields: readonly string[];
-  /**
-   * Per-request validation when requirements depend on grant/auth style
-   * (generic provider). Returns an error to reject, or `null` to proceed.
-   * When absent, the dispatcher falls back to {@link requiredFields}.
-   */
+  /** Per-request validation; returns an error to reject, or `null` to proceed. */
   validateRequest?(req: RefreshRequest): RefreshError | null;
   refresh(req: RefreshRequest): Promise<RefreshResult>;
 }

--- a/mcp-servers/oauth/src/tools.test.ts
+++ b/mcp-servers/oauth/src/tools.test.ts
@@ -128,8 +128,7 @@ describe('oauth tools', () => {
     });
 
     it('rejects when ctx is missing entirely', async () => {
-      // `ctx?.caller` defaults to '' when ctx itself is undefined — covers
-      // the `?? ''` branch in resolveCaller (tools.ts:79).
+      // ctx undefined → caller defaults to '' (resolveCaller ?? branch, tools.ts:79).
       const tools = buildTools(deps);
       const refresh = tools.find((t) => t.tool.name === 'refresh')!;
       const result = await refresh.handler({}, undefined);
@@ -138,10 +137,7 @@ describe('oauth tools', () => {
     });
 
     it('falls back to Date.now / static registry when overrides absent', async () => {
-      // Covers `deps.now ?? Date.now` and the registry fallback when
-      // `deps.providers` is omitted. We do NOT actually call Microsoft — fetch
-      // is mocked, but the branch coverage we care about (real registry →
-      // microsoftProvider → refreshMicrosoftToken → fetch) is exercised.
+      // Covers `deps.now ?? Date.now` and static registry fallback when `deps.providers` omitted.
       await seedBearerMap({ 'bearer-sp': 'sharepoint' });
       await seedState(sharepointState);
       const fetchSpy = vi
@@ -286,8 +282,7 @@ describe('oauth tools', () => {
       const refresh = tools.find((t) => t.tool.name === 'refresh')!;
 
       const result = await refresh.handler({}, ctxFor('sharepoint'));
-      // Success-noop: a caller that lost the single-flight race re-reads the
-      // fresh token and retries instead of failing for the whole window.
+      // Success-noop: caller that lost the single-flight race re-reads the fresh token.
       expect(result.isError).toBeFalsy();
       const payload = JSON.parse(getTextResult(result)) as {
         expiresIn: number;
@@ -340,9 +335,7 @@ describe('oauth tools', () => {
       const [r1, r2] = await Promise.all([first, second]);
       expect(r1.isError).toBeFalsy();
       expect(r2.isError).toBeFalsy();
-      // Exactly one IdP call total; the winner is whoever acquired the mutex
-      // first (resolveCaller is async, so order is not positionally pinned —
-      // assert on the SET of outcomes, not which of r1/r2 lost the race).
+      // Exactly one IdP call; assert outcomes as a set (async order unpinned).
       expect(refreshCalls).toHaveLength(1);
       const payloads = [r1, r2].map(
         (r) => JSON.parse(getTextResult(r)) as { rateLimited?: boolean }
@@ -520,9 +513,7 @@ describe('oauth tools', () => {
         await seedBearerMap({ 'bearer-sp': 'sharepoint' });
         await seedState(sharepointState);
         const stateFile = join(stateDir, 'sharepoint.json');
-        // Read-only parent dir → unlink fails with EACCES (non-ENOENT).
-        // Keep the audit log outside the locked dir so the error path can
-        // still record the outcome.
+        // Read-only parent dir → unlink fails with EACCES (non-ENOENT); audit log kept outside locked dir.
         const isolatedAudit = join(tokensBase, 'audit.log');
         await chmod(stateDir, 0o500);
         try {

--- a/mcp-servers/oauth/src/tools.ts
+++ b/mcp-servers/oauth/src/tools.ts
@@ -1,10 +1,6 @@
 /**
  * MCP tools for the oauth worker — `refresh` and `forget`.
- *
- * Neither tool accepts a `service` parameter. The caller's service id is
- * derived from the incoming bearer token via the bearer-map maintained by the
- * Rust supervisor (ADR-060 decision 3b). This eliminates the
- * "compromised-caller forges service" failure mode.
+ * Service id is derived from the bearer token, not a parameter (ADR-060).
  */
 import { join } from 'node:path';
 import { unlink } from 'node:fs/promises';
@@ -60,11 +56,7 @@ export interface ToolDeps {
 /** Serializes `fn` per service key; concurrent callers queue FIFO. */
 type ServiceMutex = <T>(service: string, fn: () => Promise<T>) => Promise<T>;
 
-/**
- * Per-service promise-chain mutex. Rotating refresh tokens (Slack) are
- * single-use, so load→refresh→save must never interleave for one service;
- * forget is serialized through the same chain.
- */
+/** Per-service promise-chain mutex (rotating refresh tokens are single-use). */
 function createServiceMutex(): ServiceMutex {
   const tails = new Map<string, Promise<void>>();
   return async <T>(service: string, fn: () => Promise<T>): Promise<T> => {
@@ -116,9 +108,6 @@ export function buildTools(deps: ToolDeps): ToolDefinition[] {
 
 /**
  * Resolve `service` from `ctx.caller` and the on-disk bearer map.
- * Empty caller (`''`) means the request was authenticated with the supervisor's
- * primary token; this worker has no tool the supervisor itself should call,
- * so we treat it as unauthorized.
  * @param deps - dependencies (used for stateDir)
  * @param ctx - per-call context with caller id
  */
@@ -207,8 +196,7 @@ async function refreshLocked(deps: ToolDeps, service: string): Promise<ToolsCall
     scopes: state.scopes,
     refreshToken: state.refreshToken,
   };
-  // Provider-specific validation when requirements depend on grant/auth style
-  // (generic); otherwise fall back to the static requiredFields list.
+  // Provider validation if present, else the static requiredFields check.
   const validationError = provider.validateRequest
     ? provider.validateRequest(refreshReq)
     : missingStaticField(provider.requiredFields, state.providerData);
@@ -223,11 +211,7 @@ async function refreshLocked(deps: ToolDeps, service: string): Promise<ToolsCall
     return errorResult(`${validationError.code}: ${validationError.message}`);
   }
 
-  // Rate limit: if access token is still valid AND last refresh was within the
-  // window, skip the IdP round-trip. (Slows refresh-in-a-loop after RCE —
-  // ADR-060.) Returns success-noop, not an error: a caller that lost the
-  // single-flight race re-reads the freshly written token and retries; the
-  // audit log keeps the rate_limited signal.
+  // Rate limit: skip IdP call if token still valid and refresh is recent.
   const expiresAtMs = Date.parse(state.expiresAt);
   const lastRefreshMs = Date.parse(state.lastRefreshAt);
   const skewMs = 60_000;
@@ -265,8 +249,7 @@ async function refreshLocked(deps: ToolDeps, service: string): Promise<ToolsCall
   }
 
   const nowMs = now();
-  // Clamp the IdP-supplied lifetime so `new Date(...)` stays in range — an
-  // absurd expiresIn would otherwise throw RangeError out of this handler.
+  // Clamp the IdP-supplied lifetime so `new Date(...)` stays in range.
   const expiresInMs = Math.min(result.value.expiresIn, MAX_EXPIRES_IN_SECONDS) * 1000;
   const newState: OAuthState = {
     ...state,

--- a/mcp-servers/office/src/config.test.ts
+++ b/mcp-servers/office/src/config.test.ts
@@ -22,8 +22,7 @@ describe('parsePositiveInt', () => {
 });
 
 describe('paths', () => {
-  // Canary: several test mock factories hardcode `/workspace/.speedwave/office`. If this
-  // shape ever changes, those mocks (and the SKILL.md doc) must be updated alongside.
+  // Canary: test mocks + SKILL.md hardcode `/workspace/.speedwave/office` — sync if changed.
   it('OUTPUT_DIR is `<WORKSPACE_ROOT>/.speedwave/office`', () => {
     expect(WORKSPACE_ROOT).toBe('/workspace');
     expect(OUTPUT_DIR).toBe('/workspace/.speedwave/office');

--- a/mcp-servers/office/src/config.ts
+++ b/mcp-servers/office/src/config.ts
@@ -41,10 +41,10 @@ export const TIMEOUT_STANDARD_MS = parsePositiveInt(process.env.OFFICE_TIMEOUT_S
 /** Per-subprocess wall-time timeout (ms) for LibreOffice conversions (slow cold start + render). */
 export const TIMEOUT_LIBREOFFICE_MS = parsePositiveInt(process.env.OFFICE_TIMEOUT_LO_MS, 120_000);
 
-/** Cap on captured stdout/stderr per subprocess (bytes) — without this, a chatty tool can exhaust worker memory. */
+/** Cap on captured stdout/stderr per subprocess (bytes). */
 export const MAX_SUBPROCESS_OUTPUT_BYTES = 10 * 1024 * 1024;
 
-/** Default `maxChars` for text previews returned by read/convert tools — keeps large documents out of the model context. */
+/** Default `maxChars` for text previews returned by read/convert tools. */
 export const DEFAULT_MAX_CHARS = 4000;
 
 /**

--- a/mcp-servers/office/src/engine/convert.ts
+++ b/mcp-servers/office/src/engine/convert.ts
@@ -1,6 +1,5 @@
 /**
- * Document generation and conversion: Markdown/HTML → PDF/DOCX/PPTX (pandoc + weasyprint)
- * and Office → PDF / Office ↔ Office (LibreOffice headless, serialized via the LO queue).
+ * Markdown/HTML → PDF/DOCX/PPTX (pandoc + weasyprint), Office → PDF / Office ↔ Office (LibreOffice headless).
  * @module mcp-office/engine/convert
  */
 
@@ -60,9 +59,7 @@ async function materializeTextInput(
 }
 
 /**
- * Base URL for WeasyPrint's `url_fetcher` so relative `<img>` etc. in the source resolve correctly.
- * Inline content lives in `/tmp` (which `url_fetcher` rejects), so we point at `/workspace/` and let
- * `![](chart.png)` still work; a `/workspace` path uses its own directory.
+ * Base URL for WeasyPrint's `url_fetcher`: `/workspace/` for inline content, else the file's own directory.
  * @param filePath - The materialized file path.
  * @param isTemp - Whether the materialization wrote to `/tmp` (inline content).
  * @returns A `file://` base URL under `/workspace`.
@@ -85,10 +82,7 @@ function isCssMargin(value: string): boolean {
 }
 
 /**
- * Validate `opts` and build the safe `@page` declaration (`size: …; margin: …;`). Rejects anything
- * that is not a CSS page-size keyword (optionally with an orientation), a `<length>` list (1–4 tokens,
- * since `size` also accepts `<width> <height>`), or — for `margin` — 1–4 CSS lengths, so caller-supplied
- * option strings cannot inject arbitrary CSS into the rendered document.
+ * Validate `opts` and build the safe `@page` declaration (`size: …; margin: …;`).
  * @param opts - Page-rendering options.
  * @returns The validated `size: <...>; margin: <...>;` string for an `@page` block.
  * @throws {ValidationError} If `pageSize` or `margin` is not a recognized CSS value.
@@ -100,8 +94,7 @@ function pageRuleBody(opts: PdfOptions): string {
       `pageSize must be a CSS page-size keyword (A4, Letter, …) or "<width> <height>" lengths, got: ${rawSize}`
     );
   }
-  // Strip any trailing orientation already present in the keyword so `landscape: true` + "A4 landscape"
-  // does not produce the invalid "A4 landscape landscape".
+  // Strip any trailing orientation already present in the keyword.
   const baseSize = rawSize.replace(/\s+(portrait|landscape)\s*$/i, '');
   const size = opts.landscape ? `${baseSize} landscape` : rawSize;
   const margin = (opts.margin ?? '18mm').trim();
@@ -130,9 +123,7 @@ img { max-width: 100%; }
 }
 
 /**
- * Render an HTML file to PDF via WeasyPrint (`scripts/weasyprint_render.py`), which restricts
- * resource loading to `file://` under `/workspace` and writes the PDF atomically. The script's
- * output path is a `/tmp` file we then move onto the validated destination.
+ * Render an HTML file to PDF via WeasyPrint (`scripts/weasyprint_render.py`), atomically moved onto `destAbs`.
  * @param htmlAbs - Absolute path of the source HTML.
  * @param baseUrl - Base URL for resolving relative resources (a `file://` URL under `/workspace`).
  * @param destAbs - Absolute destination path for the PDF (already validated).
@@ -227,8 +218,7 @@ export async function htmlToPdf(
 }
 
 /**
- * Markdown (path or inline) → another format via pandoc, writing to a `/tmp` file first and then
- * `atomicMoveOnto` the validated destination — so a SIGKILL mid-write never leaves a partial `dest`.
+ * Markdown (path or inline) → another format via pandoc, atomically moved onto the validated destination.
  * @param input - The Markdown source.
  * @param writer - Pandoc output writer (`"docx"` | `"pptx"`).
  * @param defaultBase - Default base filename when `outName` is omitted.

--- a/mcp-servers/office/src/engine/extract.test.ts
+++ b/mcp-servers/office/src/engine/extract.test.ts
@@ -1,6 +1,5 @@
 /**
- * Tests for the extraction engine: SheetJS spreadsheet → Markdown, the markitdown-first
- * chain with format-specific fallbacks, truncation, and `readPdfText`.
+ * Tests for the extraction engine: SheetJS/markitdown/pdftotext chains with truncation.
  * @module mcp-office/engine/extract.test
  */
 
@@ -31,8 +30,7 @@ vi.mock('node:fs/promises', async (orig) => {
 import * as XLSX from 'xlsx';
 function makeWorkbookBuffer(): Buffer {
   const wb = XLSX.utils.book_new();
-  // Ragged sheet: header row is 3 wide, a later row is 1 wide (short-row padding path). One cell
-  // contains a comma and one contains a pipe — exercises both the comma-safe parsing and pipe-escaping.
+  // Ragged rows, commas, pipes, escaping.
   const ws = XLSX.utils.aoa_to_sheet([
     ['Name', 'Score', 'Note'],
     ['Ada', 10, 'hello, world'],

--- a/mcp-servers/office/src/engine/extract.ts
+++ b/mcp-servers/office/src/engine/extract.ts
@@ -38,10 +38,7 @@ export function truncate(text: string, maxChars: number): { content: string; tru
  * @returns A Markdown string covering every sheet.
  */
 function workbookToMarkdown(wb: XLSX.WorkBook): string {
-  // One-pass cell escape for a Markdown-table cell: `\` → `\\`, `|` → `\|`, and any run of
-  // newlines (Excel Alt+Enter) → a single space (so the cell doesn't break the table row).
-  // A single replace with a callback (rather than chained `.replace` calls) keeps the escaping
-  // atomic — there is no intermediate state where `|` is escaped before `\`.
+  // Escape Markdown-table cell: `\` → `\\`, `|` → `\|`, newline runs → space.
   const escape = (cell: unknown): string =>
     (cell == null ? '' : String(cell)).replace(/[\\|]|[\r\n]+/g, (m) =>
       m === '\\' ? '\\\\' : m === '|' ? '\\|' : ' '
@@ -50,8 +47,7 @@ function workbookToMarkdown(wb: XLSX.WorkBook): string {
   for (const name of wb.SheetNames) {
     const sheet = wb.Sheets[name];
     parts.push(`## ${name}`);
-    // Array-of-arrays over the used range — handles cells that contain commas/quotes/newlines
-    // correctly (a CSV round-trip + `split(',')` would corrupt those).
+    // Array-of-arrays over the used range.
     const grid = XLSX.utils.sheet_to_json<unknown[]>(sheet, { header: 1, blankrows: false });
     const width = grid.reduce((w, r) => Math.max(w, r.length), 0);
     const rows = grid.map((r) => Array.from({ length: width }, (_, i) => escape(r[i])));
@@ -100,8 +96,7 @@ export async function readDocumentToMarkdown(
     }
     // markitdown ran but produced nothing — fall through to the type-specific fallbacks.
   } catch (err) {
-    // markitdown crashed, timed out, or is missing from the venv (spawn ENOENT). The fallback
-    // engine below will still try; log so a broken venv is diagnosable rather than invisible.
+    // markitdown crashed, timed out, or is missing; the fallback engine below still tries.
     process.stderr.write(`[office] markitdown failed (falling back): ${(err as Error).message}\n`);
   }
 

--- a/mcp-servers/office/src/engine/office-build.test.ts
+++ b/mcp-servers/office/src/engine/office-build.test.ts
@@ -1,6 +1,5 @@
 /**
- * Tests for the DSL validation and orchestration in office-build (python invocation +
- * path resolution are mocked, so this exercises the TypeScript-side validation branches).
+ * Tests for the DSL validation and orchestration in office-build.
  * @module mcp-office/engine/office-build.test
  */
 

--- a/mcp-servers/office/src/engine/office-build.ts
+++ b/mcp-servers/office/src/engine/office-build.ts
@@ -1,8 +1,5 @@
 /**
  * Create/edit Word, Excel, PowerPoint files from the normative `spec`/`ops` DSL.
- * All building runs in the bundled Python venv via `scripts/{docx,xlsx,pptx}_build.py`
- * (python-docx / openpyxl / python-pptx). This module validates the DSL shapes in
- * TypeScript before handing them to the scripts.
  * @module mcp-office/engine/office-build
  */
 

--- a/mcp-servers/office/src/engine/pdf-ops.ts
+++ b/mcp-servers/office/src/engine/pdf-ops.ts
@@ -185,8 +185,7 @@ export async function fillPdfForm(
   if (typeof fields !== 'object' || fields === null || Array.isArray(fields)) {
     throw new ValidationError('fillPdfForm: fields must be an object of name → value');
   }
-  // Coerce values to strings up front (the contract is name→string). A non-string value
-  // (number, boolean) is rejected rather than silently `String()`-ified at the Python boundary.
+  // Contract is name→string; non-string values are rejected, not coerced.
   const strFields: Record<string, string> = {};
   for (const [k, v] of Object.entries(fields)) {
     if (typeof v !== 'string') {

--- a/mcp-servers/office/src/errors.ts
+++ b/mcp-servers/office/src/errors.ts
@@ -1,14 +1,10 @@
 /**
- * Error types for the office worker. `guard()` in `tools/index.ts` turns any thrown
- * `Error` into an MCP `isError` result, so these classes exist mainly to give callers
- * (and the JSDoc) a precise name for the failure category.
+ * Error types for the office worker.
  * @module mcp-office/errors
  */
 
 /**
- * A path violated the workspace policy: outside `/workspace` after canonicalization,
- * a symlinked component, an oversize input, or a refused overwrite. Distinct from
- * `ValidationError` — this one is about filesystem confinement, not request shape.
+ * A path violated the workspace policy: outside `/workspace`, a symlinked component, oversize input, or refused overwrite.
  */
 export class PathPolicyError extends Error {
   /**
@@ -22,9 +18,7 @@ export class PathPolicyError extends Error {
 }
 
 /**
- * The caller's request was malformed: a bad DSL `spec`/`ops` shape, an invalid chart
- * type, a CSS option that fails the injection-guard regex, an out-of-range page count,
- * etc. Distinct from `PathPolicyError` — this one is about request content, not paths.
+ * The caller's request was malformed: bad DSL spec/ops, invalid chart type, injection-guard failure, or out-of-range page count.
  */
 export class ValidationError extends Error {
   /**

--- a/mcp-servers/office/src/lo-queue.ts
+++ b/mcp-servers/office/src/lo-queue.ts
@@ -1,8 +1,5 @@
 /**
- * Serialization queue for LibreOffice (`soffice`) invocations.
- * `soffice --headless` is not reentrant — two concurrent conversions on the same
- * machine corrupt each other's output even with separate `-env:UserInstallation`
- * profiles in practice — so every conversion goes through this single-slot queue.
+ * Single-slot serialization queue for LibreOffice (`soffice`) invocations.
  * @module mcp-office/lo-queue
  */
 
@@ -18,8 +15,6 @@ class SerialQueue {
    */
   run<T>(fn: () => Promise<T>): Promise<T> {
     const result = this.tail.then(fn, fn);
-    // Keep the chain alive regardless of this task's outcome; swallow here so an
-    // unhandled rejection on `tail` is impossible (the caller still sees it via `result`).
     this.tail = result.then(
       () => undefined,
       () => undefined

--- a/mcp-servers/office/src/path-policy.test.ts
+++ b/mcp-servers/office/src/path-policy.test.ts
@@ -1,8 +1,6 @@
 /**
  * Tests for the path policy: workspace confinement, symlink rejection, atomic writes,
- * overwrite refusal, and the default output directory. These run against a temp dir
- * that stands in for `/workspace` by monkeypatching the module's `WORKSPACE_ROOT`/`OUTPUT_DIR`
- * via the `vi.mock` of `./config.js`.
+ * overwrite refusal, and the default output directory.
  * @module mcp-office/path-policy.test
  */
 
@@ -14,8 +12,7 @@ import * as path from 'node:path';
 
 let workspaceDir: string;
 
-// Make the Nth-from-now `lstat`/`lstatSync` call throw `err` (1 = the very next call). Lets a
-// test exercise the EACCES/EPERM branches that real temp dirs cannot reproduce in CI.
+// Make the Nth-from-now `lstat`/`lstatSync` call throw `err` (1 = the very next call).
 const lstatThrow = vi.hoisted(() => ({
   countdown: 0,
   err: null as NodeJS.ErrnoException | null,
@@ -158,8 +155,7 @@ describe('resolveInputFile', () => {
   it('throws when a path component (not the leaf) is not a regular file', async () => {
     await fsp.mkdir(path.join(workspaceDir, 'sub'));
     await fsp.writeFile(path.join(workspaceDir, 'sub', 'f'), 'x');
-    // `sub/f` is a regular file; ask for `sub/f/inner` → `f` is a non-dir component, lstat of the
-    // full path fails → "not found". (Covers the lstat-throws branch with an existing prefix.)
+    // `sub/f` is a regular file; lstat of `sub/f/inner` fails → "not found".
     await expect(resolveInputFile('sub/f/inner')).rejects.toThrow(/not found/);
   });
 
@@ -222,8 +218,7 @@ describe('resolveOutputPath', () => {
   });
 
   it('propagates a permission error from the overwrite check (not treated as "free")', async () => {
-    // The overwrite check is the first lstat call in resolveOutputPath (no symlink walk runs before it
-    // for a bare name under OUTPUT_DIR — resolveWithinWorkspace's walk uses lstatSync, which we skip).
+    // The overwrite check is the first lstat call in resolveOutputPath for a bare name.
     lstatThrow.arm(1, Object.assign(new Error('EACCES'), { code: 'EACCES' }));
     await expect(resolveOutputPath('guarded.pdf', 'x.pdf')).rejects.toThrow(/EACCES/);
   });

--- a/mcp-servers/office/src/subprocess-pyscript.test.ts
+++ b/mcp-servers/office/src/subprocess-pyscript.test.ts
@@ -1,6 +1,5 @@
 /**
- * Tests for `runPythonScript` driving a real interpreter (node standing in for python via a
- * mocked `PYTHON_BIN`/`SCRIPTS_DIR`), so the JSON-contract parsing branches are exercised end to end.
+ * Tests for `runPythonScript` JSON-contract parsing.
  * @module mcp-office/subprocess-pyscript.test
  */
 

--- a/mcp-servers/office/src/subprocess.test.ts
+++ b/mcp-servers/office/src/subprocess.test.ts
@@ -1,8 +1,6 @@
 /**
  * Tests for the hardened subprocess wrapper: capture, timeout/SIGKILL, output cap,
- * non-zero-exit handling, stdin, cwd/env, and spawn-error. Uses real short-lived
- * `node -e` child processes so the actual spawn/timeout/stdio paths are exercised.
- * (The `runPythonScript` JSON-contract branches are covered in `subprocess-pyscript.test.ts`.)
+ * non-zero-exit, stdin, cwd/env, spawn-error.
  * @module mcp-office/subprocess.test
  */
 

--- a/mcp-servers/office/src/tools/index.test.ts
+++ b/mcp-servers/office/src/tools/index.test.ts
@@ -1,7 +1,5 @@
 /**
- * Tests for the tool definitions and handler dispatch. Engine functions are mocked so the
- * handlers' parameter coercion, the `guard` error wrapper, and the tool metadata are exercised
- * without touching subprocesses.
+ * Tests for the tool definitions and handler dispatch.
  * @module mcp-office/tools/index.test
  */
 
@@ -18,7 +16,7 @@ function fr(format: string) {
   };
 }
 
-// Mock every engine module the tools call. Hoisted so the `vi.mock` factories can reference these.
+// Mock every engine module the tools call.
 const eng = vi.hoisted(() => {
   const make = (impl: () => unknown) => vi.fn(async () => impl());
   const file = (format: string) => () => ({

--- a/mcp-servers/office/src/util.ts
+++ b/mcp-servers/office/src/util.ts
@@ -4,9 +4,7 @@
  */
 
 /**
- * No-op error handler — pass to `.catch()` on best-effort cleanup (`fs.rm` of a temp file)
- * where a failure is genuinely not actionable. Centralised so the pattern is documented once
- * rather than scattered as anonymous `() => undefined` arrows.
+ * No-op error handler for `.catch()` on best-effort cleanup where failure is not actionable.
  */
 export function ignoreError(): void {
   /* deliberately empty — used for best-effort cleanup */

--- a/mcp-servers/os/src/index.ts
+++ b/mcp-servers/os/src/index.ts
@@ -1,24 +1,12 @@
 /**
- * MCP OS Worker
- *
- * Native OS integrations (Reminders, Calendar, Mail, Notes).
- * Runs on the HOST (not in a container) — accesses native OS APIs
- * via platform-specific CLI binaries.
- *
- * Architecture:
- * - macOS: Swift CLI binaries (EventKit, AppleScript)
- * - Windows: Rust CLI binary (WinRT, MAPI)
- *
- * Auth: Bearer token from MCP_OS_AUTH_TOKEN env var.
- * Hub reaches this worker via WORKER_OS_URL.
+ * MCP OS Worker — host-side native OS integrations (Reminders, Calendar, Mail, Notes).
  * @module mcp-os
  */
 
 import { bootWorker, ts } from '@speedwave/mcp-shared';
 import { createToolDefinitions } from './tools/index.js';
 
-// Host-side worker: defaultPort '0' (OS picks) and no explicit host, so the
-// server binds MCP_LISTEN_HOST ?? '127.0.0.1' rather than a container 0.0.0.0.
+// Host-side worker: defaultPort '0' (OS picks).
 console.log(`${ts()} Platform: ${process.platform}`);
 bootWorker({
   serverName: 'mcp-os',

--- a/mcp-servers/os/src/platform-runner.test.ts
+++ b/mcp-servers/os/src/platform-runner.test.ts
@@ -128,8 +128,7 @@ describe('platform-runner', () => {
       });
     });
 
-    // Exercises resolveDarwinPaths() directly so that the `process.platform === 'darwin'`
-    // branch is covered on any host the tests happen to run on.
+    // Exercises resolveDarwinPaths() directly on any host platform.
     describe('macOS paths (resolveDarwinPaths)', () => {
       const originalPlatform = process.platform;
 

--- a/mcp-servers/os/src/platform-runner.ts
+++ b/mcp-servers/os/src/platform-runner.ts
@@ -1,12 +1,5 @@
 /**
- * Platform Runner — Cross-platform CLI binary dispatcher
- *
- * Detects the current platform and resolves the correct native CLI binary
- * for OS integrations (Reminders, Calendar, Mail, Notes).
- *
- * Platforms:
- * - macOS: 4 Swift binaries (reminders-cli, calendar-cli, mail-cli, notes-cli)
- * - Windows: 1 Rust binary (native-os-cli) with domain.command syntax
+ * Cross-platform native CLI dispatcher: macOS Swift binaries, Windows Rust binary.
  */
 
 import { execFile as execFileCb } from 'node:child_process';
@@ -50,24 +43,13 @@ export interface PlatformPaths {
 // Binary Resolution
 //=============================================================================
 
-/**
- * Detect whether we are running in dev mode or production (bundled).
- * Dev: binaries are in native/macos/<pkg>/.build/release/ or target/release/
- * Prod: binaries are alongside the app (Resources/ on macOS)
- */
+/** Detect whether we are running in dev mode or production (bundled). */
 function isDevMode(): boolean {
-  // In production, __dirname would be inside .app bundle or dist/
-  // In dev, we run from mcp-servers/os/dist/ or src/
   return !process.env.SPEEDWAVE_PROD;
 }
 
-/**
- * Resolve the project root directory.
- * In dev mode, this is the monorepo root (parent of mcp-servers/).
- */
+/** Resolve the monorepo root directory (3 levels up from src/ or dist/). */
 function resolveProjectRoot(): string {
-  // platform-runner.ts lives at mcp-servers/os/src/ (dev) or mcp-servers/os/dist/ (built)
-  // Project root is 3 levels up from src/ or dist/
   return path.resolve(import.meta.dirname, '..', '..', '..');
 }
 
@@ -140,9 +122,8 @@ export function resolvePaths(): PlatformPaths {
 const DEFAULT_TIMEOUT_MS = 30_000;
 
 /**
- * Allowlist of environment variable names safe to pass to CLI child processes.
- * Prevents leaking secrets (MCP_OS_AUTH_TOKEN, API keys, etc.) to subprocesses.
- * Sourced from the shared 14-key core ({@link BASE_SAFE_ENV_KEYS}).
+ * Allowlist of env var names safe to pass to CLI child processes.
+ * Sourced from the shared core ({@link BASE_SAFE_ENV_KEYS}).
  */
 export const SAFE_ENV_KEYS: readonly string[] = BASE_SAFE_ENV_KEYS;
 

--- a/mcp-servers/os/src/tools/index.ts
+++ b/mcp-servers/os/src/tools/index.ts
@@ -32,7 +32,6 @@ import { createNoteTools } from './notes-tools.js';
 
 /**
  * Allowlisted commands per OS domain.
- * Rejects any command not in this map before touching the filesystem or exec.
  */
 export const ALLOWED_COMMANDS: Record<OsDomain, ReadonlySet<string>> = {
   reminders: new Set([

--- a/mcp-servers/os/src/tools/mail-tools.ts
+++ b/mcp-servers/os/src/tools/mail-tools.ts
@@ -352,8 +352,7 @@ const sendEmailTool: Tool = {
   ],
 };
 
-// DESTRUCTIVE_ANNOTATIONS: sending an email reply is irreversible — once delivered,
-// it cannot be unsent or retracted, matching MCP spec's destructiveHint definition.
+// Email reply is irreversible (destructive operation)
 const replyToEmailTool: Tool = {
   name: 'replyToEmail',
   description: 'Reply to an existing email. Requires confirm_send=true as safety check.',

--- a/mcp-servers/os/src/tools/validation.ts
+++ b/mcp-servers/os/src/tools/validation.ts
@@ -86,7 +86,6 @@ const CONTROL_CHARS_STRICT = /[\x00-\x1f\x7f]/;
 
 /**
  * Validate string fields for max length and control characters.
- * Skips fields that are `undefined` (optional not provided).
  * @param params - Tool input parameters to validate.
  * @param specs - Array of string field specs [name, maxLength, allowNewlines].
  */
@@ -137,7 +136,6 @@ export function validateStringFields(
 
 /**
  * Validate number fields for type, finiteness, and range.
- * Skips fields that are `undefined` (optional not provided).
  * @param params - Tool input parameters to validate.
  * @param specs - Array of number field specs [name, min, max].
  */
@@ -178,7 +176,6 @@ export function validateNumberFields(
 
 /**
  * Validate boolean fields for strict `typeof === 'boolean'`.
- * Skips fields that are `undefined` (optional not provided).
  * @param params - Tool input parameters to validate.
  * @param fields - List of boolean field names to check.
  */
@@ -204,9 +201,6 @@ export function validateBooleanFields(
 
 /**
  * Validate string-array fields for type, item count, item length, and control characters.
- * Uses strict mode (no newlines) — array items are short labels, not multi-line content.
- * Skips fields that are `undefined` (optional not provided).
- * Note: `null` is NOT skipped — it returns INVALID_TYPE, matching validateStringFields behavior.
  * @param params - Tool input parameters to validate.
  * @param specs - Array of string-array field specs [name, maxItems, maxItemLength].
  */
@@ -299,9 +293,6 @@ export interface ValidationSpec {
 
 /**
  * Combine all validation steps in one call.
- * Order: required → booleans → strings → numbers → dates → stringArrays.
- * Returns `{ valid: true }` only when every enabled step passes.
- * Note: `required` validates presence of non-empty string fields only (delegates to `requireFields`).
  * @param params - Tool input parameters to validate.
  * @param spec - Which validations to run and with what configuration.
  */
@@ -338,7 +329,6 @@ export function validateAll(
 
 /**
  * Cast unknown params to `Record<string, unknown>`.
- * Replaces the verbose `params as unknown as Record<string, unknown>` pattern.
  * @param params - Tool input parameters.
  */
 export function asRecord(params: unknown): Record<string, unknown> {
@@ -347,7 +337,6 @@ export function asRecord(params: unknown): Record<string, unknown> {
 
 /**
  * Validate that optional date fields, when present, are in strict ISO8601 format.
- * Skips fields that are `undefined` or `null`.
  * @param params - Tool input parameters to validate.
  * @param fields - List of field names to check.
  */
@@ -372,18 +361,12 @@ export function validateDateFields(
   return { valid: true };
 }
 
-/**
- * Strict ISO8601 regex: YYYY-MM-DD with optional THH:MM:SS(.sss)(Z|±HH:MM).
- * Rejects non-ISO formats that `new Date()` would silently accept
- * (e.g., "Feb 20, 2026", unix timestamps, slash-delimited dates).
- */
+/** Strict ISO8601 regex: YYYY-MM-DD with optional THH:MM:SS(.sss)(Z|±HH:MM). */
 const ISO8601_RE =
   /^\d{4}-\d{2}-\d{2}(T([01]\d|2[0-3]):[0-5]\d:[0-5]\d(\.\d+)?(Z|[+-]([01]\d|2[0-3]):[0-5]\d)?)?$/;
 
 /**
  * Validate ISO8601 date string format.
- * Uses regex pre-check before `new Date()` to reject ambiguous formats.
- * Additionally validates month/day ranges to prevent silent date rollover.
  * @param value - Value to check for valid ISO8601 date format.
  */
 export function isValidISO8601(value: unknown): value is string {

--- a/mcp-servers/redmine/src/auth.test.ts
+++ b/mcp-servers/redmine/src/auth.test.ts
@@ -1,8 +1,5 @@
 /**
- * Redmine worker auth wiring tests (SEC-035)
- *
- * Verifies that mcp-redmine reads MCP_REDMINE_AUTH_TOKEN and passes it to createMCPServer.
- * Middleware correctness is covered by shared/src/server.test.ts — here we test wiring only.
+ * Redmine worker auth wiring tests (SEC-035): MCP_REDMINE_AUTH_TOKEN passed to createMCPServer.
  */
 
 import { describe, it, expect, afterEach } from 'vitest';

--- a/mcp-servers/redmine/src/client.test.ts
+++ b/mcp-servers/redmine/src/client.test.ts
@@ -1652,9 +1652,6 @@ describe('RedmineClient', () => {
 
       // The retry count should be set
       expect(mockError.config.__retryCount).toBe(1);
-
-      // Note: We can't easily test the setTimeout delay without useFakeTimers
-      // which vitest handles differently. The important part is the retry count logic.
     });
 
     it('should pass response through the success handler', () => {

--- a/mcp-servers/redmine/src/client.ts
+++ b/mcp-servers/redmine/src/client.ts
@@ -1,17 +1,6 @@
 /**
- * Redmine API Client
- *
- * Isolated Redmine client for mcp-redmine worker.
- * ONLY has access to Redmine API key - no other service tokens.
- *
- * Security:
- * - API key read from /tokens/ (RO mount)
- * - API key NEVER exposed in responses
- * - Blast radius containment: only Redmine exposed if compromised
- *
- * Error Handling Convention:
- * - Factory functions (initializeRedmineClient) return null on config failures (graceful degradation)
- * - Instance methods throw errors on API failures
+ * Isolated Redmine API client for mcp-redmine worker (API key only).
+ * Factory returns null on config failure; instance methods throw on API failure.
  */
 
 import axios, { AxiosInstance, AxiosError, InternalAxiosRequestConfig } from 'axios';
@@ -721,10 +710,6 @@ const SAFE_TAGS = new Set([
 
 /**
  * Sanitize Textile markup to remove potentially dangerous content.
- * Phase 1: iteratively strip dangerous tags with their full content.
- * Phase 2: whitelist remaining tags — only safe formatting tags survive.
- * Phase 3: strip event handlers and dangerous URI schemes from safe tags.
- * Runs iteratively until the output stabilizes (handles nested payloads).
  * @param textile - The Textile markup to sanitize.
  * @returns Sanitized Textile markup.
  */
@@ -834,13 +819,7 @@ export class RedmineClient {
     return this.mappings;
   }
 
-  /**
-   * Memoized lookup of the configured project's display name. Bounded to 5 s
-   * via {@link memoizedPromise} so tool calls never hang on a slow Redmine.
-   * On timeout returns `null` and leaves the cache empty (next call retries).
-   * Cached for the lifetime of the client once resolved — names are immutable
-   * in Redmine for a given project_id.
-   */
+  /** Memoized lookup of the configured project's display name (5 s timeout, null on failure). */
   private readonly _getProjectName = memoizedPromise<string | null>({
     fetch: async () => {
       const pid = this.projectConfig?.project_id;
@@ -864,8 +843,7 @@ export class RedmineClient {
   }
 
   /**
-   * Get project configuration. Resolves project_name lazily via the bounded
-   * background fetch so a slow Redmine never delays server startup.
+   * Get project configuration with lazy project_name resolution.
    * @returns Configuration object with project_id, project_name, and URL.
    */
   async getConfig(): Promise<{ project_id?: string; project_name?: string; url: string }> {
@@ -892,9 +870,7 @@ export class RedmineClient {
   }
 
   /**
-   * Resolve the configured project's numeric ID with promise deduplication.
-   * Caches the result — Redmine project numeric IDs are immutable.
-   * On failure, clears the cache so the next call retries.
+   * Resolve and cache the configured project's numeric ID (promise dedup).
    * @param scope - The configured project identifier.
    * @returns The numeric project ID.
    * @throws {ProjectScopeError} When the configured project doesn't exist (404).
@@ -924,7 +900,6 @@ export class RedmineClient {
 
   /**
    * Enforce project_id matches the configured scope.
-   * SSOT for the "reject mismatch, force scope" pattern (6 callers).
    * @param callerProjectId - The caller-provided project_id (may be undefined).
    * @returns The project_id to use (scope if scoped, callerProjectId if unscoped).
    * @throws {ProjectScopeError} When callerProjectId doesn't match scope.
@@ -942,7 +917,6 @@ export class RedmineClient {
 
   /**
    * Validate that an issue belongs to the scoped project before mutation.
-   * SSOT for the "validate issue before mutation" pattern (5+ callers).
    * @param issueId - The issue ID to validate.
    * @returns The issue (for callers that need it).
    * @throws {ProjectScopeError} When the issue belongs to a different project.
@@ -1164,11 +1138,7 @@ export class RedmineClient {
 
     await this.client.put(`/issues/${issueId}.json`, { issue });
 
-    // Return updated issue to allow verification of changes.
-    // Note: Redmine API is synchronous, so the returned data should reflect
-    // the update. However, if verification fails, the caller should check
-    // if the issue status allows the requested change (e.g., closed issues
-    // may silently reject assignment changes).
+    // Return updated issue for verification.
     return this.showIssue(issueId);
   }
 
@@ -1490,9 +1460,7 @@ export class RedmineClient {
     const response = await this.client.get(`/projects/${projectId}.json`, { params });
     const project = response.data.project;
 
-    // Post-fetch scope validation: compare Redmine's canonical identifier against config.
-    // showProject validates via identifier (has full project object),
-    // while showIssue validates via numeric project.id (issues only expose project.id).
+    // Post-fetch scope validation via identifier or numeric id.
     const scope = this.getProjectScope();
     if (scope && project.identifier !== scope && project.id.toString() !== scope) {
       throw new ProjectScopeError(scope, project.identifier);
@@ -1682,13 +1650,7 @@ export class RedmineClient {
 //═══════════════════════════════════════════════════════════════════════════════
 
 /**
- * IMPORTANT: Returns null (not throws) when tokens are missing or invalid.
- * This enables "graceful degradation" - server starts even without config:
- * - User can run `speedwave` (no subcommand) without configuring all integrations
- * - Healthcheck reports `configured: false` for unconfigured services
- * - Tools return clear "not configured" error when called
- *
- * DO NOT change this to throw - it breaks container startup for unconfigured services.
+ * Initialize the Redmine client; returns null (never throws) on config errors.
  * @returns Configured RedmineClient instance, or null if API key not found/invalid
  */
 export async function initializeRedmineClient(): Promise<RedmineClient | null> {
@@ -1697,8 +1659,7 @@ export async function initializeRedmineClient(): Promise<RedmineClient | null> {
 
     // Validate API key is not empty (0-byte placeholder file)
     if (!apiKey) {
-      // Graceful degradation: log warning, return null, let server start
-      // DO NOT throw here - see JSDoc above for rationale
+      // Graceful degradation: log and return null.
       console.warn(`${ts()} ${withSetupGuidance('Redmine API key is empty.')}`);
       return null;
     }
@@ -1719,8 +1680,7 @@ export async function initializeRedmineClient(): Promise<RedmineClient | null> {
     }
 
     if (!host) {
-      // Graceful degradation: log warning, return null, let server start
-      // DO NOT throw here - see JSDoc above for rationale
+      // Graceful degradation: log and return null.
       console.warn(`${ts()} No Redmine URL found (config.json or REDMINE_URL env var)`);
       return null;
     }
@@ -1735,9 +1695,7 @@ export async function initializeRedmineClient(): Promise<RedmineClient | null> {
       projectConfig
     );
 
-    // project_name resolves lazily via client.getProjectName() — fire-and-forget
-    // here so the cache warms in the background, but the HTTP listener never
-    // waits on Redmine. A slow or unreachable Redmine no longer delays startup.
+    // Fire-and-forget project_name resolution to avoid startup delays.
     if (
       projectConfig != null &&
       projectConfig.project_id != null &&
@@ -1749,8 +1707,7 @@ export async function initializeRedmineClient(): Promise<RedmineClient | null> {
 
     return client;
   } catch (error) {
-    // Graceful degradation: log warning, return null, let server start
-    // DO NOT throw here - see JSDoc above for rationale
+    // Graceful degradation: log and return null.
     console.warn(
       `${ts()} Failed to initialize Redmine client: ${error instanceof Error ? error.message : 'Unknown error'}`
     );

--- a/mcp-servers/redmine/src/tools/config-tools.ts
+++ b/mcp-servers/redmine/src/tools/config-tools.ts
@@ -82,7 +82,7 @@ const getConfigTool: Tool = {
 };
 
 /**
- * Tool handler function
+ * Builds the Redmine config tool definitions.
  * @param client - Redmine client instance
  */
 export function createConfigTools(client: RedmineClient | null): ToolDefinition[] {

--- a/mcp-servers/redmine/src/tools/time-entry-tools.ts
+++ b/mcp-servers/redmine/src/tools/time-entry-tools.ts
@@ -201,7 +201,7 @@ const updateTimeEntryTool: Tool = {
 };
 
 /**
- * Tool handler function
+ * Builds the Redmine time-entry tool definitions.
  * @param client - Redmine client instance
  */
 export function createTimeEntryTools(client: RedmineClient | null): ToolDefinition[] {

--- a/mcp-servers/shared/src/boot.ts
+++ b/mcp-servers/shared/src/boot.ts
@@ -1,16 +1,5 @@
 /**
- * Declarative worker boot — SSOT for the ~identical `main()` in every built-in
- * worker's `src/index.ts`. Collapses the repeated boilerplate (auth-token gate,
- * client init + retry, the two-line "not configured" warning that appeared 18×,
- * health-check wiring, port announcement, fatal-error trap) into one call.
- *
- * Legit per-worker variance is encoded as explicit params, not divergent files:
- * - `authTokenEnv` undefined → no auth gate (none today; all set auth).
- * - `initClient` undefined → no client (office); returns null → "not configured".
- * - `onNotConfigured: 'warn' | 'fail'` → graceful (slack/gitlab/…) vs fail-fast
- *   (sharepoint, whose OAuth refresh cannot be deferred).
- * - `isConfigured` → slack returns a non-null object with `_tokensStatus`, so
- *   "configured" is not just "non-null" — this predicate decides.
+ * Declarative worker boot — SSOT for every built-in worker's `main()`.
  * @module shared/boot
  */
 
@@ -34,10 +23,7 @@ export interface BootWorkerOptions<C> {
   displayName?: string;
   /** Env var holding the required Bearer token. When unset, no auth gate is applied. */
   authTokenEnv?: string;
-  /**
-   * Bind host. Containers pass `'0.0.0.0'`; host-side workers (os) omit it so
-   * `createMCPServer` falls back to `MCP_LISTEN_HOST ?? '127.0.0.1'`.
-   */
+  /** Bind host. Containers pass `'0.0.0.0'`; host-side workers omit it. */
   host?: string;
   /** Initialize the service client. Omit for credential-free workers (office). */
   initClient?: () => Promise<C | null>;
@@ -54,9 +40,7 @@ export interface BootWorkerOptions<C> {
 }
 
 /**
- * Boot a worker: validate auth, init the client (with retry), wire tools +
- * health check, start listening, announce the port on stdout, and install the
- * fatal-error trap. Returns the actual listening port.
+ * Boot a worker and return the actual listening port.
  * @template C - Service client type.
  * @param opts - Declarative boot configuration.
  */

--- a/mcp-servers/shared/src/connection-test.test.ts
+++ b/mcp-servers/shared/src/connection-test.test.ts
@@ -59,8 +59,7 @@ describe('classifyConnectionError', () => {
   });
 
   it('classifies a plain Error with no code/response as network', () => {
-    // Bare Error (e.g. fetch() failing pre-response) — duck-typing falls
-    // through to the "no response, no code" branch.
+    // Bare Error with no code/response classified as network.
     const err = new Error('boom');
     expect(classifyConnectionError(err).errorType).toBe('network');
   });

--- a/mcp-servers/shared/src/errors.ts
+++ b/mcp-servers/shared/src/errors.ts
@@ -1,6 +1,5 @@
 /**
  * SSOT for user-facing error messages across all MCP workers.
- * All servers import from here — no hardcoded "speedwave setup" strings elsewhere.
  * @module shared/errors
  */
 

--- a/mcp-servers/shared/src/forbidden-markers.test.ts
+++ b/mcp-servers/shared/src/forbidden-markers.test.ts
@@ -130,19 +130,16 @@ function gatherMarkerViolations(): string[] {
 
 describe('forbidden-markers — mcp-servers comment scan', () => {
   it('locates the mcp-servers root and finds source files to scan', () => {
-    // Guards the anchor: a broken root-finder would scan nothing and pass
-    // vacuously, hiding real markers.
+    // Guards the anchor: a broken root-finder scans nothing and hides markers.
     expect(walkTsSources(MCP_ROOT, false).length).toBeGreaterThan(0);
   });
 
   it('extracts comments but not string-literal contents', () => {
-    // The github/gitlab example inputs are the exact false-positive this guard
-    // must tolerate: `query: 'TODO'` is data, not a marker comment.
+    // A marker word inside a string literal is data, not a marker comment.
     expect(extractComments(`const x = { query: 'TODO' };`)).toEqual([]);
     expect(extractComments(`foo(); // real TODO marker`)).toEqual([' real TODO marker']);
     expect(extractComments(`/* block FIXME */`)).toEqual([' block FIXME ']);
-    // A marker word inside a string that also has a trailing comment: only the
-    // comment is extracted.
+    // Only the trailing comment is extracted, not the string-literal marker.
     expect(extractComments(`const s = 'TODO'; // and HACK here`)).toEqual([' and HACK here']);
   });
 

--- a/mcp-servers/shared/src/health-status.test.ts
+++ b/mcp-servers/shared/src/health-status.test.ts
@@ -138,8 +138,7 @@ describe('makeStandardHealthCheck', () => {
     const t = new ConnectionStatusTracker();
     t.setFailed('');
     const hc = makeStandardHealthCheck(t, 'TestService');
-    // setFailed with empty string still sets _error to ''; the factory uses
-    // `??` so falsy strings DO appear in the message — verify exact behaviour.
+    // empty-string error appears in the message (`??` keeps falsy strings).
     await expect(hc()).rejects.toThrow('TestService connection failed:');
   });
 });

--- a/mcp-servers/shared/src/jsonrpc.test.ts
+++ b/mcp-servers/shared/src/jsonrpc.test.ts
@@ -859,8 +859,7 @@ describe('jsonrpc', () => {
       });
 
       it('creates auto-reconnect session when provided sessionId is not found in tools/list', async () => {
-        // Covers the second-OR branch of: if (!sessionId || !sessionManager.getSession(sessionId))
-        // sessionId is provided but session doesn't exist — auto-reconnect fires
+        // Covers the second-OR branch: sessionId provided but session not found.
         registerNTools(handler, 1);
         const request = {
           jsonrpc: '2.0',
@@ -879,8 +878,7 @@ describe('jsonrpc', () => {
       });
 
       it('skips auto-reconnect when tools/list is called with a valid existing sessionId', async () => {
-        // Covers the false branch of: if (!sessionId || !sessionManager.getSession(sessionId))
-        // — both conditions are false: sessionId is non-null AND session exists
+        // Covers the false branch: sessionId non-null AND session exists.
         registerNTools(handler, 2);
 
         // First create a session via initialize
@@ -912,8 +910,7 @@ describe('jsonrpc', () => {
 
     describe('tools/call session auto-reconnect', () => {
       it('creates auto-reconnect session when provided sessionId is not found in tools/call', async () => {
-        // Covers the second-OR branch of: if (!sessionId || !sessionManager.getSession(sessionId))
-        // for the handleToolsCall path
+        // Covers the second-OR branch for the handleToolsCall path.
         const tool = {
           name: 'reconnect_tool',
           description: 'Test tool',
@@ -1058,9 +1055,7 @@ describe('jsonrpc', () => {
 
   describe('processRequest outer catch', () => {
     it('returns InternalError when a handler method throws unexpectedly', async () => {
-      // Covers lines 184-188: outer try-catch in processRequest.
-      // sessionManager.createSession is called inside handleInitialize; if it throws,
-      // the outer catch fires (handleInitialize has no catch of its own).
+      // Covers the outer try-catch in processRequest when createSession throws.
       vi.spyOn(console, 'log').mockImplementation(() => {});
       vi.spyOn(console, 'warn').mockImplementation(() => {});
       vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/mcp-servers/shared/src/jsonrpc.ts
+++ b/mcp-servers/shared/src/jsonrpc.ts
@@ -1,7 +1,4 @@
-/**
- * JSON-RPC 2.0 Message Handler for MCP
- * Provides a generic handler that can be configured with tools
- */
+/** JSON-RPC 2.0 message handler for MCP, configurable with tools */
 
 import type {
   JSONRPCRequest,
@@ -22,10 +19,7 @@ import { ts } from './logger.js';
 /** Page size for tools/list pagination */
 const TOOLS_LIST_PAGE_SIZE = 100;
 
-/**
- * JSON-RPC Error Builder
- * Creates standardized error objects
- */
+/** Builds standardized JSON-RPC error objects */
 export class JSONRPCErrorBuilder {
   /**
    * Creates a parse error (code -32700) for malformed JSON
@@ -83,10 +77,7 @@ export class JSONRPCErrorBuilder {
   }
 }
 
-/**
- * Configuration options for creating a JSON-RPC handler instance.
- * Used to identify the server in initialization responses.
- */
+/** Configuration options for creating a JSON-RPC handler instance */
 export interface JSONRPCHandlerOptions {
   /** Server name */
   name: string;
@@ -192,8 +183,7 @@ export class JSONRPCHandler {
   }
 
   /**
-   * Handle JSON-RPC notifications (messages without id).
-   * Per JSON-RPC spec, notifications produce no response.
+   * Handle JSON-RPC notifications (messages without id, no response).
    * @param method - Notification method name
    * @param params - Optional notification parameters
    */

--- a/mcp-servers/shared/src/logger.test.ts
+++ b/mcp-servers/shared/src/logger.test.ts
@@ -20,8 +20,7 @@ describe('ts', () => {
 
   it('emits ISO 8601 with a local offset and millisecond precision', () => {
     const inner = ts().slice(1, -1);
-    // `YYYY-MM-DDTHH:mm:ss.sss±HH:MM` — local time + offset (never bare `Z`),
-    // matching the Rust SSOT `log_ts::log_timestamp()`.
+    // `YYYY-MM-DDTHH:mm:ss.sss±HH:MM`, matching Rust SSOT `log_ts::log_timestamp()`.
     expect(inner).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}[+-]\d{2}:\d{2}$/);
   });
 
@@ -36,8 +35,6 @@ describe('ts', () => {
     if (got !== 0) expect(Math.sign(got)).toBe(Math.sign(expectedMin));
   });
 
-  // The container's `TZ` (host TZ, via `tz::detect_host_timezone` + `inject_host_timezone`)
-  // must surface in the prefix — `getTimezoneOffset()` is what `Date` reads from it.
   it.each([
     [-120, '+02:00'], // CEST
     [-330, '+05:30'], // IST

--- a/mcp-servers/shared/src/logger.ts
+++ b/mcp-servers/shared/src/logger.ts
@@ -11,15 +11,7 @@ function pad2(n: number): string {
   return String(Math.abs(n)).padStart(2, '0');
 }
 
-/**
- * Returns `[<ISO 8601 with local offset>]` for log-line prefixes — local time
- * (the container's `TZ`, injected from the host by `speedwave-runtime`'s
- * `tz::detect_host_timezone`), so log timestamps match the host clock and line
- * up with the Rust SSOT (`speedwave-runtime`'s `log_ts::log_timestamp()`).
- * @example
- * console.log(`${ts()} 🔧 Tool registered: ${tool.name}`);
- * // Output: [2026-05-12T14:34:02.814+02:00] 🔧 Tool registered: get_tree
- */
+/** Returns `[<ISO 8601 with local offset>]` for log-line prefixes (local time, container `TZ`). */
 export function ts(): string {
   const d = new Date();
   // `getTimezoneOffset()` is minutes *behind* UTC, so negate it for the sign.

--- a/mcp-servers/shared/src/oauth-authed-request.test.ts
+++ b/mcp-servers/shared/src/oauth-authed-request.test.ts
@@ -1,8 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-// Mock the two I/O collaborators so the tests exercise the helper's control
-// flow (which statuses refresh, retry-once, proactive, single-flight) without
-// touching the network or disk.
 const refreshAccessToken = vi.fn();
 const loadToken = vi.fn();
 const accessTokenExpiresWithin = vi.fn();

--- a/mcp-servers/shared/src/oauth-authed-request.ts
+++ b/mcp-servers/shared/src/oauth-authed-request.ts
@@ -15,9 +15,8 @@ import {
 const DEFAULT_AUTH_FAILURE_STATUSES = [401];
 
 /**
- * Serializes refreshes so concurrent failures trigger one refresh, not N. The
- * `generation` counter lets callers detect "someone already refreshed" without
- * relying on the new token differing from the old one.
+ * Serializes refreshes so concurrent failures trigger one refresh, not N.
+ * The `generation` counter lets callers detect "someone already refreshed".
  */
 export class RefreshLock {
   private tail: Promise<void> = Promise.resolve();
@@ -87,10 +86,8 @@ async function refreshInto(ctx: AuthedRefreshContext): Promise<void> {
   const outcome = await refreshAccessToken({ service: ctx.service });
   const dir = ctx.tokensDir ?? process.env.TOKENS_DIR ?? '/tokens';
   let fresh = await loadToken(join(dir, 'access_token'));
-  // A real refresh rewrites the file with a new value; a rate-limited noop
-  // does not. If the worker says it refreshed but we still read the old token,
-  // poll briefly — host-write → guest-read lag through the mount is a
-  // documented phenomenon (ADR-066) — then proceed with whatever is there.
+  // A real refresh rewrites the file; a rate-limited noop does not. Poll
+  // briefly for host-write → guest-read mount lag (ADR-066).
   if (!outcome.rateLimited) {
     for (let i = 0; i < STALE_READ_POLL_ATTEMPTS && fresh === before; i += 1) {
       await new Promise((r) => setTimeout(r, STALE_READ_POLL_DELAY_MS));
@@ -122,8 +119,7 @@ export async function authedRequest(opts: AuthedRequestOptions): Promise<Respons
     );
   }
 
-  // Proactive refresh is an optimization: on failure fall through to the
-  // reactive path with the current token. A scope mismatch can't self-heal.
+  // Proactive refresh failure falls through to the reactive path.
   if (
     typeof opts.proactiveWithinSeconds === 'number' &&
     accessTokenExpiresWithin(opts.state.accessToken, opts.proactiveWithinSeconds)

--- a/mcp-servers/shared/src/oauth-client.test.ts
+++ b/mcp-servers/shared/src/oauth-client.test.ts
@@ -235,8 +235,7 @@ describe('refreshAccessToken', () => {
   });
 
   it('throws on unparseable content text (JSON.parse fail)', async () => {
-    // The tool returns content[0].text that is NOT a JSON object — covers
-    // the catch around JSON.parse in oauth-client.ts:175.
+    // content[0].text is NOT a JSON object — covers the JSON.parse catch.
     const fetchImpl = vi.fn().mockResolvedValue({
       ok: true,
       status: 200,
@@ -295,8 +294,6 @@ describe('refreshAccessToken', () => {
 
   it('defaults bearerPath to /secrets/oauth-auth-token-<service> when omitted', async () => {
     // Covers `bearerPath = options.bearerPath ?? …` default-arg branch.
-    // We force the readFile to fail (file does not exist) so we observe the
-    // exact path the implementation tried.
     const fetchImpl = vi.fn();
     let observedPath: string | undefined;
     try {
@@ -313,10 +310,7 @@ describe('refreshAccessToken', () => {
   });
 
   it('defaults fetchImpl to globalThis.fetch when omitted', async () => {
-    // Covers `const fetchImpl = options.fetchImpl ?? fetch;` default-arg
-    // branch. We replace globalThis.fetch so the test does not hit the
-    // network; the call must still go through that injection (proving the
-    // fallback was selected).
+    // Covers `const fetchImpl = options.fetchImpl ?? fetch;` default-arg branch.
     const stubFetch = vi.fn().mockResolvedValue({
       ok: true,
       status: 200,
@@ -339,9 +333,7 @@ describe('refreshAccessToken', () => {
   });
 
   it('treats missing result.content as empty text (covers the ?? fallback)', async () => {
-    // result.content is undefined → text falls back to ''. Without the
-    // fallback the indexing would throw; with it, the worker's
-    // `isError` branch sees an empty body and returns the generic error.
+    // result.content is undefined → text falls back to ''.
     const fetchImpl = vi.fn().mockResolvedValue({
       ok: true,
       status: 200,
@@ -376,9 +368,7 @@ describe('refreshAccessToken', () => {
   });
 
   it('wraps TCP refused as OAuthRefreshError(worker_unreachable)', async () => {
-    // undici/Node's fetch throws TypeError("fetch failed") when the host-side
-    // oauth worker port is dead (common when WORKER_OAUTH_URL points at a
-    // stale ephemeral port after a worker respawn).
+    // undici/Node fetch throws TypeError("fetch failed") on a dead port.
     const tcpError = new TypeError('fetch failed');
     const fetchImpl = vi.fn().mockRejectedValue(tcpError);
     await expect(

--- a/mcp-servers/shared/src/oauth-client.ts
+++ b/mcp-servers/shared/src/oauth-client.ts
@@ -1,16 +1,7 @@
 /**
  * Worker → oauth-worker client (ADR-060).
- *
- * Used by OAuth-consuming workers (e.g. SharePoint) to ask the host-side oauth
- * worker for a fresh access token when their current one expires/401s. The
- * caller's service id is derived by the oauth worker from the bearer token
- * mounted at `/secrets/oauth-auth-token-<service>` — there is NO `service`
- * parameter sent on the wire.
- *
- * Env inputs (set by `apply_oauth_config` in compose.rs):
- *   WORKER_OAUTH_URL                  — base URL of the oauth worker
- *   OAUTH_BEARER_PATH                 — path inside the container to the bearer
- *                                       (default `/secrets/oauth-auth-token-<service>`)
+ *   WORKER_OAUTH_URL    — base URL of the oauth worker
+ *   OAUTH_BEARER_PATH   — bearer path (default `/secrets/oauth-auth-token-<service>`)
  */
 import { readFile } from 'node:fs/promises';
 import { randomUUID } from 'node:crypto';
@@ -28,10 +19,7 @@ export type OAuthRefreshCode =
   | 'malformed'
   | 'tool_error';
 
-/**
- * Typed error thrown when Microsoft refuses the refresh because the granted scopes
- * are a strict subset of the requested scopes (re-consent flow trigger).
- */
+/** Typed error thrown when granted scopes are a strict subset of requested (re-consent trigger). */
 export class OAuthScopeMismatchError extends Error {
   /**
    * Construct a scope-mismatch error.
@@ -61,17 +49,11 @@ export class OAuthRefreshError extends Error {
   }
 }
 
-/**
- * Refresh when the JWT `exp` claim is within this many seconds of now. Avoids
- * the 401→refresh→retry round-trip and the race window where the host oauth
- * watchdog has just respawned the worker.
- */
+/** Refresh when the JWT `exp` claim is within this many seconds of now. */
 export const PROACTIVE_REFRESH_SECONDS = 120;
 
 /**
- * Read the `exp` claim (UNIX seconds) from a Microsoft Graph access token (JWT).
- * Returns `null` for malformed/non-JWT tokens; callers treat that as "do not
- * refresh proactively" so legacy or test tokens keep working via the 401 path.
+ * Read the `exp` claim (UNIX seconds) from a JWT; `null` for malformed/non-JWT tokens.
  * @param token - JWT access token
  */
 export function readJwtExp(token: string): number | null {
@@ -88,9 +70,7 @@ export function readJwtExp(token: string): number | null {
 }
 
 /**
- * True when the access token's `exp` claim is within `seconds` of now (or in
- * the past). Returns `false` for unparseable tokens — they go through the
- * reactive 401 path.
+ * True when the token's `exp` is within `seconds` of now; `false` for unparseable tokens.
  * @param token - JWT access token
  * @param seconds - refresh window
  * @param nowMs - injectable clock for tests
@@ -130,12 +110,7 @@ interface MCPToolsCallResponse {
 }
 
 /**
- * Refresh the caller's access token by calling the oauth worker. Returns the
- * parsed response body (`{expiresIn, grantedScopes}`) on success. The caller
- * then re-reads `/tokens/access_token` — the oauth worker has written the new
- * value during this call.
- *
- * Retries once on a 401 (handles supervisor restart that rotated the bearer).
+ * Refresh the caller's access token by calling the oauth worker. Retries once on 401.
  * @param options - service id and optional overrides
  * @throws {OAuthScopeMismatchError} if the granted scopes are insufficient
  * @throws {OAuthRefreshError} for any other failure
@@ -162,8 +137,7 @@ export async function refreshAccessToken(
         `bearer file ${bearerPath} is empty; oauth worker did not provision this consumer`
       );
     }
-    // Loopback HTTP call to the host-side oauth worker — if it hangs we want
-    // to fail the caller's tool invocation rather than block its handler.
+    // Fail fast if the oauth worker hangs.
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), TIMEOUTS.TOKEN_REFRESH_MS);
     let response: Response;
@@ -183,10 +157,7 @@ export async function refreshAccessToken(
         signal: controller.signal,
       });
     } catch (err) {
-      // undici/Node's fetch throws TypeError("fetch failed") on TCP refused
-      // (stale ephemeral port after worker respawn). Wrap as typed errors so
-      // callers can branch without parsing message strings. Worker URL stays
-      // out of the user-facing message — it leaks the ephemeral oauth port.
+      // Wrap fetch failures as typed errors; worker URL stays out of user-facing messages.
       if (err instanceof Error && err.name === 'AbortError') {
         console.warn(`oauth worker timeout at ${workerUrl}`);
         const secs = TIMEOUTS.TOKEN_REFRESH_MS / 1000;
@@ -257,8 +228,7 @@ export async function refreshAccessToken(
   return {
     expiresIn,
     grantedScopes: grantedScopes.map((s) => String(s)),
-    // True when the worker skipped the IdP round-trip (token still valid) —
-    // the on-disk access token was deliberately NOT rewritten.
+    // True when the worker skipped the IdP round-trip (token still valid, not rewritten).
     rateLimited: payload.rateLimited === true,
   };
 }

--- a/mcp-servers/shared/src/promise-memo.test.ts
+++ b/mcp-servers/shared/src/promise-memo.test.ts
@@ -69,8 +69,6 @@ describe('memoizedPromise', () => {
   });
 
   it('does not call fetch on subsequent calls after timeout resolution', async () => {
-    // After a timeout, the underlying promise is still pending. Subsequent
-    // calls during that pending window share the cached race-promise.
     const fetch = vi.fn().mockImplementation(() => new Promise(() => {}));
     const get = memoizedPromise<string | null>({
       fetch,

--- a/mcp-servers/shared/src/promise-memo.ts
+++ b/mcp-servers/shared/src/promise-memo.ts
@@ -1,13 +1,5 @@
 /**
- * Promise memoization with cache-on-failure.
- *
- * Replaces ad-hoc `private _xxxPromise: Promise<T> | null = null` fields in
- * workers (e.g. Redmine `_scopedProjectIdPromise`, SharePoint
- * `_resolvedSiteIdPromise`, Redmine `_projectNamePromise`).
- *
- * Successful results are cached indefinitely. On rejection, the cache is
- * cleared so the next call retries. An optional bounded timeout via
- * `Promise.race` lets callers cap wait time and fall back to a default value.
+ * Promise memoization: caches success indefinitely, retries on rejection.
  * @module shared/promise-memo
  */
 
@@ -15,36 +7,14 @@
 export interface MemoizedPromiseOptions<T> {
   /** The async operation to memoize. Called at most once per cache miss. */
   fetch: () => Promise<T>;
-  /**
-   * Bound the time callers wait for the underlying fetch. When set, the
-   * returned promise resolves with {@link timeoutValue} after this many
-   * milliseconds even if the underlying fetch is still pending. The
-   * underlying fetch continues to populate the cache when it eventually
-   * settles, so subsequent calls benefit from the eventual result.
-   */
+  /** Resolve with {@link timeoutValue} after this many ms if fetch still pending. */
   timeoutMs?: number;
-  /**
-   * Value returned on timeout. Required when `timeoutMs` is set. Use `null`
-   * (with `T extends ... | null`) when callers should treat timeout as
-   * "value not yet available".
-   */
+  /** Value returned on timeout. Required when `timeoutMs` is set. */
   timeoutValue?: T;
 }
 
 /**
  * Build a memoized async getter.
- *
- * Usage:
- * ```ts
- * private getProjectName = memoizedPromise<string | null>({
- *   fetch: () => this.client.get('/project').then(r => r.data.name),
- *   timeoutMs: 5_000,
- *   timeoutValue: null,
- * });
- * ```
- *
- * Subsequent calls during an in-flight fetch share the same promise; calls
- * after a rejection trigger a fresh fetch.
  * @param opts - Memoization options (see {@link MemoizedPromiseOptions}).
  */
 export function memoizedPromise<T>(opts: MemoizedPromiseOptions<T>): () => Promise<T> {
@@ -52,9 +22,7 @@ export function memoizedPromise<T>(opts: MemoizedPromiseOptions<T>): () => Promi
   return () => {
     if (cache) return cache;
     const underlying = opts.fetch().catch((err) => {
-      // Clear cache so the next call retries. Re-throw so callers see the
-      // rejection (the timeout-race path below converts it to timeoutValue
-      // only when timeoutMs is set).
+      // Clear cache so the next call retries.
       cache = null;
       throw err;
     });

--- a/mcp-servers/shared/src/restricted-write.test.ts
+++ b/mcp-servers/shared/src/restricted-write.test.ts
@@ -62,18 +62,11 @@ describe('writeRestrictedSecret', () => {
   );
 
   it('cleans up the tmp file when rename fails', async () => {
-    // Force rename failure by passing a target inside a non-existent dir.
-    // Tmp file is created in the (existing) parent of `filePath` and rename
-    // would target a sibling — but here we point parent to a missing path
-    // to provoke `fs.open` failure (before tmp is ever created).
-    // To force a rename-time failure instead, point the *target name* to an
-    // existing directory: rename of a file onto a non-empty dir fails on POSIX.
+    // Target resolves to an existing dir so rename fails during atomic write.
     const sub = path.join(tmpDir, 'sub');
     await fs.mkdir(sub, { mode: 0o700 });
     await fs.writeFile(path.join(sub, 'sentinel'), 'x');
 
-    // Target path points to the directory `sub` — rename of a file to an
-    // existing non-empty directory will fail.
     await expect(writeRestrictedSecret(sub, 'data')).rejects.toThrow();
 
     // No leftover tmp files in parent

--- a/mcp-servers/shared/src/restricted-write.ts
+++ b/mcp-servers/shared/src/restricted-write.ts
@@ -29,9 +29,7 @@ export async function writeRestrictedSecret(
 ): Promise<void> {
   const parent = path.dirname(filePath);
 
-  // Defense in depth: refuse to write into a world-readable parent dir.
-  // The Rust supervisor creates `~/.speedwave/oauth/<project>/` with mode 0o700;
-  // if that invariant is violated we don't want to silently leak secrets.
+  // Refuse to write into a world-readable parent dir.
   if (process.platform !== 'win32') {
     const stat = await fs.stat(parent);
     const mode = stat.mode & 0o777;
@@ -53,8 +51,7 @@ export async function writeRestrictedSecret(
   try {
     handle = await fs.open(tmpPath, 'wx', 0o600);
     await handle.writeFile(contents);
-    // chmod again post-open: O_CREAT honors umask, so explicit chmod is needed
-    // on systems where umask masks group/other bits in unexpected ways.
+    // O_CREAT honors umask; explicit chmod ensures mode 0o600.
     await handle.chmod(0o600);
     await handle.sync();
     await handle.close();

--- a/mcp-servers/shared/src/retry.ts
+++ b/mcp-servers/shared/src/retry.ts
@@ -26,8 +26,6 @@ export interface RetryOptions {
  * increasing delay.
  *
  * Exceptions from `fn` are caught and logged — they do **not** propagate.
- * This is critical because `initializeGitLabClient()` can throw on DNS
- * resolution failures (`TypeError` from fetch) rather than returning `null`.
  * @param fn - Async function to retry. Must return `T` on success or `null` on failure.
  * @param options - Retry configuration
  * @returns The result of `fn`, or `null` if all attempts failed
@@ -43,8 +41,7 @@ export async function retryAsync<T>(
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     const delay = Math.min(baseDelayMs * 2 ** (attempt - 1), maxDelayMs);
-    // Jitter is additive (0–30% of base delay). maxDelayMs caps only the base
-    // component, so totalDelay can exceed maxDelayMs by up to 30%.
+    // Jitter is additive (0–30% of base); maxDelayMs caps only base, so total may exceed it.
     const jitter = Math.floor(Math.random() * delay * 0.3);
     const totalDelay = delay + jitter;
 

--- a/mcp-servers/shared/src/sanitizer.test.ts
+++ b/mcp-servers/shared/src/sanitizer.test.ts
@@ -4,7 +4,6 @@ import { sanitize, RULE_COUNT } from './sanitizer';
 describe('sanitize', () => {
   it('rule count matches Rust SSOT EXPECTED_RULE_COUNT', () => {
     // Mirrors `EXPECTED_RULE_COUNT` in crates/speedwave-runtime/src/log_sanitizer.rs.
-    // Bump both together when adding a rule.
     expect(RULE_COUNT).toBe(22);
   });
 

--- a/mcp-servers/shared/src/sanitizer.ts
+++ b/mcp-servers/shared/src/sanitizer.ts
@@ -1,6 +1,4 @@
-// Mirrors the Rust SSOT (`crates/speedwave-runtime/src/log_sanitizer.rs`).
-// Keep rule list in sync — any new Rust rule needs a counterpart here so
-// secrets don't leak through TS worker stdout before the Rust drain runs.
+// Mirrors the Rust SSOT (`crates/speedwave-runtime/src/log_sanitizer.rs`). Keep rule list in sync.
 
 const RULES: ReadonlyArray<readonly [RegExp, string]> = [
   [
@@ -9,14 +7,12 @@ const RULES: ReadonlyArray<readonly [RegExp, string]> = [
   ],
   [/((?:\/Users\/|\/home\/|[A-Z]:\\Users\\))[^/\\\s]+/gi, '$1<user>'],
   [/(Set-Cookie:\s*)[^;\r\n]+/gi, '$1***REDACTED***'],
-  // Cookie request header: anchor at start-of-line/whitespace so `Set-Cookie:`
-  // does not double-match via `\b` on the `-C` boundary.
+  // Cookie request header anchored at start-of-line/whitespace to avoid Set-Cookie double-match.
   [/(^|\s)(Cookie:\s*)[^\r\n]+/gi, '$1$2***REDACTED***'],
   [/(Bearer\s+)\S+/gi, '$1***REDACTED***'],
   [/(Authorization:\s*)\S+(\s+\S+)?/gi, '$1***REDACTED***'],
   [/eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g, '***REDACTED_JWT***'],
-  // Rotating-token formats first (xoxe.xoxp-… / xoxe-1-…) so the whole token
-  // is consumed before the xox[bpars]- rule matches its inner substring.
+  // Rotating-token formats (xoxe.xoxp-… / xoxe-1-…) ordered before xox[bpars]-.
   [/xoxe[.-][A-Za-z0-9.-]+/g, '***REDACTED_SLACK_TOKEN***'],
   [/xox[bpars]-[A-Za-z0-9-]+/g, '***REDACTED_SLACK_TOKEN***'],
   [/ghp_[A-Za-z0-9]{36,}/g, '***REDACTED_GITHUB_TOKEN***'],

--- a/mcp-servers/shared/src/security.ts
+++ b/mcp-servers/shared/src/security.ts
@@ -21,9 +21,7 @@ export function tokensDir(): string {
 }
 
 /**
- * Load a credential file by name from {@link tokensDir}. Thin wrapper over
- * {@link loadToken} so workers stop hand-rolling `path.join(TOKENS_DIR, name)`.
- * Errors are errno-differentiated by {@link loadToken} (cause forwarded).
+ * Load a credential file by name from {@link tokensDir}.
  * @param name - File name under the tokens directory (e.g. `bot_token`).
  * @returns Trimmed file contents.
  * @throws {Error} With errno cause forwarded (ENOENT/EACCES/EISDIR/…).
@@ -47,9 +45,6 @@ export async function loadToken(tokenPath: string): Promise<string> {
     // Differentiate error types for better debugging
     const code = (error as NodeJS.ErrnoException).code;
 
-    // Forward `cause` so callers that need the original errno (e.g.
-    // mcp-context7's optional-key fallback) can read `(e.cause as
-    // ErrnoException).code` without falling back to message matching.
     if (code === 'ENOENT') {
       throw new Error(`Token file not found: ${tokenPath}`, { cause: error });
     } else if (code === 'EACCES') {
@@ -65,10 +60,8 @@ export async function loadToken(tokenPath: string): Promise<string> {
 }
 
 /**
- * Core allowlist of env var names safe to pass to child processes — the
- * identical 14-key set shared by every worker that spawns a child. Workers
- * with extra needs spread this and append.
- * Anything carrying a secret (`MCP_*_AUTH_TOKEN`, API keys) is never here.
+ * Core allowlist of env var names safe to pass to child processes.
+ * Never includes secret-carrying names (`MCP_*_AUTH_TOKEN`, API keys).
  */
 export const BASE_SAFE_ENV_KEYS: readonly string[] = [
   // Process / shell environment
@@ -206,8 +199,7 @@ export function validateWorkerUrl(url: string): boolean {
   const port = Number(parsed.port);
   if (!Number.isInteger(port) || port < 1 || port > 65535) return false;
 
-  // URL constructor lowercases hostname, so also check the original string
-  // to reject uppercase input (Docker DNS is lowercase)
+  // URL constructor lowercases hostname; check raw string to reject uppercase input.
   const hostnameStart = url.indexOf('://') + 3;
   const hostnameEnd = url.indexOf(':', hostnameStart);
   const rawHostname = url.substring(hostnameStart, hostnameEnd);
@@ -221,9 +213,7 @@ export function validateWorkerUrl(url: string): boolean {
   if (parsed.pathname !== '/') return false;
   if (parsed.search !== '') return false;
   if (parsed.hash !== '') return false;
-  // The password sub-condition is defense-in-depth: the raw-hostname check above already
-  // rejects any URL with credentials (they shift the colon position). The branch is kept
-  // for correctness but is unreachable in practice — hence c8 ignore on the || right side.
+  // Credentials are already rejected by the raw-hostname check above.
   /* c8 ignore next */
   if (parsed.username !== '' || parsed.password !== '') return false;
 

--- a/mcp-servers/shared/src/server.test.ts
+++ b/mcp-servers/shared/src/server.test.ts
@@ -478,8 +478,7 @@ describe('server', () => {
       });
 
       it('logs health check failures even when auth is configured', async () => {
-        // Every prod worker sets auth, so health failures must still be logged
-        // (the former `!auth` gate silenced them where they matter most).
+        // Health failures must be logged even when auth is configured.
         const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
         const customHealthCheck = vi.fn().mockRejectedValue(new Error('connection refused'));
 
@@ -936,8 +935,7 @@ describe('server', () => {
       });
 
       it('DELETE route on / invokes handleMCPDelete — returns 400 when session header missing', () => {
-        // Covers line 281: handleMCPDelete(req, res) call inside app.delete('/', ...)
-        // We call the DELETE route handler directly with a request missing the session header.
+        // DELETE route handler invokes handleMCPDelete.
         const server = createMCPServer({
           name: 'delete-test',
           version: '1.0.0',
@@ -1101,9 +1099,7 @@ describe('server', () => {
     });
 
     describe('Server Lifecycle', () => {
-      // All lifecycle tests bind port 0 (OS-assigned ephemeral) so parallel
-      // vitest workers / multiple worktrees never collide on a fixed port
-      // (EADDRINUSE). start() returns the actual port for assertions.
+      // Port 0 (OS-assigned ephemeral) avoids collisions between parallel workers and worktrees.
       it('starts server successfully', async () => {
         const server = createMCPServer({
           name: 'test-server',
@@ -1229,11 +1225,9 @@ describe('server', () => {
 
         await server.start();
 
-        // Patch the internal http.Server's close to call back with an error
+        // Patch net.Server.close to invoke the callback with an error.
         const httpServer = (server.app as any).listen ? null : null; // unused — we access it differently
 
-        // Access the underlying server instance via the closure by re-starting
-        // the server and then forcing close to error. We spy on the net.Server.close.
         const net = await import('net');
         const originalClose = net.Server.prototype.close;
         net.Server.prototype.close = function (cb?: (err?: Error) => void) {
@@ -1421,9 +1415,7 @@ describe('server', () => {
         ).toThrow('auth.token must be a non-empty string');
       });
 
-      // ADR-060 per-service bearer: auth.callerTokens lets the oauth worker
-      // map bearer → caller identity. The constructor rejects malformed maps
-      // so a corrupt bearer file cannot land an unauth caller silently.
+      // auth.callerTokens maps bearer → caller id; constructor rejects malformed maps.
       it('rejects empty bearer key in auth.callerTokens', () => {
         expect(() =>
           createMCPServer({
@@ -2209,9 +2201,8 @@ describe('server', () => {
       });
 
       const routes = (server.app as any).router.stack.filter((layer: any) => layer.route);
-      // app.all() registers the last route on '/'; it comes after POST and DELETE routes
+      // app.all() is the last route on '/'; catch-all for unsupported methods.
       const allRoutes = routes.filter((layer: any) => layer.route?.path === '/');
-      // The app.all catch-all is the last of the '/' routes
       const catchAllRoute = allRoutes[allRoutes.length - 1];
 
       expect(catchAllRoute).toBeDefined();

--- a/mcp-servers/shared/src/server.ts
+++ b/mcp-servers/shared/src/server.ts
@@ -134,8 +134,7 @@ export interface MCPServer {
  * @returns MCP server instance
  */
 export function createMCPServer(options: MCPServerOptions): MCPServer {
-  // Default 127.0.0.1 is macOS-only; Windows supervisor always sets MCP_LISTEN_HOST
-  // to the WSL adapter IP (compose::host_bind_address). See ADR-067 / SSOT row.
+  // Windows supervisor sets MCP_LISTEN_HOST to the WSL adapter IP; see ADR-067.
   const {
     name,
     version,
@@ -190,8 +189,6 @@ export function createMCPServer(options: MCPServerOptions): MCPServer {
       const header = req.headers.authorization ?? '';
       const provided = header.startsWith('Bearer ') ? header.slice(7) : '';
 
-      // res.locals is set up by Express on real requests, but absent in some
-      // unit-test mocks — guard with an `??=`.
       const locals: Record<string, unknown> = (res.locals ??= {});
       if (provided && safeTokenCompare(provided, token)) {
         locals.caller = '';
@@ -283,8 +280,6 @@ export function createMCPServer(options: MCPServerOptions): MCPServer {
       try {
         await options.healthCheck();
       } catch (error) {
-        // Always log: every prod worker sets auth, so gating on `!auth` meant
-        // health failures were never logged where they matter most.
         console.error(`[${name}] Health check failed:`, error);
         res.status(500).json({ status: 'error' });
         return;

--- a/mcp-servers/shared/src/session.ts
+++ b/mcp-servers/shared/src/session.ts
@@ -9,7 +9,6 @@ import { ts } from './logger.js';
 
 /**
  * Configuration options for session manager behavior.
- * Controls session timeout and cleanup frequency.
  */
 export interface SessionManagerOptions {
   /** Session timeout in milliseconds (default: 30 minutes) */
@@ -20,7 +19,6 @@ export interface SessionManagerOptions {
 
 /**
  * Manages active MCP sessions with automatic expiration.
- * Tracks client connections and enforces session timeouts.
  */
 export class SessionManager {
   private sessions: Map<string, Session> = new Map();
@@ -90,7 +88,6 @@ export class SessionManager {
 
   /**
    * Destroy a session explicitly (e.g., on logout).
-   * Sessions also expire automatically via TTL, but this allows immediate termination.
    * @param sessionId Session ID to destroy
    */
   public destroySession(sessionId: string): void {

--- a/mcp-servers/shared/src/sse.test.ts
+++ b/mcp-servers/shared/src/sse.test.ts
@@ -670,14 +670,6 @@ describe('sse', () => {
 
   describe('sendEvent retry field', () => {
     it('includes retry field in SSE output when event has a retry value', () => {
-      // The private sendEvent method is exercised via sendMessage which builds an event
-      // without retry. We test the retry branch by accessing the SSEStream internals
-      // indirectly: since SSEEvent type has an optional retry field and sendEvent is
-      // private, we create a minimal SSEStream subclass to call it.
-      //
-      // Alternative: extend SSEStream in a test-only subclass exposing sendEvent.
-      // We use a different approach — spy on res.write and feed an event with retry
-      // via a custom SSEStream subclass.
       class TestSSEStream extends SSEStream {
         public sendRawEvent(event: {
           id?: string;

--- a/mcp-servers/shared/src/sse.ts
+++ b/mcp-servers/shared/src/sse.ts
@@ -64,10 +64,7 @@ export class SSEStream {
   }
 
   /**
-   * Send a raw SSE event.
-   * Defense-in-depth: all fields are sanitized even though current callers
-   * only pass internally-produced values (JSON.stringify for data, integer
-   * counter for id, literal "message" for event).
+   * Send a raw SSE event with sanitized fields.
    * @param event - SSE event structure to send
    */
   private sendEvent(event: SSEEvent): void {

--- a/mcp-servers/shared/src/tool-validation.ts
+++ b/mcp-servers/shared/src/tool-validation.ts
@@ -98,11 +98,7 @@ export interface ClientValidationOptions {
   serviceName: string;
   /** Map a thrown error to a user-facing string (e.g. `Client.formatError`). */
   formatError: (error: unknown) => string;
-  /**
-   * Optional hook invoked when a caught error is NOT a recognised API error
-   * (a programming bug in the handler) — used to log it at error level so it
-   * does not masquerade as a plain API error. Return value is ignored.
-   */
+  /** Optional hook for an error that is not a recognised API error; return value ignored. */
   onUnexpectedError?: (error: unknown) => void;
 }
 

--- a/mcp-servers/shared/src/transport.test.ts
+++ b/mcp-servers/shared/src/transport.test.ts
@@ -413,8 +413,6 @@ describe('transport', () => {
 
       await handleMCPPost(handler, req as Request, res as unknown as Response);
 
-      // Empty string is falsy, so Accept validation is skipped
-      // (same behavior as absent header)
       expect(res.status).not.toHaveBeenCalledWith(406);
     });
 
@@ -491,7 +489,6 @@ describe('transport', () => {
 
     it('handles non-Error thrown value from handler (String() branch in outer catch)', async () => {
       // Covers line 50 false branch: error instanceof Error ? ... : String(error)
-      // When the thrown value is not an Error instance
       const throwingHandler = {
         processRequest: vi.fn().mockRejectedValue('plain string thrown'),
       } as unknown as JSONRPCHandler;

--- a/mcp-servers/shared/src/transport.ts
+++ b/mcp-servers/shared/src/transport.ts
@@ -71,7 +71,7 @@ async function handleMCPPostInner(
   const body = req.body;
   const wantsSSE = req.headers.accept?.includes('text/event-stream') ?? false;
 
-  // Validate MCP-Protocol-Version header (skip for initialize — it negotiates the version)
+  // Validate MCP-Protocol-Version header
   const protocolVersion = req.get('mcp-protocol-version');
   const isInitialize =
     !Array.isArray(body) &&
@@ -90,8 +90,7 @@ async function handleMCPPostInner(
     return;
   }
 
-  // Validate Accept header — client must accept both application/json and
-  // text/event-stream per MCP spec (skip for initialize and absent header)
+  // Validate Accept header per MCP spec
   const acceptHeader = req.headers.accept;
   if (acceptHeader && !isInitialize) {
     const acceptsAll = acceptHeader.includes('*/*');

--- a/mcp-servers/shared/src/types.ts
+++ b/mcp-servers/shared/src/types.ts
@@ -470,11 +470,7 @@ export interface SSEEvent {
 //═══════════════════════════════════════════════════════════════════════════════
 
 /**
- * Optional per-call context passed to tool handlers. Currently carries the
- * authenticated caller id resolved from the request bearer token (set by the
- * shared `bearerAuth` middleware via `auth.callerTokens`). Tools that need to
- * derive identity from the bearer (e.g. the `oauth` worker per ADR-060) read
- * `context.caller`; tools that don't care can ignore it.
+ * Optional per-call context passed to tool handlers (caller id from bearer token, ADR-060).
  */
 export interface ToolHandlerContext {
   /** Caller id, '' for primary supervisor token, '' if auth is unset. */

--- a/mcp-servers/shared/vitest.config.ts
+++ b/mcp-servers/shared/vitest.config.ts
@@ -8,16 +8,7 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
-      // Floors trail measured values by ~1 pp so CI never auto-loosens but
-      // does not block on two stubborn fn-coverage paths in
-      // `restricted-write.ts` (the `.catch(() => {})` arrows inside the
-      // error-cleanup branch — fired only when `handle.writeFile` /
-      // `handle.chmod` / `handle.sync` throw after `fs.open` succeeded;
-      // the ESM `fs/promises` module namespace is not configurable so
-      // those handle methods cannot be spied on at unit-test scope).
-      //
-      // Actual at landing (PR #671): stmts 99.3 / branches 97.9 /
-      //                              funcs 96.77 / lines 99.46
+      // Floors trail measured values; funcs floor reflects unspyable ESM fs/promises paths in restricted-write.ts.
       thresholds: {
         lines: 99,
         functions: 96,

--- a/mcp-servers/sharepoint/src/auth.test.ts
+++ b/mcp-servers/sharepoint/src/auth.test.ts
@@ -1,8 +1,6 @@
 /**
- * SharePoint worker auth wiring tests (SEC-035)
- *
- * Verifies that mcp-sharepoint reads MCP_SHAREPOINT_AUTH_TOKEN and passes it to createMCPServer.
- * Middleware correctness is covered by shared/src/server.test.ts — here we test wiring only.
+ * SharePoint worker auth wiring tests (SEC-035).
+ * Wiring only; middleware correctness covered by shared/src/server.test.ts.
  */
 
 import { describe, it, expect, afterEach } from 'vitest';

--- a/mcp-servers/sharepoint/src/client.test.ts
+++ b/mcp-servers/sharepoint/src/client.test.ts
@@ -38,9 +38,7 @@ vi.mock('@speedwave/mcp-shared', async (importOriginal) => {
       expiresIn: 3600,
       grantedScopes: ['https://graph.microsoft.com/Sites.Manage.All'],
     }),
-    // The shared refresh-retry loop is unit-tested in oauth-authed-request.test.ts;
-    // here we mock it to assert SharePoint delegates correctly. Its default
-    // implementation (one send) is wired in beforeEach.
+    // Mocked to assert SharePoint delegates; default impl wired in beforeEach.
     authedRequest: vi.fn(),
     ts: () => '[00:00:00]',
   };
@@ -85,16 +83,13 @@ describe('SharePointClient', () => {
     fetchMock = vi.fn();
     global.fetch = fetchMock as typeof fetch;
 
-    // After ADR-060, SharePointClient.refreshAccessToken re-reads access_token
-    // from /tokens after the oauth worker writes it. Default the mock to a
-    // valid token so 401-retry paths can proceed.
+    // ADR-060: refreshAccessToken re-reads access_token from /tokens.
     mockLoadToken.mockResolvedValue('refreshed-access-token');
     mockOauthRefresh.mockResolvedValue({
       expiresIn: 3600,
       grantedScopes: ['https://graph.microsoft.com/Sites.Manage.All'],
     });
-    // Default: delegate straight to `send` once (the no-refresh happy path).
-    // Refresh-specific tests override this per case.
+    // Default: delegate to `send` once; refresh tests override per case.
     mockAuthedRequest.mockImplementation((opts) => opts.send(opts.state.accessToken));
 
     // Create fresh client instance
@@ -121,8 +116,7 @@ describe('SharePointClient', () => {
     });
   });
 
-  // Health getters delegate to TokenManager. Cheap to test, important for
-  // the OAuth diagnostics path used by the Desktop integrations card.
+  // Tests OAuth diagnostics path used by Desktop integrations card.
   describe('token save error getters', () => {
     it('getLastTokenSaveError starts null and survives clear', () => {
       expect(client.getLastTokenSaveError()).toBeNull();
@@ -131,8 +125,6 @@ describe('SharePointClient', () => {
     });
 
     it('getHealthStatus exposes tokenSaveError + connection status', () => {
-      // Now returns the shared HealthStatus shape with SharePoint's
-      // tokenSaveError as an optional extension.
       expect(client.getHealthStatus()).toEqual({
         connection: 'unknown',
         connectionError: null,
@@ -147,8 +139,7 @@ describe('SharePointClient', () => {
     });
   });
 
-  // 401 → host-side oauth worker refresh → retry. The new path (ADR-060)
-  // replaces the v1 Microsoft endpoint hit; this batch covers the wiring.
+  // 401 → host-side oauth worker refresh → retry (ADR-060).
   describe('auth delegation (host-side oauth worker, ADR-060)', () => {
     it('delegates the Graph call to authedRequest with the sharepoint service + proactive window', async () => {
       fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ value: [] }) });
@@ -173,10 +164,7 @@ describe('SharePointClient', () => {
     });
   });
 
-  // graphRequest is the public Graph wrapper used by tools/page-tools.ts +
-  // tools/list-tools.ts (PR4 / PR5). Hits every code path of the helper:
-  // path form, absolute-URL form, body + Content-Type injection, 204 no
-  // content, non-2xx with Graph error message, non-2xx with non-JSON body.
+  // Public Graph wrapper used by tools/page-tools.ts + tools/list-tools.ts.
   describe('graphRequest', () => {
     it('expands /sites/{site-id} path and adds v1.0 prefix', async () => {
       fetchMock.mockResolvedValueOnce({
@@ -262,9 +250,6 @@ describe('SharePointClient', () => {
     });
 
     it('falls back to status line when Graph returns valid JSON without an error.message field', async () => {
-      // Some Graph error responses arrive as `{}` or `{error: {}}`. Without
-      // a message we keep the bare status line — appending ": undefined"
-      // would be a regression caller error UIs surface.
       fetchMock.mockResolvedValueOnce({
         ok: false,
         status: 422,
@@ -277,9 +262,7 @@ describe('SharePointClient', () => {
     });
   });
 
-  // SharePointClient.formatError() is a static helper used by every tool's
-  // wrapErr() — coverage of its branches is what makes audit/diagnostics
-  // surfaces consistent.
+  // Static helper used by every tool's wrapErr().
   describe('formatError', () => {
     it('rewrites 401 / Unauthorized with setup guidance', () => {
       expect(SharePointClient.formatError(new Error('401 Unauthorized'))).toMatch(
@@ -335,7 +318,7 @@ describe('SharePointClient', () => {
     });
 
     it('flows a 401-retry result back through authedRequest (the helper owns the retry)', async () => {
-      // Simulate the helper's 401 → retry: send is called twice (first 401, then 200).
+      // Helper's 401 → retry: send called twice (401, then 200).
       fetchMock
         .mockResolvedValueOnce({ status: 401, ok: false })
         .mockResolvedValueOnce({ ok: true, json: async () => ({ value: [] }) });
@@ -356,8 +339,7 @@ describe('SharePointClient', () => {
     });
 
     it('state is a live view — a helper token write propagates to later requests', async () => {
-      // The shim's setter must mutate config.accessToken (not a copy), so a
-      // refresh performed by the helper sticks for every subsequent call.
+      // Shim setter must mutate config.accessToken, not a copy.
       fetchMock.mockResolvedValue({ ok: true, json: async () => ({ value: [] }) });
       mockAuthedRequest.mockImplementationOnce(async (opts) => {
         opts.state.accessToken = 'rotated-token';
@@ -434,10 +416,6 @@ describe('SharePointClient', () => {
     });
   });
 
-  // getDriveItemForSharePointPath is the lookup path that addImageWebPart
-  // relies on — it must reject traversal attempts before issuing a Graph
-  // call, and must surface usable errors when Graph returns 4xx/5xx or a
-  // malformed payload.
   describe('getDriveItemForSharePointPath', () => {
     it('rejects path-traversal input before issuing any Graph call (security)', async () => {
       await expect(client.getDriveItemForSharePointPath('../../etc/passwd')).rejects.toThrow(
@@ -471,8 +449,6 @@ describe('SharePointClient', () => {
     });
 
     it('rejects responses missing id or sharepointIds (defensive parse)', async () => {
-      // Graph normally returns both fields, but a malformed/incomplete payload
-      // would surface as a confusing error later in addImageWebPart. Fail fast.
       fetchMock.mockResolvedValueOnce({
         ok: true,
         json: async () => ({ name: 'hero.jpg' /* no id, no sharepointIds */ }),
@@ -721,9 +697,7 @@ describe('SharePointClient', () => {
       const result = await client.listFiles({ path: 'Reports' });
 
       expect(result.files[0].path).toBe('Reports/report.pdf');
-      // After dropping base_path, file ops resolve straight against the site
-      // drive root — `listFiles({ path: 'Reports' })` hits
-      // `/sites/{siteId}/drive/root:/Reports:/children`.
+      // listFiles({ path: 'Reports' }) hits /drive/root:/Reports:/children.
       expect(fetchMock).toHaveBeenCalledWith(
         expect.stringContaining(`drive/root:/Reports:/children`),
         expect.any(Object)
@@ -1348,8 +1322,7 @@ describe('SharePointClient', () => {
 
       await client.uploadFile('file.txt', '/workspace/file.txt');
 
-      // After dropping base_path: file in root has no parent segments to check,
-      // so only the upload PUT happens.
+      // File in root has no parent segments; only the upload PUT happens.
       expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
@@ -1388,16 +1361,13 @@ describe('SharePointClient', () => {
     });
 
     it('should return early from ensureParentFolders when path has no parent (single segment)', async () => {
-      // A single segment path like "file.txt" has no parent — should return immediately
-      // without making any API calls
+      // Single-segment path has no parent — returns without API calls.
       await client.ensureParentFolders('file.txt');
       expect(fetchMock).not.toHaveBeenCalled();
     });
 
     it('should create folder at root drive level when first segment does not exist', async () => {
-      // When the first segment (accum = single segment) is 404, we call
-      // buildFolderChildrenUrl("") which returns the root/children URL.
-      // We test this via ensureParentFolders directly with a top-level path.
+      // First-segment 404 hits buildFolderChildrenUrl("") → root/children URL.
       // 'Documents' doesn't exist (404)
       fetchMock.mockResolvedValueOnce({ status: 404, ok: false });
 
@@ -1592,8 +1562,7 @@ describe('SharePointClient', () => {
     });
 
     it('should throw when folder path has trailing slash (empty folder name)', async () => {
-      // "folder/" passes path validation but splitPath gives empty folderName.
-      // ensureParentFolders on "folder/" checks the single "folder" segment.
+      // "folder/" passes validation but splitPath gives empty folderName.
       fetchMock.mockResolvedValueOnce({
         ok: true,
         status: 200,
@@ -1672,11 +1641,7 @@ describe('SharePointClient', () => {
     });
 
     it('emits a debug log entry with the parseError context when DEBUG is set', async () => {
-      // debugLog has a two-arg overload (message, data) used by createRemoteFolder
-      // when JSON parsing fails. Under DEBUG=1 the log must include the parseError
-      // so the operator can see *why* the body was unparseable, not just that it
-      // was. This guards the two-arg branch from regressing when someone refactors
-      // the logger.
+      // debugLog has a two-arg overload used when JSON parsing fails.
       const prev = process.env.DEBUG;
       process.env.DEBUG = '1';
       const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
@@ -1723,8 +1688,7 @@ describe('SharePointClient', () => {
     });
 
     it('should initialize client with valid tokens', async () => {
-      // mockReset clears any leftover mockResolvedValueOnce from earlier tests
-      // (vi.clearAllMocks does not drain the Once queue, only call history).
+      // vi.clearAllMocks does not drain the Once queue, only call history.
       mockLoadToken.mockReset();
       mockLoadToken.mockImplementation(async (path: string) => {
         if (path.includes('access_token')) return 'test-access-token';
@@ -1788,10 +1752,7 @@ describe('SharePointClient', () => {
       expect(console.warn).toHaveBeenCalled();
     });
 
-    // ADR-060 + base_path removal: SharePoint container mounts only
-    // access_token / site_id. The other former fields (refresh_token /
-    // client_id / tenant_id) live in the host-only oauth.json; base_path
-    // was dropped because site_id already scopes the worker.
+    // ADR-060: refresh_token/client_id/tenant_id live in host-only oauth.json.
     it('should return null when any worker-mounted required token is missing', async () => {
       const required = ['access_token', 'site_id'];
 
@@ -2115,9 +2076,7 @@ describe('SharePointClient', () => {
     });
 
     it('delegates the cold-start lookup to authedRequest and returns its refreshed result', async () => {
-      // Cold-start scenario: /tokens/access_token is stale. The shared helper
-      // owns the 401 → refresh → retry; here we drive it via the mock (send
-      // twice: stale 401, then fresh 200) and assert the composite id flows out.
+      // Cold-start: /tokens/access_token stale; helper owns 401 → refresh → retry.
       const fetchMock = vi
         .fn()
         .mockResolvedValueOnce({ ok: false, status: 401, statusText: 'Unauthorized' })
@@ -2149,8 +2108,7 @@ describe('SharePointClient', () => {
     });
 
     it('logs and continues when authedRequest rejects during init (refresh failure)', async () => {
-      // If the shared helper rejects during the cold-start lookup, the catch
-      // must log a usable warning and fall through to a bare lookup — not crash.
+      // Helper rejection during cold-start: log warning and fall through.
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const fetchMock = vi
         .fn()
@@ -2171,11 +2129,7 @@ describe('SharePointClient', () => {
     });
 
     it('passes an AbortSignal to the cold-start fetch (timeout guard against hangs)', async () => {
-      // Pre-fix the cold-start fetch had no timeout — a hung Graph response
-      // would block initializeSharePointClient indefinitely and starve the
-      // hub's discovery retry budget. The signal proves the AbortController
-      // is wired up; the actual timeout behavior is exercised by the
-      // dedicated "aborts and returns transient" test below.
+      // Cold-start Graph hang would block initializeSharePointClient indefinitely.
       const fetchMock = vi.fn().mockResolvedValueOnce({
         ok: true,
         json: async () => ({ id: 'contoso.sharepoint.com,site-guid,web-guid' }),
@@ -2204,9 +2158,7 @@ describe('SharePointClient', () => {
     });
 
     it('guards both the initial and the post-401-refresh retry fetch with an AbortSignal', async () => {
-      // The cold-start `send` SharePoint passes to authedRequest wires a per-
-      // request AbortController. Drive the helper through both attempts (401,
-      // then 200) and assert each carries a signal — pre-fix only the initial had one.
+      // Cold-start send wires per-request AbortController; pre-fix only initial had signal.
       const fetchMock = vi
         .fn()
         .mockResolvedValueOnce({ ok: false, status: 401, statusText: 'Unauthorized' })

--- a/mcp-servers/sharepoint/src/client.ts
+++ b/mcp-servers/sharepoint/src/client.ts
@@ -104,12 +104,7 @@ export interface DriveItemMetadata {
   eTag?: string;
 }
 
-/**
- * Projection of `driveItem` used by image web part composition. Holds the
- * exact fields SharePoint requires for the picker validator to accept the
- * payload on "Save & Close": `sharepointIds` (siteId/webId/listId/
- * listItemUniqueId) + `image` (width/height).
- */
+/** Projection of `driveItem` with the fields image web part composition requires. */
 export interface DriveItemForImage {
   id: string;
   name: string;
@@ -156,12 +151,7 @@ export class SharePointClient {
   private refreshLock = new RefreshLock();
   /** Connection status tracker — surfaces siteId resolve / token health. */
   public readonly statusTracker = new ConnectionStatusTracker();
-  /**
-   * Memoized lazy resolve of composite siteId — reuses the shared
-   * {@link memoizedPromise} helper (`shared/promise-memo.ts`). First call
-   * does the Graph lookup + token re-read + mutates `this.config.siteId`
-   * to composite form. Subsequent calls share the cached promise.
-   */
+  /** Memoized lazy resolve of composite siteId via {@link memoizedPromise}. */
   private readonly _resolveSiteIdMemo = memoizedPromise<void>({
     fetch: () => this._resolveSiteIdOnce(),
   });
@@ -180,13 +170,8 @@ export class SharePointClient {
   }
 
   /**
-   * Inner resolve: Graph lookup + token re-read + mutate `this.config.siteId`
-   * to composite form. Updates the status tracker. Throws on failure so the
-   * shared {@link memoizedPromise} clears its cache for retry.
-   *
-   * Path-form siteIds still work against Graph during the warm-up window
-   * (most file/page endpoints accept both forms), so tools called before
-   * resolve completes degrade gracefully.
+   * Resolve path-form siteId to composite; updates the status tracker.
+   * Throws on failure so the memoized cache clears for retry.
    */
   private async _resolveSiteIdOnce(): Promise<void> {
     if (!this.config.siteId.includes(':')) {
@@ -223,12 +208,7 @@ export class SharePointClient {
     }
   }
 
-  /**
-   * Fire-and-forget warm-up from `initializeSharePointClient`. The HTTP
-   * listener is never blocked — resolve runs in the background, mutating
-   * `this.config.siteId` once Graph responds. Subsequent calls share the
-   * cached promise from {@link memoizedPromise} (shared SSOT).
-   */
+  /** Fire-and-forget background siteId resolution; mutates config.siteId once Graph responds. */
   warmupSiteId(): void {
     void this._resolveSiteIdMemo().catch(() => {
       // Failure already logged + tracker updated in _resolveSiteIdOnce.
@@ -253,12 +233,7 @@ export class SharePointClient {
     this.tokenManager.clearTokenSaveError();
   }
 
-  /**
-   * Get health status. Returns the shared HealthStatus shape extended with
-   * SharePoint's `tokenSaveError` (ADR-060) so a single shape covers both the
-   * connection-test pattern used by other workers and SharePoint's
-   * token-refresh-aware health check.
-   */
+  /** Get health status including `tokenSaveError` (ADR-060). */
   getHealthStatus(): HealthStatus {
     const { tokenSaveError } = this.tokenManager.getHealthStatus();
     return {
@@ -649,12 +624,7 @@ export class SharePointClient {
   }
 
   /**
-   * Fetch a driveItem by its path under the site's default drive. Used by
-   * page tools that need `sharepointIds` (siteId/webId/listId/listItemUniqueId)
-   * + image dimensions to compose an image web part body — SharePoint's UI
-   * "Save & Close" reconciliation drops external image URLs that lack these
-   * ids, so the worker must pin every image to a real Site Assets / Documents
-   * file before pushing the web part.
+   * Fetch a driveItem by its path under the site's default drive.
    * @param sharepointPath - path relative to the drive root (e.g. "speedwave-hero.jpg")
    * @returns driveItem id, sharepointIds, image dimensions, webUrl, name
    * @throws {Error} If path is invalid or the driveItem is not found
@@ -866,23 +836,12 @@ export type ResolveResult =
   | { ok: false; reason: 'validation' | 'transient' | 'not_found' | 'network'; detail: string };
 
 /**
- * Resolve a path-form site id (`{hostname}:/sites/{path}:`) to its composite
- * id (`{hostname},{site-guid},{web-guid}`). Composite is accepted by every
- * Graph endpoint; path-form has documented support for `/sites/{path}` and
- * `/sites/{path}:/drive` but surfaces as 400 on some sub-endpoints (notably
- * `/drive/root/children`). One authorised lookup at startup sidesteps the
- * whole class of bugs and adds no new trust surface — the token is already
- * present in `/tokens`.
- *
- * Defence in depth: the function re-validates `siteId` through
- * `validateGraphSiteId` even though `initializeSharePointClient` already
- * does so. The helper is exported, so a future caller that forgets the
- * validator would otherwise interpolate user-controlled data into a URL.
+ * Resolve a path-form site id to its composite id; re-validates via `validateGraphSiteId`.
  * @param siteId - site id loaded from `/tokens/site_id` (any accepted form)
  * @param accessToken - bearer token used for the lookup
  * @param opts - cold-start refresh tuning
  * @param opts.tokensDir - tokens mount path (default {@link defaultTokensDir}); only read when refreshing
- * @param opts.refreshOn401 - on a 401, refresh via `authedRequest` and retry once (default true). Set false in unit tests that don't mock the refresh worker.
+ * @param opts.refreshOn401 - on a 401, refresh via `authedRequest` and retry once (default true)
  * @returns the composite id (or untouched value if already composite), or a typed error
  */
 export async function resolveCompositeSiteId(
@@ -986,10 +945,7 @@ export async function resolveCompositeSiteId(
 }
 
 /**
- * Reject anything that isn't a Graph site id. Fail-closed: no URL normalization
- * in the worker — the token mount sits at a trust boundary and a parser bug
- * could send the bearer to a wrong tenant. Accept only the two Graph-native
- * forms (composite, path) and let setup-time tooling produce them.
+ * Validate a Graph site id, fail-closed (accept only composite or path form).
  * @param siteId - raw value loaded from `/tokens/site_id`
  * @returns user-facing error message, or `null` when the value is acceptable
  */
@@ -1025,13 +981,7 @@ export function validateGraphSiteId(siteId: string): string | null {
 }
 
 /**
- * IMPORTANT: Returns null (not throws) when tokens are missing or invalid.
- * This enables "graceful degradation" - server starts even without config:
- * - User can run `speedwave up` without configuring all integrations
- * - Healthcheck reports `configured: false` for unconfigured services
- * - Tools return clear "not configured" error when called
- *
- * DO NOT change this to throw - it breaks container startup for unconfigured services.
+ * Initialize the SharePoint client; returns null (not throws) when tokens are missing/invalid.
  * @returns Configured SharePointClient instance, or null if tokens not found/invalid
  */
 export async function initializeSharePointClient(): Promise<SharePointClient | null> {

--- a/mcp-servers/sharepoint/src/graph/columns-client.ts
+++ b/mcp-servers/sharepoint/src/graph/columns-client.ts
@@ -5,14 +5,7 @@
  *   - `POST   /sites/{site-id}/lists/{list-id}/columns`                  (addListColumn)
  *   - `DELETE /sites/{site-id}/lists/{list-id}/columns/{column-id}`      (removeListColumn)
  *
- * Column reads (`getList`) come through {@link ./lists-client.ts} via
- * `?$expand=columns` — there is no separate `GET /columns` tool in the PR5
- * surface, so this module is intentionally write-only.
- *
- * Limited to the column types Microsoft Graph documents as creatable through
- * delegated `Sites.Manage.All`: `text`, `number`, `boolean`, `dateTime`,
- * `choice`, `lookup`. Calculated / geolocation / term columns are out of
- * scope — the tool layer enforces this via JSON Schema `enum`.
+ * Column reads come through {@link ./lists-client.ts}; this module is write-only.
  */
 import type { GraphRequester } from './site-client.js';
 import { ListsClient } from './lists-client.js';

--- a/mcp-servers/sharepoint/src/graph/pages-client.test.ts
+++ b/mcp-servers/sharepoint/src/graph/pages-client.test.ts
@@ -58,9 +58,7 @@ describe('PagesClient URL builders', () => {
   });
 
   it('webpartItemPath omits section/column ids — Graph routes by webpart id', () => {
-    // Per-web-part PATCH/DELETE goes to the documented `/webParts/{id}` form.
-    // The PR4 empty-segments form (`.../horizontalSections/columns/webparts/{id}`)
-    // returned `Resource not found` from Graph (live-tested).
+    // Per-web-part PATCH/DELETE uses the `/webParts/{id}` form, not the empty-segments form.
     const r = fakeRequester();
     expect(new PagesClient(r).webpartItemPath('p1', 'wp1')).toBe(
       `/sites/${SITE_ID}/pages/p1/${PAGE_RESOURCE}/webParts/wp1`
@@ -356,13 +354,11 @@ describe('PagesClient request helpers', () => {
   });
 
   it('htmlToPlainText strips tags and decodes safe entities (preserves &lt; / &gt;)', () => {
-    // Stripping tags first leaves spaces at tag boundaries; that is fine for
-    // the screen-reader / search-index field the value is used for.
+    // Stripping tags first leaves spaces at tag boundaries.
     expect(htmlToPlainText('<p>Hello&nbsp;<b>world</b> &amp; goodbye</p>')).toBe(
       'Hello world & goodbye'
     );
-    // Angle-bracket entities are preserved verbatim — never decoded back to
-    // `<` / `>` to keep the `value` field XSS-safe for downstream consumers.
+    // Angle-bracket entities are preserved verbatim, never decoded back to `<` / `>`.
     expect(htmlToPlainText('&lt;tag&gt;')).toBe('&lt;tag&gt;');
     expect(htmlToPlainText('&amp;lt;script&amp;gt;')).toBe('&lt;script&gt;');
     expect(htmlToPlainText('&quot;quoted&quot; &#39;single&#39;')).toBe('"quoted" \'single\'');
@@ -388,8 +384,7 @@ describe('PagesClient request helpers', () => {
   });
 
   it('deletePage DELETEs at /sites/{site-id}/pages/{page-id} (no cast)', async () => {
-    // deletePage uses the base /pages collection — the sitePage cast is for
-    // GET/PATCH only. We assert that explicitly to lock the behaviour in.
+    // deletePage uses the base /pages collection; the sitePage cast is GET/PATCH only.
     const r = fakeRequester();
     await new PagesClient(r).deletePage('p1');
     expect(r.graphRequest).toHaveBeenCalledWith('DELETE', `/sites/${SITE_ID}/pages/p1`);
@@ -410,8 +405,7 @@ describe('PagesClient never accepts a site_id from callers (ADR-060)', () => {
     await pages.listPages();
     await pages.getPage('p1');
     await pages.publishPage('p1');
-    // Every URL builder must call back through GraphRequester — never cache
-    // or accept a caller-supplied site id.
+    // Every URL builder calls back through GraphRequester, never a caller-supplied site id.
     expect(calls).toBeGreaterThanOrEqual(3);
   });
 });
@@ -471,9 +465,7 @@ describe('Table-of-contents helpers', () => {
   });
 
   it('injectHeadingAnchors leaves empty headings (no visible text) untouched', () => {
-    // Empty headings are extracted as 0-result, so we feed them with no
-    // matching heading and verify they survive verbatim — the renderer must
-    // not invent ids for non-content blocks.
+    // Empty headings survive verbatim; no id is invented for non-content blocks.
     const input = '<h1>Real</h1><h2>   </h2><h2><img alt=""/></h2>';
     const out = injectHeadingAnchors(input, [{ level: 1, anchor: 'real', text: 'Real' }]);
     expect(out).toContain('<h2>   </h2>');
@@ -482,9 +474,7 @@ describe('Table-of-contents helpers', () => {
   });
 
   it('injectHeadingAnchors leaves headings past the supplied anchor list untouched', () => {
-    // Source HTML has 3 real headings but caller supplied only 1 anchor;
-    // the trailing headings must remain unchanged rather than crash or
-    // receive a stray id.
+    // 3 real headings but only 1 anchor supplied; trailing headings stay unchanged.
     const input = '<h1>One</h1><h2>Two</h2><h2>Three</h2>';
     const out = injectHeadingAnchors(input, [{ level: 1, anchor: 'one', text: 'One' }]);
     expect(out).toBe('<h1 id="one">One</h1><h2>Two</h2><h2>Three</h2>');
@@ -492,9 +482,7 @@ describe('Table-of-contents helpers', () => {
 
   it('slugifyHeading produces kebab-case ASCII', () => {
     expect(slugifyHeading('Hello World')).toBe('hello-world');
-    // NFKD decomposes a + combining acute; bare `Ł`/`ł` are not decomposable
-    // and fall through the non-ASCII filter as separators (single letters
-    // without accents survive).
+    // NFKD decomposes accented letters; bare `Ł`/`ł` fall through as separators.
     expect(slugifyHeading('Café — naprawdę')).toBe('cafe-naprawde');
     expect(slugifyHeading('   --- ')).toBe('');
   });

--- a/mcp-servers/sharepoint/src/graph/pages-client.ts
+++ b/mcp-servers/sharepoint/src/graph/pages-client.ts
@@ -1,45 +1,17 @@
 /**
- * Graph URL builders for the SharePoint Pages API
- * (`microsoft.graph.sitePage` resource and `canvasLayout` web-part endpoints).
- *
- * All URL construction for the pages domain lives here so the tool layer never
- * concatenates Graph paths directly. The single rule: the site id is always
- * resolved through `GraphRequester.getSiteId()` — no tool may accept `site_id`
- * from the model (ADR-060 site-policy invariant).
- *
- * Endpoint set (PR4):
- *   - `GET    /sites/{site-id}/pages/microsoft.graph.sitePage`
- *   - `GET    /sites/{site-id}/pages/{page-id}/microsoft.graph.sitePage?$expand=canvasLayout`
- *   - `POST   /sites/{site-id}/pages`                                              (createPage)
- *   - `PATCH  /sites/{site-id}/pages/{page-id}/microsoft.graph.sitePage`          (updatePage)
- *   - `POST   .../canvasLayout/horizontalSections/{section-id}/columns/{col-id}/webparts`
- *   - `PATCH  /sites/{site-id}/pages/{page-id}/microsoft.graph.sitePage/webParts/{webpart-id}`
- *   - `DELETE /sites/{site-id}/pages/{page-id}/microsoft.graph.sitePage/webParts/{webpart-id}`
- *   - `POST   /sites/{site-id}/pages/{page-id}/microsoft.graph.sitePage/publish`
+ * Graph URL builders for the SharePoint Pages API.
+ * Site id is always resolved through `GraphRequester.getSiteId()` — no tool accepts `site_id` from the model (ADR-060).
  */
 import type { GraphRequester } from './site-client.js';
 
 /** Graph cast segment that scopes a generic `baseSitePage` to a `sitePage`. */
 export const PAGE_RESOURCE = 'microsoft.graph.sitePage';
-/**
- * `@odata.type` discriminators for the createWebPart endpoint. Graph treats
- * the outer (envelope) type and the inner (properties) type as distinct values
- * with different capitalisation — verified against the official endpoint docs.
- * Sending `#microsoft.graph.textWebPart` as the envelope (PR4 MVP wording)
- * makes Graph respond with 400 Bad Request.
- */
+/** `@odata.type` discriminators for the createWebPart endpoint (envelope and properties types differ in capitalisation). */
 export const TEXT_WEBPART_ENVELOPE_TYPE = '#microsoft.graph.textwebpart';
 export const TEXT_WEBPART_PROPERTIES_TYPE = '#microsoft.graph.textwebPart';
 export const STANDARD_WEBPART_ENVELOPE_TYPE = '#microsoft.graph.standardwebpart';
 
-/**
- * SSOT map of human-friendly web-part names to the GUIDs Graph expects in
- * the `webPartType` field. Verified against the official "Supported web parts"
- * table in `sitepage-update.md` (Microsoft Graph docs). The table also lists
- * "Title Area" but that is a sitePage property (`sitePage.titleArea`) handled
- * by `updatePage` — it is NOT a standardWebPart you POST to `/webparts`, so
- * it is intentionally absent here. Posting it via addWebPart returns 400.
- */
+/** SSOT map of human-friendly web-part names to the GUIDs Graph expects in `webPartType`. */
 export const STANDARD_WEBPART_TYPES = {
   bingMaps: 'e377ea37-9047-43b9-8cdb-a761be2f8e09',
   button: '0f087d7f-520e-42b7-89c0-496aaf979d58',
@@ -67,11 +39,9 @@ export interface TocHeading {
 }
 
 /**
- * Pull headings (h1–h6) out of a text web part body and assign anchor ids when
- * they are missing. The returned anchor lives inside the source string only
- * if the caller re-emits it via `injectHeadingAnchors` — this helper is pure.
+ * Extract headings (h1–h6) from text web part HTML, assigning anchor ids when missing.
  * @param innerHtml - text web part HTML
- * @returns ordered list of headings discovered in source order
+ * @returns headings discovered in source order
  */
 export function extractHeadings(innerHtml: string): TocHeading[] {
   const results: TocHeading[] = [];
@@ -87,8 +57,7 @@ export function extractHeadings(innerHtml: string): TocHeading[] {
     const idMatch = /\bid\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/i.exec(attrs);
     let anchor = idMatch ? (idMatch[1] ?? idMatch[2] ?? idMatch[3]) : slugifyHeading(text);
     if (!anchor) anchor = `heading-${results.length + 1}`;
-    // Deduplicate within a single web part — Graph + browsers tolerate it but
-    // a unique slug per ToC entry keeps click-through deterministic.
+    // Deduplicate within a single web part for deterministic click-through.
     let dedup = anchor;
     let i = 2;
     while (usedAnchors.has(dedup)) {
@@ -101,16 +70,7 @@ export function extractHeadings(innerHtml: string): TocHeading[] {
 }
 
 /**
- * Rewrite `innerHtml` so every heading carries the matching anchor `id`.
- * Headings that already have an id keep it. Caller is responsible for passing
- * `headings` extracted from the SAME `innerHtml` in document order — anchors
- * are zipped positionally. Used by `generateTableOfContents` to make link
- * targets actually resolve.
- *
- * Note on SharePoint: the rich-text sanitizer is not formally documented; in
- * some tenants it strips inline `id` attributes from `<hN>` tags. We still
- * emit them so the ToC works when the sanitizer is permissive and the source
- * HTML is preserved on round-trip.
+ * Rewrite `innerHtml` so every heading carries the matching anchor `id`; headings with an id keep it.
  * @param innerHtml - original text web part HTML
  * @param headings - headings already extracted from `innerHtml`
  * @returns innerHtml with `id="..."` injected on headings that lacked one
@@ -148,17 +108,13 @@ export function injectHeadingAnchors(innerHtml: string, headings: TocHeading[]):
   return out;
 }
 
-/**
- * Shared regex for `<h1>`…`<h6>` blocks. Returns a fresh instance each call
- *  because `/g` flag carries mutable `lastIndex` state.
- */
+/** Regex for `<h1>`…`<h6>` blocks; fresh instance each call to avoid `/g` mutable `lastIndex`. */
 function headingRegex(): RegExp {
   return /<h([1-6])(\s[^>]*)?>([\s\S]*?)<\/h\1>/gi;
 }
 
 /**
- * Slugify a heading for use as a bookmark anchor. Lower-case, alphanumeric
- * plus dashes; never empty (falls back to "heading-N" via caller if needed).
+ * Slugify a heading to an anchor (lower-case, alphanumeric + dashes, never empty).
  * @param text - heading text
  * @returns kebab-case slug
  */
@@ -172,10 +128,7 @@ export function slugifyHeading(text: string): string {
 }
 
 /**
- * Render a ToC body (HTML) from a list of headings. Nested lists are placed
- * INSIDE the parent `<li>` (valid HTML / a11y), not as siblings. Levels skip
- * gracefully: an `h3` after an `h1` opens one intermediate `<ul>` so the tree
- * stays well-formed.
+ * Render ToC HTML from headings (nested lists inside the parent `<li>`, levels skip gracefully).
  * @param headings - extracted headings (h1–h6, preserving order)
  * @param title - optional header rendered above the ToC (`<h2>`)
  * @returns HTML string suitable for a text web part body
@@ -185,8 +138,7 @@ export function renderTableOfContents(headings: TocHeading[], title?: string): s
     return title ? `<h2>${escapeHtml(title)}</h2>` : '';
   }
   const titleHtml = title ? `<h2>${escapeHtml(title)}</h2>` : '';
-  // Stack tracks open elements: 'ul' for open lists, 'li' for open items
-  // awaiting either a sibling or a nested list.
+  // Stack of open elements: 'ul' for lists, 'li' for items.
   const stack: ('ul' | 'li')[] = [];
   let html = '';
 
@@ -207,8 +159,7 @@ export function renderTableOfContents(headings: TocHeading[], title?: string): s
   for (const h of headings) {
     const currentUls = stack.filter((t) => t === 'ul').length;
     if (h.level > currentUls) {
-      // Need to descend. Open new <ul> inside the current <li> if there is
-      // one, else at the root. Bridge any level gaps with empty <li><ul>.
+      // Descend: open a <ul> per level, bridging gaps with empty <li><ul>.
       let needed = h.level - currentUls;
       while (needed > 0) {
         html += '<ul>';
@@ -221,8 +172,7 @@ export function renderTableOfContents(headings: TocHeading[], title?: string): s
         }
       }
     } else if (h.level < currentUls) {
-      // Ascend: close lists down to the target depth, then close the open
-      // sibling <li> at that depth so the next <li> is a sibling.
+      // Ascend: close lists to the target depth, then close the open sibling <li>.
       closeUntilDepth(h.level);
       if (stack[stack.length - 1] === 'li') {
         stack.pop();
@@ -261,22 +211,11 @@ function escapeHtmlAttr(s: string): string {
   return escapeHtml(s);
 }
 
-/**
- * Fields that the SharePoint UI writes into web part bodies on its own Save
- * pass but that Graph PATCH refuses to accept on a subsequent updatePage
- * round-trip. List grew from live tests (2026-05): `customContentDropSupport`
- * is set by the editor to `"externallink"` for embed-capable parts; the
- * worker does not orchestrate round-trips itself but exports this list so
- * external callers (e.g. the Claude container, helper scripts) can strip
- * the fields before re-PATCHing a layout returned from `getPage`.
- */
+/** Fields the SharePoint UI writes but Graph PATCH refuses on round-trip (e.g. `customContentDropSupport`). */
 export const UI_ONLY_WEBPART_FIELDS = ['customContentDropSupport'] as const;
 
 /**
- * Recursively remove UI-only fields from a canvasLayout returned by `getPage`,
- * so the cleaned layout can be re-PATCHed via `updatePage` without Graph
- * rejecting fields like `customContentDropSupport`. Returns a deep clone
- * (does not mutate the input).
+ * Recursively remove UI-only fields from a canvasLayout so it can be re-PATCHed via `updatePage` (deep clone).
  * @param layout - canvasLayout from `getPage` or any nested subtree
  * @returns the same structure with UI-only fields removed at every depth
  */
@@ -314,14 +253,7 @@ export interface ImageWebPartOptions {
 }
 
 /**
- * Build an image web part `data` payload pinned to a real driveItem in the
- * site's drive. SharePoint's UI image-picker reconciliation drops external
- * URLs that lack the driveItem ids, so the worker must always compose the
- * body from a Graph `driveItem` lookup. `imageSourceType: 2` denotes
- * "drive-item" and is the only value that survives "Save & Close" in the UI
- * (verified live 2026-05). Field set reverse-engineered from the official
- * Microsoft example (`sitepage-create.md`) — Graph does not publish a per-
- * type schema.
+ * Build an image web part `data` payload pinned to a driveItem in the site's drive (`imageSourceType: 2`).
  * @param imageWebUrl - server-relative URL of the image (driveItem.webUrl)
  * @param sharepointIds - ids from the driveItem facet (see SharePointIds resource)
  * @param sharepointIds.siteId - SharePoint site id
@@ -383,9 +315,7 @@ export function buildImageWebPartData(
 }
 
 /**
- * Build the createWebPart envelope Graph expects for standard (non-text) web
- * parts. `data` carries the webPart-specific properties (each type has its
- * own schema — see SharePoint UI / SPFx docs for individual shapes).
+ * Build the createWebPart envelope for standard (non-text) web parts.
  * @param webPartType - GUID of the standard web part type
  * @param data - optional webPartData payload (audiences, properties, serverProcessedContent, title, …)
  * @returns request body for POST on a webparts collection
@@ -405,16 +335,7 @@ export function buildStandardWebPartBody(
 }
 
 /**
- * Strip HTML tags + decode the safe entities SharePoint Modern Pages uses for
- * the `value` field on text web parts (stored alongside `formattedValue`; used
- * for screen readers and search indexing).
- *
- * Safety note: we DELIBERATELY do not decode `&lt;` / `&gt;` to `<` / `>`. If
- * a downstream consumer renders this `value` field without re-escaping (a
- * known pattern for plain-text fields), turning `&lt;script&gt;` into a real
- * tag would create an XSS sink. Stripping decodes only ampersand, non-break
- * space, quote, and apostrophe — character-level transformations that cannot
- * reintroduce tag syntax.
+ * Strip HTML tags + decode safe entities, leaving `&lt;`/`&gt;` as entities (see ADR for XSS rationale).
  * @param html - HTML body of the text web part
  * @returns plain-text equivalent (angle-bracket entities preserved verbatim)
  */
@@ -425,8 +346,7 @@ export function htmlToPlainText(html: string): string {
       .replace(/&nbsp;/g, ' ')
       .replace(/&quot;/g, '"')
       .replace(/&#39;/g, "'")
-      // Decode `&amp;` LAST so an attacker-supplied `&amp;lt;` decodes only to
-      // `&lt;` (still an entity), never to `<`.
+      // Decode `&amp;` LAST so `&amp;lt;` decodes to `&lt;`, never to `<`.
       .replace(/&amp;/g, '&')
       .replace(/\s+/g, ' ')
       .trim()
@@ -434,9 +354,7 @@ export function htmlToPlainText(html: string): string {
 }
 
 /**
- * Build the createWebPart envelope Graph expects for text web parts. Shape
- * mirrors the official endpoint docs; the inner `value` is derived from
- * `innerHtml` so the screen-reader / search-index field stays in sync.
+ * Build the createWebPart envelope for text web parts (inner `value` derived from `innerHtml`).
  * @param innerHtml - HTML body of the text web part
  * @returns request body for POST / PATCH on a webparts collection / item
  */
@@ -455,10 +373,7 @@ export function buildTextWebPartBody(innerHtml: string): Record<string, unknown>
   };
 }
 
-/**
- * Builder of Graph paths for the pages domain. Stateless apart from the
- *  shared {@link GraphRequester} which owns the configured `siteId`.
- */
+/** Builder of Graph paths for the pages domain (stateless apart from the shared {@link GraphRequester}). */
 export class PagesClient {
   /**
    * Build a Graph URL+request helper for the pages domain.
@@ -496,12 +411,7 @@ export class PagesClient {
   }
 
   /**
-   * `.../webParts/{webpart-id}` — the dedicated PATCH / DELETE endpoint Graph
-   * documents for per-web-part operations. NOTE: PR4 used a `canvasLayout/
-   * horizontalSections/columns/webparts/{id}` path with empty section/column
-   * segments; that form is undocumented and Graph returns `Resource not found`
-   * for both PATCH and DELETE (live-tested 2026-05). Use `/webParts/{id}`
-   * (camelCase, no canvas segment) as per the official endpoint docs.
+   * `.../webParts/{webpart-id}` — PATCH / DELETE endpoint (the canvas-segment form returns 404).
    * @param pageId - Graph id of the page
    * @param webpartId - Graph id of the web part
    */
@@ -534,9 +444,7 @@ export class PagesClient {
   }
 
   /**
-   * `PATCH .../{page-id}/microsoft.graph.sitePage` — replace the canvasLayout
-   * (Graph requires the FULL layout). Convenience wrapper around `patchPage`
-   * kept for backwards compatibility with callers that only update the layout.
+   * `PATCH .../{page-id}/microsoft.graph.sitePage` — replace the (full) canvasLayout.
    * @param pageId - target page id
    * @param canvasLayout - complete canvasLayout
    */
@@ -545,12 +453,7 @@ export class PagesClient {
   }
 
   /**
-   * `PATCH .../{page-id}/microsoft.graph.sitePage` with an arbitrary subset of
-   * sitePage properties (title, description, showComments, titleArea,
-   * canvasLayout, …). Used by tools that need to update metadata without
-   * touching the layout. When `canvasLayout` is present, UI-only fields
-   * (see `UI_ONLY_WEBPART_FIELDS`) are stripped automatically — these are
-   * written by the SharePoint editor on Save but Graph PATCH rejects them.
+   * `PATCH .../{page-id}/microsoft.graph.sitePage` with a subset of sitePage properties; strips `UI_ONLY_WEBPART_FIELDS` from any `canvasLayout`.
    * @param pageId - target page id
    * @param body - partial sitePage payload
    */
@@ -563,9 +466,7 @@ export class PagesClient {
   }
 
   /**
-   * `POST` a text web part into the addressed section/column. Graph requires
-   * the createWebPart envelope (envelope `@odata.type` + `webPartProperties`)
-   * — the shorter PR4 shape (`@odata.type` + `innerHtml`) surfaces as 400.
+   * `POST` a text web part into the addressed section/column.
    * @param pageId - target page id
    * @param sectionId - section Graph id
    * @param columnId - column Graph id within the section
@@ -585,8 +486,7 @@ export class PagesClient {
   }
 
   /**
-   * `PATCH` a text web part by id — replaces `innerHtml`. Uses the same
-   * createWebPart envelope as the POST path.
+   * `PATCH` a text web part by id — replaces `innerHtml`.
    * @param pageId - target page id
    * @param webpartId - Graph id of the web part
    * @param innerHtml - new HTML body
@@ -601,10 +501,6 @@ export class PagesClient {
 
   /**
    * `POST` a standard (non-text) web part into the addressed section/column.
-   * The `data` payload is web-part-type-specific — Graph docs do not publish
-   * per-type schemas, so callers must supply the right shape (consult the
-   * SharePoint UI / SPFx docs / PnPjs examples). Passing `undefined` creates
-   * the web part with Graph defaults.
    * @param pageId - target page id
    * @param sectionId - section Graph id
    * @param columnId - column Graph id within the section

--- a/mcp-servers/sharepoint/src/graph/site-client.test.ts
+++ b/mcp-servers/sharepoint/src/graph/site-client.test.ts
@@ -1,10 +1,5 @@
 /**
- * Tests for {@link ./site-client.ts} — the shared `GraphRequester` interface
- * and base-URL helper used by the per-domain Graph clients.
- *
- * `SharePointClient` implements `GraphRequester` directly; here we only assert
- * the contract is small and stable. A consumer that imports this module must
- * be able to wire any object that provides `getSiteId` + `graphRequest`.
+ * Tests for {@link ./site-client.ts} — `GraphRequester` interface and `graphV1BaseUrl`.
  */
 import { describe, it, expect, vi } from 'vitest';
 import { graphV1BaseUrl, type GraphRequester } from './site-client.js';

--- a/mcp-servers/sharepoint/src/graph/site-client.ts
+++ b/mcp-servers/sharepoint/src/graph/site-client.ts
@@ -1,38 +1,17 @@
 /**
- * Site-scoped Graph client.
- *
- * Encapsulates the **site policy by omission** invariant (ADR-060): the worker
- * stores its `siteId` once at construction and every Graph URL is derived from
- * it. Page / list tools must never accept a `site_id` parameter from the model,
- * so URL builders for those domains live in their respective `graph/<area>-client.ts`
- * modules and consult `getSiteId()` here — never a caller-supplied value.
- *
- * `siteId` and `accessToken` are loaded from the worker's `/tokens` mount; the
- * application credentials (`client_id`, `tenant_id`, `refresh_token`) live in
- * `~/.speedwave/oauth/<project>/sharepoint.json` and are NOT visible here.
- *
- * This module is intentionally tiny — it owns nothing but the site id and a
- * generic `graphRequest` helper. Domain-specific URL building lives in the
- * `pages-client`, `lists-client`, and `columns-client` siblings.
+ * Site-scoped Graph client: immutable `siteId`, site-derived URL building (ADR-060).
  */
 
 const GRAPH_BASE_URL = 'https://graph.microsoft.com/v1.0';
 
 /**
- * Inversion-of-control surface that the domain Graph clients (pages, lists,
- * columns) call back into. The concrete implementation is `SharePointClient`,
- * which handles 401-refresh + retry and bearer injection. Splitting it out as
- * an interface lets domain clients be unit-tested without spinning up the full
- * file-ops facade.
+ * IOC surface for domain Graph clients. Concrete: `SharePointClient` (401-refresh + bearer).
  */
 export interface GraphRequester {
   /** Returns the configured site id. Never accepts a caller-supplied value. */
   getSiteId(): string;
   /**
-   * Performs a Graph request. The path form (`/sites/{site-id}/...`) gets the
-   * site id substituted and is prefixed with the v1.0 base URL; absolute URLs
-   * are passed through. Inherits the OAuth refresh / retry behaviour of the
-   * concrete implementation.
+   * Graph request: path (`/sites/{site-id}/...`) or absolute URL; handles OAuth refresh + retry.
    */
   graphRequest<T = unknown>(
     method: string,

--- a/mcp-servers/sharepoint/src/handlers.test.ts
+++ b/mcp-servers/sharepoint/src/handlers.test.ts
@@ -1,12 +1,6 @@
 /**
- * SharePoint Handler Integration Tests
- *
- * Tests the full handler pipeline: createToolDefinitions routing,
- * withClient guard (null client), withValidation wrapper,
- * authentication error handling, and path traversal rejection.
- *
- * Complements the per-tool unit tests in tools/*.test.ts by testing
- * the wiring and integration at the handler level.
+ * SharePoint handler integration tests: routing, null-client guard,
+ * withValidation wrapper, auth errors, path traversal rejection.
  */
 
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
@@ -656,9 +650,7 @@ describe('SharePoint handler integration', () => {
       const tools = createToolDefinitions(client as unknown as SharePointClient);
       const listTool = tools.find((t) => t.tool.name === 'listFileIds')!;
 
-      // Simulate an unexpected crash inside the handler by throwing in listFiles
-      // and then making the handler itself throw (instead of returning ToolResult)
-      // This tests the outer catch in withValidation
+      // Synchronous throw exercises withValidation's outer catch.
       client.listFiles.mockImplementation(() => {
         throw new Error('Unexpected synchronous error');
       });

--- a/mcp-servers/sharepoint/src/index.test.ts
+++ b/mcp-servers/sharepoint/src/index.test.ts
@@ -1,8 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-// The worker entry delegates to the shared bootWorker; mock it so we can assert
-// the declarative options (fail-fast policy, health-check wiring) without
-// opening a socket. bootWorker's own behaviour is covered in shared/boot.test.ts.
 const { bootWorkerMock } = vi.hoisted(() => ({ bootWorkerMock: vi.fn() }));
 
 vi.mock('@speedwave/mcp-shared', async () => {

--- a/mcp-servers/sharepoint/src/path-validator.ts
+++ b/mcp-servers/sharepoint/src/path-validator.ts
@@ -1,16 +1,9 @@
-/**
- * Path Validation Module - Security validation for SharePoint and local paths
- * @module sharepoint/path-validator
- */
+/** Path validation for SharePoint and local paths. */
 
 import path from 'path';
 import { ts } from '@speedwave/mcp-shared';
 
-/**
- * Paths that are denied within /workspace to protect sensitive project files.
- * Each entry is matched as a prefix: the path must equal the entry or start with entry + '/'.
- * Exception: '/workspace/.env' is an exact match only (blocks .env but allows .envrc).
- */
+/** Denied paths within /workspace; prefix-matched except '/workspace/.env' which is exact-match only. */
 const DENYLIST: string[] = [
   '/workspace/.git',
   '/workspace/.env',
@@ -21,15 +14,10 @@ const DENYLIST: string[] = [
   '/workspace/.kube',
 ];
 
-/**
- * Validates paths for security to prevent path traversal attacks and unauthorized access
- * @class PathValidator
- */
+/** Validates paths against traversal, absolute paths, null bytes, and URL-encoded attacks. */
 export class PathValidator {
   /**
-   * Validate SharePoint path (security: prevent traversal)
-   * Checks for path traversal attempts, absolute paths, null bytes,
-   * and URL-encoded traversal sequences (%2e%2e)
+   * Validate SharePoint path: rejects traversal, absolute paths, null bytes, URL-encoded sequences.
    * @param {string} pathStr - Path to validate
    * @returns {boolean} True if path is safe, false otherwise
    */
@@ -112,10 +100,7 @@ export class PathValidator {
   }
 
   /**
-   * Validate local path for security.
-   * Accepts paths within /workspace only (wide mount).
-   * Rejects paths targeting sensitive locations via denylist (.git, .env, .speedwave).
-   * Claude and MCP workers share the same mount, so no path translation needed.
+   * Validate local path: must be within /workspace and not on the denylist.
    * @param {string} localPath - Local path to validate
    * @returns {boolean} True if path is safe, false otherwise
    */

--- a/mcp-servers/sharepoint/src/token-manager.test.ts
+++ b/mcp-servers/sharepoint/src/token-manager.test.ts
@@ -1,9 +1,5 @@
 /**
  * Health-status accessor tests for TokenManager (post-ADR-060).
- *
- * Refresh logic moved to the host-side `oauth` worker — those code paths are
- * tested in `mcp-servers/shared/src/oauth-client.test.ts`. The SharePoint
- * worker's own refresh round-trip is tested in `client.test.ts`.
  */
 import { describe, it, expect } from 'vitest';
 import { TokenManager } from './token-manager.js';

--- a/mcp-servers/sharepoint/src/token-manager.ts
+++ b/mcp-servers/sharepoint/src/token-manager.ts
@@ -1,29 +1,16 @@
 /**
  * Token Management Module — health-status helpers only.
- *
- * Refresh logic moved to the host-side `oauth` worker (ADR-060 / PR3). The
- * SharePoint container has a `/tokens:ro` mount and cannot write tokens
- * itself; refresh is delegated via `@speedwave/mcp-shared`'s `oauth-client`.
- *
- * This file keeps the previous `lastTokenSaveError` accessors so the worker's
- * health endpoint can still report token-related errors that surface during
- * the refresh round-trip.
  * @module sharepoint/token-manager
  */
 
 /**
  * Tracks OAuth refresh-side errors for the SharePoint worker's health endpoint.
- * Post-ADR-060 the worker no longer performs the refresh itself (the host-side
- * `oauth` worker does); this class just remembers the most recent error so
- * the health endpoint can surface it.
  */
 export class TokenManager {
   private lastTokenSaveError: Error | null = null;
 
   /**
-   * Get the last refresh-side error (if any). Set by callers (e.g. SharePoint
-   * client) when an oauth-client call surfaces a non-fatal error worth
-   * reporting on the health endpoint.
+   * Get the last refresh-side error (if any).
    * @returns last error or null
    */
   getLastTokenSaveError(): Error | null {

--- a/mcp-servers/sharepoint/src/tools/file-tools.ts
+++ b/mcp-servers/sharepoint/src/tools/file-tools.ts
@@ -19,7 +19,6 @@ import { SharePointClient } from '../client.js';
 
 /**
  * Normalize upload parameters to accept both snake_case and camelCase
- * Hub executor sends snake_case, but our handlers expect camelCase
  * @param params - Tool parameters
  */
 function normalizeUploadParams(params: Record<string, unknown>): {

--- a/mcp-servers/sharepoint/src/tools/list-tools.test.ts
+++ b/mcp-servers/sharepoint/src/tools/list-tools.test.ts
@@ -1,12 +1,6 @@
 /**
  * Tests for SharePoint list / item / column / page-deletion tools (PR5).
- *
- * Covers:
- * - Metadata: tool names + critical schema invariants.
- * - Site-policy by omission: NO tool's input schema accepts `site_id`.
- * - Happy path for each handler (mocked graphRequest).
- * - Error paths via NOT_CONFIGURED + Graph rejections.
- * - Column type enum is exactly the 6 supported types.
+ * Metadata, site-policy-by-omission (no site_id), happy/error paths, column type enum.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ToolsCallResult } from '@speedwave/mcp-shared';
@@ -150,10 +144,8 @@ describe('list-tools handlers — happy paths', () => {
   });
 
   it('createList returns empty strings (not undefined) when Graph response omits id/webUrl', async () => {
-    // Some Graph environments return a 204/empty body for fast-create flows.
-    // The tool contract is "always return a {listId, webUrl} pair" — empty
-    // string is the documented fallback so downstream callers don't crash on
-    // `out.listId.startsWith(...)`.
+    // Contract: always return a {listId, webUrl} pair; empty string is the
+    // fallback when Graph omits them (e.g. 204).
     graph.mockResolvedValueOnce(undefined);
     const tools = createListTools(client);
     const out = parseContent(
@@ -245,9 +237,8 @@ describe('list-tools handlers — happy paths', () => {
   });
 
   it('addListColumn returns empty columnId when Graph response omits id', async () => {
-    // Same contract as createList: always return a {columnId} key, never
-    // undefined. Empty string signals to callers that the create succeeded
-    // server-side but the id was not echoed back (e.g. 204 / async create).
+    // Contract: always return a {columnId} key; empty string when Graph omits
+    // the id (e.g. 204 / async create).
     graph.mockResolvedValueOnce(undefined);
     const tools = createListTools(client);
     const out = parseContent(
@@ -283,9 +274,7 @@ describe('list-tools handlers — happy paths', () => {
   });
 
   it('listItems returns an empty items array when Graph response omits value', async () => {
-    // Graph occasionally returns `{}` or null on empty pages; the tool must
-    // surface a stable `{items: []}` shape so the model can treat "empty
-    // list" the same as "no value field".
+    // Contract: stable {items: []} shape when Graph omits value (e.g. {} or null).
     graph.mockResolvedValueOnce(undefined);
     const tools = createListTools(client);
     const out = parseContent(
@@ -394,9 +383,7 @@ describe('list-tools handlers — error paths', () => {
     expect(parsed.code).toBe('LIST_LISTS_FAILED');
   });
 
-  // Each handler wraps Graph failures in its own `XXX_FAILED` code. One
-  // table-driven test per code so every `wrapErr` line gets a corresponding
-  // 500-response path.
+  // One table-driven case per handler's XXX_FAILED code (each wrapErr path).
   it.each([
     ['getList', { listId: 'L1' }, 'GET_LIST_FAILED'],
     ['createList', { displayName: 'X', description: 'd', template: 't' }, 'CREATE_LIST_FAILED'],
@@ -420,8 +407,7 @@ describe('list-tools handlers — error paths', () => {
   });
 
   it('updateList errors when description is provided alone', async () => {
-    // Covers the `if (params.description !== undefined)` branch when
-    // displayName is omitted (the dual-branch matters for branch coverage).
+    // Covers the description-only branch (displayName omitted).
     const graph = vi.fn().mockResolvedValueOnce(undefined);
     const client = createMockClient(graph as unknown as Parameters<typeof createMockClient>[0]);
     const tools = createListTools(client);
@@ -442,8 +428,7 @@ describe('list-tools handlers — error paths', () => {
     expect(body).not.toHaveProperty('description');
   });
 
-  // Per-tool listId / itemId / columnId validateGraphId rejections. Covers
-  // every `if (XErr) return XErr;` line in list-tools.ts.
+  // Per-tool listId / itemId / columnId validateGraphId rejections.
   it.each([
     ['getList', { listId: 'bad/../path' }],
     ['updateList', { listId: 'bad/../path', displayName: 'X' }],
@@ -480,8 +465,7 @@ describe('list-tools handlers — error paths', () => {
   });
 
   it('listItems passes through optional filter and top', async () => {
-    // Covers the `if (params.filter)` and `if (params.top)` branches in
-    // handleListItems — without this only the no-args path was exercised.
+    // Covers the filter and top branches in handleListItems.
     const graph = vi.fn().mockResolvedValueOnce({ value: [] });
     const client = createMockClient(graph as unknown as Parameters<typeof createMockClient>[0]);
     const tools = createListTools(client);

--- a/mcp-servers/sharepoint/src/tools/page-tools.test.ts
+++ b/mcp-servers/sharepoint/src/tools/page-tools.test.ts
@@ -73,12 +73,7 @@ describe('page-tools metadata', () => {
     ]);
   });
 
-  // SITE-POLICY-BY-OMISSION REGRESSION TEST (ADR-060).
-  //
-  // The whole point of this invariant is that the model never picks a site.
-  // Any future tool that grows a `site_id` property must fail loudly here so
-  // we re-think the security model rather than silently widen the attack
-  // surface to "model can target any SharePoint site the worker can reach".
+  // Regression: no page tool accepts site_id (security invariant per ADR-060).
   it('NO page tool accepts site_id from the model', () => {
     for (const tool of PAGE_TOOL_SCHEMAS) {
       const schema = tool.inputSchema as {
@@ -588,8 +583,7 @@ describe('page-tools handlers — happy paths', () => {
     expect(getDriveItem).toHaveBeenCalledWith('Shared Documents/hero.jpg');
 
     const [, , body] = localGraph.mock.calls[1];
-    // Body must embed the driveItem ids — those are what SharePoint's UI
-    // image-picker reconciliation checks on Save & Close.
+    // Body embeds driveItem ids for SharePoint UI reconciliation.
     const properties = (
       body as { webPartProperties?: unknown; data?: { properties: Record<string, unknown> } }
     ).data?.properties;
@@ -645,9 +639,7 @@ describe('page-tools handlers — happy paths', () => {
   });
 
   it('addImageWebPart returns COLUMN_OUT_OF_RANGE when the column index does not exist', async () => {
-    // Authors hit this when they invoke addImageWebPart against a layout that
-    // only has one column but pass columnIndex: 1. Without the typed code the
-    // model would retry with random indexes, wasting Graph calls.
+    // Column-index bounds prevent wasted Graph round-trips.
     const driveItem = {
       id: 'item-1',
       webUrl: 'https://example/hero.jpg',
@@ -678,10 +670,7 @@ describe('page-tools handlers — happy paths', () => {
   });
 
   it('addImageWebPart rejects out-of-range section/column indexes before any Graph call', async () => {
-    // The handler validates index bounds against MAX_SECTION / MAX_COLUMN
-    // BEFORE issuing the driveItem lookup, so a typo (sectionIndex: 999)
-    // does not waste a Graph round-trip or surface a confusing
-    // SECTION_OUT_OF_RANGE that callers would interpret as "no such section".
+    // Handler validates index bounds before driveItem lookup.
     const getDriveItem = vi.fn();
     const c = createMockClient(undefined, { getDriveItemForSharePointPath: getDriveItem });
     const tools = createPageTools(c);
@@ -726,10 +715,7 @@ describe('page-tools handlers — happy paths', () => {
   });
 
   it('addImageWebPart wraps unexpected driveItem-lookup errors as ADD_IMAGE_WEBPART_FAILED', async () => {
-    // getDriveItemForSharePointPath can throw from inside callGraphAPI (token
-    // refresh blew up, Graph hiccup, JSON parse failure on retry). All of
-    // those have to surface with a stable error code so the model knows to
-    // retry the tool call rather than treat it as a validation error.
+    // Unexpected driveItem-lookup throws surface with a stable error code.
     const getDriveItem = vi.fn().mockRejectedValue(new Error('Graph 503 Service Unavailable'));
     const c = createMockClient(undefined, {
       getDriveItemForSharePointPath: getDriveItem,
@@ -811,8 +797,7 @@ describe('page-tools handlers — error paths', () => {
     expect(parsed.code).toBe('LIST_PAGES_FAILED');
   });
 
-  // Table-driven Graph-500 error tests for the page tools that wrap their
-  // own `XXX_FAILED` code. Covers every `wrapErr` line in page-tools.ts.
+  // Table-driven Graph-500 error tests covering every wrapErr code.
   it.each([
     ['getPage', { pageId: 'p1' }, 'GET_PAGE_FAILED'],
     ['createPage', { title: 'Hi', name: 'hi.aspx' }, 'CREATE_PAGE_FAILED'],
@@ -890,9 +875,7 @@ describe('page-tools handlers — error paths', () => {
     expect((parseContent(result) as { code: string }).code).toBe('INVALID_INPUT');
   });
 
-  // Per-tool pageId / webPartId validateGraphId rejections. Covers every
-  // `if (idErr) return idErr;` line — without these the Graph URL builders
-  // would receive an injection-prone segment.
+  // Per-tool pageId / webPartId validateGraphId rejections.
   it.each([
     [
       'addWebPart',
@@ -913,9 +896,7 @@ describe('page-tools handlers — error paths', () => {
   });
 
   it('addWebPart rejects malformed section.id from Graph response (defense-in-depth)', async () => {
-    // Graph normally generates safe ids, but the worker still validates them
-    // before stitching into a URL — covers the `if (sectErr)` defensive
-    // branch.
+    // Defense-in-depth: validate Graph ids before URL stitching.
     const graph = vi.fn().mockResolvedValueOnce({
       id: 'p1',
       canvasLayout: {

--- a/mcp-servers/sharepoint/src/tools/page-tools.ts
+++ b/mcp-servers/sharepoint/src/tools/page-tools.ts
@@ -211,8 +211,7 @@ const addWebPartTool: Tool = {
     type: 'object',
     properties: {
       pageId: { type: 'string' },
-      // Capped to prevent OOM from a malicious/buggy caller passing a huge index.
-      // SharePoint pages have a handful of sections in practice; 20/10 is generous.
+      // Capped to bound index values from an untrusted caller.
       sectionIndex: { type: 'number', minimum: 0, maximum: 20 },
       columnIndex: { type: 'number', minimum: 0, maximum: 10 },
       innerHtml: {
@@ -221,8 +220,7 @@ const addWebPartTool: Tool = {
       },
       webPartType: {
         type: 'string',
-        // Derived from the SSOT (`STANDARD_WEBPART_TYPES`) so the schema enum
-        // and the runtime lookup can never drift.
+        // Derived from the SSOT `STANDARD_WEBPART_TYPES`.
         enum: Object.keys(STANDARD_WEBPART_TYPES),
         description:
           'Standard web part type. Mutually exclusive with `innerHtml` (which targets text web parts).',
@@ -516,10 +514,7 @@ interface UpdatePageParams {
 }
 
 /**
- * Handler for `updatePage` — PATCH a sitePage. Supports updating any subset of
- * metadata fields (title, description, thumbnailWebUrl, showComments,
- * showRecommendedPages, titleArea) plus canvasLayout. Graph requires the FULL
- * canvasLayout when present; other fields can be set independently.
+ * Handler for `updatePage` — PATCH a sitePage (any subset of metadata fields plus canvasLayout).
  * @param client - the SharePoint client
  * @param params - input parameters; pageId is required, every other field is optional
  */
@@ -563,14 +558,6 @@ async function handleUpdatePage(
 
 /**
  * Handler for `addWebPart` — POST a text or standard web part to a column.
- *
- * Index-to-id resolution: SharePoint addresses sections/columns by GUID, not
- * by index. We GET the layout, walk by index, then POST to the dedicated
- * `.../horizontalSections/{section-id}/columns/{column-id}/webparts` endpoint.
- *
- * Mode selection: `innerHtml` triggers the text web part path; `webPartType`
- * triggers the standard web part path (one of the 14 documented types). The
- * two are mutually exclusive.
  * @param client - the SharePoint client
  * @param params - input parameters
  * @param params.pageId - target page id
@@ -593,8 +580,7 @@ async function handleAddWebPart(
 ): Promise<ToolResult> {
   const idErr = validateGraphId(params.pageId, 'pageId');
   if (idErr) return idErr;
-  // Defense in depth — schema enforces the same range but `withValidation`
-  // does not run JSON Schema validation, so cap here too.
+  // Defense in depth — cap here since `withValidation` skips JSON Schema validation.
   const MAX_SECTION = 20;
   const MAX_COLUMN = 10;
   if (
@@ -678,8 +664,7 @@ async function handleAddWebPart(
         },
       };
     }
-    // The Graph ids are URL path segments — defend against injection at the
-    // boundary, even though Graph generated them.
+    // Graph ids become URL path segments — validate against injection.
     const sectErr = validateGraphId(section.id, 'section.id');
     if (sectErr) return sectErr;
     const colErr = validateGraphId(column.id, 'column.id');
@@ -708,9 +693,6 @@ async function handleAddWebPart(
 
 /**
  * Handler for `updateWebPart` — PATCH a text web part directly by id.
- *
- * Graph supports per-web-part PATCH at `.../webparts/{webPartId}`; we don't
- * need to fetch + re-PATCH the whole layout.
  * @param client - the SharePoint client
  * @param params - input parameters
  * @param params.pageId - target page id
@@ -741,8 +723,6 @@ async function handleUpdateWebPart(
 
 /**
  * Handler for `removeWebPart` — DELETE a web part directly by id.
- *
- * Graph supports per-web-part DELETE at `.../webparts/{webPartId}`.
  * @param client - the SharePoint client
  * @param params - input parameters
  * @param params.pageId - target page id
@@ -785,10 +765,7 @@ async function handlePublishPage(
 }
 
 /**
- * Handler for `generateTableOfContents` — fetches the page, walks every text
- * web part on it (in section/column/index order), extracts headings, renders
- * a nested `<ul>` of anchor links, and posts the result as a new text web
- * part to the addressed section/column.
+ * Handler for `generateTableOfContents` — scans text web parts for headings, injects ids for anchor resolution, renders a nested ToC as HTML.
  * @param client - the SharePoint client
  * @param params - input parameters
  * @param params.pageId - target page id
@@ -855,9 +832,7 @@ async function handleGenerateTableOfContents(
     const colErr = validateGraphId(column.id, 'column.id');
     if (colErr) return colErr;
 
-    // Walk every text web part, extract its headings, and PATCH the body with
-    // `id="…"` injected on each heading so ToC anchors actually resolve. The
-    // PATCH is a no-op for web parts whose headings are already anchored.
+    // Extract headings from text web parts and inject anchor ids where missing.
     const allHeadings = [] as ReturnType<typeof extractHeadings>;
     let anchorsInjected = 0;
     for (const s of sections) {
@@ -902,9 +877,7 @@ async function handleGenerateTableOfContents(
 }
 
 /**
- * Handler for `addImageWebPart` — adds an image web part backed by a real
- * driveItem (Site Assets / Documents). Looks up the file's `sharepointIds`
- * and `image` facet so the payload survives SharePoint UI Save & Close.
+ * Handler for `addImageWebPart` — adds an image web part backed by a real driveItem from Site Assets or Documents.
  * @param client - the SharePoint client
  * @param params - input parameters
  * @param params.pageId - target page id

--- a/mcp-servers/sharepoint/src/tools/validation.ts
+++ b/mcp-servers/sharepoint/src/tools/validation.ts
@@ -1,32 +1,17 @@
 /**
- * Validation Helpers for Tool Parameters
- *
- * `withValidation` delegates to the shared Family-A wrapper
- * ({@link withResultValidation}) with compact JSON output (indent 0).
- * `validateGraphId` is a SharePoint-specific extra kept local.
+ * Validation helpers for tool parameters.
  */
 
 import { withResultValidation, type ToolResult, type ToolsCallResult } from '@speedwave/mcp-shared';
 
 export type { ToolResult };
 
-/**
- * Permitted characters in a Microsoft Graph id segment used in page/list/item/column
- * URLs. Graph guids and SharePoint page names are alphanumerics, dashes, and
- * underscores; allowing dots covers some legacy page filenames (e.g. "Home.aspx").
- *
- * Used by the page and list tools to refuse model-supplied ids that contain
- * path separators or URL meta characters (e.g. `"P1/../../drives/X/items"` or
- * `"1?$select=secret"`). This is defense in depth on top of the "no site_id
- * from model" invariant — the worker still controls `site_id`, but every other
- * Graph-path segment comes from the model and must be a single safe token.
- */
+/** Permitted characters in a Microsoft Graph id segment: alphanumerics, dashes, underscores, dots. */
 const GRAPH_ID_RE = /^[A-Za-z0-9._-]{1,128}$/;
 
 /**
  * Assert that `value` is a non-empty string matching {@link GRAPH_ID_RE}.
- * Returns `null` on success or a `ToolResult` error on failure (suitable for
- * early return at the top of a handler).
+ * Returns `null` on success or a `ToolResult` error on failure.
  * @param value - candidate id from the tool call
  * @param fieldName - parameter name to mention in the error message
  */

--- a/mcp-servers/sharepoint/vitest.config.ts
+++ b/mcp-servers/sharepoint/vitest.config.ts
@@ -8,17 +8,7 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
-      // Floors below intentionally trail the actual measurement by ~1 pp so
-      // CI never auto-loosens on accidental regressions, yet does not block
-      // on the two stubborn paths in `client.ts`: the race-condition retry
-      // inside `callGraphAPI` (mid-401 token-rotation by another caller)
-      // and `debugLog(msg, data)` (gated by `process.env.DEBUG` AND the
-      // two-arg overload — only `createRemoteFolder` hits the two-arg form
-      // and only when JSON parse throws, so the combinatoric test surface
-      // would dwarf the line coverage gained).
-      //
-      // Actual values at landing (commit fdca21 / PR #671):
-      //   stmts 99.1%   funcs 98.5%   lines 99.4%   branches 94.1%
+      // Measured at fdca21: stmts 99.1%, funcs 98.5%, lines 99.4%, branches 94.1%
       thresholds: {
         lines: 98,
         functions: 98,

--- a/mcp-servers/slack/src/client.test.ts
+++ b/mcp-servers/slack/src/client.test.ts
@@ -31,18 +31,13 @@ const mockWebClientInstance = {
   users: {
     lookupByEmail: vi.fn(),
   },
-  // `auth.test` is invoked by the background connection test that
-  // initializeSlackClients schedules after successful token load. The default
-  // resolves so that path is exercised in the happy-token test; specific
-  // tests can override via mockWebClientInstance.auth.test.mockResolvedValueOnce.
+  // Background auth.test defaults to success; override per-test with mockResolvedValueOnce
   auth: {
     test: vi.fn().mockResolvedValue({ ok: true }),
   },
 };
 
-// Mock @slack/web-api - use class for vitest 4.x compatibility. The mock
-// records the constructor token so slackCall's recreate-on-rotation check
-// (`client.token !== token`) behaves like the real WebClient.
+// Class mock records the token so slackCall's rotate-on-change check (client.token !== token) works
 vi.mock('@slack/web-api', () => ({
   WebClient: vi.fn().mockImplementation(function (
     this: typeof mockWebClientInstance & { token?: string },
@@ -53,11 +48,7 @@ vi.mock('@slack/web-api', () => ({
   }),
 }));
 
-// Mock fs/promises. The named `readFile` mirrors the default-object one
-// because @speedwave/mcp-shared's oauth-client imports it as a named binding
-// from 'node:fs/promises' (the slackCall refresh path reads the bearer file).
-// `mkdir`/`writeFile` back downloadFile's workspace write — both shapes are
-// exported so named (`import { mkdir }`) and default-object access resolve.
+// Mock both named and default-object fs exports (oauth-client imports named; refresh reads bearer)
 const { readFileMock, mkdirMock, writeFileMock } = vi.hoisted(() => ({
   readFileMock: vi.fn(),
   mkdirMock: vi.fn().mockResolvedValue(undefined),
@@ -257,9 +248,7 @@ describe('slack client', () => {
     });
 
     it('wraps a non-Error fs rejection into an errno-aware message (still returns missing)', async () => {
-      // The shared loadTokenFile wraps any non-Error rejection into a proper
-      // Error ("Failed to read token file: … (plain string failure)"), so the
-      // message — not "Unknown error" — surfaces in the warning.
+      // Non-Error rejection is wrapped so its message (not "Unknown error") surfaces in the warning
       vi.mocked(fs.readFile).mockRejectedValueOnce('plain string failure');
 
       const result = await initializeSlackClients();
@@ -457,8 +446,7 @@ describe('slack client', () => {
     });
 
     it('resolves a channel that lives on a later list page', async () => {
-      // Slack pages can carry far fewer entries than `limit` — a channel on
-      // page 2+ must still resolve (the original single-page read missed it).
+      // Pagination: a channel on page 2+ must still resolve even when pages are sparse
       const mockList = vi
         .fn()
         .mockResolvedValueOnce({
@@ -1085,8 +1073,7 @@ describe('slack client', () => {
         url_private: 'https://files.slack.com/files-pri/T1-F4/notes.md',
       });
       stubDownload('<html>login</html>', 'text/html');
-      // No WORKER_OAUTH_URL in tests → the triggered refresh fails loudly
-      // instead of returning the login page as content.
+      // No WORKER_OAUTH_URL: refresh fails instead of returning the login page as content
       await expect(getFileContent(mockClients, { file: 'F4' })).rejects.toThrow();
     });
 
@@ -1266,8 +1253,7 @@ describe('slack client', () => {
         url_private: 'https://files.slack.com/files-pri/T1-F5/doc.pdf',
       });
       stubDownload(Buffer.from('<html>login</html>'), 'text/html');
-      // No WORKER_OAUTH_URL in tests → the triggered refresh fails loudly
-      // instead of persisting the login page as a "file".
+      // No WORKER_OAUTH_URL: refresh fails instead of persisting the login page
       await expect(downloadFile(mockClients, { file: 'F5' })).rejects.toThrow();
       expect(fs.writeFile).not.toHaveBeenCalled();
     });

--- a/mcp-servers/slack/src/client.ts
+++ b/mcp-servers/slack/src/client.ts
@@ -221,7 +221,7 @@ const AUTH_EXPIRED_ERRORS = new Set(['token_expired', 'invalid_auth']);
 /**
  * True when a thrown `@slack/web-api` error indicates a stale access token.
  * Terminal states (`token_revoked`, `account_inactive`) deliberately return
- * false — a refresh cannot heal them and would burn the rate window.
+ * false — a refresh cannot heal them.
  * @param err - error thrown by a WebClient call
  */
 export function isSlackAuthExpiredError(err: unknown): boolean {
@@ -230,10 +230,7 @@ export function isSlackAuthExpiredError(err: unknown): boolean {
 }
 
 /**
- * Run a WebClient call with rotating-token semantics: on a stale-token error,
- * `authedSdkCall` refreshes once via the oauth worker (single-flight) and
- * retries once. The WebClient binds its token at construction, so it is
- * recreated whenever the token on disk rotated.
+ * Run a WebClient call with rotating-token refresh-and-retry on stale errors.
  * @param clients - the client container
  * @param fn - the SDK call to execute
  */
@@ -266,8 +263,7 @@ export async function slackCall<T>(
  * @returns {string} Formatted, user-friendly error message
  */
 export function formatSlackError(error: unknown): string {
-  // Refresh-path failures (oauth worker): an invalid_grant class means the
-  // refresh token is dead (30-day expiry, revocation) — only a new sign-in helps.
+  // invalid_grant: refresh token dead (revocation or 30-day expiry) — only new sign-in helps.
   if (error instanceof OAuthRefreshError) {
     if (error.message.includes('invalid_grant')) {
       return withSetupGuidance(
@@ -327,11 +323,7 @@ export function formatSlackError(error: unknown): string {
 // Helpers
 //═══════════════════════════════════════════════════════════════════════════════
 
-/**
- * `conversations.list` pages may carry FAR fewer entries than `limit`
- * (Slack returns ~200 even with limit=1000), so a single call silently
- * drops channels — iterate `next_cursor` until exhausted.
- */
+// conversations.list may return far fewer entries than limit; iterate next_cursor until exhausted.
 const CHANNEL_LIST_PAGE_LIMIT = 1000;
 
 /** Hard cap on pagination (20k channels) — runaway-cursor backstop. */
@@ -724,8 +716,7 @@ export async function getFileContent(
         'Download it into the workspace with downloadFile instead.'
     );
   }
-  // Buffering is bounded — the worker container has 128 MiB total, so a huge
-  // text file must be rejected from metadata, not buffered then truncated.
+  // Reject oversized files from metadata — bounded worker buffer.
   if (meta.size !== undefined && meta.size > MAX_DOWNLOAD_BYTES) {
     throw new Error(
       `File '${meta.name}' is ${meta.size} bytes — too large to read. ` +

--- a/mcp-servers/slack/src/index.ts
+++ b/mcp-servers/slack/src/index.ts
@@ -1,8 +1,5 @@
 /**
- * MCP Slack Worker
- *
- * Isolated Slack MCP server with per-service token isolation.
- * Architecture: Domain-tools pattern with separation of concerns.
+ * MCP Slack Worker with per-service token isolation.
  * @module mcp-slack
  */
 
@@ -10,8 +7,7 @@ import { bootWorker, ts, makeStandardHealthCheck } from '@speedwave/mcp-shared';
 import { initializeSlackClients, type SlackClients } from './client.js';
 import { createToolDefinitions } from './tools/index.js';
 
-// initializeSlackClients always resolves a non-null object; `_tokensStatus`
-// (not null) carries the "configured" signal — encoded via isConfigured.
+// `_tokensStatus === 'present'` signals configuration via isConfigured.
 bootWorker<SlackClients>({
   serverName: 'mcp-slack',
   version: '1.0.0',

--- a/mcp-servers/slack/src/tools/channel-tools.ts
+++ b/mcp-servers/slack/src/tools/channel-tools.ts
@@ -381,8 +381,7 @@ export async function handleListChannelIds(
 
 /**
  * Tool handler function.
- * @param clients - Slack client instances (always non-null; checks
- *   `_tokensStatus === 'missing'` to surface the configuration error).
+ * @param clients - Slack client instances (non-null; null check via _tokensStatus)
  */
 export function createChannelTools(clients: SlackClients): ToolDefinition[] {
   const gate = withClients(clients);

--- a/mcp-servers/slack/src/tools/channel.test.ts
+++ b/mcp-servers/slack/src/tools/channel.test.ts
@@ -29,8 +29,7 @@ vi.mock('../client.js', async () => {
   };
 });
 
-// Mock the user-directory boundary — its machinery has its own test file;
-// here we only verify the handlers route messages through enrichment.
+// Mock the user-directory boundary; its machinery has its own test file.
 vi.mock('../user-directory.js', () => ({
   enrichMessagesWithAuthors: vi.fn(async (_clients: unknown, msgs: unknown[]) => msgs),
 }));

--- a/mcp-servers/slack/src/tools/dm-tools.ts
+++ b/mcp-servers/slack/src/tools/dm-tools.ts
@@ -1,7 +1,5 @@
 /**
  * Direct-Message Tools — listing and opening DM conversations (im + mpim).
- * Reading and sending ride the existing channel tools with a `D…` conversation
- * ID; these tools only discover and create the conversations.
  */
 
 import {

--- a/mcp-servers/slack/src/tools/file-tools.ts
+++ b/mcp-servers/slack/src/tools/file-tools.ts
@@ -133,7 +133,7 @@ export async function handleGetFileContent(
 }
 
 /**
- * Tool factory (mirrors createChannelTools' not-configured gating).
+ * Tool factory.
  * @param clients - Slack client instances
  */
 export function createFileTools(clients: SlackClients): ToolDefinition[] {

--- a/mcp-servers/slack/src/tools/index.ts
+++ b/mcp-servers/slack/src/tools/index.ts
@@ -1,8 +1,4 @@
-/**
- * Slack Tools Index
- *
- * Central registry for all Slack tools following the domain-tools pattern.
- */
+/** Central registry for all Slack tools (domain-tools pattern). */
 
 import { ToolDefinition } from '@speedwave/mcp-shared';
 import { SlackClients } from '../client.js';
@@ -16,8 +12,7 @@ import { createUserTools } from './user-tools.js';
 
 /**
  * Creates complete tool definitions array for Slack MCP server.
- * @param clients - Slack client instances (never null after this PR;
- *   `_tokensStatus === 'missing'` indicates an unconfigured worker).
+ * @param clients - Slack client instances; `_tokensStatus === 'missing'` means unconfigured.
  */
 export function createToolDefinitions(clients: SlackClients): ToolDefinition[] {
   return [

--- a/mcp-servers/slack/src/tools/validation.test.ts
+++ b/mcp-servers/slack/src/tools/validation.test.ts
@@ -1,9 +1,4 @@
-/**
- * Validation Helper Tests
- *
- * Tests for withValidation wrapper: parameter validation, success path,
- * error path, and handler exceptions.
- */
+/** Tests for withValidation wrapper. */
 
 import { describe, it, expect, vi } from 'vitest';
 import { withValidation, ToolResult } from './validation.js';

--- a/mcp-servers/slack/src/tools/validation.ts
+++ b/mcp-servers/slack/src/tools/validation.ts
@@ -1,8 +1,5 @@
 /**
- * Validation Helpers for Tool Parameters
- *
- * Thin re-exports of the shared Family-A wrapper ({@link withResultValidation})
- * so Slack tools keep importing a local `withValidation`/`ToolResult`.
+ * Validation helpers re-exporting the shared Family-A wrapper.
  */
 
 import {
@@ -16,9 +13,7 @@ import type { SlackClients } from '../client.js';
 export type { ToolResult };
 
 /**
- * NOT_CONFIGURED gate shared by every tool factory: when the worker booted
- * without a token, short-circuit with a clear configuration error instead
- * of calling the handler.
+ * Gate: returns NOT_CONFIGURED when clients._tokensStatus is 'missing'.
  * @param clients - Slack client container
  */
 export function withClients(clients: SlackClients) {

--- a/mcp-servers/slack/src/user-directory.ts
+++ b/mcp-servers/slack/src/user-directory.ts
@@ -1,8 +1,6 @@
 /**
- * User Directory — lazy, cached workspace user map built from `users.list`
- * (requires only the already-granted `users:read`). One mechanism serves both
- * directions: ID→name (message author enrichment) and name→ID (findUsers).
- * Slack has no server-side name search, so the full listing is unavoidable.
+ * User Directory — lazy, cached workspace user map built from `users.list`.
+ * Serves ID→name and name→ID lookups.
  */
 
 import type { UsersListResponse } from '@slack/web-api';
@@ -87,8 +85,7 @@ async function fetchAllUsers(clients: SlackClients): Promise<Map<string, SlackDi
 }
 
 /**
- * Start (or join) a directory build; clears `inflight` on settle so a failed
- * build retries on the next call instead of latching the rejection.
+ * Start (or join) a directory build, clearing `inflight` on settle.
  * @param clients - Slack client container
  */
 function buildDirectory(clients: SlackClients): Promise<Map<string, SlackDirectoryUser>> {
@@ -109,8 +106,7 @@ function buildDirectory(clients: SlackClients): Promise<Map<string, SlackDirecto
 }
 
 /**
- * Fresh-or-rebuilt directory. With stale data present, a rebuild failure
- * degrades to the stale map (warn); with no data at all it throws.
+ * Fresh-or-rebuilt directory; degrades to stale data on rebuild failure, else throws.
  * @param clients - Slack client container
  */
 export async function ensureUserDirectory(
@@ -133,9 +129,7 @@ export async function ensureUserDirectory(
 }
 
 /**
- * Non-blocking, never-throwing directory lookup for read paths. Stale data is
- * returned immediately (kicking a background rebuild); otherwise the build is
- * raced against `waitMs` and null is returned on timeout/failure.
+ * Non-blocking, never-throwing directory lookup; returns stale data immediately, else races build against `waitMs`.
  * @param clients - Slack client container
  * @param waitMs - Maximum time to wait for a first build
  */
@@ -171,9 +165,7 @@ export function displayNameOf(u: SlackDirectoryUser): string {
 }
 
 /**
- * Set `author` on each message from the directory. Unknown IDs fall back to
- * the message's own `username` (bots). Never throws — reads must not fail
- * because name resolution did.
+ * Set `author` on each message from the directory; unknown IDs fall back to the message's `username`. Never throws.
  * @param clients - Slack client container
  * @param messages - Messages to enrich in place
  */
@@ -194,8 +186,7 @@ export async function enrichMessagesWithAuthors(
 }
 
 /**
- * Search-normalize: lowercase, strip diacritics. The explicit ł→l step is
- * load-bearing — U+0142 does not decompose under NFD, unlike ą/ć/ę/ń/ó/ś/ź/ż.
+ * Search-normalize: lowercase, strip diacritics, explicit ł→l (U+0142 does not decompose under NFD).
  * @param s - Raw string
  */
 export function normalizeForSearch(s: string): string {
@@ -207,9 +198,7 @@ export function normalizeForSearch(s: string): string {
 }
 
 /**
- * Case- and diacritic-insensitive substring search over name/real_name/
- * display_name. Excludes deleted users. Uses ensureUserDirectory — a failed
- * build surfaces as an error (explicit user intent, no silent empty result).
+ * Case- and diacritic-insensitive substring search over name/real_name/display_name; excludes deleted users.
  * @param clients - Slack client container
  * @param params - Parameters
  * @param params.query - Partial name to match

--- a/native/macos/audio-capture/Package.swift
+++ b/native/macos/audio-capture/Package.swift
@@ -1,12 +1,8 @@
 // swift-tools-version: 5.9
 import PackageDescription
 
-// Embeds Resources/Info.plist into Mach-O `__TEXT,__info_plist` so the CLI
-// binary carries `CFBundleIdentifier` (`pl.speedwave.desktop.audio-capture`),
-// `NSAudioCaptureUsageDescription`, and `NSMicrophoneUsageDescription` —
-// required by TCC because the parent .app's Info.plist is not inherited when
-// we spawn this binary directly (ADR-049 rationale). macOS 14.4+ for taps;
-// `Package.swift` targets 14 and the runtime check enforces 14.4.
+// Embeds Resources/Info.plist into Mach-O `__TEXT,__info_plist` so the CLI binary
+// carries CFBundleIdentifier, NSAudioCaptureUsageDescription, NSMicrophoneUsageDescription.
 let package = Package(
     name: "audio-capture-cli",
     platforms: [.macOS(.v14)],

--- a/native/macos/audio-capture/Sources/AudioCaptureCLI.swift
+++ b/native/macos/audio-capture/Sources/AudioCaptureCLI.swift
@@ -22,10 +22,7 @@ import SharedCLI
 /// 16 kHz mono float32 — the only output format. Whisper expects this rate.
 let kSampleRate: Double = 16_000.0
 
-/// Owns all stdout writes (header + binary chunks). CoreAudio IOProc threads
-/// and the mic-engine tap only hand it already-copied raw frames and let the
-/// resample + write happen here — never on a real-time audio thread (a full
-/// stdout pipe blocking the audio path would glitch the whole system).
+/// Owns all stdout writes (header + binary chunks); never runs on an audio thread.
 final class WriterQueue {
     static let shared = WriterQueue()
     private let queue = DispatchQueue(label: "pl.speedwave.audio-capture.writer")
@@ -38,9 +35,7 @@ final class WriterQueue {
 
     /// Writes the JSON header line synchronously (called once, before any chunk).
     func writeHeader(streams: [String]) {
-        // `started_at_ns` uses wall-clock; per-chunk `offset_ns` is a monotonic
-        // mach-time delta. They are in different clock domains — the Rust reader
-        // ignores `started_at_ns`, so this is informational only.
+        // `started_at_ns` is wall-clock; the Rust reader ignores it (per-chunk offset is monotonic).
         let startedAtNs = UInt64(Date().timeIntervalSince1970 * 1_000_000_000)
         let header: [String: Any] = [
             "sample_rate": Int(kSampleRate), "channels": 1, "format": "f32le",
@@ -73,9 +68,7 @@ final class WriterQueue {
                   let inBuf = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: inFrames)
             else { return }
             inBuf.frameLength = inFrames
-            // Copy the raw interleaved samples into the input buffer. The input
-            // format we hand the converter is always non-interleaved float (we
-            // build it that way in the callers), so write one channel at a time.
+            // Copy raw samples into the input buffer (non-interleaved float per channel).
             if format.isInterleaved {
                 if let dst = inBuf.floatChannelData?[0] {
                     interleaved.withUnsafeBufferPointer { src in
@@ -140,9 +133,7 @@ func logErr(_ message: String) {
 // MARK: - Argument parsing
 
 /// Source for `--record --source`. `all` = system-wide tap; `pid:N` = single
-/// process; `all-except:N` = system minus one process; `mic-only` = no system
-/// tap at all, just the microphone (uses the public AVCaptureDevice consent
-/// API, so the OS prompt fires — unlike CoreAudio process taps).
+/// process; `all-except:N` = system minus one process; `mic-only` = microphone only.
 enum AudioSource {
     case all
     case pid(pid_t)
@@ -212,10 +203,8 @@ func parseRecordOptions(_ args: [String]) -> RecordOptions? {
 
 // MARK: - Process enumeration (--list)
 
-/// Looks up `kAudioHardwarePropertyProcessObjectList` and emits a JSON array
-/// of running audio processes on stdout, one element per pid that the OS
-/// currently treats as an "audio object". Used by the Desktop UI to populate
-/// the per-app source picker.
+/// Emits a JSON array of running audio processes (one element per pid) on stdout
+/// from `kAudioHardwarePropertyProcessObjectList`.
 @available(macOS 14.4, *)
 func listAudioProcesses() throws -> Data {
     var addr = AudioObjectPropertyAddress(
@@ -434,9 +423,8 @@ func runRecord(_ opts: RecordOptions) {
         return
     }
 
-    // System tap path. The system-audio TCC prompt has no public trigger, so
-    // request it via the private API first — without it the tap silently
-    // delivers zeroed buffers (ADR-056 decision 3).
+    // System tap path: request system-audio TCC consent via the private API first
+    // (no public trigger; ADR-056 decision 3).
     guard preflightSystemAudioConsent() else {
         logErr(
             "system audio recording permission denied — grant it in System Settings → Privacy & Security → System Audio Recording Only")
@@ -565,10 +553,7 @@ func startSystemTap(session: RecordSession, source: AudioSource) throws {
     }
     session.aggregateId = aggId
 
-    // The aggregate device's input stream format tells us the *real* sample
-    // rate + channel count CoreAudio will deliver — never assume 48 kHz. A tap
-    // mixdown arrives as one interleaved float buffer, so we hand the writer
-    // queue an interleaved float format matching it.
+    // Query the aggregate device's real input format; the tap mixdown arrives interleaved.
     let inputFormat = inputStreamFormat(of: aggId)
     let inChannels = max(1, inputFormat.mChannelsPerFrame)
     guard let avInFormat = AVAudioFormat(
@@ -580,9 +565,8 @@ func startSystemTap(session: RecordSession, source: AudioSource) throws {
             userInfo: [NSLocalizedDescriptionKey: "could not build input AVAudioFormat (rate \(inputFormat.mSampleRate))"])
     }
 
-    // IOProc runs on a real-time CoreAudio thread: it only copies the buffer's
-    // float samples into a Swift array and hands them to the writer queue. No
-    // resampling, no stdout, no locking on the audio path.
+    // IOProc runs on a real-time CoreAudio thread: copy samples to the writer queue only,
+    // no resampling/stdout/locking on the audio path.
     var procId: AudioDeviceIOProcID?
     let procStatus = AudioDeviceCreateIOProcIDWithBlock(
         &procId, aggId, nil
@@ -640,12 +624,8 @@ func inputStreamFormat(of device: AudioObjectID) -> AudioStreamBasicDescription 
     return fallback
 }
 
-/// Requests the "System Audio Recording" (TCC `kTCCServiceAudioCapture`) consent
-/// via the private `TCCAccessRequest` API — there is no public trigger for this
-/// prompt (decision 3, ADR-056). `dlopen`/`dlsym`-guarded: if the symbol is
-/// missing on a future macOS, returns `false` and the caller exits "permission
-/// unavailable" (the UI then deep-links the user to System Settings) — it does
-/// not crash. Blocks for the prompt result. Returns `true` if granted.
+/// Requests system-audio (TCC `kTCCServiceAudioCapture`) consent via the private
+/// `TCCAccessRequest` API (dlopen/dlsym-guarded). Blocks; returns `true` if granted.
 func preflightSystemAudioConsent() -> Bool {
     typealias TCCRequestFn = @convention(c) (
         CFString, @escaping @convention(block) (Bool) -> Void
@@ -673,11 +653,8 @@ func preflightSystemAudioConsent() -> Bool {
     return granted
 }
 
-/// Requests microphone consent via the public `AVCaptureDevice` API. This DOES
-/// show the macOS consent prompt (the embedded `NSMicrophoneUsageDescription`
-/// supplies the text) — unlike CoreAudio process taps, which have no public
-/// trigger. Blocks until the user responds (or, if already decided, returns
-/// immediately). Returns `true` if access is granted.
+/// Requests microphone consent via the public `AVCaptureDevice` API (shows the
+/// macOS prompt). Blocks until decided; returns `true` if granted.
 func requestMicrophoneAccess() -> Bool {
     switch AVCaptureDevice.authorizationStatus(for: .audio) {
     case .authorized:
@@ -711,10 +688,7 @@ func startMicEngine(session: RecordSession, selector: MicSelector, streamIndex: 
         let frames = Int(buf.frameLength)
         let channels = Int(buf.format.channelCount)
         guard frames > 0, let chan = buf.floatChannelData else { return }
-        // Interleave the engine's non-interleaved channels into one array, then
-        // hand a matching interleaved format to the writer queue (which will
-        // deinterleave + down-mix + resample). Keeping it simple: the engine's
-        // float format is what we pass through unchanged otherwise.
+        // Interleave engine channels for the writer queue; engine float format unchanged.
         var interleaved = [Float](repeating: 0, count: frames * channels)
         for f in 0..<frames {
             for c in 0..<channels { interleaved[f * channels + c] = chan[c][f] }
@@ -729,9 +703,7 @@ func startMicEngine(session: RecordSession, selector: MicSelector, streamIndex: 
             offsetNs: offset)
     }
 
-    // The `selector` is plumbed so a future iteration can route to a named
-    // device UID via `kAudioDevicePropertyDeviceUID`; today we honor the
-    // engine default. We log the selector for transparency.
+    // Device routing not yet wired; the selector is logged for transparency.
     switch selector {
     case .device(let uid):
         logErr("mic selector device='\(uid)' (default device used; named routing not yet wired)")

--- a/native/macos/audio-capture/Tests/AudioCaptureTests.swift
+++ b/native/macos/audio-capture/Tests/AudioCaptureTests.swift
@@ -61,9 +61,7 @@ final class AudioCaptureTests: XCTestCase {
     /// The header JSON line must be valid UTF-8 + JSON and carry the expected
     /// schema before the parent reads any binary chunks.
     func testHeaderShapeIsStable() throws {
-        // We can't easily intercept FileHandle.standardOutput in-process, but
-        // we can pre-serialize the same structure the writer uses and assert
-        // that the parser side will accept it. This guards the schema.
+        // Pre-serialize the writer's header structure and assert the parser accepts it.
         let header: [String: Any] = [
             "sample_rate": 16000,
             "channels": 1,
@@ -82,15 +80,12 @@ final class AudioCaptureTests: XCTestCase {
     }
 
     /// Chunk framing: 4-byte stream index, 4-byte nframes, 8-byte offset_ns,
-    /// then nframes × 4-byte little-endian floats. The Rust side parses this
-    /// shape — regression-guard the byte layout from the producer side.
+    /// then nframes × 4-byte little-endian floats.
     func testChunkFramingByteLayout() {
         let samples: [Float] = [0.0, 0.25, -0.25, 1.0]
         let bytesPerChunk = 4 + 4 + 8 + samples.count * MemoryLayout<Float32>.size
         XCTAssertEqual(bytesPerChunk, 32)
-        // Float32 little-endian sanity — Swift's native byte order on Apple
-        // Silicon and Intel is little-endian, but assert the contract anyway
-        // so a future port doesn't silently flip endianness.
+        // Assert the Float32 little-endian byte-order contract.
         var v: Float32 = 1.0
         let raw = withUnsafeBytes(of: &v) { Array($0) }
         XCTAssertEqual(raw.count, 4)
@@ -101,11 +96,8 @@ final class AudioCaptureTests: XCTestCase {
         XCTAssertEqual(raw[3], 0x3f)
     }
 
-    /// Stream indices: 0 = app/system, 1 = mic. A frame's 4-byte LE prefix is
-    /// that index; the Rust reader treats it positionally. Encode both and
-    /// decode them back — if the LE encoding ever changes this fails. (Changing
-    /// the *meaning* of 0/1 also requires changing
-    /// crates/speedwave-runtime/src/transcription/audio_macos.rs.)
+    /// Stream indices: 0 = app/system, 1 = mic, encoded as a 4-byte LE prefix.
+    /// The meaning of 0/1 is mirrored in crates/speedwave-runtime/src/transcription/audio_macos.rs.
     func testStreamIndexEncodingRoundTrips() {
         for idx: UInt32 in [0, 1] {
             var le = idx.littleEndian
@@ -125,8 +117,7 @@ final class AudioCaptureTests: XCTestCase {
         let pid: pid_t = 42
         let cases: [AudioSource] = [.all, .pid(pid), .allExcept(pid), .micOnly(nil), .micOnly("UID-1")]
         XCTAssertEqual(cases.count, 5)
-        // Compile-time exhaustiveness — if a new variant lands the parser must
-        // learn it before this test will pass again.
+        // Compile-time exhaustiveness check over AudioSource variants.
         for c in cases {
             switch c {
             case .all, .pid(_), .allExcept(_), .micOnly(_): break

--- a/native/macos/calendar/Package.swift
+++ b/native/macos/calendar/Package.swift
@@ -2,17 +2,7 @@
 import PackageDescription
 
 // The `-sectcreate __TEXT __info_plist Resources/Info.plist` linker flags embed
-// the package's Info.plist into the resulting Mach-O's `__TEXT,__info_plist`
-// section, which is what macOS reads for `Bundle.main.bundleIdentifier` and TCC
-// usage descriptions when the binary runs as a standalone CLI tool (no parent
-// .app bundle wrapping it). Without this, EventKit's `requestFullAccessToEvents`
-// silently rejects on macOS 14+ because it cannot find
-// `NSCalendarsFullAccessUsageDescription` — the parent .app's Info.plist is not
-// inherited across `posix_spawn`.
-//
-// The path is relative to the package root at swift build time. The version
-// string in Resources/Info.plist is stamped from tauri.conf.json by
-// `scripts/build-native-macos.sh` before this build runs.
+// Info.plist into the Mach-O so TCC reads the EventKit usage descriptions.
 let package = Package(
     name: "calendar-cli",
     platforms: [.macOS(.v13)],

--- a/native/macos/calendar/Sources/CalendarCLI.swift
+++ b/native/macos/calendar/Sources/CalendarCLI.swift
@@ -27,8 +27,7 @@ struct CalendarCLI {
         "check_permission, list_calendars, list_events, get_event, create_event, update_event, delete_event"
 
     static func main() {
-        // Shared store: the access guard requests permission, then the command
-        // handlers operate on the same store. check_permission uses its own gate.
+        // Shared store for access guard and handlers; check_permission uses its own gate.
         let store = EKEventStore()
         runCLI(
             cliName: "calendar-cli",

--- a/native/macos/calendar/Tests/CalendarTests.swift
+++ b/native/macos/calendar/Tests/CalendarTests.swift
@@ -74,20 +74,14 @@ final class CalendarTests: XCTestCase {
     // MARK: - EventStoreGate — file-scope struct reachable via @testable import
 
     func testCalendarEventStoreGateConformsToPermissionGate() {
-        // Compile-time + smoke: EventStoreGate is file-scope and reachable from tests.
-        // Calling authorizationStatus() on a real EKEventStore is a pure read.
+        // Compile-time + smoke: EventStoreGate produces RawAuthorizationStatus.
         let store = EKEventStore()
         let gate: PermissionGate = EventStoreGate(store: store)
-        // The protocol now returns RawAuthorizationStatus (not EKAuthorizationStatus);
-        // every concrete enum value is acceptable here — we just want compile-time
-        // confirmation that the gate produces the new raw type. The value depends on
-        // the test machine's TCC state and may differ between dev runs.
         let _: RawAuthorizationStatus = gate.authorizationStatus()
     }
 
     func testCalendarEventStoreGateProducesRawStatus() {
-        // Sanity: at runtime, the gate's raw status is one of the documented cases.
-        // Catches drift if mapEventKitStatusToRaw is changed without updating the gate.
+        // At runtime, the gate's raw status is one of the documented cases.
         let store = EKEventStore()
         let gate = EventStoreGate(store: store)
         let raw = gate.authorizationStatus()

--- a/native/macos/mail/Package.swift
+++ b/native/macos/mail/Package.swift
@@ -2,10 +2,7 @@
 import PackageDescription
 
 // Embeds Resources/Info.plist into Mach-O `__TEXT,__info_plist` section so the
-// CLI binary carries `CFBundleIdentifier` (`pl.speedwave.desktop.mail`) and
-// `NSAppleEventsUsageDescription` directly — required by TCC for
-// AEDeterminePermissionToAutomateTarget when the binary calls into Apple Mail.
-// See calendar/Package.swift for the full rationale.
+// CLI binary carries `CFBundleIdentifier` and `NSAppleEventsUsageDescription`.
 let package = Package(
     name: "mail-cli",
     platforms: [.macOS(.v13)],

--- a/native/macos/mail/Sources/AppleMailClient.swift
+++ b/native/macos/mail/Sources/AppleMailClient.swift
@@ -38,9 +38,7 @@ enum AppleMailClient {
             mailboxClause = "inbox"
         }
 
-        // Iterate with counter to avoid out-of-range errors.
-        // Access each message individually — Apple Mail doesn't support
-        // bulk property fetch for dates.
+        // Access each message individually; Apple Mail has no bulk property fetch.
         let script = """
         tell application "Mail"
             set output to ""

--- a/native/macos/mail/Sources/MailCLI.swift
+++ b/native/macos/mail/Sources/MailCLI.swift
@@ -11,10 +11,7 @@ struct MailCLI {
         "check_permission, detect_clients, list_mailboxes, list_emails, get_email, search_emails, send_email, reply_to_email"
 
     static func main() {
-        // check_permission validates Apple Mail automation via the unified
-        // AppleEventsGate (Outlook availability is checked separately by
-        // resolveClient). `permissionCheckScript` accesses real data — "to name"
-        // does NOT trigger the macOS Automation prompt. See notes/NotesCLI.swift.
+        // check_permission validates Apple Mail automation via AppleEventsGate; Outlook is checked by resolveClient.
         runCLI(
             cliName: "mail-cli",
             commandList: commandList,
@@ -214,8 +211,6 @@ enum MailError: LocalizedError {
 
 // MARK: - Permission Helpers
 
-/// AppleScript command used by check_permission to verify Automation access.
-/// Must access actual data (not just app metadata like `name`) to trigger the
-/// macOS Automation permission prompt. `to name` does NOT require permission.
+/// AppleScript for check_permission; must access real data to trigger the macOS Automation prompt.
 // SYNC: permissionCheckScript rationale must match notes/Sources/NotesCLI.swift
 let permissionCheckScript = "tell application \"Mail\" to count of accounts"

--- a/native/macos/mail/Sources/OutlookClient.swift
+++ b/native/macos/mail/Sources/OutlookClient.swift
@@ -5,9 +5,8 @@ import SharedCLI
 enum OutlookClient {
     static let name = "Microsoft Outlook"
 
-    /// Whether the Outlook process is running. Throws `.automationPermission` /
-    /// `.timeout` so callers don't misattribute an Apple Events denial as
-    /// "Outlook not installed"; a genuine script failure maps to `false`.
+    /// Whether the Outlook process is running. Rethrows `.automationPermission`/`.timeout`;
+    /// a genuine script failure maps to `false`.
     static func isAvailable() throws -> Bool {
         let script = """
         tell application "System Events"
@@ -54,8 +53,7 @@ enum OutlookClient {
             folderClause = "inbox"
         }
 
-        // Iterate with counter to avoid "Invalid index" error (-1719)
-        // when requesting a range beyond the actual message count.
+        // Counter loop avoids "Invalid index" error (-1719) past message count.
         let script = """
         tell application "Microsoft Outlook"
             set output to ""

--- a/native/macos/mail/Tests/MailTests.swift
+++ b/native/macos/mail/Tests/MailTests.swift
@@ -13,10 +13,6 @@ final class MailTests: XCTestCase {
     // MARK: - detectClients structure + permission/absence distinction
 
     func testDetectClientsHasMailAndOutlookEntries() {
-        // detectClients catches a permission/timeout error from OutlookClient
-        // internally; on a CI host with no Outlook it reports available=false
-        // (or an `error` field if Automation is denied). Either way both
-        // entries are present and well-formed.
         let result = detectClients()
         let clients = result["clients"] as? [[String: Any]] ?? []
         XCTAssertEqual(clients.count, 2, "must list Apple Mail + Outlook")
@@ -25,8 +21,7 @@ final class MailTests: XCTestCase {
         let outlook = clients.last
         XCTAssertEqual(outlook?["name"] as? String, OutlookClient.name)
         XCTAssertNotNil(outlook?["available"], "Outlook entry must always carry an availability flag")
-        // When an `error` is present it must be a permission/timeout message, not
-        // a misattributed "not installed" — and `available` is false alongside it.
+        // An `error` must pair with available=false.
         if let err = outlook?["error"] as? String {
             XCTAssertEqual(outlook?["available"] as? Bool, false,
                            "an Outlook error must pair with available=false")
@@ -35,10 +30,6 @@ final class MailTests: XCTestCase {
     }
 
     func testOutlookAvailabilityRethrowsPermissionAndTimeoutErrors() {
-        // Contract documented by OutlookClient.isAvailable(): permission/timeout
-        // ScriptErrors must be distinguishable (rethrown), while a generic script
-        // failure maps to "not available" (false) — so a denial is never reported
-        // as "Outlook not installed".
         let permission = ScriptError.automationPermission("not allowed")
         let timeout = ScriptError.timeout(5, nil)
         let scriptFailed = ScriptError.scriptFailed("syntax error")
@@ -119,9 +110,7 @@ final class MailTests: XCTestCase {
     // MARK: - Permission Check Script
 
     func testPermissionCheckScriptAccessesData() {
-        // "to name" does NOT require Automation permission — it returns the app
-        // name without triggering a TCC prompt. The script must access actual
-        // data (e.g. accounts, mailboxes) to force macOS to check permission.
+        // "to name" does NOT require Automation permission.
         XCTAssertFalse(
             permissionCheckScript.hasSuffix("to name"),
             "permissionCheckScript must not use 'to name' — it does not require Automation permission"
@@ -133,8 +122,7 @@ final class MailTests: XCTestCase {
     }
 
     func testPermissionCheckScriptDeniedIncludesGuidance() {
-        // When permission is denied, the error message should guide the user
-        // to System Settings > Automation (not Calendars/Reminders).
+        // Denied error must guide to System Settings > Automation.
         let detail = "Mail access denied: some error\nGrant access in System Settings > Privacy & Security > Automation"
         XCTAssertTrue(detail.contains("Automation"))
     }
@@ -173,12 +161,6 @@ final class MailTests: XCTestCase {
     }
 
     // MARK: - AppleEventsGate end-to-end through performCheckPermission
-    //
-    // Each test injects a FakeMailGate (custom RawAuthorizationStatus) into
-    // performCheckPermission to exercise the full pipeline (status check →
-    // optional request → optional verifyDataAccess) without spawning osascript
-    // or hitting real TCC. This is the same pattern as SharedCLITests.MockGate
-    // but parameterised for Mail's entity (.mail) and bundle (com.apple.mail).
 
     final class FakeMailGate: PermissionGate {
         var initialStatus: RawAuthorizationStatus = .notDetermined
@@ -207,8 +189,7 @@ final class MailTests: XCTestCase {
     }
 
     func testCheckPermissionDeniedReturnsAppleEventsTccutil() {
-        // Initial status .denied → must include `tccutil reset AppleEvents pl.speedwave.desktop.mail`,
-        // NOT `tccutil reset Mail …` (Mail uses kTCCServiceAppleEvents).
+        // Mail uses kTCCServiceAppleEvents, so denied must reset AppleEvents, not Mail.
         let gate = FakeMailGate()
         gate.initialStatus = .denied
         let result = performCheckPermission(gate: gate, entity: .mail)
@@ -222,8 +203,7 @@ final class MailTests: XCTestCase {
     }
 
     func testCheckPermissionTargetNotRunningOnProcNotFound() {
-        // post-status must also be .targetNotRunning — orchestrator no longer
-        // short-circuits on initial .targetNotRunning (gate may auto-launch).
+        // post-status must also be .targetNotRunning (no short-circuit on initial).
         let gate = FakeMailGate()
         gate.initialStatus = .targetNotRunning(bundleId: "com.apple.mail")
         gate.postRequestStatus = .targetNotRunning(bundleId: "com.apple.mail")
@@ -238,8 +218,7 @@ final class MailTests: XCTestCase {
     }
 
     func testCheckPermissionSilentRejectWhenNotDeterminedTwice() {
-        // Initial .notDetermined → request fires but post-status remains .notDetermined →
-        // mapped to .silentReject (signing/entitlement/Info.plist issue).
+        // .notDetermined unchanged after request maps to .silentReject.
         let gate = FakeMailGate()
         gate.initialStatus = .notDetermined
         gate.postRequestStatus = .notDetermined
@@ -253,9 +232,7 @@ final class MailTests: XCTestCase {
     }
 
     func testCheckPermissionGrantedButDataAccessFails() {
-        // TCC reports .granted but the AppleScript probe fails → result downgrades to
-        // silentReject with the data-access error attached. This preserves the v1
-        // invariant that Mail/Notes permission checks accessed real data.
+        // .granted but data-access probe fails downgrades to silentReject.
         let gate = FakeMailGate()
         gate.initialStatus = .granted
         gate.dataAccessError = "AppleScript error: cannot read mailboxes"

--- a/native/macos/notes/Package.swift
+++ b/native/macos/notes/Package.swift
@@ -1,11 +1,8 @@
 // swift-tools-version: 5.9
 import PackageDescription
 
-// Embeds Resources/Info.plist into Mach-O `__TEXT,__info_plist` section so the
-// CLI binary carries `CFBundleIdentifier` (`pl.speedwave.desktop.notes`) and
-// `NSAppleEventsUsageDescription` directly — required by TCC for
-// AEDeterminePermissionToAutomateTarget when the binary calls into Notes.
-// See calendar/Package.swift for the full rationale.
+// Embeds Resources/Info.plist into the Mach-O `__TEXT,__info_plist` section
+// (CFBundleIdentifier + NSAppleEventsUsageDescription) — required by TCC.
 let package = Package(
     name: "notes-cli",
     platforms: [.macOS(.v13)],

--- a/native/macos/notes/Sources/NotesCLI.swift
+++ b/native/macos/notes/Sources/NotesCLI.swift
@@ -11,9 +11,7 @@ struct NotesCLI {
         "check_permission, list_folders, list_notes, get_note, search_notes, create_note, update_note, delete_note"
 
     static func main() {
-        // check_permission validates Notes automation via the unified
-        // AppleEventsGate. 30s data-access timeout matches the original probe
-        // budget (Notes can take longer than Mail to enumerate). See mail/MailCLI.swift.
+        // check_permission validates Notes automation via AppleEventsGate.
         runCLI(
             cliName: "notes-cli",
             commandList: commandList,

--- a/native/macos/notes/Tests/NotesTests.swift
+++ b/native/macos/notes/Tests/NotesTests.swift
@@ -129,9 +129,7 @@ final class NotesTests: XCTestCase {
     // MARK: - Permission Check Script
 
     func testPermissionCheckScriptAccessesData() {
-        // "to name" does NOT require Automation permission — it returns the app
-        // name without triggering a TCC prompt. The script must access actual
-        // data (e.g. notes, folders) to force macOS to check permission.
+        // script must access data to trigger TCC prompt, not 'to name'
         XCTAssertFalse(
             permissionCheckScript.hasSuffix("to name"),
             "permissionCheckScript must not use 'to name' — it does not require Automation permission"
@@ -143,8 +141,7 @@ final class NotesTests: XCTestCase {
     }
 
     func testPermissionCheckScriptDeniedIncludesGuidance() {
-        // When permission is denied, the error message should guide the user
-        // to System Settings > Automation (not Calendars/Reminders).
+        // denied error must point to System Settings > Automation
         let detail = "Notes access denied: some error\nGrant access in System Settings > Privacy & Security > Automation"
         XCTAssertTrue(detail.contains("Automation"))
     }
@@ -248,11 +245,6 @@ final class NotesTests: XCTestCase {
     }
 
     // MARK: - AppleEventsGate end-to-end through performCheckPermission
-    //
-    // Mirrors MailTests AppleEventsGate suite — same pattern, with .notes entity
-    // and com.apple.Notes target bundle. Verifies that the notes-cli check_permission
-    // path produces status-aware output identical to mail-cli, which is the
-    // unification goal of this change.
 
     final class FakeNotesGate: PermissionGate {
         var initialStatus: RawAuthorizationStatus = .notDetermined
@@ -293,8 +285,7 @@ final class NotesTests: XCTestCase {
     }
 
     func testCheckPermissionTargetNotRunningOnProcNotFound() {
-        // post-status must also be .targetNotRunning — orchestrator no longer
-        // short-circuits on initial .targetNotRunning (gate may auto-launch).
+        // post-status must remain .targetNotRunning — gate may auto-launch
         let gate = FakeNotesGate()
         gate.initialStatus = .targetNotRunning(bundleId: "com.apple.Notes")
         gate.postRequestStatus = .targetNotRunning(bundleId: "com.apple.Notes")

--- a/native/macos/reminders/Package.swift
+++ b/native/macos/reminders/Package.swift
@@ -1,11 +1,9 @@
 // swift-tools-version: 5.9
 import PackageDescription
 
-// Embeds Resources/Info.plist into Mach-O `__TEXT,__info_plist` section so the
-// CLI binary carries `CFBundleIdentifier` (`pl.speedwave.desktop.reminders`) and
-// `NSRemindersFullAccessUsageDescription` directly — required by TCC for
-// EventKit's `requestFullAccessToReminders` on macOS 14+. See calendar/Package.swift
-// for the full rationale (parent .app's Info.plist is not inherited across spawn).
+// Embeds Resources/Info.plist into the Mach-O `__TEXT,__info_plist` section so the
+// CLI binary carries `CFBundleIdentifier` + `NSRemindersFullAccessUsageDescription`
+// (required by TCC for EventKit on macOS 14+).
 let package = Package(
     name: "reminders-cli",
     platforms: [.macOS(.v13)],

--- a/native/macos/reminders/Sources/RemindersCLI.swift
+++ b/native/macos/reminders/Sources/RemindersCLI.swift
@@ -27,8 +27,7 @@ struct RemindersCLI {
         "check_permission, list_lists, list_reminders, get_reminder, create_reminder, complete_reminder"
 
     static func main() {
-        // Shared store: the access guard requests permission, then the command
-        // handlers operate on the same store. check_permission uses its own gate.
+        // Shared store; check_permission uses its own gate.
         let store = EKEventStore()
         runCLI(
             cliName: "reminders-cli",
@@ -58,7 +57,6 @@ struct RemindersCLI {
 
 /// Requests Reminders access from EventKit. Uses the macOS 14+ full-access API
 /// when available, falling back to the legacy requestAccess(to:) API.
-/// The optional timeout (default: unbounded) is a safety net for check_permission.
 func requestReminderAccess(store: EKEventStore, timeout: TimeInterval? = nil) -> (granted: Bool, error: Error?) {
     let semaphore = DispatchSemaphore(value: 0)
     var accessGranted = false

--- a/native/macos/shared/Sources/SharedCLI/AppleEventsGate.swift
+++ b/native/macos/shared/Sources/SharedCLI/AppleEventsGate.swift
@@ -3,10 +3,8 @@ import CoreServices
 import Foundation
 
 /// Permission gate for AppleEvents-based integrations (Mail, Notes).
-/// Two-stage authorization (NSWorkspace pid → `typeKernelProcessID` AEAddressDesc)
-/// avoids the `procNotFound (-600)` bundle-id bug; optional AppleScript probe
-/// preserves the v1 real-data-access invariant. Rationale + OSStatus mapping:
-/// see docs/adr/ADR-070-appleevents-kernel-process-id-gate.md.
+/// Two-stage authorization (NSWorkspace pid → `typeKernelProcessID` AEAddressDesc).
+/// See docs/adr/ADR-070-appleevents-kernel-process-id-gate.md.
 public struct AppleEventsGate: PermissionGate {
     public let targetBundleId: String
     public let dataAccessScript: String?
@@ -14,9 +12,8 @@ public struct AppleEventsGate: PermissionGate {
     let pidResolver: PidResolver
     let appLauncher: AppLauncher
 
-    /// Public init. CLI callers pass `appLauncher: NeverLaunchAppLauncher()` to
-    /// disable auto-launch in passive (validate-startup) flows; the default
-    /// `NSWorkspaceAppLauncher` enables auto-launch for active toggle clicks.
+    /// Pass `NeverLaunchAppLauncher()` to disable auto-launch in passive flows;
+    /// the default `NSWorkspaceAppLauncher` auto-launches on toggle clicks.
     public init(
         targetBundleId: String,
         dataAccessScript: String? = nil,
@@ -36,9 +33,7 @@ public struct AppleEventsGate: PermissionGate {
     }
 
     public func requestAccess(completion: @escaping (Bool, Error?) -> Void) {
-        // Re-call AE with askUserIfNeeded=true to actually trigger the TCC consent dialog.
-        // performCheckPermission will then re-query with askUserIfNeeded=false to read
-        // the post-prompt status.
+        // askUserIfNeeded=true triggers the TCC consent dialog.
         DispatchQueue.global().async {
             let status = self.determineStatus(askUserIfNeeded: true)
             completion(status == .granted, nil)
@@ -75,8 +70,7 @@ public struct AppleEventsGate: PermissionGate {
         }
         logTrace("AEDETERMINE host-pid target=\(targetBundleId) pid=\(pid)")
 
-        // Stage 2: AEAddressDesc with typeKernelProcessID (4-byte pid_t),
-        // bypassing LaunchServices bundle-id resolution.
+        // Stage 2: AEAddressDesc with typeKernelProcessID (4-byte pid_t).
         var pidValue: pid_t = pid
         var target = AEAddressDesc()
         let createStatus: OSStatus = withUnsafePointer(to: &pidValue) { ptr in
@@ -130,9 +124,7 @@ public struct AppleEventsGate: PermissionGate {
 // MARK: - PID resolver (LaunchServices abstraction)
 
 /// Resolves a bundle identifier to the running process's PID, or `nil` when
-/// the target app is not currently running. Abstracted as a protocol so tests
-/// can inject deterministic fakes without spawning real macOS apps. Production
-/// uses `NSWorkspacePidResolver`.
+/// the target app is not currently running.
 public protocol PidResolver {
     func pid(for bundleId: String) -> pid_t?
 }
@@ -192,10 +184,8 @@ public struct NSWorkspaceAppLauncher: AppLauncher {
     }
 }
 
-/// Passive-mode launcher: declines launch by design (used in CLI's
-/// `check_permission` without `--launch`, and in tests). Returns
-/// `.notSupported` so logs read "AELAUNCH not supported" — clearer than
-/// `.failed` which would suggest an attempted launch went wrong.
+/// Passive-mode launcher: declines launch by design, returning `.notSupported`
+/// (used in CLI's `check_permission` without `--launch`, and in tests).
 public struct NeverLaunchAppLauncher: AppLauncher {
     public init() {}
     public func launch(bundleId _: String) -> AppLaunchOutcome {
@@ -205,10 +195,8 @@ public struct NeverLaunchAppLauncher: AppLauncher {
 
 // MARK: - stderr trace + RawAuthorizationStatus debug helpers
 
-/// Writes a structured trace line to stderr. Picked up by the Rust parent's
-/// `check_os_permission` stderr collector and forwarded to the unified log
-/// (tauri-plugin-log → file + webview + stdout) under the `info` level.
-/// Prefix `[SHARED]` makes the lines easy to grep in a user-supplied ZIP.
+/// Writes a `[SHARED]`-prefixed trace line to stderr, collected by the Rust
+/// parent's `check_os_permission` and forwarded to the unified log.
 public func logTrace(_ message: String) {
     let line = "[SHARED] \(message)\n"
     FileHandle.standardError.write(Data(line.utf8))
@@ -229,17 +217,10 @@ private func describeRaw(_ raw: RawAuthorizationStatus) -> String {
 // MARK: - OSStatus mapping
 
 /// SSOT mapping for AEDeterminePermissionToAutomateTarget OSStatus → RawAuthorizationStatus.
-/// Pulled out as a free function so tests can verify the mapping without instantiating
-/// a real AEAddressDesc against a live target.
-///
-/// OSStatus values per Apple's CoreServices headers (verified against developer docs):
 /// - `noErr (0)`: granted
-/// - `errAEEventNotPermitted (-1743)`: denied (also returned for "previously denied" — same value)
-/// - `errAEEventWouldRequireUserConsent (-1744)`: not yet prompted (only with askUserIfNeeded=false)
-/// - `procNotFound (-600)`: target app not running. With the `typeKernelProcessID`
-///    addressing scheme this should not occur in practice (we already verified
-///    the PID via NSWorkspace), but the case is preserved as a safety net for
-///    a process that exits between the NSWorkspace lookup and the AE call.
+/// - `errAEEventNotPermitted (-1743)`: denied
+/// - `errAEEventWouldRequireUserConsent (-1744)`: not yet prompted (askUserIfNeeded=false)
+/// - `procNotFound (-600)`: target app not running
 public func mapAEStatusToRaw(_ status: OSStatus, targetBundleId: String) -> RawAuthorizationStatus {
     switch Int(status) {
     case 0:                                       // noErr

--- a/native/macos/shared/Sources/SharedCLI/CalendarResolution.swift
+++ b/native/macos/shared/Sources/SharedCLI/CalendarResolution.swift
@@ -1,9 +1,7 @@
 import EventKit
 
 /// Resolves calendars by ID first, falling back to name match.
-/// Returns all matches — caller decides usage (filter predicate vs single pick).
-/// If multiple calendars share the same name, all are returned; create operations use [0].
-/// Throws CLIError.notFound if filter matches nothing.
+/// Returns all matches; throws CLIError.notFound if filter matches nothing.
 public func resolveCalendars(
     for entityType: EKEntityType,
     filter: String,

--- a/native/macos/shared/Sources/SharedCLI/RunCLI.swift
+++ b/native/macos/shared/Sources/SharedCLI/RunCLI.swift
@@ -1,18 +1,7 @@
 import Foundation
 
-/// Shared `main()` scaffold for the native macOS CLIs (calendar/reminders/mail/notes).
-///
-/// Handles the identical skeleton: arg-count check, `check_permission`
-/// short-circuit, JSON-args decode, optional access-gate guard, command
-/// dispatch, and pretty-printed JSON output. Each CLI supplies only its name,
-/// command list, permission gate, optional access guard, and command table.
-///
-/// - `checkPermissionGate`: receives the full argv (so AppleEvents CLIs can read
-///   the `--launch` flag) and returns the gate used for `check_permission`.
-/// - `accessGuard`: runs once before dispatch for non-`check_permission`
-///   commands; returns `nil` on success or an error message to exit with.
-///   Defaults to a no-op (mail/notes have no EventKit access gate).
-/// - `commands`: maps command name to a handler producing a JSON-serializable value.
+/// Shared `main()` scaffold for the native macOS CLIs: arg parsing, permission
+/// check, optional access guard, command dispatch, and JSON output.
 public func runCLI(
     arguments: [String] = CommandLine.arguments,
     cliName: String,

--- a/native/macos/shared/Sources/SharedCLI/ScriptRunner.swift
+++ b/native/macos/shared/Sources/SharedCLI/ScriptRunner.swift
@@ -64,10 +64,7 @@ public enum ScriptError: LocalizedError {
     }
 }
 
-/// Escape special characters for AppleScript string literals.
-/// Strips C0 control characters (U+0000–U+001F), DEL (U+007F), and Unicode
-/// line separators (U+0085 NEL, U+2028, U+2029) before escaping.
-/// Prevents injection via newline/CR-based script breakout.
+/// Escape AppleScript string literals; strips C0/DEL/line-separator scalars first.
 public func escapeAppleScript(_ s: String) -> String {
     let safe = String(s.unicodeScalars.filter { scalar in
         let v = scalar.value
@@ -78,10 +75,7 @@ public func escapeAppleScript(_ s: String) -> String {
         .replacingOccurrences(of: "\"", with: "\\\"")
 }
 
-/// Parse a single `||`-delimited email detail row into a dictionary.
-/// Layout: `subject || sender || date || read || to-list(,-joined) || body`.
-/// Body may itself contain `||`, so fields 6+ are re-joined. Throws when fewer
-/// than 6 fields are present. Shared by AppleMailClient/OutlookClient getEmail.
+/// Parse `||`-delimited email row (subject||sender||date||read||to-list||body); throws if <6 fields.
 public func parseEmailDetail(_ output: String, id: String) throws -> [String: Any] {
     let parts = output.components(separatedBy: "||")
     guard parts.count >= 6 else {

--- a/native/macos/shared/Sources/SharedCLI/Utilities.swift
+++ b/native/macos/shared/Sources/SharedCLI/Utilities.swift
@@ -42,17 +42,13 @@ public enum PermissionEntity: String {
 public let speedwaveBundleIdentifier: String = "pl.speedwave.desktop"
 
 /// Per-entity sub-identifier used as `CFBundleIdentifier` of each CLI binary's embedded
-/// Info.plist. TCC binds to this identifier (not `<svc>-cli` adhoc identifier from codesign),
-/// so the recovery `tccutil reset <Service> <subId>` command in `composeErrorMessage` actually
-/// targets the correct TCC.db row.
+/// Info.plist. TCC binds to this identifier, so `tccutil reset` targets the correct row.
 public func subBundleIdentifier(for entity: PermissionEntity) -> String {
     "\(speedwaveBundleIdentifier).\(entity.rawValue)"
 }
 
 /// kTCCService name used by the `tccutil reset <service> <bundleId>` command.
-/// Calendar/Reminders have dedicated TCC services; Mail and Notes both use AppleEvents
-/// (the TCC service kTCCServiceAppleEvents — automation permissions are scoped per
-/// (sender, target) pair under that single service name).
+/// Calendar/Reminders have dedicated TCC services; Mail and Notes both use AppleEvents.
 public func tccServiceName(for entity: PermissionEntity) -> String {
     switch entity {
     case .calendar: return "Calendar"
@@ -62,9 +58,7 @@ public func tccServiceName(for entity: PermissionEntity) -> String {
 }
 
 /// Returns `Bundle.main.bundleIdentifier` when launched from the parent .app,
-/// otherwise falls back to `speedwaveBundleIdentifier`. The internal variant
-/// accepts an explicit input for testability — production calls use the no-arg
-/// overload, which always reads from `Bundle.main`.
+/// otherwise falls back to `speedwaveBundleIdentifier`.
 public func resolvedBundleIdentifier() -> String {
     resolvedBundleIdentifier(from: Bundle.main.bundleIdentifier)
 }
@@ -144,24 +138,19 @@ public func composeErrorMessage(
     case .granted:
         return ""
     case .denied:
-        // Apple removed the + button on macOS 14+, so users cannot re-add Speedwave
-        // from Settings UI; tccutil reset is the only recovery path.
+        // macOS 14+ has no + button to re-add Speedwave; tccutil reset is the only recovery path.
         return "\(entityName) access was previously denied. Open Terminal and run:\n\(resetCmd)\nThen click the toggle again."
     case .restricted:
         return "\(entityName) access restricted by your administrator or parental controls."
     case .notDetermined:
-        // Unreachable from performCheckPermission (status-before-request gate plus post-request
-        // remap of .notDetermined to .silentReject), but kept for exhaustive switch coverage
-        // and future direct callers; the testGrantedFalseAlwaysCarriesNonEmptyError parametric
-        // invariant requires this case to return a non-empty string.
+        // Unreachable from performCheckPermission; kept for exhaustive switch coverage.
         return "\(entityName) permission was not requested. Quit Speedwave and reopen, then click the toggle again."
     case .writeOnly:
         return "Speedwave has write-only \(entityName) access. Open \(settingsPath) and grant Full Access for read support."
     case .silentReject:
         return "\(entityName) permission was silently rejected by macOS. This usually means a signing or entitlement problem — please reinstall Speedwave from a fresh download."
     case .targetNotRunning:
-        // AE-only path (mail/notes). Not a TCC issue — do NOT mention tccutil here:
-        // resetting permission would not help and would just confuse the user.
+        // AE-only path (mail/notes). Not a TCC issue — do NOT mention tccutil here.
         return "\(entityName).app is not running. Open \(entityName).app and try again — this is not a permission problem."
     }
 }
@@ -169,11 +158,8 @@ public func composeErrorMessage(
 public protocol PermissionGate {
     func authorizationStatus() -> RawAuthorizationStatus
     func requestAccess(completion: @escaping (Bool, Error?) -> Void)
-    /// Optional second-phase verification run after TCC reports `.granted`.
-    /// Returns nil on success, or an error string describing why the gate has TCC
-    /// permission but cannot actually access data. Default is no-op (nil).
-    /// Used by AppleEventsGate to run the AppleScript probe against Mail/Notes data —
-    /// preserves the v1 invariant that Mail/Notes permission checks accessed real data.
+    /// Second-phase verification after TCC reports `.granted`.
+    /// Returns nil on success, or an error string when TCC-granted but data is inaccessible.
     func verifyDataAccess() -> String?
 }
 
@@ -181,26 +167,21 @@ public extension PermissionGate {
     func verifyDataAccess() -> String? { nil }
 }
 
-/// Inner timeout (default 55s) is intentionally shorter than the outer Rust
-/// `check_os_permission_with_timeout` (60s in `desktop/src-tauri/src/integrations_cmd.rs`)
-/// so the Swift process gets to emit a structured timeout message before the
-/// parent kills it; otherwise the user only ever sees the generic Rust kill message.
+/// Inner timeout (default 55s) is shorter than the outer Rust 60s timeout
+/// so Swift emits a structured timeout message before the parent kills it.
 public func performCheckPermission(gate: PermissionGate, entity: PermissionEntity, timeout: TimeInterval = 55) -> String {
     logTrace("performCheckPermission start entity=\(entity.rawValue) timeout=\(Int(timeout))s")
     let initialRaw = gate.authorizationStatus()
     let initial = mapRawToPermissionStatus(initialRaw)
     logTrace("performCheckPermission initial entity=\(entity.rawValue) status=\(initial.rawValue)")
 
-    // Short-circuit terminal states. `.targetNotRunning` is NOT terminal here —
-    // we let it fall through so `requestAccess` can auto-launch the target
-    // (AppleEventsGate launches Mail/Notes only on the active path).
+    // Short-circuit terminal states; `.targetNotRunning` falls through so requestAccess can auto-launch the target.
     if initial != .notDetermined && initial != .targetNotRunning {
         logTrace("performCheckPermission terminal-state short-circuit entity=\(entity.rawValue) final=\(initial.rawValue)")
         return finalizeResult(status: initial, entity: entity, gate: gate)
     }
 
     // Status is .notDetermined or .targetNotRunning — fire the request and wait.
-    // (.targetNotRunning lets AppleEventsGate auto-launch Mail/Notes before probing.)
     logTrace("performCheckPermission firing requestAccess entity=\(entity.rawValue)")
     let semaphore = DispatchSemaphore(value: 0)
     var requestGranted = false
@@ -221,9 +202,7 @@ public func performCheckPermission(gate: PermissionGate, entity: PermissionEntit
     }
     logTrace("performCheckPermission requestAccess returned entity=\(entity.rawValue) granted=\(requestGranted) error=\(requestError?.localizedDescription ?? "nil")")
 
-    // Re-query status to disambiguate "user clicked Don't Allow" from "TCC silently rejected"
-    // and to enforce the invariant that the post-status is the source of truth (a request
-    // can return granted=true while a stale TCC entry remains denied; we trust post-status).
+    // Re-query status to disambiguate user-denied from silent-reject; post-status is source of truth.
     let postStatus = mapRawToPermissionStatus(gate.authorizationStatus())
     logTrace("performCheckPermission post-status entity=\(entity.rawValue) status=\(postStatus.rawValue)")
     let final: PermissionStatus
@@ -234,8 +213,7 @@ public func performCheckPermission(gate: PermissionGate, entity: PermissionEntit
         final = .silentReject
         logTrace("performCheckPermission SILENT REJECT entity=\(entity.rawValue) — post-status remained notDetermined; check Info.plist usage description and code signature")
     } else {
-        // Post-status trumps requestGranted — covers the (rare) case where the request
-        // returned granted=true but TCC.db settled to a different state.
+        // Post-status trumps requestGranted (request can return granted=true while TCC.db settled to a different state).
         final = postStatus
     }
     logTrace("performCheckPermission done entity=\(entity.rawValue) final=\(final.rawValue)")
@@ -254,8 +232,7 @@ private func finalizeResult(
     if status == .granted {
         logTrace("finalizeResult entity=\(entity.rawValue) status=granted — running verifyDataAccess()")
         if let dataAccessError = gate.verifyDataAccess() {
-            // Granted by TCC but data access fails — surface as silentReject with the
-            // gate-specific error so users see why it's broken (e.g. AppleScript probe failure).
+            // Granted by TCC but data access fails — surface as silentReject with gate-specific error.
             logTrace("finalizeResult entity=\(entity.rawValue) verifyDataAccess FAILED — downgrading granted→silentReject error=\(dataAccessError)")
             return formatPermissionResult(
                 granted: false,

--- a/native/macos/shared/Tests/SharedCLITests/AppleEventsGateTests.swift
+++ b/native/macos/shared/Tests/SharedCLITests/AppleEventsGateTests.swift
@@ -2,29 +2,9 @@ import XCTest
 @testable import SharedCLI
 
 /// Tests for `AppleEventsGate`'s two-stage authorization flow.
-///
-/// Real `NSWorkspacePidResolver` is not exercised here because it depends on
-/// the host's running-application list (non-deterministic in unit tests).
-/// Instead a `FakePidResolver` injects scripted PID values, which lets us
-/// verify that:
-///   - When the resolver returns `nil`, the gate short-circuits with
-///     `.targetNotRunning(bundleId:)` *without* invoking the real AE call.
-///     This is the new behaviour that the procNotFound bug-fix relies on.
-///   - When the resolver returns a PID, the gate proceeds to `AECreateDesc` +
-///     `AEDeterminePermissionToAutomateTarget`. The OSStatus that comes back
-///     is platform-dependent (depends on whether the calling test process is
-///     authorized to send events to the target), so we assert on the
-///     *category* of result (one of the documented `RawAuthorizationStatus`
-///     cases) rather than on a specific value.
-///
-/// The OSStatus → RawAuthorizationStatus mapping itself is tested separately
-/// in `UtilitiesTests.swift::testMapAEStatus*`.
 final class AppleEventsGateTests: XCTestCase {
 
-    /// Records how many times `pid(for:)` was called and with which bundle ids,
-    /// returning a scripted result. Used to assert that the gate consults the
-    /// resolver before the AE call, and that the gate caches/reuses the value
-    /// correctly across `authorizationStatus()` and `requestAccess`.
+    /// Records each `pid(for:)` call and returns a scripted PID.
     final class FakePidResolver: PidResolver {
         var pidByBundleId: [String: pid_t]
         private(set) var calls: [String] = []
@@ -42,10 +22,7 @@ final class AppleEventsGateTests: XCTestCase {
     // MARK: - Stage 1: NSWorkspace short-circuit
 
     func testTargetNotRunningWhenResolverReturnsNil() {
-        // The resolver maps no bundle ids → first stage returns nil → the gate
-        // must short-circuit *without* calling AE. This is what gives users the
-        // correct "open the app" hint instead of a misleading TCC reset
-        // suggestion when the target really isn't running.
+        // Nil resolver → gate short-circuits without calling AE.
         let resolver = FakePidResolver(pidByBundleId: [:])
         let gate = AppleEventsGate(
             targetBundleId: "com.apple.mail",
@@ -67,10 +44,7 @@ final class AppleEventsGateTests: XCTestCase {
     }
 
     func testResolverIsConsultedBeforeAECall() {
-        // Even when the resolver does have an entry, the gate must consult it
-        // first so that we never make an AE call against a stale ASN. We
-        // assert the resolver was invoked; the AE call's outcome is platform-
-        // dependent and not asserted on (covered by mapAEStatusToRaw tests).
+        // Gate must consult the resolver before the AE call.
         let resolver = FakePidResolver(pidByBundleId: ["com.apple.mail": 12345])
         let gate = AppleEventsGate(
             targetBundleId: "com.apple.mail",
@@ -87,9 +61,7 @@ final class AppleEventsGateTests: XCTestCase {
     }
 
     func testTargetNotRunningCarriesQueriedBundleId() {
-        // The .targetNotRunning case must propagate the *queried* bundle id
-        // (not, say, a hard-coded com.apple.mail). Composer messages and the
-        // unified logs ZIP rely on this for accurate user-facing copy.
+        // .targetNotRunning must propagate the queried bundle id.
         let resolver = FakePidResolver(pidByBundleId: [:])
         let gate = AppleEventsGate(
             targetBundleId: "com.apple.Notes",
@@ -111,12 +83,7 @@ final class AppleEventsGateTests: XCTestCase {
     // MARK: - Stage 2: PID-based AEAddressDesc
 
     func testProducesValidStatusWhenResolverReturnsPidForCallingProcess() throws {
-        // Use the test process's own PID — guaranteed to be running, so
-        // AECreateDesc + AEDeterminePermissionToAutomateTarget will see a live
-        // ASN. We can't predict whether xctest is authorized to send events
-        // to itself (depends on TCC.db state of the test runner), so we
-        // assert only that the result is one of the documented enum cases —
-        // never `.targetNotRunning` (which is the bug we're guarding against).
+        // Own PID is guaranteed running; result must never be .targetNotRunning.
         let ownPid: pid_t = ProcessInfo.processInfo.processIdentifier
         let ownBundle = Bundle.main.bundleIdentifier ?? "test.process"
         let resolver = FakePidResolver(pidByBundleId: [ownBundle: ownPid])
@@ -130,9 +97,7 @@ final class AppleEventsGateTests: XCTestCase {
 
         let raw = gate.authorizationStatus()
 
-        // The exact value is non-deterministic across CI environments, but it
-        // must NOT be .targetNotRunning — the resolver returned a live PID, so
-        // the gate must have proceeded to AE and got *some* outcome.
+        // Value is non-deterministic but must not be .targetNotRunning.
         if case .targetNotRunning = raw {
             XCTFail(
                 "Gate must NOT return .targetNotRunning when resolver gave a PID — that would indicate the bug is back. Got \(raw)"
@@ -143,9 +108,7 @@ final class AppleEventsGateTests: XCTestCase {
     // MARK: - requestAccess delegates to determineStatus(askUserIfNeeded: true)
 
     func testRequestAccessShortCircuitsWhenResolverReturnsNil() {
-        // requestAccess shares the determineStatus pipeline. With a nil
-        // resolver, the request completion fires with granted=false (because
-        // .targetNotRunning is not granted) but no AE call happens.
+        // Nil resolver → completion fires granted=false with no AE call.
         let resolver = FakePidResolver(pidByBundleId: [:])
         let gate = AppleEventsGate(
             targetBundleId: "com.apple.mail",
@@ -170,10 +133,7 @@ final class AppleEventsGateTests: XCTestCase {
     // MARK: - NSWorkspacePidResolver real-impl smoke
 
     func testNSWorkspacePidResolverReturnsNilForUnknownBundleId() {
-        // The production resolver returns nil for a bundle id that LaunchServices
-        // does not know about. Use a synthetic value that cannot collide with any
-        // running app. This validates the resolver's nil path against the real
-        // NSWorkspace API without depending on what's installed on CI.
+        // Production resolver returns nil for an unknown (synthetic) bundle id.
         let resolver = NSWorkspacePidResolver()
 
         let pid = resolver.pid(for: "pl.speedwave.testing.does-not-exist-\(UUID().uuidString)")
@@ -182,10 +142,7 @@ final class AppleEventsGateTests: XCTestCase {
     }
 
     func testNSWorkspacePidResolverReturnsPositivePidForRunningApp() throws {
-        // The production resolver should match at least one running app — the
-        // test runner itself. We use Bundle.main as a stable, always-running
-        // reference. Skip if Bundle.main lacks a bundle id (Linux CI guard,
-        // even though this whole test target is macOS-only).
+        // Production resolver should match the test runner via Bundle.main.
         guard let ownBundle = Bundle.main.bundleIdentifier else {
             throw XCTSkip("Bundle.main has no identifier in this test runner")
         }
@@ -193,10 +150,7 @@ final class AppleEventsGateTests: XCTestCase {
 
         let pid = resolver.pid(for: ownBundle)
 
-        // pid may be nil if the test runner happens to run as a non-NSApplication
-        // process (e.g. swift test from the CLI). In that case we cannot validate
-        // a positive match without spawning a helper app — accept skip rather
-        // than a flaky failure.
+        // pid may be nil for a non-NSApplication test runner; skip rather than fail.
         if pid == nil {
             throw XCTSkip(
                 "Test runner has no NSRunningApplication entry for \(ownBundle); positive resolver path is covered by manual smoke"

--- a/native/macos/shared/Tests/SharedCLITests/ScriptRunnerTests.swift
+++ b/native/macos/shared/Tests/SharedCLITests/ScriptRunnerTests.swift
@@ -55,9 +55,7 @@ final class ScriptRunnerTests: XCTestCase {
     func testEscapeAppleScriptNeutralizesDoShellScript() {
         let payload = "harmless\"\ndo shell script \"rm -rf /\"\n\""
         let result = escapeAppleScript(payload)
-        // Newlines are stripped, quotes are escaped — no breakout possible.
-        // The text "do shell script" remains in the output but is harmless:
-        // escaped quotes prevent AppleScript from interpreting it as a command.
+        // Newlines stripped, quotes escaped — no breakout possible.
         XCTAssertFalse(result.contains("\n"))
         XCTAssertTrue(result.contains("\\\""))
     }
@@ -166,8 +164,7 @@ final class ScriptRunnerTests: XCTestCase {
     }
 
     func testParseDelimitedDropsRowsWithLiteralDelimiterInValue() {
-        // A row whose field count after splitting on "||" doesn't match fields is silently dropped.
-        // "foo||bar||baz" splits into 3 parts but only 2 fields → dropped.
+        // Rows whose field count after splitting on "||" mismatches fields are dropped.
         let result = parseDelimited("foo||bar||baz", fields: ["x", "y"])
         XCTAssertEqual(result.count, 0)
     }
@@ -282,11 +279,7 @@ final class ScriptRunnerTests: XCTestCase {
 
     // MARK: - Classifier Tests
 
-    // These fixtures verify the classifier's substring-match invariant, not production TCC stderr strings.
-    // Actual macOS stderr for TCC denials (e.g. "execution error: Not authorized to send Apple events to Mail. (-1743)")
-    // is NOT matched by the current "not allowed" / "not permitted" / "assistive access" substrings —
-    // a pre-existing gap in macOS TCC stderr coverage that predates and is independent of this refactor.
-    // Tracking and closing that gap is out of scope here.
+    // These fixtures verify the classifier's substring-match invariant, not production TCC stderr.
 
     func testClassifyFailureNotAllowed() {
         let err = ScriptRunner.classifyFailure(stderr: "osascript: not allowed to send Apple events")

--- a/native/macos/shared/Tests/SharedCLITests/UtilitiesTests.swift
+++ b/native/macos/shared/Tests/SharedCLITests/UtilitiesTests.swift
@@ -221,17 +221,12 @@ final class SharedCLITests: XCTestCase {
     }
 
     func testResolvedBundleIdentifierUsesProvidedValueWhenPresent() {
-        // When a bundle identifier is present (production: Bundle.main has the parent .app's ID),
-        // the function must pass it through verbatim.
+        // When a bundle identifier is present, pass it through verbatim.
         XCTAssertEqual(resolvedBundleIdentifier(from: "pl.speedwave.desktop"), "pl.speedwave.desktop")
         XCTAssertEqual(resolvedBundleIdentifier(from: "com.example.other"), "com.example.other")
     }
 
     func testSpeedwaveBundleIdentifierMatchesTauriConf() throws {
-        // Belt-and-braces: read tauri.conf.json from disk and assert literal SSOT matches.
-        // The authoritative drift guard is the bats test in release-workflow-signing.bats;
-        // this test is a developer-experience belt-and-braces when running `swift test`
-        // from the package directory.
         let candidates = [
             "../../../desktop/src-tauri/tauri.conf.json",
             "../../../../desktop/src-tauri/tauri.conf.json",
@@ -341,9 +336,7 @@ final class SharedCLITests: XCTestCase {
     func testEntityNameUsesCapitalizedRawValue() {
         let calMsg = composeErrorMessage(status: .denied, entity: .calendar)
         XCTAssertTrue(calMsg.contains("Calendar"), "Calendar denied must contain 'Calendar'")
-        // Note: bundleId contains 'pl.speedwave.desktop.calendar' (lowercase by design),
-        // so we cannot assert that 'calendar' is fully absent from the message. We only
-        // check that the user-visible entity name is capitalised.
+        // bundleId contains lowercase by design; test only checks the capitalised entity name.
         let remMsg = composeErrorMessage(status: .denied, entity: .reminders)
         XCTAssertTrue(remMsg.contains("Reminders"), "Reminders denied must contain 'Reminders'")
     }
@@ -551,8 +544,7 @@ final class SharedCLITests: XCTestCase {
     }
 
     func testPerformTimeout() {
-        // 0.1s is large enough to avoid scheduler flake yet keeps the test fast.
-        // MockGate.requestAccess deliberately never invokes completion when deferRequest=true.
+        // 0.1s timeout; MockGate.requestAccess defers completion to exercise the timeout path.
         let gate = MockGate()
         gate.initialStatus = .notDetermined
         gate.deferRequest = true
@@ -564,10 +556,8 @@ final class SharedCLITests: XCTestCase {
     }
 
     func testPerformTargetNotRunningInvokesRequestForAutoLaunch() {
-        // .targetNotRunning is NOT terminal — orchestrator passes through to
-        // requestAccess so AppleEventsGate can attempt auto-launch. If the
-        // launch attempt also fails (mock keeps post-status = .targetNotRunning),
-        // the result remains targetNotRunning with no tccutil recovery hint.
+        // .targetNotRunning is NOT terminal; orchestrator passes through to requestAccess
+        // for an auto-launch attempt. Launch failure keeps the result targetNotRunning.
         let gate = MockGate()
         gate.initialStatus = .targetNotRunning(bundleId: "com.apple.mail")
         gate.postRequestStatus = .targetNotRunning(bundleId: "com.apple.mail")
@@ -584,8 +574,7 @@ final class SharedCLITests: XCTestCase {
     }
 
     func testPerformTargetNotRunningRecoversWhenAutoLaunchSucceeds() {
-        // Simulates the success path: gate's request returns granted=true and
-        // post-status is .granted (the auto-launch worked, AE got permission).
+        // Success path: auto-launch succeeds and the gate gets permission.
         let gate = MockGate()
         gate.initialStatus = .targetNotRunning(bundleId: "com.apple.mail")
         gate.requestGranted = true
@@ -597,8 +586,7 @@ final class SharedCLITests: XCTestCase {
     }
 
     func testPerformDataAccessFailureOverridesGranted() {
-        // TCC reports granted but verifyDataAccess returns an error string —
-        // result must be silentReject with the data-access error included.
+        // TCC granted + verifyDataAccess error = silentReject with the data-access error in the message.
         let gate = MockGate()
         gate.initialStatus = .granted
         gate.dataAccessError = "AppleScript error: probe failed"
@@ -626,7 +614,6 @@ final class SharedCLITests: XCTestCase {
     }
 
     // exitWithError calls exit(1) and cannot be unit-tested without process spawning.
-    // Covered by integration: all 4 CLIs use it and would crash on incorrect behavior.
 
     // MARK: - resolveCalendars (Reminders)
 

--- a/scripts/build-native-macos.sh
+++ b/scripts/build-native-macos.sh
@@ -18,19 +18,13 @@ for arch in "${ARCH_LIST[@]}"; do
   BUILD_ARGS+=(--arch "$arch")
 done
 
-# Read app version from tauri.conf.json (SSOT) and stamp it into each CLI's
-# embedded Info.plist before `swift build` so the Mach-O `__TEXT,__info_plist`
-# section carries the same version users see in the .app bundle. Falls back to
-# 0.0.0 if the file or key is missing — the build still succeeds, but a bats test
-# (`embedded CFBundleShortVersionString matches tauri.conf.json version`) would
-# catch the drift in CI.
+# Read app version from tauri.conf.json (SSOT), stamp into each CLI's Info.plist.
 APP_VERSION="0.0.0"
 if [[ -f "$TAURI_CONF" ]]; then
   if command -v jq >/dev/null 2>&1; then
     APP_VERSION="$(jq -r '.version // "0.0.0"' "$TAURI_CONF")"
   else
-    # jq is not available in some minimal CI images; grep is good enough for the
-    # well-formed JSON we own (single `"version": "x.y.z"` line).
+    # jq not available in some minimal CI images; grep the single version line.
     APP_VERSION="$(grep -E '^\s*"version"\s*:' "$TAURI_CONF" | head -1 | sed -E 's/.*"version"\s*:\s*"([^"]+)".*/\1/')"
     [[ -z "$APP_VERSION" ]] && APP_VERSION="0.0.0"
   fi

--- a/scripts/bundle-native-assets.sh
+++ b/scripts/bundle-native-assets.sh
@@ -32,16 +32,7 @@ resolve_binary_path() {
 
 mkdir -p "$DEST"
 
-# `swift build -c release` produces Mach-O with the `linker-signed` code-signing
-# flag (0x20000). macOS taskgated treats a `linker-signed` ad-hoc signature as
-# less trusted than a plain ad-hoc one and SIGKILLs the process ("Taskgated
-# Invalid Signature") when another process spawns it — fatal for the
-# audio-capture CLI, which links CoreAudio's hardened process-tap APIs. A
-# release build (which is what scripts/sign-bundled-binaries.sh runs over later)
-# strips that flag with the Developer ID re-sign; in dev builds nothing
-# re-signs, so do a plain ad-hoc re-sign here. (Harmless if a real signing pass
-# overwrites it afterwards.) With entitlements where one exists, so the embedded
-# entitlements survive the dev-mode re-sign too.
+# Swift release builds set the `linker-signed` flag; taskgated SIGKILLs it.
 adhoc_resign() {
   local path="$1" pkg="$2"
   command -v codesign >/dev/null 2>&1 || return 0

--- a/scripts/create-desktop-stubs.sh
+++ b/scripts/create-desktop-stubs.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
-# create-desktop-stubs.sh — Creates minimal stub files for desktop/src-tauri/
-# so that build.rs validation passes with SPEEDWAVE_ALLOW_BUNDLE_STUBS=1.
-#
-# Used by: Makefile (check-desktop-clippy), CI (test.yml).
-# Does NOT overwrite existing real files (e.g. from bundle-build-context.sh or downloads).
+# create-desktop-stubs.sh — stub files for desktop/src-tauri/ so build.rs
+# validation passes with SPEEDWAVE_ALLOW_BUNDLE_STUBS=1; never overwrites real files.
 
 set -euo pipefail
 

--- a/scripts/dev-fetch-sherpa-cache.sh
+++ b/scripts/dev-fetch-sherpa-cache.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
-# Wrapper for `make download-sherpa-onnx`: fetches the sherpa-onnx MD-Release
-# prebuilt and writes the resulting lib dir to a cache file. Exists because
-# MSYS2 (Git Bash on Windows) breaks env export propagation when make calls
-# `sh -c '... export VAR; bash ...'` — the child bash does not inherit VAR.
-# Doing the work in a single bash invocation avoids both nesting bugs.
+# Wrapper for `make download-sherpa-onnx`: fetches sherpa-onnx MD-Release
+# prebuilt and writes the resulting lib dir to a cache file.
 set -euo pipefail
 
 FETCH_DIR="${1:?missing fetch dir arg}"

--- a/scripts/dev-tauri-windows.sh
+++ b/scripts/dev-tauri-windows.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 # Helper: launch `cargo tauri dev` with sherpa-onnx env on Windows.
-# GnuWin32 make 3.81 mishandles complex quoting inline; this wrapper
-# isolates the bash logic so make only needs to pass the cache path.
+# GnuWin32 make 3.81 mishandles complex quoting inline.
 set -euo pipefail
 
 SHERPA_LIB_CACHE="${1:?missing cache file path}"

--- a/scripts/e2e-vm-setup.sh
+++ b/scripts/e2e-vm-setup.sh
@@ -26,18 +26,14 @@ NODE_VERSION="$(cat "$(dirname "$0")/../.node-version")"
 
 # -- Helper functions ----------------------------------------------------------
 
-# Run a PowerShell script on the Windows host via SSH.
-# Writes the script to a .ps1 temp file via scp, then executes via -File.
-# This is necessary because `powershell.exe -Command -` (reading from stdin)
-# ignores $ErrorActionPreference and does not propagate non-zero exit codes.
+# Run a PowerShell script on the Windows host via SSH (temp .ps1 + -File).
 windows_ps() {
     local ps_script tmpname tmpfile_win tmpfile_local
     ps_script=$(cat)
     tmpname="e2e-setup-$$.ps1"
     tmpfile_win="C:\\Windows\\Temp\\${tmpname}"
     tmpfile_local=$(mktemp)
-    # UTF-8 BOM — PowerShell on Windows defaults to the system locale
-    # (e.g., Windows-1252) when reading .ps1 files without a BOM.
+    # UTF-8 BOM — PowerShell reads .ps1 in the system locale without it.
     printf '\xEF\xBB\xBF%s\n' "$ps_script" > "$tmpfile_local"
     # shellcheck disable=SC2086
     scp -q -o ConnectTimeout=10 -o BatchMode=yes -o StrictHostKeyChecking=accept-new \
@@ -90,12 +86,7 @@ SCRIPT
     echo "[windows] Installing CMake (Kitware — required by whisper-rs-sys)..."
     windows_ps <<'SCRIPT'
 $ErrorActionPreference = 'Stop'
-# whisper-rs-sys uses the `cmake` Rust crate to drive a real cmake invocation
-# (Visual Studio's bundled cmake is not on PATH and the crate spawns
-# `cmake.exe` from PATH, not from VS's private layout). Install the official
-# Kitware build so `cmake.exe` lives in `C:\Program Files\CMake\bin` and is
-# on the Machine PATH for every process started afterwards.
-# Idempotent: skip if cmake.exe already present at the expected path.
+# whisper-rs-sys needs cmake.exe on PATH; install Kitware to Machine PATH.
 $cmakeBin = 'C:\Program Files\CMake\bin'
 if (Test-Path "$cmakeBin\cmake.exe") {
     Write-Host "CMake already installed: $cmakeBin"
@@ -116,8 +107,7 @@ if (Test-Path "$cmakeBin\cmake.exe") {
         exit 1
     }
 }
-# Belt-and-braces: ensure Machine PATH contains the cmake bin (the msi flag
-# usually does this, but verify so subsequent SSH sessions inherit it).
+# Ensure Machine PATH contains the cmake bin.
 $currentPath = [System.Environment]::GetEnvironmentVariable('Path','Machine')
 if (-not $currentPath.Contains($cmakeBin)) {
     [System.Environment]::SetEnvironmentVariable('Path', "$currentPath;$cmakeBin", 'Machine')
@@ -129,7 +119,6 @@ SCRIPT
     windows_ps <<'SCRIPT'
 $ErrorActionPreference = 'Stop'
 # whisper-rs-sys (ADR-056) uses bindgen, which requires libclang.dll.
-# Idempotent: skip if libclang.dll already present at the expected path.
 $llvmBin = 'C:\Program Files\LLVM\bin'
 if (Test-Path "$llvmBin\libclang.dll") {
     Write-Host "LLVM already installed: $llvmBin"
@@ -218,24 +207,18 @@ SCRIPT
     windows_ps <<SCRIPT
 \$ErrorActionPreference = 'Stop'
 \$distro = '${wsl_distro}'
-# wsl.exe -l -q emits UTF-16 LE. PowerShell over SSH receives the raw bytes
-# as null-interlaced ASCII (e.g. "U\0b\0u\0n\0t\0u\0"), so a naive -match
-# against the plain distro name never hits. Strip nulls before matching.
+# wsl.exe -l -q output arrives null-interlaced over SSH; strip nulls before matching.
 \$installed = (wsl.exe -l -q 2>\$null) -replace "\`0","" | Where-Object { \$_ -match [regex]::Escape(\$distro) }
 if (\$installed) {
     Write-Host "WSL2 distro \$distro already installed"
 } else {
     Write-Host "Installing \$distro..."
-    # --no-launch skips first-boot user creation. This is fine — the E2E
-    # scripts only use this distro for file operations via /mnt/c.
+    # --no-launch skips first-boot user creation.
     wsl.exe --install -d \$distro --no-launch
     if (\$LASTEXITCODE -ne 0) { Write-Error "Failed to install WSL2 distro \$distro"; exit 1 }
     Write-Host "WSL2 distro \$distro installed"
 }
-# bzip2 is required by scripts/lib/fetch-sherpa-onnx-md.sh (`tar -xjf` of the
-# sherpa-onnx MD-Release archive — ADR-061). Ubuntu minimal images ship
-# without it. Run as root via `-u root` so we don't hang on an interactive
-# sudo password prompt when the distro has a non-NOPASSWD default user.
+# bzip2 required by fetch-sherpa-onnx-md.sh (ADR-061); install as root.
 Write-Host "Ensuring bzip2 is available inside \$distro..."
 wsl.exe -d \$distro -u root -- bash -c "command -v bzip2 >/dev/null 2>&1 || { apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq bzip2; }"
 if (\$LASTEXITCODE -ne 0) { Write-Error "Failed to install bzip2 in \$distro"; exit 1 }

--- a/scripts/e2e-vm.sh
+++ b/scripts/e2e-vm.sh
@@ -33,8 +33,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "${SCRIPT_DIR}/e2e-common.sh"
 
 # SSOT: exclude list for repo transfers to remote E2E machines.
-# Both transfer functions (macos_rsync_to, windows_rsync_to) reference this
-# array. Each remote machine downloads its own platform assets.
+# Referenced by both macos_rsync_to and windows_rsync_to.
 E2E_RSYNC_EXCLUDES=(
     node_modules target dist .e2e-artifacts .git build-context
     .angular .build
@@ -57,9 +56,7 @@ MACOS_SSH_OPTS="$SSH_OPTS_BASE -o ServerAliveInterval=30 -o ServerAliveCountMax=
 # Host repo path — resolved from git root of this script's location.
 HOST_REPO_DIR="${SPEEDWAVE_REPO_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 
-# Staging dir on host for passing artifacts between phases
 # Artifacts are kept on each remote machine's ~/Desktop/ (survives clean_state).
-# No local staging needed — avoids 352 MB+ round-trip transfers over the network.
 
 # -- Auto-provisioning ---------------------------------------------------------
 # Check if remote machine has required tools; run setup if not.
@@ -103,17 +100,13 @@ ensure_provisioned_macos() {
 # PowerShell commands are run via `powershell.exe -Command ...`.
 # WSL2 Linux commands are run via `wsl.exe -d <distro> ...`.
 #
-# The WSL2 staging dir is ~/speedwave-e2e (/home/windows/speedwave-e2e) — must
-# NOT be /tmp because WSL2 clears tmpfs on each restart (and WSL2 auto-terminates
-# after idle, losing /tmp data between SSH calls).
+# The WSL2 staging dir is ~/speedwave-e2e (/home/windows/speedwave-e2e), NOT /tmp.
 # The Windows build dir is C:\speedwave-e2e.
 # The Windows install dir is C:\Speedwave.
 WINDOWS_WSL_STAGING="/home/windows/speedwave-e2e"
 
 # Run a PowerShell script on the Windows host.
 # Writes the script to a .ps1 temp file via sftp, then executes via -File.
-# This is necessary because `powershell.exe -Command -` (reading from stdin)
-# ignores $ErrorActionPreference and does not propagate non-zero exit codes.
 windows_ps() {
     local ps_script tmpname tmpfile_win tmpfile_local
     ps_script=$(cat)
@@ -123,9 +116,7 @@ windows_ps() {
     # Inject $WINDOWS_WSL_DISTRO so PS heredocs can reference it without
     # switching to unquoted heredocs (which would require escaping all PS $vars).
     local ps_prefix="\$WINDOWS_WSL_DISTRO = '${WINDOWS_WSL_DISTRO}'"
-    # Write with UTF-8 BOM — PowerShell on Windows defaults to the system
-    # locale (e.g., Windows-1252) when reading .ps1 files without a BOM.
-    # UTF-8 multi-byte characters (em-dashes, etc.) would corrupt strings.
+    # Write with UTF-8 BOM so PowerShell reads .ps1 as UTF-8, not system locale.
     printf '\xEF\xBB\xBF%s\n%s\n' "$ps_prefix" "$ps_script" > "$tmpfile_local"
     # Upload the script via scp (scp uses -P for port, not -p)
     scp -q -o ConnectTimeout=10 -o BatchMode=yes -o StrictHostKeyChecking=accept-new \
@@ -160,8 +151,7 @@ windows_rsync_to() {
     # Windows-specific extras (macOS resource forks)
     tar_excludes+=('--exclude=._*')
     local -a tar_flags=(--no-mac-metadata)
-    # Ensure the WSL distro is running before proceeding — wsl.exe may need
-    # time to restart after a --unregister of another distro shut down the VM.
+    # Ensure the WSL distro is running before proceeding.
     echo "  Waiting for WSL distro $WINDOWS_WSL_DISTRO..."
     local wsl_ready=0
     for i in $(seq 1 10); do
@@ -178,17 +168,13 @@ windows_rsync_to() {
         return 1
     fi
 
-    # Prepare the destination directory via separate SSH calls (avoids cmd.exe
-    # quoting issues with bash -c inside a single command).
+    # Prepare the destination directory via separate SSH calls.
     # shellcheck disable=SC2086
     ssh $WINDOWS_SSH_OPTS "$WINDOWS_HOST" "wsl.exe -d $WINDOWS_WSL_DISTRO -- rm -rf ${dst}"
-    # Ensure the parent directory exists — /home/<user>/ may not exist if the
-    # WSL distro was freshly installed or the default user's home wasn't created.
+    # Ensure the parent directory exists (fresh WSL install may lack a home dir).
     # shellcheck disable=SC2086
     ssh $WINDOWS_SSH_OPTS "$WINDOWS_HOST" "wsl.exe -d $WINDOWS_WSL_DISTRO -- bash -c 'mkdir -p ${dst}'"
-    # Create a local tar archive, scp it to the Windows host, then extract
-    # inside WSL2. Piping tar directly through SSH → cmd.exe → wsl.exe is
-    # unreliable — stdin forwarding breaks after WSL VM restarts.
+    # Create a local tar archive, scp it to the Windows host, then extract in WSL2.
     local tar_local
     tar_local=$(mktemp "${TMPDIR:-/tmp}/speedwave-e2e-XXXXXX.tar")
     echo "  tar: creating archive from $(dirname "$src")/$(basename "$src")..."
@@ -281,18 +267,13 @@ if (Test-Path "C:\Speedwave\uninstall.exe") {
 }
 
 # Unregister the Speedwave WSL2 distro (removes rootfs, containerd state, images).
-# Always attempt unregister — wsl.exe -l -q outputs UTF-16LE which makes
-# Select-String matching unreliable. --unregister is a no-op if the distro
-# does not exist (exits 0 with "not found" message).
+# --unregister is a no-op if the distro does not exist (exits 0).
 wsl.exe --unregister Speedwave 2>$null
-# Wait for WSL VM to fully shut down and restart — unregistering a distro
-# can terminate the lightweight VM, and subsequent wsl.exe calls may fail
-# with "The system cannot find the path specified" until it restarts.
+# Wait for the WSL VM to shut down and restart after unregister.
 Start-Sleep -Seconds 5
 
-# Remove stale CNI bridge interfaces left behind by unregistered distro.
-# These live in the WSL2 kernel (shared) and cause "already has an IP
-# address different from ..." errors on the next run.
+# Remove stale CNI bridge interfaces left behind by an unregistered distro.
+# These live in the shared WSL2 kernel and break the next run's networking.
 $bridges = wsl.exe -d $WINDOWS_WSL_DISTRO -u root -- bash -c "ip -o link show type bridge 2>/dev/null | grep -o 'br-[^:@]*'" 2>$null
 if ($bridges) {
     $bridges -split "`n" | ForEach-Object {
@@ -383,18 +364,14 @@ run_windows() {
     ensure_provisioned_windows
 
     # -- Phase 1: Build NSIS installer -----------------------------------------
-    # Copy the repo source to the Windows machine and produce a release NSIS
-    # installer. The build runs via PowerShell (Windows-native toolchain:
-    # Rust, Node, MSVC). Repo is transferred via tar-over-SSH into WSL2,
-    # then copied to C:\ for the Windows build.
+    # Copy the repo to the Windows machine and build a release NSIS installer
+    # via PowerShell (Rust, Node, MSVC).
     echo "[windows] Phase 1: Building NSIS installer..."
     echo "[windows] Syncing repo to remote..."
     windows_rsync_to "$HOST_REPO_DIR/" "$WINDOWS_WSL_STAGING/"
 
     # Copy from WSL2 filesystem to Windows filesystem, then build.
-    # Each phase is a separate windows_ps call to avoid SSH timeouts —
-    # long-running builds (cargo ~15 min) can exceed NAT idle
-    # timeouts even with SSH keepalives.
+    # Each phase is a separate windows_ps call to avoid SSH timeouts.
 
     # -- Step 1: Copy repo and install npm dependencies --
     echo "[windows] Step 1/5: Copy repo + npm install..."
@@ -493,10 +470,8 @@ $env:CARGO_TARGET_DIR = 'C:\cargo-build'
 New-Item -ItemType Directory -Path $env:CARGO_TARGET_DIR -Force | Out-Null
 Set-Location C:\speedwave-e2e
 
-# Windows CRT alignment: sherpa-onnx prebuilt MD-Release via SHERPA_ONNX_LIB_DIR
-# so the rest of the toolchain stays on /MD (default). Stage on C:\ so wslpath
-# returns a plain Windows path (not \\wsl.localhost\...) and the idempotency
-# guard survives between E2E runs. See ADR-061.
+# Windows CRT alignment: sherpa-onnx prebuilt MD-Release via SHERPA_ONNX_LIB_DIR,
+# staged on C:\ so wslpath returns a plain Windows path. See ADR-061.
 $libDir = (wsl.exe -d $WINDOWS_WSL_DISTRO -- bash -c 'SHERPA_ONNX_FETCH_DIR=/mnt/c/sherpa-onnx-md /mnt/c/speedwave-e2e/scripts/lib/fetch-sherpa-onnx-md.sh').Trim()
 Assert-ExitCode
 $env:SHERPA_ONNX_LIB_DIR = (wsl.exe -d $WINDOWS_WSL_DISTRO -- wslpath -w "$libDir").Trim()
@@ -526,8 +501,6 @@ SCRIPT
 
     # -- Phase 2: Install & test on clean system --------------------------------
     # Clean previous state — uninstall, remove user data and build artifacts.
-    # The machine is now a clean Windows desktop, simulating a real user who
-    # just downloaded the installer from GitHub Releases.
     # ~/Desktop/speedwave-setup.exe survives clean_state.
     windows_clean_state
 
@@ -572,9 +545,6 @@ SCRIPT
 
     # -- Phase 3: Second launch (clean system again) ----------------------------
     # Clean ALL state (same as Phase 2 prep) so the wizard runs from scratch.
-    # This verifies the app works correctly on a second fresh install — catching
-    # issues with leftover system-level state (WSL2 distros, registry entries)
-    # that survive user-data removal.
     echo "[windows] Phase 3: Running E2E again (second install — clean system)..."
     windows_clean_state
 
@@ -679,8 +649,7 @@ try {
 } finally {
     Stop-Process -Id $app.Id -Force -ErrorAction SilentlyContinue
     # Kill all leftover Speedwave child processes (WSL2 nerdctl, node mcp workers).
-    # Killing ALL node.exe processes is intentional — this is a dedicated build
-    # machine, not a shared server, so no other node processes should be running.
+    # Killing ALL node.exe is intentional — dedicated build machine.
     Stop-Process -Name "speedwave-desktop" -Force -ErrorAction SilentlyContinue
     Stop-Process -Name "node" -Force -ErrorAction SilentlyContinue
     # Stop WSL2 distro if it was started by the app
@@ -698,8 +667,7 @@ run_macos() {
     ensure_provisioned_macos
 
     # -- Phase 1: Build .dmg package --------------------------------------------
-    # Copy the repo source to the macOS machine and produce a release .dmg
-    # package — same as GitHub Actions CI.
+    # Copy the repo to the macOS machine and build a release .dmg (same as CI).
     echo "[macos] Phase 1: Building .dmg package..."
     echo "[macos] Syncing repo to remote..."
     macos_ssh "rm -rf /tmp/speedwave-e2e" || true
@@ -720,9 +688,7 @@ echo "── Building full release (.dmg)..."
 make test-e2e-desktop-build
 SCRIPT
 
-    # Locate and copy the .dmg artifact in a separate SSH call — the long-running
-    # build above can consume stdin (via npm/cargo subprocesses), which would
-    # swallow subsequent commands if they were in the same heredoc.
+    # Locate and copy the .dmg artifact in a separate SSH call.
     echo "[macos] Locating .dmg artifact on remote..."
     macos_ssh bash <<'SCRIPT'
 set -euo pipefail
@@ -734,9 +700,7 @@ cp desktop/src-tauri/target/release/bundle/dmg/*.dmg ~/Desktop/speedwave.dmg
 SCRIPT
 
     # -- Phase 2: Install & test on clean system --------------------------------
-    # Clean previous state — remove installed .app, user data, and build
-    # artifacts. The machine is now a clean macOS desktop, simulating a real
-    # user who just downloaded the .dmg from GitHub Releases.
+    # Clean previous state — remove installed .app, user data, and build artifacts.
     # ~/Desktop/speedwave.dmg survives clean_state.
     macos_clean_state
 
@@ -777,9 +741,6 @@ SCRIPT
 
     # -- Phase 3: Second launch (clean system again) ----------------------------
     # Clean ALL state (same as Phase 2 prep) so the wizard runs from scratch.
-    # This verifies the app works correctly on a second fresh install — catching
-    # issues with leftover system-level state (Lima cache, VM remnants)
-    # that survive user-data removal.
     echo "[macos] Phase 3: Running E2E again (second install — clean system)..."
     macos_clean_state
 
@@ -849,8 +810,7 @@ rm -rf /tmp/speedwave-e2e-project /tmp/speedwave-e2e-project-2
 mkdir -p /tmp/speedwave-e2e-project /tmp/speedwave-e2e-project-2
 
 # Launch the app in the background.
-# macOS requires a GUI session — SSH must connect to a user with an active
-# login session (e.g., auto-login enabled, or connected via Screen Sharing).
+# macOS requires an active GUI login session for the SSH user.
 "$APP_PATH" &
 APP_PID=$!
 

--- a/scripts/generate-installer-nsh.sh
+++ b/scripts/generate-installer-nsh.sh
@@ -10,15 +10,9 @@
 # Output (generated, committed):
 #   desktop/src-tauri/windows/installer-hooks.nsh
 #
-# Why this shape: Tauri inlines installerHooks content into a generated .nsi
-# placed in target/release/bundle/nsis/<arch>/. `!include` of sibling .nsh
-# files does not work (Tauri does not copy them). makensis CWD is the bundle
-# temp dir, so `File "windows\sweep.ps1"` cannot resolve either. The only
-# working pattern is single-file installerHooks with everything inline.
+# Single-file .nsh required: Tauri does not copy sibling .nsh files to the bundle temp dir.
 #
-# Drift detector: SSOT pin tests in installer_hooks.rs re-derive the embedded
-# macros from the current .ps1 files and assert byte-for-byte equality with
-# installer-hooks.nsh. If you edit any .ps1, run:
+# Drift detector: installer_hooks.rs pins installer-hooks.nsh byte-for-byte. After editing any .ps1, run:
 #
 #   make generate-installer-nsh
 #
@@ -41,8 +35,7 @@ if ! grep -q "$MARKER" "$TEMPLATE"; then
   exit 1
 fi
 
-# Emit one !macro SPEEDWAVE_MATERIALIZE_<NAME> that writes <name>.<ext> to
-# $PLUGINSDIR\<name>.<ext> at install time via FileWrite literals.
+# Emit !macro SPEEDWAVE_MATERIALIZE_<NAME> writing <name>.<ext> to $PLUGINSDIR at install time.
 # Args: <name> [<ext>]  (ext defaults to ps1; e.g. "run-hidden" "vbs").
 emit_materialize_macro() {
   local name="$1"
@@ -58,17 +51,13 @@ emit_materialize_macro() {
     exit 1
   fi
 
-  # A backtick is the NSIS FileWrite string delimiter and has no escape, so a
-  # literal backtick in the source silently truncates the NSIS string and aborts
-  # makensis. Fail loudly here instead. Use splatting, not backtick-continuation.
+  # A literal backtick truncates the NSIS FileWrite delimiter (no escape exists). Fail loudly.
   if grep -q '`' "$src"; then
     echo "ERROR: $src contains a backtick — breaks NSIS FileWrite. Use splatting." >&2
     exit 1
   fi
 
-  # Strip UTF-8 BOM before embedding — NSIS writes literal bytes, and the
-  # materialized file needs none (PowerShell handles ASCII fine; wscript REQUIRES
-  # no BOM for .vbs). So the materialized .vbs is always ANSI/BOM-free here.
+  # Strip UTF-8 BOM (NSIS writes literal bytes; wscript requires no BOM for .vbs).
   local stripped
   stripped="$(mktemp)"
   if head -c 3 "$src" | od -An -t x1 | tr -d ' \n' | grep -qi '^efbbbf$'; then
@@ -77,9 +66,7 @@ emit_materialize_macro() {
     cp "$src" "$stripped"
   fi
 
-  # Labels are uniquified per !insertmacro site via __LINE__ so the macro
-  # can be inserted multiple times in the same NSIS context (e.g. firewall
-  # is inserted in both POSTINSTALL and POSTUNINSTALL).
+  # Labels uniquified per !insertmacro site via __LINE__ (firewall is inserted twice).
   echo "!macro SPEEDWAVE_MATERIALIZE_${upper}"
   echo "  !define SW_${upper}_ID \${__LINE__}"
   echo "  InitPluginsDir"
@@ -90,11 +77,7 @@ emit_materialize_macro() {
   echo "    Goto sw_${upper}_write_done_\${SW_${upper}_ID}"
   echo "  sw_${upper}_write_ok_\${SW_${upper}_ID}:"
 
-  # Escape each line for NSIS backtick-delimited FileWrite literal:
-  #   $  -> $$
-  #   "  -> $\"  (NSIS escape for double quote)
-  # Backticks are rejected upstream (no NSIS escape exists). Backslashes are
-  # literal in backtick strings. Line endings emitted as $\r$\n.
+  # Escape for NSIS backtick FileWrite: $ -> $$, " -> $\"; line ends $\r$\n.
   local line esc
   while IFS= read -r line || [[ -n "$line" ]]; do
     esc="$line"

--- a/scripts/lib/fetch-sherpa-onnx-md.sh
+++ b/scripts/lib/fetch-sherpa-onnx-md.sh
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
-# Pre-fetches the sherpa-onnx Windows static-lib prebuilt in its MD-Release
-# (dynamic CRT) variant so cargo's sherpa-onnx-sys build skips its hard-coded
-# MT-Release download. Used by both CI (download-sherpa-onnx composite action)
-# and Windows E2E (e2e-vm.sh). Prints the absolute path of the lib/ directory
-# on stdout — caller must export that as SHERPA_ONNX_LIB_DIR.
-#
-# See ADR-061 for the architecture rationale.
+# Pre-fetches the sherpa-onnx Windows static-lib MD-Release prebuilt (ADR-061).
+# Prints the lib/ absolute path on stdout; caller exports it as SHERPA_ONNX_LIB_DIR.
 
 set -euo pipefail
 
@@ -41,9 +36,7 @@ echo "Fetching ${CHECKSUM_URL}" >&2
 CHECKSUM_PATH="${OUT_ROOT}/checksum.txt"
 curl -fsSL "$CHECKSUM_URL" -o "$CHECKSUM_PATH"
 
-# checksum.txt format today: <filename>\t<sha256>  (tab-separated, filename first).
-# Defensive: also accept the standard `sha256sum` ordering <sha256>  <filename>
-# in case k2-fsa flips the format on a future release.
+# checksum.txt is <filename>\t<sha256>; awk also accepts <sha256>\t<filename>.
 EXPECTED="$(awk -v f="$ARCHIVE" '$1 == f { print $2 } $2 == f { print $1 }' "$CHECKSUM_PATH")"
 if [ -z "$EXPECTED" ]; then
   echo "::error::no SHA256 for ${ARCHIVE} in checksum.txt" >&2
@@ -64,11 +57,8 @@ if [ "$EXPECTED" != "$ACTUAL" ]; then
 fi
 echo "SHA256 verified (${ACTUAL})" >&2
 
-# Extract under OUT_ROOT — tarball top-level is ${EXTRACTED_TOP}/.
-# `cd $OUT_ROOT` + relative archive name keeps the drive-letter colon out of
-# tar's argv: MSYS2 tar (Git Bash on windows-latest) parses a `:` in a native
-# path like `D:\a\...` as `user@host:path` SSH form. The drive letter is fine
-# in the working directory, just not in the archive argument.
+# cd $OUT_ROOT + relative archive name keeps the drive-letter colon out of
+# tar's argv (MSYS2 tar reads a `:` in a native path as SSH user@host:path).
 rm -rf "${OUT_ROOT:?}/${EXTRACTED_TOP}"
 (cd "$OUT_ROOT" && tar -xjf "$ARCHIVE")
 

--- a/scripts/sign-bundled-binaries.sh
+++ b/scripts/sign-bundled-binaries.sh
@@ -1,19 +1,6 @@
 #!/usr/bin/env bash
-# sign-bundled-binaries.sh — Signs Mach-O binaries that ship inside
-# Speedwave.app/Contents/Resources/ so the bundle passes Apple notarization.
-#
-# Apple Notary Service rejects bundles that contain unsigned Mach-O files,
-# even if the outer .app is signed. Tauri signs only Contents/MacOS/<main>;
-# every Mach-O listed in tauri.macos.conf.json under bundle.resources that
-# ends up as an executable must be signed here, before tauri bundles them.
-#
-# macOS only. On Windows exits 0 — Windows does not require OS-level code
-# signing today. If Windows signing is added, a separate branch in this
-# script will handle it.
-#
-# Required env when signing is active:
-#   APPLE_SIGNING_IDENTITY — "Developer ID Application: Name (TEAMID)"
-# When unset, the script is a no-op (unsigned dev build).
+# Signs Mach-O binaries in Speedwave.app/Contents/Resources/ for Apple notarization.
+# Requires APPLE_SIGNING_IDENTITY env; no-op on Windows.
 
 set -euo pipefail
 
@@ -27,8 +14,7 @@ if [[ -z "${APPLE_SIGNING_IDENTITY:-}" ]]; then
 fi
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-# SRC_TAURI can be overridden by tests to point at a sandbox directory.
-# In production, this resolves to desktop/src-tauri/ within the repo.
+# SRC_TAURI is overridable by tests; defaults to desktop/src-tauri/.
 SRC_TAURI="${SRC_TAURI:-$REPO_ROOT/desktop/src-tauri}"
 NODE_ENTITLEMENTS="$SRC_TAURI/entitlements/node.plist"
 VIRTUALIZATION_ENTITLEMENTS="$SRC_TAURI/entitlements/virtualization.plist"
@@ -37,17 +23,9 @@ REMINDERS_ENTITLEMENTS="$SRC_TAURI/entitlements/reminders.plist"
 APPLE_EVENTS_ENTITLEMENTS="$SRC_TAURI/entitlements/apple-events.plist"
 AUDIO_CAPTURE_ENTITLEMENTS="$SRC_TAURI/entitlements/audio-capture.plist"
 
-# Paths that tauri.macos.conf.json copies into .app/Contents/Resources/.
-# Source: desktop/src-tauri/tauri.macos.conf.json → bundle.resources.
-# Must stay in sync with that file — when a new executable resource is added
-# there, add its source path here.
-#
-# Format: "<source-path>:<entitlements-path>" — entitlements optional.
-# Binaries using restricted platform APIs under Hardened Runtime must carry
-# entitlements plists to opt back in. See ADR-037 for the full inventory
-# (virtualization for limactl, Apple Events for mail/notes CLIs, calendars
-# for calendar-cli and reminders for reminders-cli, audio-input for
-# audio-capture-cli per ADR-056, JIT for Node.js).
+# Paths tauri.macos.conf.json copies to .app/Contents/Resources/.
+# Source: desktop/src-tauri/tauri.macos.conf.json → bundle.resources (keep in sync).
+# Format: "<source-path>:<entitlements-path>" (entitlements optional; see ADR-037).
 SIGN_TARGETS=(
   "$SRC_TAURI/cli/speedwave:"
   "$SRC_TAURI/reminders-cli:$REMINDERS_ENTITLEMENTS"
@@ -100,9 +78,7 @@ verify_macho() {
   local path="$1"
   local entitlements="$2"
 
-  # codesign -v --strict is the authoritative signature validator. It verifies
-  # every resource in the signature, including that the embedded entitlements
-  # match the plist passed at signing time.
+  # codesign -v --strict is the authoritative validator.
   if ! codesign -v --strict "$path"; then
     echo "ERROR: signature verification failed for $path" >&2
     exit 1
@@ -113,10 +89,7 @@ verify_macho() {
     return
   fi
 
-  # Explicitly cross-check every <key> in the plist against the signed binary's
-  # embedded entitlements. This is belt-and-braces — codesign -v --strict should
-  # already catch mismatches — but it produces a clearer error if, say, a
-  # future codesign version relaxes that check.
+  # Cross-check plist keys against the binary's embedded entitlements.
   local key_count
   key_count="$(grep -c '<key>' "$entitlements")"
   if [[ "$key_count" -eq 0 ]]; then
@@ -149,16 +122,8 @@ verify_macho() {
   echo "  verified: signature valid, $key_count entitlement(s) present"
 }
 
-# Verifies the signed Mach-O carries the expected sub-identifier (from the
-# binary's embedded `__TEXT,__info_plist` section). codesign reads the embedded
-# CFBundleIdentifier and stores it in the signature; this is what TCC.db indexes
-# permission rows by, so a mismatch means recovery commands like `tccutil reset
-# Calendar pl.speedwave.desktop.calendar` won't work for users.
-#
-# This function is invoked only for the native macOS CLIs (calendar-cli,
-# reminders-cli, mail-cli, notes-cli, audio-capture-cli) — other bundled
-# binaries either have no user-visible TCC binding (speedwave, node) or use a
-# fixed system identifier (limactl).
+# Verifies the Mach-O's CFBundleIdentifier matches the __info_plist section.
+# Only for native macOS CLIs with TCC bindings (others use fixed or no identifiers).
 verify_identifier() {
   local path="$1"
   local expected="$2"

--- a/scripts/validate-pr-title-main.sh
+++ b/scripts/validate-pr-title-main.sh
@@ -1,10 +1,5 @@
 #!/usr/bin/env bash
-# Validates PR title for PRs targeting `main`.
-#
-# `chore(...)` is rejected here because release-please does not include
-# `chore` in its changelog-sections (release-please-config.json), so a
-# `chore` squash merge to main collapses feat/fix commits into an invisible
-# release — no version bump, no release PR. See issue #371.
+# Validates PR title for PRs targeting `main`. `chore(...)` is rejected (#371).
 #
 # Env vars:
 #   PR_TITLE — the PR title to validate
@@ -31,8 +26,7 @@ if [[ "$HEAD_REF" == chore/backmerge-* ]]; then
     exit 0
 fi
 
-# Conventional commit types allowed on `dev → main` squash merges.
-# `chore` is intentionally absent — see header comment and issue #371.
+# Conventional commit types allowed on `dev → main` squash merges (no `chore`).
 if [[ "$PR_TITLE" =~ ^(feat|fix|perf|refactor|docs|ci|test|build|style|revert)(\(.+\))?\!?:\ .+ ]]; then
     echo "PR title follows conventional commits: $PR_TITLE"
     exit 0


### PR DESCRIPTION
Shorten over-limit comments to single load-bearing facts across Rust, TypeScript (MCP + Angular desktop), shell, BATS, YAML and Swift, per the project comment-length rule (inline 1 line; doc 2-3 lines; rationale belongs in ADR/PR, not code comments). ~2500 comment blocks trimmed; changes are comment-only (verified: code identical after stripping comments).

Also fix the root cause that hid clippy lints in test code: make check-clippy ran without --all-targets, so cfg(test) modules and tests/ integration crates were never linted. Add --all-targets --features test-support,audio-transcription to the gate, add the documented allow(unwrap_used, expect_used) to test modules, and fix the surfaced style lints (struct-literal init, type aliases, if-let, contains_key) with SSOT-guard asserts kept and annotated.
