### PR TITLE
fix(deps): override piscina to ^5.2.0 (high-severity advisory)

### DIFF
--- a/desktop/src/package-lock.json
+++ b/desktop/src/package-lock.json
@@ -4417,9 +4417,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4437,9 +4434,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4457,9 +4451,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4477,9 +4468,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4732,9 +4720,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -4752,9 +4737,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -4772,9 +4754,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -4792,9 +4771,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -4812,9 +4788,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -9428,9 +9401,9 @@
       }
     },
     "node_modules/piscina": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/piscina/-/piscina-5.1.4.tgz",
-      "integrity": "sha512-7uU4ZnKeQq22t9AsmHGD2w4OYQGonwFnTypDypaWi7Qr2EvQIFVtG8J5D/3bE7W123Wdc9+v4CZDu5hJXVCtBg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/piscina/-/piscina-5.2.0.tgz",
+      "integrity": "sha512-DszUCKeVN/5G5QKo6jAVHL8fmKnkJvQ0ACiVgY7YGCq3TUB2oznAOayvZPIAdEThvhczkXR+qm3IHsNXpFCYfA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/desktop/src/package.json
+++ b/desktop/src/package.json
@@ -40,7 +40,8 @@
     "tslib": "^2.6.0"
   },
   "overrides": {
-    "undici": "^7.24.0"
+    "undici": "^7.24.0",
+    "piscina": "^5.2.0"
   },
   "devDependencies": {
     "@angular/build": "^21.2.15",


### PR DESCRIPTION
## What
Pin `piscina` to `^5.2.0` via `overrides` in `desktop/src/package.json` and refresh the lockfile.

## Why
`piscina` 5.1.4 (transitive via `@angular/build`) carries a HIGH-severity Dependabot advisory (prototype-pollution gadget → RCE via inherited `options.filename`, GHSA-x9g3-xrwr-cwfg), fixed in 5.2.0. It is not a direct dependency, so an `overrides` pin is the right lever. Resolved `node_modules/piscina` is now 5.2.0 and the alert clears.

## Verification
`npm audit` no longer lists piscina; resolved version confirmed 5.2.0 in the lockfile.