### PR TITLE
feat(runtime): auto-connect Claude to the IDE bridge via --ide

### DIFF
--- a/crates/speedwave-cli/src/main.rs
+++ b/crates/speedwave-cli/src/main.rs
@@ -1506,6 +1506,7 @@ mod tests {
         assert!(exec_cmd.contains(&"--mcp-config"));
         assert!(exec_cmd.contains(&defaults::MCP_CONFIG_PATH));
         assert!(exec_cmd.contains(&"--strict-mcp-config"));
+        assert!(exec_cmd.contains(&"--ide"));
     }
 
     /// Builds a project entry with the given name; dir is irrelevant now that

--- a/crates/speedwave-cli/src/main.rs
+++ b/crates/speedwave-cli/src/main.rs
@@ -1506,7 +1506,6 @@ mod tests {
         assert!(exec_cmd.contains(&"--mcp-config"));
         assert!(exec_cmd.contains(&defaults::MCP_CONFIG_PATH));
         assert!(exec_cmd.contains(&"--strict-mcp-config"));
-        assert!(exec_cmd.contains(&"--ide"));
     }
 
     /// Builds a project entry with the given name; dir is irrelevant now that

--- a/crates/speedwave-runtime/src/config.rs
+++ b/crates/speedwave-runtime/src/config.rs
@@ -1113,6 +1113,7 @@ mod tests {
             .iter()
             .any(|f| f == defaults::MCP_CONFIG_PATH));
         assert!(resolved.flags.iter().any(|f| f == "--strict-mcp-config"));
+        assert!(resolved.flags.iter().any(|f| f == "--ide"));
     }
 
     #[test]

--- a/crates/speedwave-runtime/src/defaults.rs
+++ b/crates/speedwave-runtime/src/defaults.rs
@@ -146,9 +146,9 @@ pub const DEFAULT_FLAGS: &[&str] = &[
     "--strict-mcp-config",
     "--thinking-display",
     "summarized",
-    // Auto-connect to the IDE bridge via the lock at ~/.claude/ide/ — the
-    // lock-file path, complementing CLAUDE_CODE_AUTO_CONNECT_IDE (which only
-    // forces the integrated-terminal path). Skipped silently when absent.
+    // Triggers lock-file auto-connect to the IDE bridge (~/.claude/ide/),
+    // complementing CLAUDE_CODE_AUTO_CONNECT_IDE (which only forces the
+    // integrated-terminal path). Skipped silently when no lock is present.
     "--ide",
 ];
 

--- a/crates/speedwave-runtime/src/defaults.rs
+++ b/crates/speedwave-runtime/src/defaults.rs
@@ -146,6 +146,10 @@ pub const DEFAULT_FLAGS: &[&str] = &[
     "--strict-mcp-config",
     "--thinking-display",
     "summarized",
+    // Auto-connect to the IDE bridge via the lock at ~/.claude/ide/ — the
+    // lock-file path, complementing CLAUDE_CODE_AUTO_CONNECT_IDE (which only
+    // forces the integrated-terminal path). Skipped silently when absent.
+    "--ide",
 ];
 
 /// Base environment variables injected into every Claude container.
