### PR TITLE
fix(ci): require release-triggering main PR titles

### DIFF
--- a/.github/workflows/merge-strategy-check.yml
+++ b/.github/workflows/merge-strategy-check.yml
@@ -1,8 +1,9 @@
 # Merge Strategy Check — ensures PRs to main follow conventions
 #
 # - Release-please and backmerge PRs are exempt
-# - All other PRs must have conventional commit titles (for squash merge)
-# - `chore` is rejected (release-please ignores it); see scripts/validate-pr-title-main.sh
+# - All other PRs must have release-triggering conventional commit titles
+#   for squash merge, so the desktop updater sees a newer semver.
+# - Non-release types are rejected; see scripts/validate-pr-title-main.sh
 
 name: Merge Strategy Check
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -165,13 +165,13 @@ That's it — no manual version bumping, no workflow dispatch, no release type s
 - Release-please also backfills file lists per commit — empty commits (`--allow-empty`) return 0 files and are excluded from path-based detection
 - Squash merge produces a single commit with the PR title as the message — if the PR title follows conventional commits (e.g. `feat(runtime): add logging`), release-please picks it up correctly
 
-#### `chore(...)` is NOT allowed as a PR title to `main`
+#### Non-release types are NOT allowed as PR titles to `main`
 
-Release-please only tracks commit types listed in its `changelog-sections` (`release-please-config.json`). `chore` is intentionally absent — a `chore` squash merge from `dev` to `main` would collapse every bundled `feat`/`fix` commit into a single `chore` commit that release-please ignores entirely. Result: no version bump, no release PR, the whole batch vanishes from the release record.
+The desktop updater installs only when `latest.json.version` is greater than the installed version. A `dev` → `main` squash merge must therefore use a release-triggering title: `feat(...)` or `fix(...)`.
 
