### PR TITLE
fix(runtime): resolve STT code-review findings (mic picker, single-model oracle, present-check)

### DIFF
--- a/crates/speedwave-runtime/src/transcription/accel.rs
+++ b/crates/speedwave-runtime/src/transcription/accel.rs
@@ -50,36 +50,9 @@ pub fn has_gpu_backend() -> bool {
     compiled_backends().iter().any(|b| b.is_gpu())
 }
 
-/// The live-path Whisper model for `backends`: `large-v3-turbo` if a GPU
-/// backend is present, else `small`.
-pub fn recommended_live_model(backends: &[Backend]) -> &'static WhisperModelInfo {
-    let want = if backends.iter().any(|b| b.is_gpu()) {
-        ModelRole::GpuLive
-    } else {
-        ModelRole::CpuLive
-    };
-    WHISPER_MODELS
-        .iter()
-        .find(|m| m.role == want && m.live_capable && matches!(m.quantization, Quantization::Full))
-        .or_else(|| {
-            WHISPER_MODELS
-                .iter()
-                .find(|m| m.role == want && m.live_capable)
-        })
-        .or_else(|| WHISPER_MODELS.iter().find(|m| m.live_capable))
-        .unwrap_or(&WHISPER_MODELS[0])
-}
-
-/// The live model for this build's compiled backends. Test-only — production
-/// passes an explicit backend set to `recommended_live_model`.
-#[cfg(test)]
-pub fn recommended_live_model_for_this_build() -> &'static WhisperModelInfo {
-    recommended_live_model(&compiled_backends())
-}
-
 /// The single best model to download for `backends`: `large-v3` on GPU, else
-/// `large-v3-turbo` (its `GpuLive` role is the best live-capable model; on CPU
-/// it serves both passes — turbo on a weak CPU may lag live, accepted). See ADR-056.
+/// `large-v3-turbo`. One model serves both the live and offline passes; on a
+/// weak CPU turbo may lag live, accepted (ADR-056).
 pub fn best_model_for_backends(backends: &[Backend]) -> &'static WhisperModelInfo {
     let want = if backends.iter().any(|b| b.is_gpu()) {
         ModelRole::Finalize
@@ -118,33 +91,6 @@ mod tests {
         assert_eq!(
             has_gpu_backend(),
             compiled_backends().iter().any(|b| b.is_gpu())
-        );
-    }
-
-    #[test]
-    fn recommended_live_model_gpu_vs_cpu() {
-        assert_eq!(
-            recommended_live_model(&[Backend::Cpu, Backend::Metal]).key,
-            "large-v3-turbo"
-        );
-        assert_eq!(recommended_live_model(&[Backend::Cpu]).key, "small");
-        assert_eq!(
-            recommended_live_model(&[Backend::Metal]).role,
-            ModelRole::GpuLive
-        );
-    }
-
-    #[test]
-    fn recommended_live_model_for_this_build_is_consistent() {
-        let m = recommended_live_model_for_this_build();
-        assert!(m.live_capable);
-        assert_eq!(
-            m.role,
-            if has_gpu_backend() {
-                ModelRole::GpuLive
-            } else {
-                ModelRole::CpuLive
-            }
         );
     }
 

--- a/crates/speedwave-runtime/src/transcription/audio.rs
+++ b/crates/speedwave-runtime/src/transcription/audio.rs
@@ -52,8 +52,6 @@ pub struct AudioSourceInfo {
     pub source: AudioSource,
     /// Human-readable label (e.g. `"System (everything)"`, `"Microphone: …"`).
     pub label: String,
-    /// Reserved for a best-effort app identifier; currently always `None`.
-    pub app_id: Option<String>,
 }
 
 /// What a capture backend on this host can do — surfaced to the UI.
@@ -210,7 +208,6 @@ impl AudioCapture for FileAudioCapture {
                     device: Some(p.to_string_lossy().into_owned()),
                 },
                 label: format!("File: {}", p.display()),
-                app_id: None,
             })
             .collect())
     }

--- a/crates/speedwave-runtime/src/transcription/audio_macos.rs
+++ b/crates/speedwave-runtime/src/transcription/audio_macos.rs
@@ -84,12 +84,10 @@ impl AudioCapture for MacOsAudioCapture {
             AudioSourceInfo {
                 source: AudioSource::Mixed { mic: None },
                 label: super::audio::DEFAULT_MIXED_SOURCE_LABEL.to_string(),
-                app_id: None,
             },
             AudioSourceInfo {
                 source: AudioSource::SystemWide,
                 label: "System (everything)".to_string(),
-                app_id: None,
             },
         ];
         // Named input devices (default flagged); generic fallback if it fails.
@@ -106,7 +104,6 @@ impl AudioCapture for MacOsAudioCapture {
                             device: Some(m.uid),
                         },
                         label,
-                        app_id: None,
                     });
                 }
             }
@@ -354,7 +351,6 @@ fn generic_default_mic() -> AudioSourceInfo {
     AudioSourceInfo {
         source: AudioSource::Microphone { device: None },
         label: "Microphone (default input)".to_string(),
-        app_id: None,
     }
 }
 

--- a/crates/speedwave-runtime/src/transcription/audio_windows.rs
+++ b/crates/speedwave-runtime/src/transcription/audio_windows.rs
@@ -64,7 +64,6 @@ impl AudioCapture for WasapiAudioCapture {
             sources.push(AudioSourceInfo {
                 source: AudioSource::Mixed { mic: None },
                 label: DEFAULT_MIXED_SOURCE_LABEL.to_string(),
-                app_id: None,
             });
         }
         // System loopback — the default output device's loopback.
@@ -75,7 +74,6 @@ impl AudioCapture for WasapiAudioCapture {
             sources.push(AudioSourceInfo {
                 source: AudioSource::SystemWide,
                 label,
-                app_id: None,
             });
         } else {
             // No output device — still offer the abstract SystemWide so the UI
@@ -83,7 +81,6 @@ impl AudioCapture for WasapiAudioCapture {
             sources.push(AudioSourceInfo {
                 source: AudioSource::SystemWide,
                 label: "System (everything)".to_string(),
-                app_id: None,
             });
         }
         // Microphones — every input device cpal sees.
@@ -95,7 +92,6 @@ impl AudioCapture for WasapiAudioCapture {
                         device: Some(name.clone()),
                     },
                     label: name,
-                    app_id: None,
                 });
             }
         }

--- a/crates/speedwave-runtime/src/transcription/mod.rs
+++ b/crates/speedwave-runtime/src/transcription/mod.rs
@@ -16,19 +16,14 @@ pub mod transcript;
 pub mod transcript_driver;
 pub mod transcript_store;
 
-pub use accel::{
-    best_model_for_this_build, compiled_backends, has_gpu_backend, recommended_live_model, Backend,
-};
+pub use accel::{best_model_for_this_build, compiled_backends, has_gpu_backend, Backend};
 pub use audio::{
     bytes_to_f32_samples, drain_child_stderr, kill_child_gracefully, parse_wav_to_mono_f32,
     AudioCapture, AudioChunk, AudioSource, AudioSourceInfo, AudioStream, CaptureCapabilities,
     CaptureError, FileAudioCapture, CHUNK_DURATION, DEFAULT_MIXED_SOURCE_LABEL, SAMPLE_RATE_HZ,
 };
 pub use mix::{poll_mixed_chunk, MixBuffer, MixSource, CHUNK_SAMPLES};