@@ -280,6 +284,13 @@ mod tests {
     #[test]
     fn default_flags_include_permission_bypass() {
         assert!(DEFAULT_FLAGS.contains(&"--dangerously-skip-permissions"));
+    }
+
+    #[test]
+    fn default_flags_include_ide_auto_connect() {
+        // Lock-file auto-connect path; safe default since Claude Code skips it
+        // silently when no ~/.claude/ide/ lock is present (CLI-only).
+        assert!(DEFAULT_FLAGS.contains(&"--ide"));
     }
 
     #[test]

--- a/docs/guides/ide-bridge.md
+++ b/docs/guides/ide-bridge.md
@@ -8,9 +8,11 @@ Speedwave.app acts as an active MCP proxy between Claude (isolated in a Lima VM 
 
 1. **IDE Bridge binds** a random TCP port on `127.0.0.1` and writes a lock file to `~/.speedwave/ide-bridge/<port>.lock`.
 2. **Host directory is mounted** read-only into the Claude container as `~/.claude/ide/`.
-3. **Claude detects the lock file**, derives the port from the **filename** (e.g. `37100.lock` → port 37100), and connects via WebSocket to `host.docker.internal:<port>`. The alias is injected into the container's `/etc/hosts` via Compose `extra_hosts` and mapped to the platform's gateway IP (Lima vzNAT on macOS, WSL2 NAT on Windows). Auto-connect needs no manual `/ide`: the container sets `CLAUDE_CODE_AUTO_CONNECT_IDE=true` (forces the attempt when terminal auto-detection fails) and `--ide` is in `DEFAULT_FLAGS` (`crates/speedwave-runtime/src/defaults.rs`, the lock-file detection path). With no lock present (CLI-only, no Desktop) Claude Code silently skips them.
+3. **Claude detects the lock file**, derives the port from the **filename** (e.g. `37100.lock` → port 37100), and connects via WebSocket to `host.docker.internal:<port>`. The alias is injected into the container's `/etc/hosts` via Compose `extra_hosts` and mapped to the platform's gateway IP (Lima vzNAT on macOS, WSL2 NAT on Windows).
 4. **IDE Bridge receives events** from Claude (e.g. `openFile`, `getDiagnostics`) and forwards them to the real IDE extension.
 5. **The IDE responds** — VS Code opens files automatically as Claude edits them.
+
+The connection is automatic — you never need to run `/ide` by hand. The container both forces the attempt (`CLAUDE_CODE_AUTO_CONNECT_IDE=true`, for when terminal auto-detection fails) and enables the lock-file detection path (`--ide`). When no lock file is present — CLI-only use without the Desktop app — Claude Code silently skips both.
 
 ### Lock File Format
 

--- a/docs/guides/ide-bridge.md
+++ b/docs/guides/ide-bridge.md
@@ -8,7 +8,7 @@ Speedwave.app acts as an active MCP proxy between Claude (isolated in a Lima VM 
 
 1. **IDE Bridge binds** a random TCP port on `127.0.0.1` and writes a lock file to `~/.speedwave/ide-bridge/<port>.lock`.
 2. **Host directory is mounted** read-only into the Claude container as `~/.claude/ide/`.
-3. **Claude detects the lock file**, derives the port from the **filename** (e.g. `37100.lock` → port 37100), and connects via WebSocket to `host.docker.internal:<port>`. The alias is injected into the container's `/etc/hosts` via Compose `extra_hosts` and mapped to the platform's gateway IP (Lima vzNAT on macOS, WSL2 NAT on Windows).
+3. **Claude detects the lock file**, derives the port from the **filename** (e.g. `37100.lock` → port 37100), and connects via WebSocket to `host.docker.internal:<port>`. The alias is injected into the container's `/etc/hosts` via Compose `extra_hosts` and mapped to the platform's gateway IP (Lima vzNAT on macOS, WSL2 NAT on Windows). Auto-connect needs no manual `/ide`: the container sets `CLAUDE_CODE_AUTO_CONNECT_IDE=true` (forces the attempt when terminal auto-detection fails) and `--ide` is in `DEFAULT_FLAGS` (`crates/speedwave-runtime/src/defaults.rs`, the lock-file detection path). With no lock present (CLI-only, no Desktop) Claude Code silently skips them.
 4. **IDE Bridge receives events** from Claude (e.g. `openFile`, `getDiagnostics`) and forwards them to the real IDE extension.
 5. **The IDE responds** — VS Code opens files automatically as Claude edits them.
 


### PR DESCRIPTION
## Problem

When Claude Code starts inside the Speedwave container, the user has to run `/ide` manually to connect Claude to the Speedwave IDE bridge (the Desktop app). Speedwave already mounts the bridge lock file into `~/.claude/ide/` and injects `CLAUDE_CODE_IDE_HOST_OVERRIDE`, so the connection info is present — Claude just isn't told to auto-connect via the lock file.

## Why the existing env var isn't sufficient

The container already sets `CLAUDE_CODE_AUTO_CONNECT_IDE=true`. Per the [Claude Code docs](https://code.claude.com/docs/en/env-vars), that env var *"forces a connection attempt when auto-detection fails, such as when tmux obscures the parent terminal"* — i.e. it patches the **integrated-terminal** detection path. The Speedwave container TTY is **not** an IDE integrated terminal, so relying on the env var alone is fragile.

`--ide` triggers the **separate lock-file detection path**: per `claude --help`, *"Automatically connect to IDE on startup if exactly one valid IDE is available."* The container mounts exactly one lock at `~/.claude/ide/`, so the condition holds. The two mechanisms are **complementary**, not redundant — belt-and-suspenders for reliable headless auto-connect.

## Change

- Add `--ide` to `DEFAULT_FLAGS` (`crates/speedwave-runtime/src/defaults.rs`).
- Tests: `default_flags_include_ide_auto_connect` + `--ide` assertions in the existing `config.rs` and `cli/main.rs` flag tests.
- Docs: `docs/guides/ide-bridge.md` updated to describe both auto-connect paths.

## CLI-only safety

When no lock file is present (CLI-only usage without Desktop running), Claude Code silently skips the flag — verified against `claude --help` / official docs. So `--ide` is safe as an unconditional default.

## Testing

- `cargo test -p speedwave-runtime` (config + defaults flag tests) ✅
- `cargo test -p speedwave-cli` (exec_cmd flag test) ✅
- `cargo clippy -p speedwave-runtime -p speedwave-cli` ✅ / `cargo fmt --check` ✅ / `prettier --check` ✅

Closes #404