-`merge-strategy-check.yml` enforces this by rejecting `chore(...)` PR titles on PRs to `main`. Allowed types for `dev → main`: `feat, fix, perf, refactor, docs, ci, test, build, style, revert`.
+Release-please may not create a version bump for non-release types such as `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `revert`, `style`, or `test`. If one of those titles is used for the squash merge, code can land on `main` without a newer updater version. Result: no release PR, no desktop build, and users who check for updates remain on the previous app code.
 
-If a `dev → main` PR contains only housekeeping, wait for the next `feat`/`fix` before merging — do not promote a `chore`-only batch on its own. `chore` remains valid for PRs targeting `dev`.
+`merge-strategy-check.yml` enforces this by rejecting non-release titles on PRs to `main`. If a `dev` → `main` PR contains only housekeeping, wait for the next `feat`/`fix` batch before merging, or retitle the PR to the dominant user-visible release reason. Non-release types remain valid for PRs targeting `dev`.
 
 #### What happens if you accidentally use a regular merge
 

--- a/_tests/ci/validate-pr-title-main.bats
+++ b/_tests/ci/validate-pr-title-main.bats
@@ -8,7 +8,7 @@ run_script() {
 }
 
 # ---------------------------------------------------------------------------
-# Happy path — allowed conventional commit types
+# Happy path — allowed release-triggering conventional commit types
 # ---------------------------------------------------------------------------
 
 @test "feat with scope passes" {
@@ -33,46 +33,6 @@ run_script() {
 
 @test "feat with scope and breaking-change marker passes" {
     run_script "feat(api)!: redesign surface"
-    [ "$status" -eq 0 ]
-}
-
-@test "perf passes" {
-    run_script "perf(runtime): faster container boot"
-    [ "$status" -eq 0 ]
-}
-
-@test "refactor passes" {
-    run_script "refactor(desktop): extract hub logic"
-    [ "$status" -eq 0 ]
-}
-
-@test "docs passes" {
-    run_script "docs: update ADR index"
-    [ "$status" -eq 0 ]
-}
-
-@test "ci passes" {
-    run_script "ci: bump action version"
-    [ "$status" -eq 0 ]
-}
-
-@test "test passes" {
-    run_script "test(cli): cover edge case"
-    [ "$status" -eq 0 ]
-}
-
-@test "build passes" {
-    run_script "build: update toolchain"
-    [ "$status" -eq 0 ]
-}
-
-@test "style passes" {
-    run_script "style: format Rust sources"
-    [ "$status" -eq 0 ]
-}
-
-@test "revert passes" {
-    run_script "revert: undo feat(runtime): bad change"
     [ "$status" -eq 0 ]
 }
 
@@ -131,6 +91,56 @@ run_script() {
     [ "$status" -eq 1 ]
     [[ "$output" == *"feat(...)"* ]]
     [[ "$output" == *"fix(...)"* ]]
+}
+
+@test "perf is REJECTED because it may not bump updater version" {
+    run_script "perf(runtime): faster container boot"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"release-please version bump"* ]]
+    [[ "$output" == *"latest.json.version"* ]]
+}
+
+@test "refactor is REJECTED because it may not bump updater version" {
+    run_script "refactor(desktop): extract shell logic"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"release-please version bump"* ]]
+    [[ "$output" == *"latest.json.version"* ]]
+}
+
+@test "docs is REJECTED because it may not bump updater version" {
+    run_script "docs: update release notes"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"release-please version bump"* ]]
+}
+
+@test "ci is REJECTED because it may not bump updater version" {
+    run_script "ci: update release workflow"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"release-please version bump"* ]]
+}
+
+@test "test is REJECTED because it may not bump updater version" {
+    run_script "test(cli): cover release gate"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"release-please version bump"* ]]
+}
+
+@test "build is REJECTED because it may not bump updater version" {
+    run_script "build(desktop): update tauri packaging"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"release-please version bump"* ]]
+}
+
+@test "style is REJECTED because it may not bump updater version" {
+    run_script "style(desktop): adjust app css"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"release-please version bump"* ]]
+}
+
+@test "revert is REJECTED because it may not bump updater version" {
+    run_script "revert: undo broken desktop update"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"release-please version bump"* ]]
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/validate-pr-title-main.sh
+++ b/scripts/validate-pr-title-main.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
-# Validates PR title for PRs targeting `main`. `chore(...)` is rejected (#371).
+# Validates PR title for PRs targeting `main`.
+#
+# The desktop updater installs only when latest.json.version is strictly newer
+# than the installed version. A dev -> main squash commit must therefore use a
+# release-triggering Conventional Commit type; otherwise release-please may
+# produce no version bump, no release, and no update for end users.
 #
 # Env vars:
 #   PR_TITLE — the PR title to validate
@@ -26,8 +31,9 @@ if [[ "$HEAD_REF" == chore/backmerge-* ]]; then
     exit 0
 fi
 
-# Conventional commit types allowed on `dev → main` squash merges (no `chore`).
-if [[ "$PR_TITLE" =~ ^(feat|fix|perf|refactor|docs|ci|test|build|style|revert)(\(.+\))?\!?:\ .+ ]]; then
+# Conventional commit types allowed on `dev -> main` squash merges.
+# Keep this set restricted to types that produce a release-please semver bump.
+if [[ "$PR_TITLE" =~ ^(feat|fix)(\(.+\))?\!?:\ .+ ]]; then
     echo "PR title follows conventional commits: $PR_TITLE"
     exit 0
 fi
@@ -36,14 +42,16 @@ echo "::error::PR title does not follow the conventions required for dev→main 
 echo "::error::Your title: $PR_TITLE"
 echo "::error::"
 echo "::error::Expected format: type(scope): description"
-echo "::error::Allowed types: feat, fix, perf, refactor, docs, ci, test, build, style, revert"
+echo "::error::Allowed release-triggering types for PRs to main: feat, fix"
 echo "::error::"
-if [[ "$PR_TITLE" =~ ^chore(\(.+\))?\!?:\ .+ ]]; then
-    echo "::error::'chore' is NOT allowed for PRs to main — release-please ignores chore commits,"
-    echo "::error::so the squash merge would collapse all feat/fix commits from dev into an"
-    echo "::error::invisible release (no version bump, no release PR). See issue #371."
+if [[ "$PR_TITLE" =~ ^(build|chore|ci|docs|perf|refactor|revert|style|test)(\(.+\))?\!?:\ .+ ]]; then
+    echo "::error::'${BASH_REMATCH[1]}' is NOT allowed for PRs to main — it does not guarantee"
+    echo "::error::a release-please version bump. The desktop updater only installs when"
+    echo "::error::latest.json.version is greater than the installed version, so a non-releasing"
+    echo "::error::main squash can strand code changes outside the user update path. See issue #371."
     echo "::error::"
-    echo "::error::Use 'feat(...)' or 'fix(...)' instead, matching the dominant change in this merge."
-    echo "::error::'chore' is still fine for PRs targeting 'dev'."
+    echo "::error::Use 'feat(...)' or 'fix(...)' instead, matching the"
+    echo "::error::dominant user-visible release reason. Non-release types remain valid for"
+    echo "::error::PRs targeting 'dev'."
 fi
 exit 1


### PR DESCRIPTION
## Summary

- restrict the main-branch merge title gate to release-triggering commit types (`feat` and `fix`)
- reject non-release types that can land code without producing a newer updater version
- update release documentation and regression tests for the updater/versioning failure mode

## Test plan

- `bats _tests/ci/validate-pr-title-main.bats`
- `git diff --check`
- manual validator checks for rejected `perf` and accepted `fix` titles