-pub use model_catalog::{
-    model_for_recommendation, whisper_model, ModelRecommendation, ModelRole, Quantization,
-    WhisperModelInfo, WHISPER_MODELS,
-};
+pub use model_catalog::{whisper_model, ModelRole, Quantization, WhisperModelInfo, WHISPER_MODELS};
 pub use model_store::{
     no_progress, DownloadProgress, ModelStatusEntry, ModelStore, ModelStoreError,
 };

--- a/crates/speedwave-runtime/src/transcription/model_catalog.rs
+++ b/crates/speedwave-runtime/src/transcription/model_catalog.rs
@@ -42,17 +42,6 @@ pub enum ModelRole {
     Finalize,
 }
 
-/// SSOT for "which model to pick" per pass (one model per value). Read by
-/// `accel::best_model_for_backends` + `pick_offline_model`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ModelRecommendation {
-    /// Recommended live (low-latency) model.
-    Live,
-    /// Recommended highest-quality model for the offline finalize pass.
-    FinalQuality,
-}
-
 /// Whether a model is a full-precision GGML model or a quantised variant.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -88,8 +77,6 @@ pub struct WhisperModelInfo {
     /// `true` for the models v1 considers "live-capable" on the relevant
     /// backend (`small` on CPU, `large-v3-turbo` on GPU/Metal).
     pub live_capable: bool,
-    /// UI recommendation badge, if any (at most one model per recommendation).
-    pub recommendation: Option<ModelRecommendation>,
     /// SPDX-ish licence string for the model weights.
     pub license: &'static str,
 }
@@ -114,7 +101,6 @@ pub const WHISPER_MODELS: &[WhisperModelInfo] = &[
         role: ModelRole::CpuLive,
         quantization: Quantization::Full,
         live_capable: true,
-        recommendation: Some(ModelRecommendation::Live),
         license: "MIT",
     },
     WhisperModelInfo {
@@ -126,7 +112,6 @@ pub const WHISPER_MODELS: &[WhisperModelInfo] = &[
         role: ModelRole::CpuLive,
         quantization: Quantization::Q5_1,
         live_capable: true,
-        recommendation: None,
         license: "MIT",
     },
     WhisperModelInfo {
@@ -138,7 +123,6 @@ pub const WHISPER_MODELS: &[WhisperModelInfo] = &[
         role: ModelRole::Mid,
         quantization: Quantization::Full,
         live_capable: false,
-        recommendation: None,
         license: "MIT",
     },
     WhisperModelInfo {
@@ -150,7 +134,6 @@ pub const WHISPER_MODELS: &[WhisperModelInfo] = &[
         role: ModelRole::Mid,
         quantization: Quantization::Q5_0,
         live_capable: false,
-        recommendation: None,
         license: "MIT",
     },
     WhisperModelInfo {
@@ -162,7 +145,6 @@ pub const WHISPER_MODELS: &[WhisperModelInfo] = &[
         role: ModelRole::GpuLive,
         quantization: Quantization::Full,
         live_capable: true,
-        recommendation: None,
         license: "MIT",
     },
     WhisperModelInfo {
@@ -174,7 +156,6 @@ pub const WHISPER_MODELS: &[WhisperModelInfo] = &[
         role: ModelRole::GpuLive,
         quantization: Quantization::Q5_0,
         live_capable: true,
-        recommendation: None,
         license: "MIT",
     },
     WhisperModelInfo {
@@ -186,7 +167,6 @@ pub const WHISPER_MODELS: &[WhisperModelInfo] = &[
         role: ModelRole::Finalize,
         quantization: Quantization::Full,
         live_capable: false,
-        recommendation: Some(ModelRecommendation::FinalQuality),
         license: "MIT",
     },
     WhisperModelInfo {
@@ -198,7 +178,6 @@ pub const WHISPER_MODELS: &[WhisperModelInfo] = &[
         role: ModelRole::Finalize,
         quantization: Quantization::Q5_0,
         live_capable: false,
-        recommendation: None,
         license: "MIT",
     },
     WhisperModelInfo {
@@ -210,7 +189,6 @@ pub const WHISPER_MODELS: &[WhisperModelInfo] = &[
         role: ModelRole::SmallestUsable,
         quantization: Quantization::Full,
         live_capable: true,
-        recommendation: None,
         license: "MIT",
     },
     WhisperModelInfo {
@@ -222,7 +200,6 @@ pub const WHISPER_MODELS: &[WhisperModelInfo] = &[
         role: ModelRole::DevTest,
         quantization: Quantization::Full,
         live_capable: true,
-        recommendation: None,
         license: "MIT",
     },
 ];
@@ -230,13 +207,6 @@ pub const WHISPER_MODELS: &[WhisperModelInfo] = &[
 /// Looks up a Whisper model by its catalogue [`key`](WhisperModelInfo::key).
 pub fn whisper_model(key: &str) -> Option<&'static WhisperModelInfo> {
     WHISPER_MODELS.iter().find(|m| m.key == key)
-}
-
-/// The model the catalogue marks with `rec` (the selection SSOT).
-pub fn model_for_recommendation(rec: ModelRecommendation) -> Option<&'static WhisperModelInfo> {
-    WHISPER_MODELS
-        .iter()
-        .find(|m| m.recommendation == Some(rec))
 }
 
 #[cfg(test)]
@@ -325,35 +295,6 @@ mod tests {
     }
 
     #[test]
-    fn recommendations_have_exactly_one_final_quality_and_at_least_one_live() {
-        // PR-4: the download list badges one model "Recommended for final
-        // quality" (large-v3) and at least one "Recommended for live".
-        let final_q: Vec<&str> = WHISPER_MODELS
-            .iter()
-            .filter(|m| m.recommendation == Some(ModelRecommendation::FinalQuality))
-            .map(|m| m.key)
-            .collect();
-        assert_eq!(
-            final_q,
-            vec!["large-v3"],
-            "exactly one model must be recommended for final quality"
-        );
-        let live: Vec<&str> = WHISPER_MODELS
-            .iter()
-            .filter(|m| m.recommendation == Some(ModelRecommendation::Live))
-            .map(|m| m.key)
-            .collect();
-        assert!(!live.is_empty(), "need at least one live-recommended model");
-        // A live-recommended model must actually be live-capable.
-        for key in &live {
-            assert!(
-                whisper_model(key).is_some_and(|m| m.live_capable),
-                "live-recommended {key} must be live_capable"
-            );
-        }
-    }
-
-    #[test]
     fn lookups_work() {
         assert_eq!(
             whisper_model("medium").map(|m| m.file),
@@ -378,13 +319,6 @@ mod tests {
         for q in [Quantization::Full, Quantization::Q5_0, Quantization::Q5_1] {
             let j = serde_json::to_string(&q).unwrap();
             assert_eq!(serde_json::from_str::<Quantization>(&j).unwrap(), q);
-        }
-        for rec in [ModelRecommendation::Live, ModelRecommendation::FinalQuality] {
-            let j = serde_json::to_string(&rec).unwrap();
-            assert_eq!(
-                serde_json::from_str::<ModelRecommendation>(&j).unwrap(),
-                rec
-            );
         }
     }
 

--- a/crates/speedwave-runtime/src/transcription/model_store.rs
+++ b/crates/speedwave-runtime/src/transcription/model_store.rs
@@ -150,12 +150,16 @@ impl ModelStore {
         self.whisper_dir().join(info.file)
     }
 
-    /// `true` if the model file exists at ≥90% of its catalogue size estimate.
-    /// Download SHA256-verifies before rename, so the floor only rejects a
-    /// truncated leftover (the estimate drifts as upstream re-publishes).
+    /// `true` if the file size is within `[90%, 105%]` of the catalogue estimate
+    /// (download SHA-verifies before rename; the window rejects truncated or
+    /// oversized leftovers while tolerating upstream size drift).
     fn whisper_is_present(&self, info: &WhisperModelInfo) -> bool {
         match std::fs::metadata(self.whisper_path(info)) {
-            Ok(m) => m.len() >= info.approx_bytes / 10 * 9,
+            Ok(m) => {
+                let floor = info.approx_bytes / 10 * 9;
+                let ceil = info.approx_bytes + info.approx_bytes / 20 + 1024;
+                m.len() >= floor && m.len() <= ceil
+            }
             Err(_) => false,
         }
     }
@@ -894,6 +898,19 @@ mod tests {
         assert!(
             !store.whisper_is_present(info),
             "a clearly-truncated file (<90%) is not present"
+        );
+
+        // At the +5% ceiling → present; clearly above it (corrupt/oversized) → not.
+        let ceil = info.approx_bytes + info.approx_bytes / 20 + 1024;
+        write_sparse(ceil);
+        assert!(
+            store.whisper_is_present(info),
+            "exactly at the ceiling is present"
+        );
+        write_sparse(ceil + info.approx_bytes / 10);
+        assert!(
+            !store.whisper_is_present(info),
+            "a wildly-oversized file (>105%) is not present"
         );
     }
 

--- a/crates/speedwave-runtime/src/transcription/transcript.rs
+++ b/crates/speedwave-runtime/src/transcription/transcript.rs
@@ -245,7 +245,6 @@ mod tests {
         AudioSourceInfo {
             source: AudioSource::SystemWide,
             label: "System (everything)".to_string(),
-            app_id: None,
         }
     }
     fn seg(start_s: f32, end_s: f32, text: &str) -> Segment {

--- a/crates/speedwave-runtime/src/transcription/transcript.rs
+++ b/crates/speedwave-runtime/src/transcription/transcript.rs
@@ -407,7 +407,7 @@ mod tests {
         assert_eq!(s.len(), 20);
         assert!(s.ends_with('Z'));
         let year: i32 = s[..4].parse().unwrap();
-        assert!(year >= 2020 && year < 2100, "year {year} not plausible");
+        assert!((2020..2100).contains(&year), "year {year} not plausible");
     }
 
     #[test]

--- a/crates/speedwave-runtime/src/transcription/transcript_driver.rs
+++ b/crates/speedwave-runtime/src/transcription/transcript_driver.rs
@@ -467,7 +467,6 @@ mod tests {
             AudioSourceInfo {
                 source: AudioSource::SystemWide,
                 label: "System".to_string(),
-                app_id: None,
             },
             audio_path.to_path_buf(),
         );

--- a/crates/speedwave-runtime/src/transcription/transcript_store.rs
+++ b/crates/speedwave-runtime/src/transcription/transcript_store.rs
@@ -416,7 +416,6 @@ mod tests {
             AudioSourceInfo {
                 source: AudioSource::SystemWide,
                 label: "System".to_string(),
-                app_id: None,
             },
             audio_path.to_path_buf(),
         )

--- a/crates/speedwave-runtime/tests/transcription_pipeline_e2e.rs
+++ b/crates/speedwave-runtime/tests/transcription_pipeline_e2e.rs
@@ -4,6 +4,7 @@
 //! `STT_E2E_EXPECT` (markdown substring assertion, requires STT_E2E_WAV).
 
 #![cfg(feature = "audio-transcription")]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -44,8 +45,8 @@ fn synth_wav(dir: &std::path::Path, secs: f32) -> PathBuf {
 
 #[test]
 fn full_pipeline_capture_transcribe_finalize_markdown() {
+    // Opt-in: skip silently unless RUN_STT_E2E=1 (see the module doc).
     if env("RUN_STT_E2E").is_none() {
-        eprintln!("skipping: set RUN_STT_E2E=1 to run the STT pipeline E2E test");
         return;
     }
     let model_key = env("STT_E2E_MODEL").unwrap_or_else(|| "small".to_string());

--- a/crates/speedwave-runtime/tests/transcription_pipeline_e2e.rs
+++ b/crates/speedwave-runtime/tests/transcription_pipeline_e2e.rs
@@ -76,7 +76,6 @@ fn full_pipeline_capture_transcribe_finalize_markdown() {
         AudioSourceInfo {
             source: AudioSource::SystemWide,
             label: "E2E".to_string(),
-            app_id: None,
         },
         audio_wav.clone(),
     );

--- a/desktop/src-tauri/src/transcription_cmd.rs
+++ b/desktop/src-tauri/src/transcription_cmd.rs
@@ -124,13 +124,11 @@ pub async fn start_transcription(
     // Defend at the boundary (the UI should already hide unsupported choices).
     validate_source_against_caps(&audio_source, &caps)?;
 
-    // Pick live model: recommendation if downloaded, else any downloaded.
-    // Never download implicitly — error with a hint if nothing is present.
+    // Pick live model: the one model this build downloads if present, else any
+    // downloaded. Never download implicitly — error with a hint if none present.
     let store_arc = store.inner().clone();
     let models_arc = models.inner().clone();
-    let recommended = transcription::recommended_live_model(&transcription::compiled_backends())
-        .key
-        .to_string();
+    let recommended = transcription::best_model_for_this_build().key.to_string();
     let live_key: String = {
         let m = models_arc.clone();
         let rec = recommended.clone();
@@ -169,7 +167,6 @@ pub async fn start_transcription(
         AudioSourceInfo {
             source: audio_source.clone(),
             label,
-            app_id: None,
         },
         audio_wav.clone(),
     );
@@ -385,17 +382,13 @@ fn session_language(store: &TranscriptStore, id: Uuid) -> Language {
     store.get(id).map(|s| s.language).unwrap_or(Language::Pl)
 }
 
-/// Picks the model for the offline pass: `large-v3` if downloaded, otherwise
-/// the first downloaded Whisper model in the catalogue (the live model is
-/// guaranteed present at this point). `None` if somehow nothing is downloaded.
+/// Picks the model for the offline pass: this build's model if downloaded, else
+/// the first downloaded Whisper model (the live one is guaranteed present here).
+/// `None` if somehow nothing is downloaded.
 fn pick_offline_model(models: &ModelStore) -> Option<String> {
-    // The catalogue's FinalQuality model if present, else any downloaded one.
-    if let Some(best) =
-        transcription::model_for_recommendation(transcription::ModelRecommendation::FinalQuality)
-    {
-        if models.whisper_is_present_by_key(best.key) {
-            return Some(best.key.to_string());
-        }
+    let best = transcription::best_model_for_this_build().key;
+    if models.whisper_is_present_by_key(best) {
+        return Some(best.to_string());
     }
     models
         .whisper_status()
@@ -646,7 +639,6 @@ mod tests {
             AudioSourceInfo {
                 source: speedwave_runtime::transcription::AudioSource::SystemWide,
                 label: "Test".to_string(),
-                app_id: None,
             },
             PathBuf::from("/tmp/a.wav"),
         );

--- a/desktop/src/src/app/chat/composer/attachment-strip.component.ts
+++ b/desktop/src/src/app/chat/composer/attachment-strip.component.ts
@@ -1,5 +1,7 @@
 import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
 
+import { formatBytes } from '../../shared/format-bytes';
+
 /** View-model rendered as one pill in the attachment strip. */
 export interface AttachmentViewModel {
   id: string;
@@ -57,13 +59,6 @@ export class AttachmentStripComponent {
   readonly attachments = input.required<ReadonlyArray<AttachmentViewModel>>();
   readonly remove = output<string>();
 
-  /**
-   * Pretty-prints a byte count for the thumbnail title.
-   * @param bytes - Encoded size on disk.
-   */
-  formatBytes(bytes: number): string {
-    if (bytes < 1024) return `${bytes} B`;
-    if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
-    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  }
+  /** Pretty-prints a byte count for the thumbnail title (shared helper). */
+  readonly formatBytes = formatBytes;
 }

--- a/desktop/src/src/app/meeting-transcription/live-transcript/live-transcript.component.spec.ts
+++ b/desktop/src/src/app/meeting-transcription/live-transcript/live-transcript.component.spec.ts
@@ -18,7 +18,7 @@ function session(over: Partial<TranscriptSession> = {}): TranscriptSession {
     id: 'sess-1',
     created_at: '2026-05-12T00:00:00Z',
     language: 'pl',
-    audio_source: { source: { kind: 'system_wide' }, label: 'System', app_id: null },
+    audio_source: { source: { kind: 'system_wide' }, label: 'System' },
     status: { state: 'recording' },
     live_segments: [],
     final_segments: null,

--- a/desktop/src/src/app/meeting-transcription/meeting-transcription.component.spec.ts
+++ b/desktop/src/src/app/meeting-transcription/meeting-transcription.component.spec.ts
@@ -32,6 +32,11 @@ describe('MeetingTranscriptionComponent', () => {
     accel_label: 'CPU',
   });
 
+  const models = (downloaded: boolean) => ({
+    whisper: [{ key: 'large-v3', downloaded, size_bytes: 3_100_000_000, path: null }],
+    total_bytes_used: downloaded ? 3_100_000_000 : 0,
+  });
+
   beforeEach(async () => {
     activeSig.set(null);
     svc = {
@@ -48,7 +53,8 @@ describe('MeetingTranscriptionComponent', () => {
         backends: ['cpu'],
       })),
       listAudioSources: vi.fn(async () => []),
-      listModels: vi.fn(async () => ({ whisper: [], total_bytes_used: 0 })),
+      // Gate predicate matches recording-controls hasModel — any downloaded model lifts it.
+      listModels: vi.fn(async () => models(true)),
       list: vi.fn(async () => []),
       openMicrophonePrivacyPane: vi.fn(async () => undefined),
       openAudioCapturePrivacyPane: vi.fn(async () => undefined),
@@ -77,7 +83,7 @@ describe('MeetingTranscriptionComponent', () => {
   });
 
   it('shows the model-required gate (and hides the panes) when no model is downloaded', async () => {
-    svc.recommendedModel.mockResolvedValueOnce(recommended(false));
+    svc.listModels.mockResolvedValue(models(false));
     await component.ngOnInit();
     fixture.detectChanges();
     const gate = fixture.nativeElement.querySelector('[data-testid="model-required-gate"]');
@@ -94,12 +100,38 @@ describe('MeetingTranscriptionComponent', () => {
   });
 
   it('fails open (shows the panes) if the model check errors', async () => {
-    svc.recommendedModel.mockRejectedValueOnce(new Error('boom'));
+    svc.listModels.mockRejectedValue(new Error('boom'));
     await component.ngOnInit();
     fixture.detectChanges();
     expect(component.modelReady()).toBe(true);
     expect(fixture.nativeElement.querySelector('[data-testid="model-required-gate"]')).toBeNull();
     expect(fixture.nativeElement.querySelector('app-recording-controls')).not.toBeNull();
+  });
+
+  it('clears the gate when the window regains focus after a Settings download', async () => {
+    // Start with no model → gate up.
+    svc.listModels.mockResolvedValue(models(false));
+    await component.ngOnInit();
+    fixture.detectChanges();
+    expect(component.modelReady()).toBe(false);
+    // The user downloads the model in Settings, then returns → focus re-checks.
+    svc.listModels.mockResolvedValue(models(true));
+    window.dispatchEvent(new Event('focus'));
+    await Promise.resolve();
+    await Promise.resolve();
+    fixture.detectChanges();
+    expect(component.modelReady()).toBe(true);
+    expect(fixture.nativeElement.querySelector('[data-testid="model-required-gate"]')).toBeNull();
+  });
+
+  it('removes the focus/visibility listeners on destroy', async () => {
+    await component.ngOnInit();
+    await component.ngOnDestroy();
+    svc.listModels.mockClear();
+    // A focus event after destroy must not trigger another model check.
+    window.dispatchEvent(new Event('focus'));
+    await Promise.resolve();
+    expect(svc.listModels).not.toHaveBeenCalled();
   });
 
   it('shows the "audio local, send uses network" banner text', () => {

--- a/desktop/src/src/app/meeting-transcription/meeting-transcription.component.ts
+++ b/desktop/src/src/app/meeting-transcription/meeting-transcription.component.ts
@@ -139,20 +139,40 @@ export class MeetingTranscriptionComponent implements OnInit, OnDestroy {
     });
   }
 
-  /** Checks whether the speech model is downloaded; if not, the gate shows. */
+  /** Re-checks model availability when the window/tab regains focus. */
+  private readonly onActivate = (): void => {
+    void this.refreshModelReady();
+  };
+
+  /** Checks model availability on first paint and re-checks on re-activation. */
   async ngOnInit(): Promise<void> {
-    try {
-      this.modelReady.set((await this.transcription.recommendedModel()).downloaded);
-    } catch (err) {
-      // Don't trap the user behind the gate on a transient read error.
-      this.log.warn(`recommended-model check failed: ${String(err)}`);
-      this.modelReady.set(true);
-    }
+    await this.refreshModelReady();
+    // Clear the gate after a download in Settings without recreating the tab.
+    window.addEventListener('focus', this.onActivate);
+    document.addEventListener('visibilitychange', this.onActivate);
   }
 
-  /** Detaches the live-stream listener when the tab is destroyed. */
+  /** Detaches the live-stream listener and removes activation listeners. */
   async ngOnDestroy(): Promise<void> {
+    window.removeEventListener('focus', this.onActivate);
+    document.removeEventListener('visibilitychange', this.onActivate);
     await this.transcription.detach();
+  }
+
+  /**
+   * Lifts the gate when any Whisper model is downloaded — the same predicate
+   * recording-controls uses for `hasModel()`. Fails open on a read error.
+   */
+  private async refreshModelReady(): Promise<void> {
+    if (document.visibilityState === 'hidden') return;
+    try {
+      const ack = await this.transcription.listModels();
+      this.modelReady.set(ack.whisper.some((m) => m.downloaded));
+    } catch (err) {
+      // Don't trap the user behind the gate on a transient read error.
+      this.log.warn(`model-availability check failed: ${String(err)}`);
+      this.modelReady.set(true);
+    }
   }
 
   /**

--- a/desktop/src/src/app/meeting-transcription/recording-controls/recording-controls.component.spec.ts
+++ b/desktop/src/src/app/meeting-transcription/recording-controls/recording-controls.component.spec.ts
@@ -5,11 +5,10 @@ import { TranscriptionService } from '../../services/transcription.service';
 import type { AudioSourceInfo, CapabilitiesAck, StartAck } from '../../models/transcript';
 
 const SOURCES: AudioSourceInfo[] = [
-  { source: { kind: 'system_wide' }, label: 'System (everything)', app_id: null },
+  { source: { kind: 'system_wide' }, label: 'System (everything)' },
   {
     source: { kind: 'microphone', device: null },
     label: 'Microphone (default input)',
-    app_id: null,
   },
 ];
 
@@ -18,13 +17,11 @@ const SOURCES_WITH_MIXED: AudioSourceInfo[] = [
   {
     source: { kind: 'mixed', mic: null },
     label: 'Whole meeting (system audio + your microphone)',
-    app_id: null,
   },
-  { source: { kind: 'system_wide' }, label: 'System (everything)', app_id: null },
+  { source: { kind: 'system_wide' }, label: 'System (everything)' },
   {
     source: { kind: 'microphone', device: null },
     label: 'Microphone (default input)',
-    app_id: null,
   },
 ];
 
@@ -33,17 +30,14 @@ const SOURCES_WITH_MICS: AudioSourceInfo[] = [
   {
     source: { kind: 'mixed', mic: null },
     label: 'Whole meeting (system audio + your microphone)',
-    app_id: null,
   },
   {
     source: { kind: 'microphone', device: 'BuiltInMicrophoneDevice' },
     label: 'Microphone: MacBook Pro Microphone (default)',
-    app_id: null,
   },
   {
     source: { kind: 'microphone', device: 'AppleUSBAudioEngine:USB MIC:1' },
     label: 'Microphone: USB MIC',
-    app_id: null,
   },
 ];
 
@@ -118,8 +112,8 @@ describe('RecordingControlsComponent', () => {
     // A host that only exposes mic sources. sourceIndex stays 0; the mixed
     // computed reads sources()[0] safely (it's a microphone, not undefined).
     svc.listAudioSources.mockResolvedValueOnce([
-      { source: { kind: 'microphone', device: 'mic-a' }, label: 'Mic A', app_id: null },
-      { source: { kind: 'microphone', device: 'mic-b' }, label: 'Mic B', app_id: null },
+      { source: { kind: 'microphone', device: 'mic-a' }, label: 'Mic A' },
+      { source: { kind: 'microphone', device: 'mic-b' }, label: 'Mic B' },
     ]);
     await component.ngOnInit();
     fixture.detectChanges();
@@ -272,7 +266,11 @@ describe('RecordingControlsComponent', () => {
     await component.ngOnInit();
     fixture.detectChanges();
     expect(component.hasModel()).toBe(false);
-    expect(fixture.nativeElement.querySelector('[data-testid="no-model-note"]')).not.toBeNull();
+    const note = fixture.nativeElement.querySelector('[data-testid="no-model-note"]');
+    expect(note).not.toBeNull();
+    // Points users to Settings, not a removed model picker (no hardcoded size).
+    expect(note.textContent).toContain('Settings');
+    expect(note.textContent).not.toContain('Models panel');
     expect(fixture.nativeElement.querySelector('[data-testid="start-btn"]').disabled).toBe(true);
   });
 

--- a/desktop/src/src/app/meeting-transcription/recording-controls/recording-controls.component.ts
+++ b/desktop/src/src/app/meeting-transcription/recording-controls/recording-controls.component.ts
@@ -123,8 +123,8 @@ function accelLabel(backends: Backend[]): string {
 
       @if (modelsKnown() && !hasModel()) {
         <p class="mono mt-2 text-[10px] text-[var(--ink-mute)]" data-testid="no-model-note">
-          No speech-to-text model is downloaded yet. Download one in the Models panel (the smallest,
-          'small', is about 488 MB) — downloads use the network.
+          No speech-to-text model is downloaded yet. Download it in Settings → Meeting transcription
+          — the download uses the network.
         </p>
       }
 

--- a/desktop/src/src/app/meeting-transcription/session-list/session-list.component.spec.ts
+++ b/desktop/src/src/app/meeting-transcription/session-list/session-list.component.spec.ts
@@ -9,7 +9,7 @@ function session(id: string, createdAt: string, audioKept: boolean): TranscriptS
     id,
     created_at: createdAt,
     language: 'pl',
-    audio_source: { source: { kind: 'system_wide' }, label: 'System', app_id: null },
+    audio_source: { source: { kind: 'system_wide' }, label: 'System' },
     status: { state: 'done' },
     live_segments: [],
     final_segments: null,

--- a/desktop/src/src/app/models/transcript.ts
+++ b/desktop/src/src/app/models/transcript.ts
@@ -24,7 +24,6 @@ export type AudioSource =
 export interface AudioSourceInfo {
   source: AudioSource;
   label: string;
-  app_id: string | null;
 }
 
 /** A word with its time span (populated only when word_timestamps is set). */

--- a/desktop/src/src/app/services/transcription.service.spec.ts
+++ b/desktop/src/src/app/services/transcription.service.spec.ts
@@ -25,7 +25,7 @@ function snapshot(overrides: Partial<TranscriptSession> = {}): TranscriptSession
     id: 'sess-1',
     created_at: '2026-05-12T00:00:00Z',
     language: 'pl',
-    audio_source: { source: { kind: 'system_wide' }, label: 'System', app_id: null },
+    audio_source: { source: { kind: 'system_wide' }, label: 'System' },
     status: { state: 'recording' },
     live_segments: [],
     final_segments: null,

--- a/desktop/src/src/app/settings/settings.component.spec.ts
+++ b/desktop/src/src/app/settings/settings.component.spec.ts
@@ -142,6 +142,46 @@ describe('SettingsComponent', () => {
     expect(() => scroll.call(component, null)).not.toThrow();
   });
 
+  it('schedules a retry when the target section is missing, then clears it on destroy', () => {
+    vi.useFakeTimers();
+    try {
+      fixture.detectChanges();
+      const inner = component as unknown as {
+        scrollToFragment(id: string | null): void;
+        scrollTimer: ReturnType<typeof setTimeout> | null;
+      };
+      // A fragment with no matching section → a retry timer is armed.
+      inner.scrollToFragment('section-does-not-exist');
+      expect(inner.scrollTimer).not.toBeNull();
+      // Destroy must cancel the pending retry so it can't fire post-destroy.
+      component.ngOnDestroy();
+      expect(inner.scrollTimer).toBeNull();
+      // Advancing time triggers nothing (no throw on the detached host).
+      expect(() => vi.advanceTimersByTime(2000)).not.toThrow();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('clears a prior retry timer when scrollToFragment is re-entered', () => {
+    vi.useFakeTimers();
+    try {
+      fixture.detectChanges();
+      const inner = component as unknown as {
+        scrollToFragment(id: string | null): void;
+        scrollTimer: ReturnType<typeof setTimeout> | null;
+      };
+      inner.scrollToFragment('missing-one');
+      const first = inner.scrollTimer;
+      expect(first).not.toBeNull();
+      // Re-entry (e.g. a new fragment) cancels the previous timer.
+      inner.scrollToFragment('missing-two');
+      expect(inner.scrollTimer).not.toBe(first);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('reloads project info on project_switch_succeeded event', async () => {
     const projectState = TestBed.inject(ProjectStateService);
     await projectState.init();

--- a/desktop/src/src/app/settings/settings.component.ts
+++ b/desktop/src/src/app/settings/settings.component.ts
@@ -219,6 +219,8 @@ export class SettingsComponent implements OnInit, OnDestroy {
   private tauri = inject(TauriService);
   private projectState = inject(ProjectStateService);
   private unsubProjectReady: (() => void) | null = null;
+  /** Pending scroll-retry timer; cleared on re-entry and on destroy. */
+  private scrollTimer: ReturnType<typeof setTimeout> | null = null;
 
   /** Loads project information on component initialization. */
   ngOnInit(): void {
@@ -242,6 +244,11 @@ export class SettingsComponent implements OnInit, OnDestroy {
    * @param attempt - internal retry counter.
    */
   private scrollToFragment(id: string | null, attempt = 0): void {
+    // Cancel any retry from a previous fragment so it can't fire post-destroy.
+    if (this.scrollTimer !== null) {
+      clearTimeout(this.scrollTimer);
+      this.scrollTimer = null;
+    }
     if (!id) return;
     // CSS.escape guards against a fragment with CSS-special chars throwing
     // (guarded — not present in every test environment).
@@ -253,15 +260,19 @@ export class SettingsComponent implements OnInit, OnDestroy {
     }
     // Give up after ~1s of retries — the section never mounted (cosmetic).
     if (attempt < 20) {
-      setTimeout(() => this.scrollToFragment(id, attempt + 1), 50);
+      this.scrollTimer = setTimeout(() => this.scrollToFragment(id, attempt + 1), 50);
     }
   }
 
-  /** Unsubscribes from the project ready listener. */
+  /** Unsubscribes from the project ready listener and cancels any scroll retry. */
   ngOnDestroy(): void {
     if (this.unsubProjectReady) {
       this.unsubProjectReady();
       this.unsubProjectReady = null;
+    }
+    if (this.scrollTimer !== null) {
+      clearTimeout(this.scrollTimer);
+      this.scrollTimer = null;
     }
   }
 

--- a/desktop/src/src/app/settings/transcription-section/transcription-section.component.spec.ts
+++ b/desktop/src/src/app/settings/transcription-section/transcription-section.component.spec.ts
@@ -62,7 +62,7 @@ describe('TranscriptionSectionComponent', () => {
     expect(fixture.nativeElement.querySelector('[data-testid="download-model"]')).not.toBeNull();
     expect(fixture.nativeElement.querySelector('[data-testid="remove-model"]')).toBeNull();
     const state = fixture.nativeElement.querySelector('[data-testid="model-state"]');
-    expect(state.textContent).toContain('3.1 GB');
+    expect(state.textContent).toContain('2.9 GB');
     expect(state.textContent).toContain('best quality for your hardware');
   });
 
@@ -114,7 +114,7 @@ describe('TranscriptionSectionComponent', () => {
   });
 
   it('size() formats GB and MB', () => {
-    expect(component.size({ ...notDownloaded, size_bytes: 3_100_000_000 })).toBe('3.1 GB');
-    expect(component.size({ ...notDownloaded, size_bytes: 488_000_000 })).toBe('488 MB');
+    expect(component.size({ ...notDownloaded, size_bytes: 3_100_000_000 })).toBe('2.9 GB');
+    expect(component.size({ ...notDownloaded, size_bytes: 488_000_000 })).toBe('465.4 MB');
   });
 });

--- a/desktop/src/src/app/settings/transcription-section/transcription-section.component.ts
+++ b/desktop/src/src/app/settings/transcription-section/transcription-section.component.ts
@@ -10,16 +10,7 @@ import {
 
 import { TranscriptionService } from '../../services/transcription.service';
 import type { RecommendedModelAck } from '../../models/transcript';
-
-/**
- * Formats a byte count as a short `GB`/`MB` string.
- * @param bytes - size in bytes.
- */
-function humanSize(bytes: number): string {
-  const gb = bytes / 1_000_000_000;
-  if (gb >= 1) return `${gb.toFixed(1)} GB`;
-  return `${Math.round(bytes / 1_000_000)} MB`;
-}
+import { formatBytes } from '../../shared/format-bytes';
 
 /**
  * Settings → Meeting transcription (ADR-056). One auto-selected model for this
@@ -178,6 +169,6 @@ export class TranscriptionSectionComponent implements OnInit {
    * @param m - the recommended-model ack.
    */
   size(m: RecommendedModelAck): string {
-    return humanSize(m.size_bytes);
+    return formatBytes(m.size_bytes);
   }
 }

--- a/desktop/src/src/app/shared/format-bytes.spec.ts
+++ b/desktop/src/src/app/shared/format-bytes.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { formatBytes } from './format-bytes';
+
+describe('formatBytes', () => {
+  it('formats sub-KB byte counts (happy path)', () => {
+    expect(formatBytes(500)).toBe('500 B');
+    expect(formatBytes(2048)).toBe('2 KB');
+    expect(formatBytes(3_145_728)).toBe('3.0 MB');
+  });
+
+  it('formats GB-range sizes', () => {
+    // 3 GiB exactly.
+    expect(formatBytes(3 * 1024 ** 3)).toBe('3.0 GB');
+    expect(formatBytes(1_610_612_736)).toBe('1.5 GB');
+  });
+
+  it('handles the 0-byte edge', () => {
+    expect(formatBytes(0)).toBe('0 B');
+  });
+
+  it('handles unit boundaries', () => {
+    expect(formatBytes(1023)).toBe('1023 B');
+    expect(formatBytes(1024)).toBe('1 KB');
+    expect(formatBytes(1024 * 1024)).toBe('1.0 MB');
+    expect(formatBytes(1024 ** 3)).toBe('1.0 GB');
+  });
+});

--- a/desktop/src/src/app/shared/format-bytes.ts
+++ b/desktop/src/src/app/shared/format-bytes.ts
@@ -1,0 +1,14 @@
+/**
+ * Pretty-prints a byte count as a short B/KB/MB/GB string (binary units,
+ * 1024-based). Shared by the attachment strip and the transcription section.
+ * @param bytes - size in bytes.
+ */
+export function formatBytes(bytes: number): string {
+  const KB = 1024;
+  const MB = KB * 1024;
+  const GB = MB * 1024;
+  if (bytes < KB) return `${bytes} B`;
+  if (bytes < MB) return `${Math.round(bytes / KB)} KB`;
+  if (bytes < GB) return `${(bytes / MB).toFixed(1)} MB`;
+  return `${(bytes / GB).toFixed(1)} GB`;
+}

--- a/native/macos/audio-capture/Sources/AudioCaptureCLI.swift
+++ b/native/macos/audio-capture/Sources/AudioCaptureCLI.swift
@@ -188,6 +188,11 @@ struct RecordOptions {
     let mic: MicSelector
 }
 
+/// The mic selector for a `mic-only[:uid]` source: the named device, or default.
+func micSelector(forMicOnly uid: String?) -> MicSelector {
+    uid.map { .device($0) } ?? .defaultDevice
+}
+
 /// Parses `--record --source <s> [--mic <m>]` from argv (after the subcommand).
 /// `--mic` is optional and defaults to `none`. Returns `nil` if any flag is
 /// missing or malformed — caller exits with usage.
@@ -458,7 +463,7 @@ func runRecord(_ opts: RecordOptions) {
                 "microphone access denied — grant it in System Settings → Privacy & Security → Microphone")
             exit(2)
         }
-        let selector: MicSelector = uid.map { .device($0) } ?? .defaultDevice
+        let selector = micSelector(forMicOnly: uid)
         WriterQueue.shared.writeHeader(streams: ["mic"])
         do {
             try startMicEngine(session: session, selector: selector, streamIndex: 0)

--- a/native/macos/audio-capture/Sources/AudioCaptureCLI.swift
+++ b/native/macos/audio-capture/Sources/AudioCaptureCLI.swift
@@ -126,8 +126,34 @@ final class WriterQueue {
         samples.withUnsafeBufferPointer { buf in stdout.write(Data(buffer: buf)) }
     }
 
-    /// Drains any queued writes (best-effort, used on shutdown).
-    func flush() { queue.sync {} }
+    /// Flushes each converter's resampler tail, then drains queued writes, so a
+    /// graceful stop is not truncated. Best-effort, used on shutdown.
+    func flush(offsetNs: UInt64) {
+        queue.sync { [self] in
+            for (idx, converter) in converters {
+                drainConverterTail(streamIndex: UInt32(idx), converter: converter, offsetNs: offsetNs)
+            }
+        }
+    }
+
+    /// Feeds `.endOfStream` to one converter and writes its tail. On `queue` only.
+    private func drainConverterTail(
+        streamIndex: UInt32, converter: AVAudioConverter, offsetNs: UInt64
+    ) {
+        guard let outBuf = AVAudioPCMBuffer(pcmFormat: outFormat, frameCapacity: 4096) else {
+            return
+        }
+        var convErr: NSError?
+        converter.convert(to: outBuf, error: &convErr) { _, status in
+            status.pointee = .endOfStream
+            return nil
+        }
+        if convErr != nil { return }
+        let n = Int(outBuf.frameLength)
+        guard n > 0, let raw = outBuf.floatChannelData else { return }
+        let mono = Array(UnsafeBufferPointer(start: raw[0], count: n))
+        writeChunk(streamIndex: streamIndex, samples: mono, offsetNs: offsetNs)
+    }
 }
 
 /// Writes a diagnostic line to stderr — never stdout.
@@ -223,10 +249,17 @@ func listInputDevices() throws -> Data {
     }
     let count = Int(dataSize) / MemoryLayout<AudioObjectID>.size
     var ids = [AudioObjectID](repeating: 0, count: count)
-    _ = ids.withUnsafeMutableBufferPointer { buf in
-        AudioObjectGetPropertyData(
-            AudioObjectID(kAudioObjectSystemObject), &addr, 0, nil, &dataSize,
-            buf.baseAddress!)
+    if count > 0 {
+        let status = ids.withUnsafeMutableBufferPointer { buf -> OSStatus in
+            guard let base = buf.baseAddress else { return kAudioHardwareUnspecifiedError }
+            return AudioObjectGetPropertyData(
+                AudioObjectID(kAudioObjectSystemObject), &addr, 0, nil, &dataSize, base)
+        }
+        guard status == noErr else {
+            throw NSError(
+                domain: "AudioCapture", code: Int(status),
+                userInfo: [NSLocalizedDescriptionKey: "device list query failed"])
+        }
     }
     let defaultId = defaultInputDevice()
     var out: [[String: Any]] = []
@@ -398,12 +431,13 @@ var activeSession: RecordSession?
 
 /// SIGTERM/SIGINT handler — installed once at record start.
 let cleanupHandler: @convention(c) (Int32) -> Void = { _ in
+    var tailOffset: UInt64 = 0
     if #available(macOS 14.4, *) {
+        tailOffset = activeSession?.offsetNs() ?? 0
         activeSession?.teardown()
     }
-    // Drain any frames still queued on the writer thread, then flush the C
-    // stdio buffer so the parent doesn't see a truncated chunk.
-    WriterQueue.shared.flush()
+    // Flush converter tails + queued writes, then the C stdio buffer.
+    WriterQueue.shared.flush(offsetNs: tailOffset)
     fflush(stdout)
     _exit(0)
 }
@@ -416,17 +450,18 @@ func runRecord(_ opts: RecordOptions) {
     signal(SIGTERM, cleanupHandler)
     signal(SIGINT, cleanupHandler)
 
-    // mic-only: no system tap, just the microphone on stream 0. Uses the public
-    // AVCaptureDevice consent API so the OS prompt fires.
-    if case .micOnly = opts.source {
+    // mic-only: no system tap, mic on stream 0 (public AVCaptureDevice consent,
+    // so the OS prompt fires). `mic-only:<uid>` selects that device, bare = default.
+    if case .micOnly(let uid) = opts.source {
         guard requestMicrophoneAccess() else {
             logErr(
                 "microphone access denied — grant it in System Settings → Privacy & Security → Microphone")
             exit(2)
         }
+        let selector: MicSelector = uid.map { .device($0) } ?? .defaultDevice
         WriterQueue.shared.writeHeader(streams: ["mic"])
         do {
-            try startMicEngine(session: session, selector: .defaultDevice, streamIndex: 0)
+            try startMicEngine(session: session, selector: selector, streamIndex: 0)
         } catch {
             logErr("mic record start failed: \(error.localizedDescription)")
             session.teardown()
@@ -445,25 +480,23 @@ func runRecord(_ opts: RecordOptions) {
         exit(2)
     }
 
-    // System tap (+ optionally the mic mixed in as stream 1; the Rust side
-    // sums streams 0 and 1 into one mono stream — see CliAudioStream).
-    let streams: [String]
-    switch opts.mic {
-    case .none: streams = ["app"]
-    default: streams = ["app", "mic"]
+    // Resolve the mic permission BEFORE the header so it lists only streams we
+    // actually capture — a denied mic must not leave the reader waiting on a
+    // "mic" stream that never produces frames (ADR-056). Header is still
+    // written before the IOProc starts, so no chunk precedes it.
+    let micGranted: Bool
+    if case .none = opts.mic {
+        micGranted = false
+    } else {
+        micGranted = requestMicrophoneAccess()
+        if !micGranted { logErr("microphone access denied — recording system audio only") }
     }
-    WriterQueue.shared.writeHeader(streams: streams)
+    WriterQueue.shared.writeHeader(streams: micGranted ? ["app", "mic"] : ["app"])
 
     do {
         try startSystemTap(session: session, source: opts.source)
-        if case .none = opts.mic {} else {
-            // The mic prompt fires here too (public API), so a mixed capture
-            // gets at least the mic if the system-tap permission is missing.
-            if requestMicrophoneAccess() {
-                try startMicEngine(session: session, selector: opts.mic, streamIndex: 1)
-            } else {
-                logErr("microphone access denied — recording system audio only")
-            }
+        if micGranted {
+            try startMicEngine(session: session, selector: opts.mic, streamIndex: 1)
         }
     } catch {
         logErr("record start failed: \(error.localizedDescription)")
@@ -732,10 +765,13 @@ func inputDeviceId(forUID uid: String) -> AudioDeviceID? {
             AudioObjectID(kAudioObjectSystemObject), &addr, 0, nil, &size) == noErr
     else { return nil }
     let count = Int(size) / MemoryLayout<AudioObjectID>.size
+    guard count > 0 else { return nil }
     var ids = [AudioObjectID](repeating: 0, count: count)
-    _ = ids.withUnsafeMutableBufferPointer { buf in
-        AudioObjectGetPropertyData(
-            AudioObjectID(kAudioObjectSystemObject), &addr, 0, nil, &size, buf.baseAddress!)
+    let status = ids.withUnsafeMutableBufferPointer { buf -> OSStatus in
+        guard let base = buf.baseAddress else { return kAudioHardwareUnspecifiedError }
+        return AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject), &addr, 0, nil, &size, base)
     }
+    guard status == noErr else { return nil }
     return ids.first { deviceHasInput($0) && deviceStringProperty($0, kAudioDevicePropertyDeviceUID) == uid }
 }

--- a/native/macos/audio-capture/Tests/AudioCaptureTests.swift
+++ b/native/macos/audio-capture/Tests/AudioCaptureTests.swift
@@ -120,6 +120,19 @@ final class AudioCaptureTests: XCTestCase {
         }
     }
 
+    func testMicSelectorForMicOnly() {
+        // A `mic-only:<uid>` source must route to the named device, not default.
+        if case .device(let uid) = micSelector(forMicOnly: "UID-7") {
+            XCTAssertEqual(uid, "UID-7")
+        } else {
+            XCTFail("expected device(_) selector for mic-only:<uid>")
+        }
+        // Bare `mic-only` uses the default input.
+        if case .defaultDevice = micSelector(forMicOnly: nil) {} else {
+            XCTFail("expected defaultDevice selector for bare mic-only")
+        }
+    }
+
     func testParseRecordOptionsMicOnly() {
         // `--source mic-only` without `--mic` (mic-only IS the microphone).
         let opts = parseRecordOptions(["--source", "mic-only"])


### PR DESCRIPTION
Follow-up to #833 (already merged) — resolves the findings from the post-merge `/code-review` recall pass on the meeting-transcription feature. No behavior change to the shipped feature beyond the fixes below; all `make check` + `make test` green.

## Correctness (macOS audio-capture-cli)
- **Named mic was ignored.** `mic-only:<uid>` parsed the device UID but `runRecord` discarded it and always recorded the default input. Now routes the UID to the mic selector (extracted `micSelector(forMicOnly:)`, unit-tested).
- **Mixed capture lost audio on mic denial.** The `["app","mic"]` stream header was written before the mic-permission outcome, so a denied mic left the reader waiting on a mic stream that never produced frames. Header is now written after the permission is resolved, before any IOProc starts.
- **Device-enumeration safety.** `listInputDevices`/`inputDeviceId` force-unwrapped an empty buffer's `baseAddress` and discarded the `OSStatus`; now guarded + checked.
- **Converter tail flushed on stop.** Graceful teardown now feeds `.endOfStream` to each `AVAudioConverter` so the resampler tail isn't truncated.

## Correctness (runtime / desktop)
- **Single-model oracle.** GPU builds downloaded `large-v3` but the live pass wanted `large-v3-turbo` (never downloaded) → silent fallback ran the heavy model live. Both passes now use the one model `best_model_for_this_build()` selects; removed the redundant `ModelRecommendation` / `model_for_recommendation` / `recommended_live_model` machinery.
- **Model present-check bounded.** `whisper_is_present` now requires the file size in `[90%, 105%]` of the catalogue estimate (rejects oversized/corrupt leftovers; download still SHA-verifies before rename).

## Angular
- **Model-required gate** re-checks availability on focus/visibility (clears after a Settings download without recreating the tab) and uses the same presence predicate as `recording-controls.hasModel()`.
- **Settings scroll** clears its `scrollToFragment` retry timer on re-entry and `ngOnDestroy` (no post-destroy `querySelector`).
- **Stale UI prose** removed (no more "Models panel" / hardcoded model size); points users to Settings → Meeting transcription.
- **Shared `formatBytes`** extracted (de-dups attachment-strip + transcription-section).

## Cleanup
- Removed the always-`None` `AudioSourceInfo.app_id` field (Rust + TS mirror + specs).
- Satisfied clippy on the audio-transcription targets (test-only unwrap/expect allow on the opt-in e2e test; dropped a denied `eprintln!`; `Range::contains`).

Findings verified REFUTED and intentionally not "fixed": the mixed-abort mic-only race (the `min(sys,mic)` buffer stalls and surfaces the abort), the WASAPI partial-frame phase drift (the queue only ever holds whole frames), and the `live_splice_at` "cache-only" claim (it uses the same session map as `replace_segments`).

Tests: macOS Swift (12, +1 new), runtime audio-transcription lib (115), desktop (1432), Angular (1963) — all green. New tests cover `micSelector`, the bounded present-check window, the gate re-check, the scroll-timer cleanup, and `formatBytes`.